### PR TITLE
docs: add working project link to chat tutorial

### DIFF
--- a/Ivy.Docs/Docs/01_Onboarding/01_GettingStarted/06_ChatTutorial.md
+++ b/Ivy.Docs/Docs/01_Onboarding/01_GettingStarted/06_ChatTutorial.md
@@ -135,3 +135,5 @@ You can now run the application and try it out! Describe your application, and t
 <Callout Icon="Info">
 Make sure you have set your OpenAI API key in the environment variables before running the application.
 </Callout>
+
+You can find the full source code for the project at https://github.com/Ivy-Interactive/Ivy-Framework/tree/main/Ivy.Samples/Apps/Demos/LucideIconAgentApp.cs.


### PR DESCRIPTION
Added link to LucideIconAgentApp.cs in Ivy.Samples following the same pattern used in other tutorials like the Todo tutorial. This provides users with access to the complete working implementation for comparison and verification.

Fixes #345

Generated with [Claude Code](https://claude.ai/code)