### PR TITLE
Remove EFCore as a dependency

### DIFF
--- a/Ivy/Charts/AreaChartView.cs
+++ b/Ivy/Charts/AreaChartView.cs
@@ -5,7 +5,6 @@ using System.Runtime.CompilerServices;
 using Ivy.Core;
 using Ivy.Core.Helpers;
 using Ivy.Core.Hooks;
-using Microsoft.EntityFrameworkCore.Infrastructure;
 
 namespace Ivy.Charts;
 

--- a/Ivy/Charts/BarChartView.cs
+++ b/Ivy/Charts/BarChartView.cs
@@ -6,7 +6,6 @@ using Ivy.Core;
 using Ivy.Core.Helpers;
 using Ivy.Core.Hooks;
 using Ivy.Shared;
-using Microsoft.EntityFrameworkCore.Infrastructure;
 
 namespace Ivy.Charts;
 

--- a/Ivy/Charts/LineChartView.cs
+++ b/Ivy/Charts/LineChartView.cs
@@ -5,7 +5,6 @@ using System.Runtime.CompilerServices;
 using Ivy.Core;
 using Ivy.Core.Helpers;
 using Ivy.Core.Hooks;
-using Microsoft.EntityFrameworkCore.Infrastructure;
 
 namespace Ivy.Charts;
 

--- a/Ivy/Charts/PivotTable.cs
+++ b/Ivy/Charts/PivotTable.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections;
 using System.Linq.Expressions;
 using System.Runtime.CompilerServices;
-using Microsoft.EntityFrameworkCore;
 
 namespace Ivy.Charts;
 
@@ -77,7 +76,7 @@ public class PivotTable<T>
 
             var grouped = data.GroupBy(keySelectorLambda);
             // Convert to list asynchronously
-            var groups = await grouped.ToListAsync(cancellationToken);
+            var groups = await grouped.ToListAsync2(cancellationToken);
             
             foreach (var group in groups)
             {

--- a/Ivy/Dashboards/MetricView.cs
+++ b/Ivy/Dashboards/MetricView.cs
@@ -1,7 +1,6 @@
 ﻿using Ivy.Core;
 using Ivy.Helpers;
 using Ivy.Shared;
-using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Ivy.Dashboards;
 

--- a/Ivy/Ivy.csproj
+++ b/Ivy/Ivy.csproj
@@ -40,7 +40,6 @@
     <PackageReference Include="ExcelNumberFormat" Version="1.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.2.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.4" />
     <PackageReference Include="Spectre.Console" Version="0.50.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.8.0" />


### PR DESCRIPTION
This fixes Google Spanner integration, which needs EFCore 8