### PR TITLE
support tooltip label colors for charts

### DIFF
--- a/frontend/src/components/ui/chart.tsx
+++ b/frontend/src/components/ui/chart.tsx
@@ -190,7 +190,12 @@ const ChartTooltipContent = React.forwardRef<
           {payload.map((item, index) => {
             const key = `${nameKey || item.name || item.dataKey || 'value'}`;
             const itemConfig = getPayloadConfigFromPayload(config, item, key);
-            const indicatorColor = color || item.payload.fill || item.color;
+            const indicatorColor =
+              item.color ||
+              item.payload?.fill ||
+              item.payload?.stroke ||
+              color ||
+              `var(--color-${key})`;
 
             return (
               <div
@@ -209,22 +214,20 @@ const ChartTooltipContent = React.forwardRef<
                     ) : (
                       !hideIndicator && (
                         <div
-                          className={cn(
-                            'shrink-0 rounded-[2px] border-[--color-border] bg-[--color-bg]',
-                            {
-                              'h-2.5 w-2.5': indicator === 'dot',
-                              'w-1': indicator === 'line',
-                              'w-0 border-[1.5px] border-dashed bg-transparent':
-                                indicator === 'dashed',
-                              'my-0.5': nestLabel && indicator === 'dashed',
-                            }
-                          )}
-                          style={
-                            {
-                              '--color-bg': indicatorColor,
-                              '--color-border': indicatorColor,
-                            } as React.CSSProperties
-                          }
+                          className={cn('shrink-0 rounded-[2px] border', {
+                            'h-2.5 w-2.5': indicator === 'dot',
+                            'w-1': indicator === 'line',
+                            'w-0 border-[1.5px] border-dashed bg-transparent':
+                              indicator === 'dashed',
+                            'my-0.5': nestLabel && indicator === 'dashed',
+                          })}
+                          style={{
+                            backgroundColor:
+                              indicator === 'dashed'
+                                ? 'transparent'
+                                : indicatorColor,
+                            borderColor: indicatorColor,
+                          }}
                         />
                       )
                     )}
@@ -305,7 +308,7 @@ const ChartLegendContent = React.forwardRef<
                 <div
                   className="h-2 w-2 shrink-0 rounded-[2px]"
                   style={{
-                    backgroundColor: item.color,
+                    backgroundColor: item.color || `var(--color-${key})`,
                   }}
                 />
               )}


### PR DESCRIPTION
<img width="991" height="653" alt="Screenshot 2025-07-30 at 20 18 43" src="https://github.com/user-attachments/assets/862a6a4d-ddd3-4dde-a490-279d95b252a5" />
Аdd working cell color styling