### PR TITLE
chore: update env vars

### DIFF
--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,1 +1,1 @@
-IVY_HOST=https://localhost:5000
+IVY_HOST=https://localhost:5010


### PR DESCRIPTION
Not sure why it worked before since we updated BE to run on 5010. 

The only use of the env var is here 
![image](https://github.com/user-attachments/assets/b3887496-c3ff-4877-8a2b-747b058440f3)

And I guess it has to be configured in `.env`, not in `.env.development`.

But we have had no information on how to use env files and the 5010 port is specified as fallback.