### PR TITLE
fix: remove border from sidebar toggle icon

### DIFF
--- a/frontend/src/widgets/layouts/SidebarLayoutWidget.tsx
+++ b/frontend/src/widgets/layouts/SidebarLayoutWidget.tsx
@@ -157,7 +157,7 @@ export const SidebarLayoutWidget: React.FC<SidebarLayoutWidgetProps> = ({
       {showToggleButton && mainAppSidebar && (
         <button
           onClick={handleManualToggle}
-          className="absolute top-2 z-50 p-2 rounded-md bg-background border border-border hover:bg-accent hover:text-accent-foreground cursor-pointer transition-all duration-200"
+          className="absolute top-2 z-50 p-2 rounded-md bg-background hover:bg-accent hover:text-accent-foreground cursor-pointer transition-all duration-200"
           style={{
             left: isSidebarOpen ? 'calc(16rem + 8px)' : '8px',
             transition: 'left 300ms ease-in-out',


### PR DESCRIPTION
Removes the unwanted border styling from the sidebar toggle button in SidebarLayoutWidget.tsx by removing the 'border border-border' classes. This addresses the visual issue where the toggle icon had an unnecessary border box around it.

Fixes #411

Generated with [Claude Code](https://claude.ai/code)