### PR TITLE
chore: node version requirement in readme

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,5 +1,7 @@
 # Frontend
 
+**Node.js Version Requirement**: This project requires Node.js version 22.12.0 or greater.
+
 ## Development
 
 ```bash


### PR DESCRIPTION
we didn't have it before

22.12 is required by vite 7.