### PR TITLE
(docs): copy-paste: include terminal windows 

### DIFF
--- a/frontend/src/widgets/internal/TerminalWidget.tsx
+++ b/frontend/src/widgets/internal/TerminalWidget.tsx
@@ -1,4 +1,5 @@
 import { cn } from '@/lib/utils';
+import CopyToClipboardButton from '@/components/CopyToClipboardButton';
 
 export interface TerminalLine {
   content: string;
@@ -16,12 +17,22 @@ const TerminalWidget = ({ lines, title, showHeader }: TerminalWidgetProps) => {
   const commandColor = 'text-white';
   const outputColor = 'text-muted-foreground';
 
+  // Create a copyable text representation of the terminal content
+  const copyableContent = lines
+    .map(line => (line.isCommand ? `> ${line.content}` : line.content))
+    .join('\n');
+
   return (
     <div
       className={cn(
-        'rounded-lg overflow-hidden border border-border shadow-md'
+        'rounded-lg overflow-hidden border border-border shadow-md relative'
       )}
     >
+      {/* Copy button positioned in the top-right corner */}
+      <div className="absolute top-2 right-2 z-10">
+        <CopyToClipboardButton textToCopy={copyableContent} />
+      </div>
+
       {showHeader && (
         <div className="bg-zinc-800 px-4 py-2 flex items-center">
           <div className="text-zinc-400 text-body font-medium flex-1 text-center">
@@ -34,6 +45,12 @@ const TerminalWidget = ({ lines, title, showHeader }: TerminalWidgetProps) => {
           </div>
         </div>
       )}
+
+      {/* Hidden copyable content for better accessibility and copying */}
+      <div className="sr-only">
+        <pre>{copyableContent}</pre>
+      </div>
+
       <div className="bg-zinc-900 p-4 font-mono text-body overflow-x-auto">
         {lines.map((line, index) => (
           <div
@@ -54,7 +71,7 @@ const TerminalWidget = ({ lines, title, showHeader }: TerminalWidgetProps) => {
               </div>
               <span
                 className={cn(
-                  'text-sm',
+                  'text-sm select-text',
                   line.isCommand ? commandColor : outputColor
                 )}
               >


### PR DESCRIPTION
<img width="1243" height="746" alt="Screenshot 2025-08-30 at 00 37 57" src="https://github.com/user-attachments/assets/5f746684-38e8-4b8d-bc61-ef047cb672c4" />
