### PR TITLE
chore: remove untested bool input vars

### DIFF
--- a/Ivy/Widgets/Inputs/BoolInput.cs
+++ b/Ivy/Widgets/Inputs/BoolInput.cs
@@ -37,16 +37,15 @@ public abstract record BoolInputBase : WidgetBase<BoolInputBase>, IAnyBoolInput
         // Boolean types
         typeof(bool), typeof(bool?),
         // Signed integer types
-        typeof(sbyte), typeof(sbyte?), typeof(short), typeof(short?),
-        typeof(int), typeof(int?), typeof(long), typeof(long?),
-        typeof(Int128), typeof(Int128?),
+        typeof(short), typeof(short?),
+        typeof(int), typeof(int?),
+        typeof(long), typeof(long?),
         // Unsigned integer types
-        typeof(byte), typeof(byte?), typeof(ushort), typeof(ushort?),
-        typeof(uint), typeof(uint?), typeof(ulong), typeof(ulong?),
-        typeof(UInt128), typeof(UInt128?),
+        typeof(byte), typeof(byte?),
         // Floating-point types
         typeof(float), typeof(float?),
-        typeof(double), typeof(double?), typeof(decimal), typeof(decimal?)
+        typeof(double), typeof(double?),
+        typeof(decimal), typeof(decimal?)
     ];
 }
 


### PR DESCRIPTION
As discussed some time ago, I remove also support in BE for unsigned numeric types.

Here is what we decided to keep:

```csharp
    public Type[] SupportedStateTypes() =>
    [
        // Boolean types
        typeof(bool), typeof(bool?),
        // Signed integer types
        typeof(short), typeof(short?),
        typeof(int), typeof(int?),
        typeof(long), typeof(long?),
        // Unsigned integer types
        typeof(byte), typeof(byte?),
        // Floating-point types
        typeof(float), typeof(float?),
        typeof(double), typeof(double?),
        typeof(decimal), typeof(decimal?)
    ];
 ```