### PR TITLE
improve usage of scrollbars in code blocks

### DIFF
--- a/frontend/src/components/ErrorDisplay.tsx
+++ b/frontend/src/components/ErrorDisplay.tsx
@@ -3,7 +3,7 @@ import { Button } from './ui/button';
 import { ClipboardCopy, Check } from 'lucide-react';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { createPrismTheme } from '@/lib/ivy-prism-theme';
-import { ScrollArea } from '@/components/ui/scroll-area';
+import { ScrollArea, ScrollBar } from '@/components/ui/scroll-area';
 
 interface ErrorDisplayProps {
   title?: string | null;
@@ -60,6 +60,7 @@ export const ErrorDisplay: React.FC<ErrorDisplayProps> = ({
             >
               {stackTrace}
             </SyntaxHighlighter>
+            <ScrollBar orientation="horizontal" />
           </ScrollArea>
         </div>
       )}

--- a/frontend/src/components/ErrorDisplay.tsx
+++ b/frontend/src/components/ErrorDisplay.tsx
@@ -3,6 +3,7 @@ import { Button } from './ui/button';
 import { ClipboardCopy, Check } from 'lucide-react';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { createPrismTheme } from '@/lib/ivy-prism-theme';
+import { ScrollArea } from '@/components/ui/scroll-area';
 
 interface ErrorDisplayProps {
   title?: string | null;
@@ -50,14 +51,16 @@ export const ErrorDisplay: React.FC<ErrorDisplayProps> = ({
       {stackTrace && (
         <div>
           <h4 className="text-sm font-medium mb-2">Stack Trace</h4>
-          <SyntaxHighlighter
-            language="csharp"
-            style={createPrismTheme()}
-            wrapLongLines={false}
-            showLineNumbers={false}
-          >
-            {stackTrace}
-          </SyntaxHighlighter>
+          <ScrollArea className="w-full border border-border rounded-md">
+            <SyntaxHighlighter
+              language="csharp"
+              style={createPrismTheme()}
+              wrapLongLines={false}
+              showLineNumbers={false}
+            >
+              {stackTrace}
+            </SyntaxHighlighter>
+          </ScrollArea>
         </div>
       )}
 

--- a/frontend/src/components/MarkdownRenderer.tsx
+++ b/frontend/src/components/MarkdownRenderer.tsx
@@ -17,7 +17,7 @@ import { cn, getIvyHost } from '@/lib/utils';
 import CopyToClipboardButton from './CopyToClipboardButton';
 import { createPrismTheme } from '@/lib/ivy-prism-theme';
 import { textBlockClassMap, textContainerClass } from '@/lib/textBlockClassMap';
-import { ScrollArea } from '@/components/ui/scroll-area';
+import { ScrollArea, ScrollBar } from '@/components/ui/scroll-area';
 
 const SyntaxHighlighter = lazy(() =>
   import('react-syntax-highlighter').then(mod => ({ default: mod.Prism }))
@@ -110,6 +110,7 @@ const CodeBlock = memo(
                   </div>
                 ))}
               </pre>
+              <ScrollBar orientation="horizontal" />
             </ScrollArea>
           </div>
         );
@@ -120,6 +121,7 @@ const CodeBlock = memo(
           fallback={
             <ScrollArea className="w-full border border-border rounded-md">
               <pre className="p-4 bg-muted rounded-md">{content}</pre>
+              <ScrollBar orientation="horizontal" />
             </ScrollArea>
           }
         >
@@ -135,6 +137,7 @@ const CodeBlock = memo(
               >
                 {content}
               </SyntaxHighlighter>
+              <ScrollBar orientation="horizontal" />
             </ScrollArea>
           </div>
         </Suspense>

--- a/frontend/src/components/MarkdownRenderer.tsx
+++ b/frontend/src/components/MarkdownRenderer.tsx
@@ -17,6 +17,7 @@ import { cn, getIvyHost } from '@/lib/utils';
 import CopyToClipboardButton from './CopyToClipboardButton';
 import { createPrismTheme } from '@/lib/ivy-prism-theme';
 import { textBlockClassMap, textContainerClass } from '@/lib/textBlockClassMap';
+import { ScrollArea } from '@/components/ui/scroll-area';
 
 const SyntaxHighlighter = lazy(() =>
   import('react-syntax-highlighter').then(mod => ({ default: mod.Prism }))
@@ -98,16 +99,18 @@ const CodeBlock = memo(
             <div className="absolute top-2 right-2 z-10">
               <CopyToClipboardButton textToCopy={cleanContent} />
             </div>
-            <pre className="p-4 bg-muted rounded-md overflow-x-auto font-mono text-body">
-              {lines.map((line, index) => (
-                <div key={index} className="flex">
-                  <span className="text-muted-foreground select-none pointer-events-none mr-2">
-                    {'> '}
-                  </span>
-                  <span className="flex-1">{line}</span>
-                </div>
-              ))}
-            </pre>
+            <ScrollArea className="w-full border border-border rounded-md">
+              <pre className="p-4 bg-muted rounded-md font-mono text-body">
+                {lines.map((line, index) => (
+                  <div key={index} className="flex">
+                    <span className="text-muted-foreground select-none pointer-events-none mr-2">
+                      {'> '}
+                    </span>
+                    <span className="flex-1">{line}</span>
+                  </div>
+                ))}
+              </pre>
+            </ScrollArea>
           </div>
         );
       }
@@ -115,22 +118,24 @@ const CodeBlock = memo(
       return (
         <Suspense
           fallback={
-            <pre className="p-4 bg-muted rounded-md overflow-x-auto">
-              {content}
-            </pre>
+            <ScrollArea className="w-full border border-border rounded-md">
+              <pre className="p-4 bg-muted rounded-md">{content}</pre>
+            </ScrollArea>
           }
         >
           <div className="relative">
             <div className="absolute top-2 right-2 z-10">
               <CopyToClipboardButton textToCopy={content} />
             </div>
-            <SyntaxHighlighter
-              language={match[1]}
-              style={dynamicTheme}
-              customStyle={{ margin: 0 }}
-            >
-              {content}
-            </SyntaxHighlighter>
+            <ScrollArea className="w-full border border-border rounded-md">
+              <SyntaxHighlighter
+                language={match[1]}
+                style={dynamicTheme}
+                customStyle={{ margin: 0 }}
+              >
+                {content}
+              </SyntaxHighlighter>
+            </ScrollArea>
           </div>
         </Suspense>
       );

--- a/frontend/src/lib/ivy-prism-theme.ts
+++ b/frontend/src/lib/ivy-prism-theme.ts
@@ -15,8 +15,8 @@ const createIvyPrismTheme = (): Record<string, CSSProperties> => ({
     padding: '1em',
     margin: 0,
     color: 'var(--foreground)',
-    overflow: 'auto',
-    border: '1px solid var(--border)',
+    // Remove overflow: 'auto' to use ScrollArea instead
+    // Remove border since it's now applied to ScrollArea container
     borderRadius: '0.5em',
   },
   comment: { color: 'var(--muted-foreground)', fontStyle: 'italic' },

--- a/frontend/src/widgets/primitives/CodeWidget.tsx
+++ b/frontend/src/widgets/primitives/CodeWidget.tsx
@@ -3,7 +3,7 @@ import { getHeight, getWidth } from '@/lib/styles';
 import React, { CSSProperties, useMemo, memo } from 'react';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { createPrismTheme } from '@/lib/ivy-prism-theme';
-import { ScrollArea } from '@/components/ui/scroll-area';
+import { ScrollArea, ScrollBar } from '@/components/ui/scroll-area';
 import { cn } from '@/lib/utils';
 
 interface CodeWidgetProps {
@@ -99,6 +99,7 @@ const CodeWidget: React.FC<CodeWidgetProps> = memo(
           >
             {content}
           </SyntaxHighlighter>
+          <ScrollBar orientation="horizontal" />
         </ScrollArea>
       </div>
     );

--- a/frontend/src/widgets/primitives/CodeWidget.tsx
+++ b/frontend/src/widgets/primitives/CodeWidget.tsx
@@ -3,6 +3,8 @@ import { getHeight, getWidth } from '@/lib/styles';
 import React, { CSSProperties, useMemo, memo } from 'react';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { createPrismTheme } from '@/lib/ivy-prism-theme';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { cn } from '@/lib/utils';
 
 interface CodeWidgetProps {
   id: string;
@@ -58,7 +60,7 @@ const CodeWidget: React.FC<CodeWidgetProps> = memo(
         ...getWidth(width),
         ...getHeight(height),
         margin: 0,
-        overflow: 'auto',
+        // Remove overflow: 'auto' to use ScrollArea instead
       };
 
       if (!showBorder) {
@@ -81,16 +83,23 @@ const CodeWidget: React.FC<CodeWidgetProps> = memo(
     return (
       <div className="relative">
         {showCopyButton && <MemoizedCopyButton textToCopy={content} />}
-        <SyntaxHighlighter
-          language={mapLanguageToPrism(language)}
-          customStyle={styles}
-          style={dynamicTheme}
-          showLineNumbers={showLineNumbers}
-          wrapLines={true}
-          key={highlighterKey}
+        <ScrollArea
+          className={cn(
+            'w-full h-full',
+            showBorder && 'border border-border rounded-md'
+          )}
         >
-          {content}
-        </SyntaxHighlighter>
+          <SyntaxHighlighter
+            language={mapLanguageToPrism(language)}
+            customStyle={styles}
+            style={dynamicTheme}
+            showLineNumbers={showLineNumbers}
+            wrapLines={true}
+            key={highlighterKey}
+          >
+            {content}
+          </SyntaxHighlighter>
+        </ScrollArea>
       </div>
     );
   }


### PR DESCRIPTION
This brings more consistency in scrollbars in our framework and more

Fixed this to resolve issue with scrollbars moving containers around in Ivy.Docs. 
We got jank before when you hover on a code block