### PR TITLE
fix: eliminate gaps in loading animation

### DIFF
--- a/frontend/src/components/Loading.tsx
+++ b/frontend/src/components/Loading.tsx
@@ -176,7 +176,7 @@ export function Loading() {
         const color = COLORS[colorIndex] || COLORS[0];
 
         return (
-          <div key={index} className="w-6 h-6">
+          <div key={index} className="w-7 h-7">
             {shape && (
               <svg
                 viewBox="0 0 28 28"


### PR DESCRIPTION
Fixes #271

Eliminated visual gaps in the Ivy loading animation by matching container size to SVG viewBox:

- Changed container from `w-6 h-6` (24px) to `w-7 h-7` (28px) to match SVG viewBox (28x28)
- Eliminates sub-pixel rendering gaps between squares
- Fixes visual gaps visible in dark mode and at different zoom levels

Generated with [Claude Code](https://claude.ai/code)