### PR TITLE
docs: fix typos and broken links for Lucide icons

### DIFF
--- a/Ivy.Docs/Docs/02_Widgets/03_Primitives/Icon.md
+++ b/Ivy.Docs/Docs/02_Widgets/03_Primitives/Icon.md
@@ -2,9 +2,9 @@
 
 The Icon widget displays vector icons from Ivy's built-in icon set. Icons enhance visual communication and can be customized with different colors and sizes.
 
-## Luicide Icons
+## Lucide Icons
 
-We use the [Luicide Icons](https://luicide.com/icons/) set, which is a collection of 1000+ free icons. You can find the full set [here](https://luicide.com/icons/).
+We use the [Lucide Icons](https://lucide.dev/icons/) set, which is a collection of 1000+ free icons. You can find the full set [here](https://lucide.dev/icons/).
 
 ```csharp demo-tabs
 Layout.Horizontal()


### PR DESCRIPTION
Fixed typos in Icon.md documentation:
- Changed "Luicide" to "Lucide"
- Updated broken URLs from luicide.com to lucide.dev

Fixes #335

🤖 Generated with [Claude Code](https://claude.ai/code)