### PR TITLE
Number input fix

### DIFF
--- a/Ivy/Widgets/Inputs/NumberInput.cs
+++ b/Ivy/Widgets/Inputs/NumberInput.cs
@@ -92,8 +92,8 @@ public static class NumberInputExtensions
         return input;
     }
 
-    public static NumberInputBase ToMoneyInput(this IAnyState state, string? placeholder = null, bool disabled = false, NumberInputs variant = NumberInputs.Number, NumberFormatStyle formatStyle = NumberFormatStyle.Currency) 
-        => state.ToNumberInput(placeholder, disabled, variant, formatStyle);
+    public static NumberInputBase ToMoneyInput(this IAnyState state, string? placeholder = null, bool disabled = false, NumberInputs variant = NumberInputs.Number, string currency = "USD") 
+        => state.ToNumberInput(placeholder, disabled, variant, NumberFormatStyle.Currency).Currency(currency);
 
     internal static IAnyNumberInput ScaffoldDefaults(this IAnyNumberInput input, string? name, Type type)
     {
@@ -101,6 +101,13 @@ public static class NumberInputExtensions
         input.Step ??= type.SuggestStep();
         input.Min ??= type.SuggestMin();
         input.Max ??= type.SuggestMax();
+        
+        // Add default currency for Currency style inputs
+        if (input.FormatStyle == NumberFormatStyle.Currency && string.IsNullOrEmpty(input.Currency))
+        {
+            input.Currency = "USD";
+        }
+        
         return input;
     }
     


### PR DESCRIPTION
Before there seemed to be auto rounding of decimals like tax rates and prices to the nearest integer when typing manually. This is changed, so stepping with buttons works for integers, while manual typing results in the decimals being kept. 