### PR TITLE
feat: center bool input for docs

### DIFF
--- a/frontend/src/widgets/inputs/BoolInputWidget.tsx
+++ b/frontend/src/widgets/inputs/BoolInputWidget.tsx
@@ -62,7 +62,7 @@ const InputLabel: React.FC<{
   if (!label && !description) return null;
 
   return (
-    <div className="grid gap-1.5 leading-none bg-background">
+    <div>
       {label && <Label htmlFor={id}>{label}</Label>}
       {description && (
         <p className="text-sm text-muted-foreground">{description}</p>
@@ -113,7 +113,7 @@ const VariantComponents = {
 
       const content = (
         <div
-          className="flex items-start space-x-2"
+          className="flex items-center gap-2"
           onClick={e => e.stopPropagation()}
         >
           {withTooltip(checkboxElement, invalid)}
@@ -149,7 +149,7 @@ const VariantComponents = {
 
       const content = (
         <div
-          className="flex items-start space-x-2"
+          className="flex items-center gap-2"
           onClick={e => e.stopPropagation()}
         >
           {withTooltip(switchElement, invalid)}
@@ -189,7 +189,7 @@ const VariantComponents = {
 
       const content = (
         <div
-          className="flex items-start space-x-2"
+          className="flex items-center space-x-2"
           onClick={e => e.stopPropagation()}
         >
           {withTooltip(toggleElement, invalid)}


### PR DESCRIPTION
- now relying more on flex instead of grid for placing elements in bool input
- the button is now centered relative to label/labels
![image](https://github.com/user-attachments/assets/a233c696-43f3-43a6-8516-a92a609a5d52)

due to this documentation looks cleaner
![image](https://github.com/user-attachments/assets/e95eaf29-a037-43f3-8a3c-6269728b24c6)


This is how it looked before

![image](https://github.com/user-attachments/assets/fa55cf7d-bb38-4a9b-b78b-590fcc556c8d)


