### PR TITLE
(docs): (icons): make available to copy icons to clipboard

### DIFF
--- a/Ivy.Docs.Shared/Docs/03_ApiReference/IvyShared/Icons.md
+++ b/Ivy.Docs.Shared/Docs/03_ApiReference/IvyShared/Icons.md
@@ -2,7 +2,7 @@
 
 Ivy use the [Lucide](https://lucide.dev/icons/) icon library.
 
-```csharp demo-tabs 
+```csharp demo-tabs
 public class SearchIconsView : ViewBase
 {
     public override object? Build()
@@ -21,9 +21,14 @@ public class SearchIconsView : ViewBase
         
         var searchInput = searchState.ToSearchInput().Placeholder("Type a icon name");
         
-        var icons  = iconsState.Value.Select(e => Layout.Horizontal()
-            | e.ToIcon()
-            | Text.InlineCode("Icons." + e.ToString())
+        var icons  = iconsState.Value.Select(e => Layout.Horizontal().Gap(2)
+            | new Button(null, @event =>
+            {
+                var iconCode = "Icons." + e.ToString();
+                client.CopyToClipboard(iconCode);
+                client.Toast($"Copied '{iconCode}' to clipboard", "Icon Code Copied");
+            }, ButtonVariant.Ghost, e).Small().WithTooltip($"Click to copy {e.ToString()}")
+            | Text.Label("Icons." + e.ToString())
             );
 
         return Layout.Vertical()


### PR DESCRIPTION
<img width="946" height="617" alt="Screenshot 2025-08-29 at 19 00 21" src="https://github.com/user-attachments/assets/ed44e73f-cb7d-4f94-9ff7-5fadc09148c9" />

The issue with centering text was in using Text.Inline, Text.Block or other methods except Text.Label
With Text.Label it's centering perfectly for some reason