### PR TITLE
Support public key license via meta tag in dev mode

### DIFF
--- a/Ivy/Server.cs
+++ b/Ivy/Server.cs
@@ -231,8 +231,11 @@ public class Server
         var builder = WebApplication.CreateBuilder();
 
         builder.Configuration.AddEnvironmentVariables();
-        builder.Configuration.AddUserSecrets(Assembly.GetExecutingAssembly());
-
+        if (Assembly.GetEntryAssembly() is { } entryAssembly)
+        {
+            builder.Configuration.AddUserSecrets(entryAssembly);
+        }
+        
         foreach (var mod in _builderMods)
         {
             mod(builder);
@@ -367,6 +370,15 @@ public static class WebApplicationExtensions
                     var ivyLicenseTag = $"<meta name=\"ivy-license\" content=\"{ivyLicense}\" />";
                     html = html.Replace("</head>", $"  {ivyLicenseTag}\n</head>");
                 }
+#if DEBUG
+                var ivyLicensePublicKey = configuration["IVY_LICENSE_PUBLIC_KEY"] ?? "";
+                if (!string.IsNullOrEmpty(ivyLicensePublicKey))
+                {
+                    var ivyLicensePublicKeyTag =
+                        $"<meta name=\"ivy-license-public-key\" content=\"{ivyLicensePublicKey}\" />";
+                    html = html.Replace("</head>", $"  {ivyLicensePublicKeyTag}\n</head>");
+                }
+#endif
 
                 //Inject Meta Title and Description
                 if (!string.IsNullOrEmpty(serverArgs.MetaDescription))
@@ -374,6 +386,7 @@ public static class WebApplicationExtensions
                     var metaDescriptionTag = $"<meta name=\"description\" content=\"{serverArgs.MetaDescription}\" />";
                     html = html.Replace("</head>", $"  {metaDescriptionTag}\n</head>");
                 }
