### PR TITLE
(docs): improve Layout usage (missing brackets) across all the docs

### DIFF
--- a/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/Signals.md
+++ b/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/Signals.md
@@ -146,9 +146,7 @@ public class RequestResponseDemo : ViewBase
                 new Button("Search", SearchData)
             ),
             Text.Block(isSearching.Value ? "Searching..." : $"Found {results.Value.Length} results"),
-            Layout.Vertical(
-                results.Value.Select(r => Text.Block(r))
-            ),
+            results.Value.Select(r => Text.Block(r)),
             Layout.Horizontal(
                 new DataProvider("User Database", new[] { "John Doe", "Jane Smith", "Bob Johnson" }),
                 new DataProvider("Product Catalog", new[] { "Laptop", "Smartphone", "Tablet" })

--- a/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/State.md
+++ b/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/State.md
@@ -21,7 +21,7 @@ public class CounterApp : ViewBase
         
         return new Card(
             Layout.Vertical(
-                Text.H2($"Hello, {name.Value}!"),
+                Text.Literal($"Hello, {name.Value}!"),
                 Text.Literal($"Count: {count.Value}"),
                 Layout.Horizontal(
                     new Button("Increment", _ => count.Set(count.Value + 1)),

--- a/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/TasksAndObservables.md
+++ b/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/TasksAndObservables.md
@@ -186,9 +186,7 @@ public class TransformationExample : ViewBase
         }
 
         return Layout.Vertical(
-            Layout.Horizontal(
-                new Button("Generate New Data", GenerateNewData)
-            ),
+            new Button("Generate New Data", GenerateNewData),
             Text.Block("Generated data: " + string.Join(", ", generatedData.Value)),
             Text.Block("Last Generated Result: " + string.Join(", ", lastTransformed.Value))
         );

--- a/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/Views.md
+++ b/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/Views.md
@@ -15,18 +15,8 @@ Views are the fundamental building blocks of Ivy apps. They are similar to React
 
 Here's a simple view that displays a greeting:
 
-```csharp demo-below 
-public class GreetingView : ViewBase
-{
-    public override object? Build()
-    {
-        return Text.P("Hello, World!");
-    }
-}
-```
-
-```csharp demo-tabs 
-Text.P("Hello from a View!")
+```csharp demo-below
+Text.P("Hello, World!")
 ```
 
 ### The ViewBase Class
@@ -50,7 +40,7 @@ The `Build()` method is the heart of every view. It can return:
 - Collections (arrays, lists)
 - `null` (to render nothing)
 
-```csharp demo-tabs 
+```csharp demo-tabs
 public class FlexibleContentView : ViewBase
 {
     public override object? Build()
@@ -69,7 +59,7 @@ public class FlexibleContentView : ViewBase
 
 Views use React-like hooks for state management. The most common hook is `UseState()`:
 
-```csharp demo-tabs 
+```csharp demo-tabs
 public class CounterView : ViewBase
 {
     public override object? Build()
@@ -142,7 +132,7 @@ public class TimerView : ViewBase
 
 Views can be composed together to create complex UIs:
 
-```csharp demo-below 
+```csharp demo-below
 Layout.Vertical()
     | Text.H2("Team Members")
     | new Card(
@@ -191,7 +181,7 @@ The `[App]` attribute supports several properties:
 
 ### Conditional Rendering
 
-```csharp demo-tabs 
+```csharp demo-tabs
 public class ConditionalView : ViewBase
 {
     public override object? Build()
@@ -210,7 +200,7 @@ public class ConditionalView : ViewBase
 
 ### Dynamic Lists
 
-```csharp demo-tabs 
+```csharp demo-tabs
 public class TodoApp : ViewBase
 {
     public override object? Build()
@@ -221,7 +211,7 @@ public class TodoApp : ViewBase
         return Layout.Vertical()
             | new Card(
                 Layout.Vertical()
-                    | Layout.Horizontal()
+                    | (Layout.Horizontal()
                         | newTodo.ToTextInput(placeholder: "Add a todo...").Width(Size.Grow())
                         | new Button("Add", onClick: _ => {
                             if (!string.IsNullOrWhiteSpace(newTodo.Value))
@@ -229,7 +219,7 @@ public class TodoApp : ViewBase
                                 todos.Set([..todos.Value, newTodo.Value]);
                                 newTodo.Set("");
                             }
-                        }).Icon(Icons.Plus)
+                        }).Icon(Icons.Plus))
                     | todos.Value.Select((todo, index) => 
                         Layout.Horizontal()
                             | Text.Literal(todo).Width(Size.Grow())
@@ -246,14 +236,13 @@ public class TodoApp : ViewBase
 
 ### Simple User Profile Example
 
-```csharp demo-tabs 
+```csharp demo-tabs
 new Card(
     Layout.Vertical()
-        | Layout.Horizontal()
             | new Avatar("John Doe", "JD")
-            | Layout.Vertical()
-                | Text.P("John Doe")
-                | Text.Small("42 posts")
+        | (Layout.Horizontal()
+            | Text.P("John Doe")
+            | Text.P("42 posts"))
         | new Button("Follow")
             .Variant(ButtonVariant.Primary)
             .Width(Size.Full())

--- a/Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/Color.md
+++ b/Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/Color.md
@@ -21,8 +21,7 @@ public class ColorDemo : ViewBase
     public override object? Build()
     {    
         var colorState = this.UseState("#ff0000");
-        return Layout.Horizontal()
-                | colorState.ToColorInput();
+        return colorState.ToColorInput();
     }   
 }
 ```
@@ -131,9 +130,7 @@ public class DisabledColorInput : ViewBase
 {
     public override object? Build()
     {    
-        return Layout.Vertical()
-                | new ColorInput<string>("#ff0000")
-                        .Disabled();
+        return new ColorInput<string>("#ff0000").Disabled();
     }
 }    
 ```
@@ -148,13 +145,12 @@ public class InvalidStyleDemo : ViewBase
 { 
     public override object? Build()
     {    
-        return Layout.Vertical()
-                | new ColorInput<string>("#ff0000")
-                        .Invalid("This is not used now");
+        return new ColorInput<string>("#ff0000").Invalid("This is not used now");
     }
 }
 
 ```
+
 
 <WidgetDocs Type="Ivy.ColorInput" ExtensionTypes="Ivy.ColorInputExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Inputs/ColorInput.cs"/>
 

--- a/Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/Feedback.md
+++ b/Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/Feedback.md
@@ -15,7 +15,7 @@ The `FeedbackInput` widget provides a specialized input for collecting user feed
 
 Here's a simple example of a `FeedbackInput` with a default variant:
 
-```csharp demo-below 
+```csharp demo-below
 public class BasicFeedbackDemo : ViewBase
 {    
     public override object? Build()
@@ -45,7 +45,7 @@ public class BasicFeedbackDemo : ViewBase
  the variant `FeedbackInputs.Thumbs` should be used. `FeedbackInputs.Emojis` should be used
  for collecting sentiment analysis feedbacks about anything.
 
-```csharp demo-below 
+```csharp demo-below
 public class FeedbackDemo : ViewBase
 {
     public override object? Build()
@@ -73,7 +73,7 @@ public class FeedbackDemo : ViewBase
 
 The following example shows how change events can be handled for `FeedbackInput`s.
 
-```csharp demo-below 
+```csharp demo-below
 public class FeedbackHandling: ViewBase
 {    
     public override object? Build()
@@ -105,14 +105,13 @@ public class FeedbackHandling: ViewBase
 
 To render a `FeedbackInput` in disabled state, this function `Disabled` should be used.
 
-```csharp demo-below 
+```csharp demo-below
 public class DisabledFeedbackDemo : ViewBase
 {
     public override object? Build()
     {    
         var fdb = UseState(3);
-        return Layout.Vertical()
-            | new FeedbackInput<int>(fdb)
+        return new FeedbackInput<int>(fdb)
                     .Variant(FeedbackInputs.Stars)
                     .Disabled();
     }
@@ -123,14 +122,13 @@ public class DisabledFeedbackDemo : ViewBase
 
 To render a `FeedbackInput` in invalid (or error) state, the function `Invalid` should be used.
 
-```csharp demo-below 
+```csharp demo-below
 public class InvalidFeedbackDemo : ViewBase
 {
     public override object? Build()
     {    
         var fdb = UseState(3);
-        return Layout.Vertical()
-            | new FeedbackInput<int>(fdb)
+        return new FeedbackInput<int>(fdb)
                     .Variant(FeedbackInputs.Stars)
                     .Invalid("We are maintaining this.");
     }

--- a/Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/File.md
+++ b/Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/File.md
@@ -57,14 +57,13 @@ public class FileDropDemo : ViewBase
 
 To render a disabled `FileInput` control, the `Disabled` function should be used.
 
-```csharp
+```csharp demo-below
 public class FileInputDisabledDemo : ViewBase
 {
     public override object? Build()
     {
         var fileState = this.UseState((FileInput?)null);
-         return Layout.Vertical()
-                |  fileState.ToFileInput()
+         return fileState.ToFileInput()
                     .Placeholder("Select a file")
                     .Accept(".jpg,.png")
                     .Disabled();

--- a/Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/Number.md
+++ b/Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/Number.md
@@ -22,8 +22,7 @@ public class SimpleNumericValueDemo : ViewBase
     public override object? Build()
     {
         var value = UseState(0);
-        return Layout.Horizontal() 
-                | new NumberInput<double>(value)
+        return new NumberInput<double>(value)
                      .Min(-10)
                      .Max(10);
     }

--- a/Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/ReadOnly.md
+++ b/Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/ReadOnly.md
@@ -10,7 +10,7 @@ The `ReadOnlyInput` widget displays data in an input-like format that cannot be 
 
 Here's a simple example of a `ReadOnlyInput` displaying a value:
 
-```csharp demo-below 
+```csharp demo-below
 public class ReadOnlyDemo : ViewBase
 {    
     public override object? Build()

--- a/Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/ReadOnly.md
+++ b/Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/ReadOnly.md
@@ -17,8 +17,7 @@ public class ReadOnlyDemo : ViewBase
     {    
         double value = 123.45;
         var readOnlyInput = new ReadOnlyInput<double>(value);
-        return Layout.Vertical()
-                | readOnlyInput;
+        return readOnlyInput;
     }    
 }    
 ```

--- a/Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/Text.md
+++ b/Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/Text.md
@@ -263,8 +263,7 @@ public class DisabledInputDemo : ViewBase
 {
     public override object? Build()
     {
-        return Layout.Horizontal()
-                | new TextInput(UseState(""))
+        return new TextInput(UseState(""))
                      .Placeholder("Disabled Input")
                      .Disabled();
     }

--- a/Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/Text.md
+++ b/Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/Text.md
@@ -330,32 +330,32 @@ public class DataCaptureUsingExtensionDemo: ViewBase
         var address = UseState("");
         var website = UseState("");
         return Layout.Vertical()
-                | Layout.Horizontal()
-                   | Text.Block("Username")
+                | (Layout.Horizontal()
+                   | Text.Block("Username").Width(Size.Fraction(0.15f))
                    | userName.ToTextInput()
-                             .Placeholder("User name") 
-                | Layout.Horizontal()
-                   | Text.Block("Password")
+                             .Placeholder("User name"))
+                | (Layout.Horizontal()
+                   | Text.Block("Password").Width(Size.Fraction(0.15f))
                    | password.ToPasswordInput(placeholder: "Password")
-                             .Disabled(userName.Value.Length == 0)
-                | Layout.Horizontal()
-                   | Text.Block("Email")
+                             .Disabled(userName.Value.Length == 0))
+                | (Layout.Horizontal()
+                   | Text.Block("Email").Width(Size.Fraction(0.15f))
                    | email.ToEmailInput()
-                           .Placeholder("Email")
-                | Layout.Horizontal() 
-                   | Text.Block("Mobile")
+                           .Placeholder("Email"))
+                | (Layout.Horizontal() 
+                   | Text.Block("Mobile").Width(Size.Fraction(0.15f))
                    | tel.ToTelInput()
-                        .Placeholder("Mobile")
-                | Layout.Horizontal()
-                   | Text.Block("Address")  
+                        .Placeholder("Mobile"))
+                | (Layout.Horizontal()
+                   | Text.Block("Address").Width(Size.Fraction(0.15f))
                    | address.ToTextAreaInput()
                             .Placeholder("Address Line1\nAddress Line2\nAddress Line 3")
                             .Height(40)
-                            .Width(100)
-                | Layout.Horizontal()
-                   | Text.Block("Website")
+                            .Width(100))
+                | (Layout.Horizontal()
+                   | Text.Block("Website").Width(Size.Fraction(0.15f))
                    | website.ToUrlInput()
-                            .Placeholder("https://ivy.app/");                             
+                            .Placeholder("https://ivy.app/"));                             
     }
 }
 ```
@@ -393,7 +393,7 @@ public class BasicFilter : ViewBase
 
 <WidgetDocs Type="Ivy.TextInput" ExtensionTypes="Ivy.TextInputExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Inputs/TextInput.cs"/>
 
-### Examples
+## Examples
 
 The following demo shows how to use style like `Invalid` in form validations.
 
@@ -465,10 +465,9 @@ public class LoginForm : ViewBase
                     .Placeholder("Enter your password")
                      // Disabled when username is empty
                     .Disabled(string.IsNullOrWhiteSpace(usernameState.Value))
-                | Layout.Horizontal()
-                    | new Button("Login")
-                        .Disabled(string.IsNullOrWhiteSpace(usernameState.Value) || 
-                             string.IsNullOrWhiteSpace(passwordState.Value));                             
+                | new Button("Login")
+                    .Disabled(string.IsNullOrWhiteSpace(usernameState.Value) || 
+                        string.IsNullOrWhiteSpace(passwordState.Value));                             
     }     
 }
 ```

--- a/Ivy.Docs.Shared/Docs/02_Widgets/03_Primitives/Fragment.md
+++ b/Ivy.Docs.Shared/Docs/02_Widgets/03_Primitives/Fragment.md
@@ -16,7 +16,7 @@ public class BasicFragmentView : ViewBase
     public override object? Build()
     {
         return new Fragment(
-            Text.H1("Welcome"),
+            Text.P("Welcome"),
             Text.P("This text is grouped with the heading above.")
         );
     }
@@ -36,7 +36,7 @@ public class ConditionalRenderingView : ViewBase
         var viewMode = UseState("user"); 
         
         return Layout.Vertical().Gap(4)
-            | Text.H2("User Dashboard")
+            | Text.P("User Dashboard")
             | (Layout.Horizontal().Gap(2)
                 | new Button("User View", _ => {
                     viewMode.Set("user");
@@ -50,14 +50,14 @@ public class ConditionalRenderingView : ViewBase
                     .Variant(viewMode.Value == "admin" ? ButtonVariant.Primary : ButtonVariant.Secondary))
             | (viewMode.Value == "admin"
                 ? new Fragment(
-                    Text.H3("Admin Controls"),
+                    Text.P("Admin Controls"),
                     Layout.Horizontal().Gap(2)
                         | new Button("Reset System", _ => client.Toast("System reset initiated!"), variant: ButtonVariant.Destructive)
                         | new Button("View Logs", _ => client.Toast("Opening system logs..."))
                         | new Button("Manage Users", _ => client.Toast("User management panel opened"))
                   )
                 : new Fragment(
-                    Text.H3("User Profile"),
+                    Text.P("User Profile"),
                     Layout.Horizontal().Gap(2)
                         | new Button("Edit Profile", _ => client.Toast("Profile editor opened"))
                         | new Button("Change Password", _ => client.Toast("Password change dialog opened"))
@@ -85,7 +85,7 @@ public class MultipleElementsView : ViewBase
         var tabs = new[] { "Overview", "Details", "Settings" };
         
         return new Fragment(
-            Text.H1("Application"),
+            Text.P("Application"),
             new Spacer().Height(4),
             // Tab navigation
             Layout.Horizontal().Gap(2)
@@ -131,7 +131,7 @@ public class DynamicContentView : ViewBase
         var showDetails = UseState(false);
         
         return Layout.Vertical().Gap(4)
-            | Text.H2("Dynamic Content")
+            | Text.P("Dynamic Content")
             | new Fragment(
                 // Static controls
                 Layout.Horizontal().Gap(2)

--- a/Ivy.Docs.Shared/Docs/02_Widgets/03_Primitives/Image.md
+++ b/Ivy.Docs.Shared/Docs/02_Widgets/03_Primitives/Image.md
@@ -6,9 +6,8 @@ Display images with automatic loading, responsive sizing, and proper accessibili
 
 The `Image` widget displays images in your app.
 
-```csharp demo-below 
-Layout.Horizontal()
-    | new Image("https://api.images.cat/150/150")
+```csharp demo-below
+new Image("https://api.images.cat/150/150")
 ```
 
 <WidgetDocs Type="Ivy.Image" ExtensionTypes="Ivy.ImageExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Primitives/Image.cs"/>

--- a/Ivy.Docs.Shared/Docs/02_Widgets/03_Primitives/Separator.md
+++ b/Ivy.Docs.Shared/Docs/02_Widgets/03_Primitives/Separator.md
@@ -33,34 +33,34 @@ public class ProfileDetailView : ViewBase
             
             | Layout.Vertical().Gap(2)
                 | Text.H2("Personal Information")
-                | Layout.Horizontal().Gap(2)
+                | (Layout.Horizontal().Gap(2)
                     | Text.Strong("Name:")
-                    | Text.Inline(user.Name)
-                | Layout.Horizontal().Gap(2)
+                    | Text.Inline(user.Name))
+                | (Layout.Horizontal().Gap(2)
                     | Text.Strong("Email:")
-                    | Text.Inline(user.Email)
+                    | Text.Inline(user.Email))
             
             | new Separator()
             
             | Layout.Vertical().Gap(2)
                 | Text.H2("Work Information")
-                | Layout.Horizontal().Gap(2)
+                | (Layout.Horizontal().Gap(2)
                     | Text.Strong("Role:")
-                    | Text.Inline(user.Role)
-                | Layout.Horizontal().Gap(2)
+                    | Text.Inline(user.Role))
+                | (Layout.Horizontal().Gap(2)
                     | Text.Strong("Department:")
-                    | Text.Inline(user.Department)
-                | Layout.Horizontal().Gap(2)
+                    | Text.Inline(user.Department))
+                | (Layout.Horizontal().Gap(2)
                     | Text.Strong("Join Date:")
-                    | Text.Inline(user.JoinDate.ToShortDateString())
+                    | Text.Inline(user.JoinDate.ToShortDateString()))
             
             | new Separator()
             
             | Layout.Vertical().Gap(2)
                 | Text.H2("Skills")
-                | Layout.Horizontal().Gap(2).Wrap(true)
+                | (Layout.Horizontal().Gap(2).Wrap(true)
                     | user.Skills.Select(skill => 
-                        new Badge(skill).Variant(BadgeVariant.Secondary))
+                        new Badge(skill).Variant(BadgeVariant.Secondary)))
             
             | new Separator()
             

--- a/Ivy.Docs.Shared/Docs/02_Widgets/04_Layouts/FooterLayout.md
+++ b/Ivy.Docs.Shared/Docs/02_Widgets/04_Layouts/FooterLayout.md
@@ -19,7 +19,7 @@ public class BasicFooterExample : ViewBase
         
         return Layout.Vertical()
             | new Card("Main Section")
-                    | Text.H2("Welcome to Ivy Framework")
+                    | Text.P("Welcome to Ivy Framework")
             | new FooterLayout(
                 footer: new Button("Save", _ => client.Toast("Content saved!"))
                     .Variant(ButtonVariant.Primary),
@@ -79,7 +79,7 @@ public class SheetWithFooterExample : ViewBase
         return Layout.Vertical()
             | new Card("Sheet Header")
                     | Layout.Vertical()
-                        | Text.H1("Article Editor")
+                        | Text.P("Article Editor")
                         | Text.Small("Create and edit your articles with ease").Color(Colors.Gray)
             | new FooterLayout(
                 footer: Layout.Horizontal().Align(Align.Right)
@@ -124,7 +124,7 @@ public class ComplexFooterExample : ViewBase
         return Layout.Vertical()
             | new Card("Project Header")
                     | Layout.Vertical()
-                        | Text.H1("Document Editor")
+                        | Text.P("Document Editor")
                         | Text.Small("Comprehensive project management tool").Color(Colors.Gray)
             | new FooterLayout(
                 footer: Layout.Horizontal().Align(Align.Right)

--- a/Ivy.Docs.Shared/Docs/02_Widgets/04_Layouts/HeaderLayout.md
+++ b/Ivy.Docs.Shared/Docs/02_Widgets/04_Layouts/HeaderLayout.md
@@ -208,10 +208,9 @@ public class FormHeaderExample : ViewBase
         var formHeader = new Card(
             Layout.Horizontal().Gap(4)
                 | Text.Label("Edit Profile")
-                | new Spacer()
-                | Layout.Horizontal().Gap(2)
-                    | new Button("Cancel").Variant(ButtonVariant.Ghost)
-                    | new Button("Save").Variant(ButtonVariant.Primary)
+                | new Spacer().Width(Size.Grow())
+                | new Button("Cancel").Variant(ButtonVariant.Ghost)
+                | new Button("Save").Variant(ButtonVariant.Primary)
                         .HandleClick(_ => client.Toast("Profile saved!"))
         );
 

--- a/Ivy.Docs.Shared/Docs/02_Widgets/07_Advanced/Sheet.md
+++ b/Ivy.Docs.Shared/Docs/02_Widgets/07_Advanced/Sheet.md
@@ -183,12 +183,12 @@ public class NavigationSheetContent : ViewBase
         var pages = new[] { "Home", "Profile", "Settings", "Help" };
         
         return Layout.Vertical()
-            | Layout.Horizontal().Gap(2)
+            | (Layout.Horizontal().Gap(2)
                 | pages.Select((page, index) => 
                     new Button(page)
                         .Variant(currentPage.Value == index ? ButtonVariant.Primary : ButtonVariant.Outline)
                         .HandleClick(_ => currentPage.Value = index)
-                ).ToArray()
+                ).ToArray())
             | new Card(
                 $"This is the {pages[currentPage.Value]} page content"
             ).Title("Page Content");
@@ -198,7 +198,7 @@ public class NavigationSheetContent : ViewBase
 
 <WidgetDocs Type="Ivy.Sheet" ExtensionTypes="Ivy.SheetExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Sheet.cs"/>
 
-## Advanced example
+## Examples
 
 ### Conditional Rendering
 
@@ -246,7 +246,7 @@ public class ConditionalSheetExample : ViewBase
             | new Button("Open Conditional Sheet").HandleClick(_ => isOpen.Value = true)
             | (isOpen.Value ? new Sheet((Event<Sheet> _) => isOpen.Value = false,
                 Layout.Vertical().Gap(2)
-                    | Layout.Horizontal().Gap(2)
+                    | (Layout.Horizontal().Gap(2)
                         | new Button("List").Variant(viewMode.Value == "list" ? ButtonVariant.Primary : ButtonVariant.Outline)
                             .HandleClick(_ => {
                                 viewMode.Value = "list";
@@ -261,7 +261,7 @@ public class ConditionalSheetExample : ViewBase
                             .HandleClick(_ => {
                                 viewMode.Value = "details";
                                 client.Toast("Switched to Details view");
-                            })
+                            }))
                     | RenderContent(),
                 title: "Conditional Content Sheet",
                 description: "Switch between different view modes"


### PR DESCRIPTION
<img width="647" height="299" alt="Screenshot 2025-08-29 at 00 41 02" src="https://github.com/user-attachments/assets/0ae11250-4c8f-4aab-a9ff-639647c4d686" />

Usually while using multi layouts (horizontal and vertical) there was a mistake with missing brackets. The examples looked weird because of that. Fixed

Also, while viewing every doc file, fixed some headings (using Text.H1 in examples was showing it in TOC, used Text.P instead) 