### PR TITLE
feat: expandable remove extra padding

### DIFF
--- a/frontend/src/widgets/ExpandableWidget.tsx
+++ b/frontend/src/widgets/ExpandableWidget.tsx
@@ -32,7 +32,7 @@ export const ExpandableWidget: React.FC<ExpandableWidgetProps> = ({
       key={id}
       open={isOpen}
       onOpenChange={setIsOpen}
-      className="w-full space-y-2 rounded-md border border-gray-200 p-2 shadow-sm"
+      className="w-full rounded-md border border-gray-200 p-2 shadow-sm"
     >
       <div className="flex justify-between space-x-4">
         <CollapsibleTrigger asChild>


### PR DESCRIPTION
This had some padding that got attached. I think this was another issue from the update.

<img width="1271" height="455" alt="image" src="https://github.com/user-attachments/assets/a96932a4-66ce-4d16-9120-739073648f94" />
