### PR TITLE
(docs): remove custom colors section from buttons documentation

### DIFF
--- a/Ivy.Docs.Shared/Docs/02_Widgets/01_Common/Button.md
+++ b/Ivy.Docs.Shared/Docs/02_Widgets/01_Common/Button.md
@@ -89,24 +89,6 @@ Layout.Grid().Columns(3)
     | new Button("Full").Destructive().BorderRadius(BorderRadius.Full)
 ```
 
-### Custom Colors
-
-```csharp demo-tabs
-Layout.Grid().Columns(4)
-    | new Button("Blue").Foreground(Colors.Blue)
-    | new Button("Green").Foreground(Colors.Green)
-    | new Button("Purple").Foreground(Colors.Purple)
-    | new Button("Orange").Foreground(Colors.Orange)
-    | new Button("Blue").Secondary().Foreground(Colors.Blue)
-    | new Button("Green").Secondary().Foreground(Colors.Green)
-    | new Button("Purple").Secondary().Foreground(Colors.Purple)
-    | new Button("Orange").Secondary().Foreground(Colors.Orange)
-    | new Button("Blue").Destructive().Foreground(Colors.Blue)
-    | new Button("Green").Destructive().Foreground(Colors.Green)
-    | new Button("Purple").Destructive().Foreground(Colors.Purple)
-    | new Button("Orange").Destructive().Foreground(Colors.Orange)
-```
-
 ### Icons
 
 #### Icons on the Left


### PR DESCRIPTION
<img width="639" height="617" alt="Screenshot 2025-08-08 at 21 50 44" src="https://github.com/user-attachments/assets/7db71ba4-8e9e-4125-8c86-357b378fb8c3" />
