### PR TITLE
(code): defer fixup of index group properties

### DIFF
--- a/Ivy/Apps/AppRepository.cs
+++ b/Ivy/Apps/AppRepository.cs
@@ -69,7 +69,7 @@ public class AppRepository : IAppRepository
             AddApp(app);
         }
 
-        //traverse the tree and on each leaf (node that are not groups set link next and previous)
+        //traverse the tree and on each leaf (nodes that are not groups) set link next and previous
         if (Root is AppRepositoryGroup rootGroup)
         {
             // Get all leaf nodes in a flat list, maintaining their order


### PR DESCRIPTION
This fixes unwanted duplication of index groups in the hierarchy. Previously, changing the name of a group in `AddApp()` could break lookup by title in subsequent calls to `GetApp()`.