### PR TITLE
Critical versioning fix. Match Ivy-Framework with Ivy to enable ivy db add to work at all.

### DIFF
--- a/Ivy/Ivy.csproj
+++ b/Ivy/Ivy.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>Ivy</PackageId>
+    <Version>0.1.2.1</Version>
     <Company>Ivy</Company>
     <Description>Build Internal Applications with AI and Pure C#</Description>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>


### PR DESCRIPTION
Critical versioning fix. Match Ivy-Framework with Ivy to enable ivy db add to work at all.

Problem:
ivy init creates csproj referencing the assembly version of the local ivy console version (a problem itself that i fixed in other pull request), this causes it to look for the same version of the ivy framework which is not found. The simplest fix would be to sync the ivy versions. 