+
                 if (!string.IsNullOrEmpty(serverArgs.MetaTitle))
                 {
                     var metaTitleTag = $"<title>{serverArgs.MetaTitle}</title>";

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,15 +3,52 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
 
+function transferMeta(htmlServer: string, htmlLocal: string): string {
+  const titleMatch = htmlServer.match(/<title[^>]*>(.*?)<\/title>/i);
+  const serverTitle = titleMatch ? titleMatch[1] : null;
+
+  let result = htmlLocal;
+
+  if (serverTitle) {
+    result = result.replace(
+      /<title[^>]*>.*?<\/title>/i,
+      `<title>${serverTitle}</title>`
+    );
+  }
+
+  const ivyMetaMatches = htmlServer.match(
+    /<meta[^>]*name\s*=\s*["']ivy-[^"']*["'][^>]*>/gi
+  );
+
+  if (ivyMetaMatches) {
+    const headEndIndex = result.indexOf('</head>');
+    if (headEndIndex !== -1) {
+      const metasToInsert = ivyMetaMatches
+        .map(meta => `    ${meta}`)
+        .join('\n');
+      result =
+        result.slice(0, headEndIndex) +
+        metasToInsert +
+        '\n  ' +
+        result.slice(headEndIndex);
+    }
+  }
+
+  return result;
+}
+
 const injectMeta = (mode: string) => {
   return {
     name: 'inject-ivy-meta',
-    transformIndexHtml(html: string) {
+    async transformIndexHtml(localHtml: string) {
       if (mode === 'development') {
-        const ivyHostTag = `<meta name="ivy-host" content="${process.env.IVY_HOST || 'http://localhost:5010'}" />`;
-        return html.replace('</head>', `  ${ivyHostTag}\n</head>`);
+        const host = process.env.IVY_HOST || 'http://localhost:5010';
+        const serverHtml = await fetch(`${host}`).then(res => res.text());
+        const transformedHtml = transferMeta(serverHtml, localHtml);
+        const ivyHostTag = `<meta name="ivy-host" content="${host}" />`;
+        return transformedHtml.replace('</head>', `  ${ivyHostTag}\n</head>`);
       }
-      return html;
+      return localHtml;
     },
   };
 };


### PR DESCRIPTION
## Overview

This pull request introduces support for injecting a public key for license verification via a `<meta>` tag in development mode, streamlining the local dev experience for features gated by licensing. Additionally, the PR standardizes text styles across several frontend widgets, cleans up dialog focus ring CSS, and enhances the Vite dev server to carry over server-rendered meta tags into the client, ensuring metadata consistency in dev.

---

## Changes

### License Public Key via Meta Tag (Development Mode)

- **Server-Side (C#):**
  - In `DEBUG` builds, the server now injects a `<meta name="ivy-license-public-key" ...>` into the HTML head if the `IVY_LICENSE_PUBLIC_KEY` environment variable is present.
  - This allows the frontend to retrieve the public key used for license checks directly from the DOM in development, removing the need for hardcoded or bundled keys.
  - Adjusted how user secrets are loaded to use the entry assembly rather than always the executing assembly.

- **Frontend (TypeScript/React):**
  - Added `getIvyLicensePublicKey()` to retrieve the public key from the meta tag.
  - Modified the license verification logic to:
    - Use the meta tag public key automatically in development if the env var placeholder is present in the config.
    - Pass the actual public key PEM to the `getPublicKey()` function.
  - Improved type safety and fallback handling in the licensing feature check.

- **Vite Dev Server:**
  - Enhanced the `inject-ivy-meta` Vite plugin to:
    - Fetch the HTML from the backend dev server and transfer over any `<meta name="ivy-*">` tags and the `<title>` to the local dev HTML.
    - Ensures that frontend and backend meta tags remain in sync during local development.

### Frontend Styling and Usability

- Standardized the use of `text-large-body` and `font-medium` in various widgets, improving typographic consistency.
- Upgraded several headings (`h2`, `h4`, dialog titles, labels) and button classes for uniformity and visual clarity.
- Removed redundant and problematic CSS that forcibly suppressed focus rings on dialogs, restoring expected accessibility behavior.

---

## Code Examples

### 1. Server-Side License Public Key Meta Injection

```csharp
#if DEBUG
var ivyLicensePublicKey = configuration["IVY_LICENSE_PUBLIC_KEY"] ?? "";
if (!string.IsNullOrEmpty(ivyLicensePublicKey))
{
    var ivyLicensePublicKeyTag =
        $"<meta name=\"ivy-license-public-key\" content=\"{ivyLicensePublicKey}\" />";
    html = html.Replace("</head>", $"  {ivyLicensePublicKeyTag}\n</head>");
}
#endif
```

### 2. Frontend License Public Key Retrieval

```ts
function getIvyLicensePublicKey(): string | null {
  return (
    document
      .querySelector('meta[name="ivy-license-public-key"]')
      ?.getAttribute('content') ?? null
  );
}
```

### 3. License Feature Check Usage

```ts
export async function hasLicensedFeature(hasFeature: string): Promise<boolean> {
  let _publicKeyPem = publicKeyPem;
  if (publicKeyPem.includes('IVY_LICENSE_PUBLIC_KEY')) {
    const publicKey = getIvyLicensePublicKey();
    if (!publicKey) return false;
    _publicKeyPem = publicKey;
  }
  // ...rest of logic
}
```

### 4. Vite Meta Transfer Function

```ts
function transferMeta(htmlServer: string, htmlLocal: string): string {
  const titleMatch = htmlServer.match(/<title[^>]*>(.*?)<\/title>/i);
  const serverTitle = titleMatch ? titleMatch[1] : null;

  let result = htmlLocal;

  if (serverTitle) {
    result = result.replace(
      /<title[^>]*>.*?<\/title>/i,
      `<title>${serverTitle}</title>`
    );
  }

  const ivyMetaMatches = htmlServer.match(
    /<meta[^>]*name\s*=\s*["']ivy-[^"']*["'][^>]*>/gi
  );

  if (ivyMetaMatches) {
    const headEndIndex = result.indexOf('</head>');
    if (headEndIndex !== -1) {
      const metasToInsert = ivyMetaMatches
        .map(meta => `    ${meta}`)
        .join('\n');
      result =
        result.slice(0, headEndIndex) +
        metasToInsert +
        '\n  ' +
        result.slice(headEndIndex);
    }
  }

  return result;
}
```

---

## Widget/Styling Standardization

- Changed `text-body` to `text-large-body` in:
  - `BladeWidget.tsx`
  - `FormFieldWidget.tsx`
  - `AsyncSelectInputWidget.tsx`
  - `ReadOnlyInputWidget.tsx`
  - `SidebarLayoutWidget.tsx`
  - `TabsLayoutWidget.tsx`
- Added `font-medium` to headings and menu items for improved readability.
- Dialog title size increased from `text-base` to `text-lg`.
- Removed global CSS rules that forcibly hid focus outlines in dialogs.

---

## Notes & Breaking Changes

- **Meta Tag Public Key is only injected in `DEBUG` (development) mode.** Production builds are unaffected.
- **Dialog focus rings are now visible again,** improving accessibility. If you relied on the previous suppression, you may need to update your styles.
- **Vite plugin now fetches and injects backend meta tags and title into the dev HTML**—ensure your backend server is running on the expected host during frontend development.
- **No breaking public API changes** for end users, but developers working on licensing or integration tests should note the new meta tag mechanism.

---

## Summary

- Adds support for license public key via meta tag in dev mode for local development licensing.
- Standardizes font sizes and weights for improved UI consistency.
- Restores dialog focus outlines for accessibility.
- Ensures Vite dev HTML includes all relevant meta tags from backend, preventing mismatched metadata in local dev.
- No production impact or breaking changes, but improves DX and accessibility.