### PR TITLE
147 code input invalid with copy button case test

### DIFF
--- a/Ivy.Samples/Apps/Widgets/Inputs/CodeInputApp.cs
+++ b/Ivy.Samples/Apps/Widgets/Inputs/CodeInputApp.cs
@@ -49,46 +49,85 @@ public class CodeInputApp : SampleBase
             </html>
             """);
 
-        var variants = Layout.Grid().Columns(7)
+        var firstGrid = Layout.Grid().Columns(4)
                | null!
-               | Text.Block("Default")
-               | Text.Block("Disabled")
-               | Text.Block("Invalid")
-               | Text.Block("With Placeholder")
-               | Text.Block("Empty State")
-               | Text.Block("With Copy Button")
+               | Text.InlineCode("Default")
+               | Text.InlineCode("Disabled")
+               | Text.InlineCode("Invalid")
 
                | Text.InlineCode("C#")
                | csharpCode.ToCodeInput().Language(Languages.Csharp)
                | csharpCode.ToCodeInput().Language(Languages.Csharp).Disabled()
                | csharpCode.ToCodeInput().Language(Languages.Csharp).Invalid("Invalid code")
-               | csharpCode.ToCodeInput().Language(Languages.Csharp).Placeholder("Enter C# code here...")
-               | UseState("").ToCodeInput().Language(Languages.Csharp).Placeholder("Enter C# code here...")
-               | csharpCode.ToCodeInput().Language(Languages.Csharp).ShowCopyButton()
 
                | Text.InlineCode("JSON")
                | jsonCode.ToCodeInput().Language(Languages.Json)
                | jsonCode.ToCodeInput().Language(Languages.Json).Disabled()
                | jsonCode.ToCodeInput().Language(Languages.Json).Invalid("Invalid JSON")
-               | jsonCode.ToCodeInput().Language(Languages.Json).Placeholder("Enter JSON here...")
-               | UseState("").ToCodeInput().Language(Languages.Json).Placeholder("Enter JSON here...")
-               | jsonCode.ToCodeInput().Language(Languages.Json).ShowCopyButton()
 
                | Text.InlineCode("SQL")
                | sqlCode.ToCodeInput().Language(Languages.Sql)
                | sqlCode.ToCodeInput().Language(Languages.Sql).Disabled()
                | sqlCode.ToCodeInput().Language(Languages.Sql).Invalid("Invalid SQL")
-               | sqlCode.ToCodeInput().Language(Languages.Sql).Placeholder("Enter SQL query here...")
-               | UseState("").ToCodeInput().Language(Languages.Sql).Placeholder("Enter SQL query here...")
-               | sqlCode.ToCodeInput().Language(Languages.Sql).ShowCopyButton()
 
                | Text.InlineCode("HTML")
                | htmlCode.ToCodeInput().Language(Languages.Html)
                | htmlCode.ToCodeInput().Language(Languages.Html).Disabled()
                | htmlCode.ToCodeInput().Language(Languages.Html).Invalid("Invalid HTML")
+            ;
+
+        var secondGrid = Layout.Grid().Columns(4)
+               | null!
+               | Text.InlineCode("With Placeholder")
+               | Text.InlineCode("Empty State")
+               | Text.InlineCode("With Copy Button")
+
+               | Text.InlineCode("C#")
+               | csharpCode.ToCodeInput().Language(Languages.Csharp).Placeholder("Enter C# code here...")
+               | UseState("").ToCodeInput().Language(Languages.Csharp).Placeholder("Enter C# code here...")
+               | csharpCode.ToCodeInput().Language(Languages.Csharp).ShowCopyButton()
+
+               | Text.InlineCode("JSON")
+               | jsonCode.ToCodeInput().Language(Languages.Json).Placeholder("Enter JSON here...")
+               | UseState("").ToCodeInput().Language(Languages.Json).Placeholder("Enter JSON here...")
+               | jsonCode.ToCodeInput().Language(Languages.Json).ShowCopyButton()
+
+               | Text.InlineCode("SQL")
+               | sqlCode.ToCodeInput().Language(Languages.Sql).Placeholder("Enter SQL query here...")
+               | UseState("").ToCodeInput().Language(Languages.Sql).Placeholder("Enter SQL query here...")
+               | sqlCode.ToCodeInput().Language(Languages.Sql).ShowCopyButton()
+
+               | Text.InlineCode("HTML")
                | htmlCode.ToCodeInput().Language(Languages.Html).Placeholder("Enter HTML here...")
                | UseState("").ToCodeInput().Language(Languages.Html).Placeholder("Enter HTML here...")
                | htmlCode.ToCodeInput().Language(Languages.Html).ShowCopyButton()
+            ;
+
+        var thirdGrid = Layout.Grid().Columns(4)
+               | null!
+               | Text.InlineCode("Invalid + Copy")
+               | null!
+               | null!
+
+               | Text.InlineCode("C#")
+               | csharpCode.ToCodeInput().Language(Languages.Csharp).Invalid("Invalid code").ShowCopyButton()
+               | null!
+               | null!
+
+               | Text.InlineCode("JSON")
+               | jsonCode.ToCodeInput().Language(Languages.Json).Invalid("Invalid JSON").ShowCopyButton()
+               | null!
+               | null!
+
+               | Text.InlineCode("SQL")
+               | sqlCode.ToCodeInput().Language(Languages.Sql).Invalid("Invalid SQL").ShowCopyButton()
+               | null!
+               | null!
+
+               | Text.InlineCode("HTML")
+               | htmlCode.ToCodeInput().Language(Languages.Html).Invalid("Invalid HTML").ShowCopyButton()
+               | null!
+               | null!
             ;
 
         var dataBinding = CreateStringTypeTests();
@@ -96,7 +135,9 @@ public class CodeInputApp : SampleBase
         return Layout.Vertical()
                | Text.H1("CodeInput")
                | Text.H2("Variants")
-               | variants
+               | firstGrid
+               | secondGrid
+               | thirdGrid
                | Text.H2("Data Binding")
                | dataBinding
                ;

--- a/frontend/src/components/CopyToClipboardButton.tsx
+++ b/frontend/src/components/CopyToClipboardButton.tsx
@@ -25,6 +25,9 @@ const CopyToClipboardButton = ({ textToCopy = '', label = '' }) => {
         py-2 
         rounded-lg
         transition-all duration-200 ease-in-out
+        cursor-pointer
+        hover:bg-gray-100
+        hover:shadow-sm
         ${
           copied
             ? 'bg-green-100 text-green-700'

--- a/frontend/src/components/InvalidIcon.tsx
+++ b/frontend/src/components/InvalidIcon.tsx
@@ -5,6 +5,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from './ui/tooltip';
+import { cn } from '@/lib/utils';
 
 export const InvalidIcon: React.FC<{ message: string; className?: string }> = ({
   message,
@@ -13,8 +14,8 @@ export const InvalidIcon: React.FC<{ message: string; className?: string }> = ({
   return (
     <TooltipProvider>
       <Tooltip>
-        <TooltipTrigger className={className}>
-          <InfoIcon className="h-4 w-4 text-red-900 hover:text-red-400" />
+        <TooltipTrigger className={cn(className, 'cursor-pointer')}>
+          <InfoIcon className="h-4 w-4 text-red-900 hover:text-red-400 transition-colors duration-200" />
         </TooltipTrigger>
         <TooltipContent className="bg-popover text-popover-foreground shadow-md">
           <div className="max-w-60">{message}</div>

--- a/frontend/src/widgets/inputs/CodeInputWidget.tsx
+++ b/frontend/src/widgets/inputs/CodeInputWidget.tsx
@@ -133,7 +133,7 @@ export const CodeInputWidget: React.FC<CodeInputWidgetProps> = ({
   return (
     <div style={styles} className="relative w-full h-full overflow-hidden">
       {showCopyButton && (
-        <div className="absolute top-2 right-2 z-10">
+        <div className="absolute top-2 right-2 z-10 p-1 rounded-md hover:bg-gray-50 transition-colors duration-200">
           <CopyToClipboardButton
             textToCopy={localValue}
             aria-label="Copy to clipboard"

--- a/frontend/src/widgets/inputs/CodeInputWidget.tsx
+++ b/frontend/src/widgets/inputs/CodeInputWidget.tsx
@@ -163,7 +163,12 @@ export const CodeInputWidget: React.FC<CodeInputWidgetProps> = ({
         }}
       />
       {invalid && (
-        <div className="absolute right-4 top-2.5">
+        <div
+          className={cn(
+            'absolute top-2.5',
+            showCopyButton ? 'right-12' : 'right-4'
+          )}
+        >
           <InvalidIcon message={invalid} />
         </div>
       )}


### PR DESCRIPTION
<img width="1590" height="844" alt="image" src="https://github.com/user-attachments/assets/5a8c61b3-a9fa-4501-995c-2dbccd64fb91" />

Some might argue that positioning is odd, but usually in code the first line is a lot shorter than the second, so it makes sense to move the icons sligthly up.

Also added on hover events to invalid icon and copy buttons