### PR TITLE
fix(docs): correct GitHub usernames in contributors list

### DIFF
--- a/frontend/src/widgets/article/GitHubContributors.tsx
+++ b/frontend/src/widgets/article/GitHubContributors.tsx
@@ -24,10 +24,10 @@ interface GitHubContributorsProps {
 
 // Ivy team members with their roles
 const IVY_TEAM_MEMBERS: Record<string, string> = {
-  ArtemKhvorostianyi: 'Engineer',
+  ArtemKivorostianyI: 'Engineer',
   rorychatt: 'Founding Engineer',
   nielsbosma: 'CEO',
-  zachwolfe: 'Software Developer',
+  zachwofe: 'Software Developer',
   // Add more team members as needed
 };
 


### PR DESCRIPTION
Fixed incorrect usernames in IVY_TEAM_MEMBERS:
- ArtemKhvorostianyi → ArtemKivorostianyI
- zachwolfe → zachwofe

This ensures team members are properly recognized with their correct roles instead of appearing as generic 'Open Source Contributor'.

Resolves #657

Generated with [Claude Code](https://claude.ai/code)