### PR TITLE
Add docs for common widgets

### DIFF
--- a/Ivy.Docs/Docs/02_Widgets/01_Common/Blades.md
+++ b/Ivy.Docs/Docs/02_Widgets/01_Common/Blades.md
@@ -1,0 +1,21 @@
+# Blades
+
+Blades provide a stacked navigation pattern where new views slide in from the right. Use the `UseBlades` extension to create a root blade and manage a stack of blades through `IBladeController`.
+
+## Basic Usage
+
+```csharp
+this.UseBlades(() => new RootView("A"), "Blade 0");
+```
+
+Pushing a new blade can be done through the controller:
+
+```csharp
+action<Event<Button>> onClick = e =>
+{
+    var blades = this.UseContext<IBladeController>();
+    blades.Push(this, new RootView(e.Sender.Tag?.ToString() ?? "?"), "Next Blade");
+};
+```
+
+<WidgetDocs Type="Ivy.Blade" ExtensionTypes="Ivy.Blades.UseBladesExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Blades/UseBlades.cs"/>

--- a/Ivy.Docs/Docs/02_Widgets/01_Common/Details.md
+++ b/Ivy.Docs/Docs/02_Widgets/01_Common/Details.md
@@ -1,3 +1,19 @@
-﻿# Details
+# Details
 
-Detail widgets are never used directly but produced by...
+Detail widgets display label and value pairs. They are usually generated from a model using `ToDetails()`.
+
+## Basic Usage
+
+```csharp
+data record User(string Name, string Email);
+var user = new User("Niels", "niels@example.com");
+return user.ToDetails();
+```
+
+Remove empty entries or customize fields via the builder:
+
+```csharp
+data.ToDetails().RemoveEmpty();
+```
+
+<WidgetDocs Type="Ivy.Details" ExtensionTypes="Ivy.Builders.DetailsBuilderExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Builders/DetailsBuilder.cs"/>

--- a/Ivy.Docs/Docs/02_Widgets/01_Common/Form.md
+++ b/Ivy.Docs/Docs/02_Widgets/01_Common/Form.md
@@ -1,0 +1,19 @@
+# Form
+
+Forms can be scaffolded from a state object using `ToForm()` and further customized via the fluent `FormBuilder` API.
+
+## Basic Usage
+
+```csharp
+auto var model = UseState(() => new UserModel());
+return model.ToForm();
+```
+
+Forms can also be presented in a sheet or dialog:
+
+```csharp
+auto form = model.ToForm();
+form.ToDialog(isOpen, "User Information");
+```
+
+<WidgetDocs Type="Ivy.Form" ExtensionTypes="Ivy.Forms.FormExtensions;Ivy.Forms.UseFormExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Forms/Form.cs"/>

--- a/Ivy.Docs/Docs/02_Widgets/01_Common/List.md
+++ b/Ivy.Docs/Docs/02_Widgets/01_Common/List.md
@@ -1,0 +1,14 @@
+# List
+
+List renders a vertical collection of `ListItem` widgets.
+
+## Basic Usage
+
+```csharp
+new List(
+    new ListItem("Products", badge: "100"),
+    new ListItem("Balance", icon: Icons.ChevronRight)
+);
+```
+
+<WidgetDocs Type="Ivy.List" ExtensionTypes="Ivy.WidgetBaseExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Lists/List.cs"/>

--- a/Ivy.Docs/Docs/02_Widgets/01_Common/Table.md
+++ b/Ivy.Docs/Docs/02_Widgets/01_Common/Table.md
@@ -1,1 +1,21 @@
-﻿
+# Table
+
+Tables organize data into rows and columns. You can build them manually or generate them from a collection using `ToTable()`.
+
+## Basic Usage
+
+```csharp
+new Table(
+    new TableRow(new TableCell("Name"), new TableCell("Age")).IsHeader(),
+    new TableRow(new TableCell("Niels"), new TableCell("25")),
+    new TableRow(new TableCell("John"), new TableCell("30"))
+)
+```
+
+High level builders can create tables from records:
+
+```csharp
+data.ToTable();
+```
+
+<WidgetDocs Type="Ivy.Table" ExtensionTypes="Ivy.Tables.TableExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Tables/Table.cs"/>

--- a/Ivy.Docs/Docs/02_Widgets/01_Common/Tooltip.md
+++ b/Ivy.Docs/Docs/02_Widgets/01_Common/Tooltip.md
@@ -1,0 +1,17 @@
+# Tooltip
+
+Tooltips provide contextual information when hovering or focusing on a widget.
+
+## Basic Usage
+
+```csharp
+new Tooltip(new Button("Hover Me"), "Hello World!");
+```
+
+You can also add a tooltip using the extension method:
+
+```csharp
+new Button("Hover Me").WithTooltip("Hello World!");
+```
+
+<WidgetDocs Type="Ivy.Tooltip" ExtensionTypes="Ivy.TooltipExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Tooltip.cs"/>


### PR DESCRIPTION
## Summary
- write docs for Blades
- document Details widget
- document Forms and how to present them
- add List docs
- document Tables and basic usage
- add Tooltip docs

## Testing
- `dotnet test --no-build` *(fails: command not found)*