### PR TITLE
feat: theme colors for labels

### DIFF
--- a/frontend/src/components/ui/slider.tsx
+++ b/frontend/src/components/ui/slider.tsx
@@ -39,7 +39,7 @@ const Slider = React.forwardRef<
         <SliderPrimitive.Range className="absolute h-full bg-primary" />
       </SliderPrimitive.Track>
       <SliderPrimitive.Thumb className="relative block h-4 w-4 rounded-full border bg-background shadow transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50">
-        <div className="absolute -top-6 left-1/2 transform -translate-x-1/2 text-xs bg-white p-1 rounded shadow">
+        <div className="absolute -top-6 left-1/2 transform -translate-x-1/2 text-xs bg-popover text-popover-foreground p-1 rounded shadow">
           {formattedValue}
         </div>
       </SliderPrimitive.Thumb>


### PR DESCRIPTION
It's just better now.

<img width="2846" height="1786" alt="image" src="https://github.com/user-attachments/assets/0f7259a1-cc5e-4e7b-8d57-0d0c6ac044c8" />
<img width="2867" height="1789" alt="image" src="https://github.com/user-attachments/assets/e309cd01-24a8-4b8f-af23-d0b9453e0dd9" />
