### PR TITLE
Fix login form clearing fields on validation errors

### DIFF
--- a/Ivy/Auth/DefaultAuthApp.cs
+++ b/Ivy/Auth/DefaultAuthApp.cs
@@ -88,7 +88,7 @@ public class PasswordEmailFlowView(IState<string?> errorMessage) : ViewBase
          | user.ToTextInput().Disabled(loading.Value)
          | Text.Label("Password:")
          | password.ToPasswordInput().Disabled(loading.Value)
-         | new Button("Login").Width(Size.Full()).HandleClick(login.HandleError(this)).Loading(loading.Value).Disabled(loading.Value)
+         | new Button("Login").Width(Size.Full()).HandleClick(_ => login()).Loading(loading.Value).Disabled(loading.Value)
          | result
          ;
     }
@@ -120,6 +120,6 @@ public class OAuthFlowView(AuthOption option, IState<string?> errorMessage) : Vi
             }
         };
 
-        return new Button(option.Name).Secondary().Icon(option.Icon).Width(Size.Full()).HandleClick(login.HandleError(this));
+        return new Button(option.Name).Secondary().Icon(option.Icon).Width(Size.Full()).HandleClick(_ => login());
     }
 }


### PR DESCRIPTION
Remove obsolete HandleError wrapper that was causing form state to reset when login validation failed. The login form now properly preserves user input values when showing error messages.

Fixes #310

🤖 Generated with [Claude Code](https://claude.ai/code)