### PR TITLE
feat: theme aware loading screens

### DIFF
--- a/frontend/src/components/LoadingScreen.tsx
+++ b/frontend/src/components/LoadingScreen.tsx
@@ -13,7 +13,7 @@ export const LoadingScreen = () => {
   }, []);
 
   return (
-    <div className="flex items-center justify-center h-screen">
+    <div className="flex items-center justify-center h-screen -p-4 -m-4">
       {showAnimation && <Loading />}
     </div>
   );

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -14,28 +14,8 @@ import { hasLicensedFeature } from './lib/license';
 
 function ConnectionModal() {
   return (
-    <div
-      style={{
-        position: 'fixed',
-        top: 0,
-        left: 0,
-        right: 0,
-        bottom: 0,
-        backgroundColor: 'rgba(0, 0, 0, 0.5)',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        zIndex: 1000,
-      }}
-    >
-      <div
-        style={{
-          padding: '1rem 2rem',
-          backgroundColor: 'white',
-          borderRadius: '4px',
-          boxShadow: '0 2px 8px rgba(0, 0, 0, 0.2)',
-        }}
-      >
+    <div className="fixed inset-0 bg-background/80 flex items-center justify-center z-[1000]">
+      <div className="px-8 py-4 bg-card border border-border rounded-lg shadow-lg">
         <TextShimmer>Connection lost. Trying to reconnect...</TextShimmer>
       </div>
     </div>


### PR DESCRIPTION
<img width="611" height="309" alt="image" src="https://github.com/user-attachments/assets/45b74587-921e-446d-a1b4-2424f71d970f" />
<img width="1791" height="1349" alt="image" src="https://github.com/user-attachments/assets/c037a8d8-d817-4129-9983-2b7dd15de887" />
<img width="1777" height="1350" alt="image" src="https://github.com/user-attachments/assets/58dfcb1a-415d-44aa-99e7-ff66e4eb2791" />


OLD:
<img width="488" height="219" alt="image" src="https://github.com/user-attachments/assets/53e913ed-9913-4764-a7f3-3792ff3cbed3" />
<img width="1774" height="1353" alt="image" src="https://github.com/user-attachments/assets/1cb71ef9-fea2-46a4-b9cd-3009ff4aee6e" />

