### PR TITLE
fix: add cursor pointer to dismiss button in SidebarNewsWidget

### DIFF
--- a/frontend/src/widgets/internal/SidebarNewsWidget.tsx
+++ b/frontend/src/widgets/internal/SidebarNewsWidget.tsx
@@ -357,7 +357,7 @@ function NewsCard({
             <button
               type="button"
               onClick={dismiss}
-              className="text-muted-foreground hover:text-foreground transition-colors duration-75"
+              className="text-muted-foreground hover:text-foreground transition-colors duration-75 cursor-pointer"
             >
               Dismiss
             </button>


### PR DESCRIPTION
Fixes #334

## Summary
• Added cursor-pointer class to dismiss button in SidebarNewsWidget
• Ensures proper mouse pointer cursor on hover for star ivy popup dismiss button

## Test plan
[ ] Test dismiss button cursor behavior in sidebar news widget
[ ] Verify cursor changes to pointer on hover
[ ] Confirm dismiss functionality still works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)