### PR TITLE
chore: fix confusing relative pathing

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ You can also run `ivy samples` to see all the components that Ivy offers and `iv
 3. **Build the frontend**:
 
    ```bash
-   cd ../frontend
+   cd frontend
    npm install
    npm run build
    npm run dev


### PR DESCRIPTION
We had `../` as leftover from previous variant, where FE step was after the BE step.

We moved it  around, and now relative pathing might confuse ppl because this is the first step.

My suggestion is to keep the paths without relative navigation not to confuse anyone.