### PR TITLE
feat: terminal icon and text is now centered

### DIFF
--- a/frontend/src/widgets/internal/TerminalWidget.tsx
+++ b/frontend/src/widgets/internal/TerminalWidget.tsx
@@ -40,13 +40,18 @@ const TerminalWidget = ({ lines, title, showHeader }: TerminalWidgetProps) => {
             key={index}
             className={cn('whitespace-pre-wrap', index > 0 ? 'mt-1' : '')}
           >
-            <div className="flex pl-2">
-              {line.isCommand && (
-                <span className="text-primary select-none pointer-events-none mr-2">
-                  {'> '}
-                </span>
-              )}
-              {!line.isCommand && <div style={{ paddingLeft: '25px' }}></div>}
+            <div className="flex">
+              <div className="w-8 flex-shrink-0 relative flex items-center">
+                {line.isCommand ? (
+                  <span className="text-primary select-none pointer-events-none w-full text-center leading-none -mt-0.5">
+                    {'> '}
+                  </span>
+                ) : (
+                  <span className="text-primary select-none pointer-events-none w-full text-center leading-none">
+                    {'  '}
+                  </span>
+                )}
+              </div>
               <span className={line.isCommand ? commandColor : outputColor}>
                 {line.content}
               </span>


### PR DESCRIPTION
<img width="820" height="337" alt="Screenshot 2025-08-05 at 21 25 00" src="https://github.com/user-attachments/assets/04f3c011-67d3-4566-b77e-20d05e4b5602" />
