### PR TITLE
Fix doc generation paths for non-windows

### DIFF
--- a/Ivy.Docs.Tools.Test/UtilsTests.cs
+++ b/Ivy.Docs.Tools.Test/UtilsTests.cs
@@ -1,20 +1,22 @@
-﻿namespace Ivy.Docs.Tools.Test;
+namespace Ivy.Docs.Tools.Test;
 
 public class UtilsTests
 {
+    public static IEnumerable<object[]> RelativeFolderWithoutOrderTestData() =>
+    [
+        [@"C:\Foo\Bar\Input\", @"C:\Foo\Bar\Input\01_Baz\03_Fizz\Goo\Qux.md", Path.Combine("Baz", "Fizz", "Goo")],
+        [@"C:\Data\", @"C:\Data\Baz\Fizz\Qux.md", Path.Combine("Baz", "Fizz")],
+        [@"C:\Root\", @"C:\Root\001_Alpha\Beta\Qux.md", Path.Combine("Alpha", "Beta")],
+        [@"C:\Test\", @"C:\Test\Qux.md", ""],
+        [@"C:\Test\", @"C:\Test\01_Baz\Qux.md", "Baz"],
+        [@"C:\Test\", @"C:\Test\Baz\Qux.md", "Baz"],
+        [@"/mnt/data/input/", @"/mnt/data/input/01_Baz/03_Fizz/Goo/Qux.md", Path.Combine("Baz", "Fizz", "Goo")],
+    ];
+
     [Theory]
-    [InlineData(@"C:\Foo\Bar\Input\", @"C:\Foo\Bar\Input\01_Baz\03_Fizz\Goo\Qux.md", @"Baz\Fizz\Goo")]
-    [InlineData(@"C:\Data\", @"C:\Data\Baz\Fizz\Qux.md", @"Baz\Fizz")]
-    [InlineData(@"C:\Root\", @"C:\Root\001_Alpha\Beta\Qux.md", @"Alpha\Beta")]
-    [InlineData(@"C:\Test\", @"C:\Test\Qux.md", @"")]
-    [InlineData(@"C:\Test\", @"C:\Test\01_Baz\Qux.md", @"Baz")]
-    [InlineData(@"C:\Test\", @"C:\Test\Baz\Qux.md", @"Baz")]
-    [InlineData(@"/mnt/data/input/", @"/mnt/data/input/01_Baz/03_Fizz/Goo/Qux.md", @"Baz\Fizz\Goo")]
-    public void GetRelativeFolderWithoutOrder_ReturnsExpected(string inputFolder, string inputFile, string expected)
-    {
-        var result = Utils.GetRelativeFolderWithoutOrder(inputFolder, inputFile);
-        Assert.Equal(expected, result);
-    }
+    [MemberData(nameof(RelativeFolderWithoutOrderTestData))]
+    public void GetRelativeFolderWithoutOrder_ReturnsExpected(string inputFolder, string inputFile, string expected) =>
+        Assert.Equal(expected, Utils.GetRelativeFolderWithoutOrder(inputFolder, inputFile));
 
     [Theory]
     [InlineData(@"01_Onboarding/01_Introduction.md", @"02_Installation.md", @"01_Onboarding/02_Installation.md")]
@@ -43,4 +45,3 @@ public class UtilsTests
         Assert.Equal(expectedAppId, result);
     }
 }
-

--- a/Ivy.Docs.Tools/Utils.cs
+++ b/Ivy.Docs.Tools/Utils.cs
@@ -63,6 +63,7 @@ public static class Utils
         {
             ns = ns[(Array.IndexOf(ns, "Apps") + 1)..];
         }
+
         return string.Join("/", ns.Select(Utils.TitleCaseToFriendlyUrl));
     }
 
@@ -122,16 +123,15 @@ public static class Utils
             .Where(p => !string.IsNullOrWhiteSpace(p))
             .ToArray();
 
-        // Use Path.Combine for cross-platform compatibility, then normalize to expected format
+        // Use Path.Combine for cross-platform compatibility
         var result = Path.Combine(parts);
 
         // Handle the case where result is "." (current directory)
         if (result == "." || string.IsNullOrEmpty(result))
             return "";
 
-        // Normalize path separators to match expected test format (backslashes for Windows-style paths)
-        // This ensures tests pass on both Windows and Unix systems
-        return result.Replace(Path.DirectorySeparatorChar, '\\').Replace(Path.AltDirectorySeparatorChar, '\\');
+        // Return OS specific path
+        return result;
     }
 
     private static string NormalizePath(string path)
@@ -230,6 +230,7 @@ public static class Utils
         {
             return (order, string.Join("_", parts.Skip(1)));
         }
+
         return (null, nameWithoutExtension);
     }
 
@@ -394,7 +395,8 @@ public static class Utils
         using var sha256 = SHA256.Create();
         byte[] hash = sha256.ComputeHash(Encoding.UTF8.GetBytes(input));
         string base64 = System.Convert.ToBase64String(hash);
-        return new string(base64.Replace("+", "-").Replace("/", "_").ToLower().Where(char.IsLetterOrDigit).ToArray())[..length];
+        return new string(base64.Replace("+", "-").Replace("/", "_").ToLower().Where(char.IsLetterOrDigit).ToArray())
+            [..length];
     }
 
     public static string EatRight(this string input, char food)
@@ -417,10 +419,12 @@ public static class Utils
                 break;
             }
         }
+
         return input.Substring(0, i + 1);
     }
 
-    public static string EatRight(this string input, string food, StringComparison stringComparison = StringComparison.CurrentCulture)
+    public static string EatRight(this string input, string food,
+        StringComparison stringComparison = StringComparison.CurrentCulture)
     {
         if (string.IsNullOrEmpty(input) || string.IsNullOrEmpty(food)) return input;
 


### PR DESCRIPTION
The docs generation generated files with Windows style separators which made builds on mac fail with

```
  Ivy.Docs failed with 1 error(s) and 5 warning(s) (0.1s)                                                              
    /Users/oscargullberg/Repos/Ivy-Framework/Ivy.Docs/Ivy.Docs.csproj : warning NU1903: Package 'Newtonsoft.Json' 11.0.2 has a known high severity vulnerability, https://github.com/advisories/GHSA-5crp-9r3c-p9vr
    /Users/oscargullberg/Repos/Ivy-Framework/Ivy.Docs/Ivy.Docs.csproj : warning NU1903: Package 'System.Net.Http' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-7jgj-8wvc-jh57
    /Users/oscargullberg/Repos/Ivy-Framework/Ivy.Docs/Ivy.Docs.csproj : warning NU1903: Package 'System.Text.Json' 8.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-8g4q-xg66-9fp4
    /Users/oscargullberg/Repos/Ivy-Framework/Ivy.Docs/Ivy.Docs.csproj : warning NU1903: Package 'System.Text.Json' 8.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-hh2w-p6rv-4g7w
    /Users/oscargullberg/Repos/Ivy-Framework/Ivy.Docs/Ivy.Docs.csproj : warning NU1903: Package 'System.Text.RegularExpressions' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-cmhx-cq75-c4mj
    /usr/local/share/dotnet/sdk/9.0.100/Microsoft.Common.CurrentVersion.targets(3414,5): error MSB3552: Resource file "**/*.resx" cannot be found.
  Ivy.Docs.Test failed with 4 warning(s) (0.0s)                                                                        
```

So... updated the generated paths to use OS separators and tests to match


