### PR TITLE
Add custom quadrant shape to confetti widget

### DIFF
--- a/frontend/src/widgets/effects/ConfettiWidget.tsx
+++ b/frontend/src/widgets/effects/ConfettiWidget.tsx
@@ -12,12 +12,17 @@ const ConfettiWidget: React.FC<ConfettiWidgetProps> = ({
 }) => {
   const elementRef = useRef<HTMLDivElement>(null);
 
+  const quadrant = confetti.shapeFromPath({
+    path: 'M47 0H0V47.0222C25.9234 47.0222 47 25.9801 47 0Z',
+  });
+
   const triggerConfetti = (x: number, y: number) => {
     confetti({
       particleCount: 100,
       spread: 70,
       origin: { x, y },
-      colors: ['#004734', '#006d4c', '#009464', '#00b97d', '#00df97'],
+      shapes: [quadrant],
+      colors: ['#00CC92', '#0D4A2F'],
     });
   };
 


### PR DESCRIPTION
## Overview

This pull request enhances the existing ConfettiWidget by introducing a custom "quadrant" shape for confetti particles. The new shape is defined using a specific SVG path, and replaces the default confetti shapes, resulting in a more unique and branded visual effect. Additionally, the color palette has been updated to use new green tones.

## Changes

- **Added a custom quadrant confetti shape:**
  - Introduced a new shape for confetti particles using `confetti.shapeFromPath`.
  - The shape is defined by the SVG path: `M47 0H0V47.0222C25.9234 47.0222 47 25.9801 47 0Z`.
- **Updated confetti colors:**
  - Changed the confetti color palette to use two specific colors: `#00CC92` and `#0D4A2F`.
- **Modified confetti trigger to use new shape and colors:**
  - The `triggerConfetti` function now applies the custom shape and updated palette when firing confetti.

## Code Examples

### Defining a Custom Shape

```tsx
const quadrant = confetti.shapeFromPath({
  path: 'M47 0H0V47.0222C25.9234 47.0222 47 25.9801 47 0Z',
});
```

### Using the Custom Shape in Confetti

```tsx
const triggerConfetti = (x: number, y: number) => {
  confetti({
    particleCount: 100,
    spread: 70,
    origin: { x, y },
    shapes: [quadrant],
    colors: ['#00CC92', '#0D4A2F'],
  });
};
```

## Notes

- **No breaking changes**: The interface and usage of `ConfettiWidget` remain the same; only the visual output is affected.
- The custom quadrant shape offers a more distinctive effect, which can better match branding or design requirements.
- If your project relies on the previous default confetti shapes or color palette, note that these have been replaced in this widget’s implementation.

## Summary

- Added a custom SVG path-based confetti shape ("quadrant") to `ConfettiWidget`.
- Updated the confetti color scheme to two green shades.
- All confetti triggered by this widget now uses the new shape and colors by default.