### PR TITLE
use common styling for inline codes

### DIFF
--- a/frontend/src/components/MarkdownRenderer.tsx
+++ b/frontend/src/components/MarkdownRenderer.tsx
@@ -137,14 +137,7 @@ const CodeBlock = memo(
     }
 
     return (
-      <code
-        className={cn(
-          'relative rounded bg-muted px-[0.25rem] py-[0.05rem] font-mono text-body',
-          className
-        )}
-      >
-        {children}
-      </code>
+      <code className={cn(textBlockClassMap.code, className)}>{children}</code>
     );
   }
 );

--- a/frontend/src/components/MarkdownRenderer.tsx
+++ b/frontend/src/components/MarkdownRenderer.tsx
@@ -139,7 +139,7 @@ const CodeBlock = memo(
     return (
       <code
         className={cn(
-          'relative rounded bg-muted px-[0.3rem] py-[0.3rem] font-mono text-body',
+          'relative rounded bg-muted px-[0.25rem] py-[0.05rem] font-mono text-body',
           className
         )}
       >

--- a/frontend/src/lib/textBlockClassMap.ts
+++ b/frontend/src/lib/textBlockClassMap.ts
@@ -17,7 +17,7 @@ export const textBlockClassMap: Record<string, string> = {
 
   // Inline code styling
   InlineCode:
-    'relative rounded bg-muted px-[0.3rem] py-[0.3rem] font-mono text-sm',
+    'relative rounded bg-muted px-[0.25rem] py-[0.05rem] font-mono text-sm',
 
   // HTML tag equivalents
   h1: 'text-display-60 scroll-m-20 mt-8 mb-4',
@@ -37,7 +37,7 @@ export const textBlockClassMap: Record<string, string> = {
   tr: 'border border-border',
   th: 'border border-border px-4 py-2 text-left font-bold text-large-label',
   td: 'border border-border px-4 py-2 text-body',
-  code: 'relative rounded bg-muted px-[0.3rem] py-[0.3rem] font-mono text-sm',
+  code: 'relative rounded bg-muted px-[0.25rem] py-[0.05rem] font-mono text-sm',
   img: 'max-w-full h-auto cursor-zoom-in mb-2',
 };
 


### PR DESCRIPTION
New:
<img width="919" height="805" alt="image" src="https://github.com/user-attachments/assets/8c4b843c-893e-4fcc-b380-d2abdc0351c2" />

Current deployment:
<img width="911" height="1206" alt="image" src="https://github.com/user-attachments/assets/c5d76894-a76e-459b-ab17-b65c6a2dcbf7" />
