### PR TITLE
(Samples): (Products): fix gaps in product view(edit)

### DIFF
--- a/frontend/src/widgets/layouts/FooterLayoutWidget.tsx
+++ b/frontend/src/widgets/layouts/FooterLayoutWidget.tsx
@@ -23,7 +23,7 @@ export const FooterLayoutWidget: React.FC<FooterLayoutWidgetProps> = ({
     <div className="h-full flex flex-col">
       <div className="flex-1 min-h-0 overflow-hidden">
         <ScrollArea className="h-full">
-          <div className="p-4">{slots.Content}</div>
+          <div>{slots.Content}</div>
         </ScrollArea>
       </div>
       <div className="flex-none p-4 border-t w-full bg-background">


### PR DESCRIPTION
<img width="1180" height="524" alt="Screenshot 2025-08-30 at 14 51 49" src="https://github.com/user-attachments/assets/a2040299-b9a8-4262-9faa-0055f6d3ead2" />

The issues was in the FE part of FooterLayout. Edit Product window is a sheet, and it's content inits as a footer content. Footer sets extra padding for content above, so this change will fix all the sheets visibility, too (I saw this issue in sheet doc, which had footer usage)

Sheets with footer usage now:
<img width="1440" height="524" alt="Screenshot 2025-08-30 at 14 55 37" src="https://github.com/user-attachments/assets/1ae861c9-67ae-44e7-a52a-58dbf4411f87" />
The card in it also had extra padding before

And because of it footer with content mentions changed:
<img width="1150" height="382" alt="Screenshot 2025-08-30 at 14 57 16" src="https://github.com/user-attachments/assets/f2d38fff-2133-4324-b361-69efb1d43732" />
I think it's correct and more natural now, btw
@rorychatt , need your thought 