### PR TITLE
(expandable): resolve disabled data state nested component state mismatch issue

### DIFF
--- a/Ivy.Samples.Shared/Apps/Widgets/ExpandableApp.cs
+++ b/Ivy.Samples.Shared/Apps/Widgets/ExpandableApp.cs
@@ -7,6 +7,68 @@ public class ExpandableApp : SampleBase
 {
     protected override object? BuildSample()
     {
-        return new Expandable("This is an expandable", "This is the content of the expandable");
+        // Original basic expandable
+        var basicExpandable = new Expandable("This is an expandable", "This is the content of the expandable");
+
+        // PROBLEMATIC CASE - Switch in Header (replicates the exact issue from HTML)
+        var headerSwitchState1 = UseState(false);
+        var headerSwitchState2 = UseState(true);
+        var headerSwitchState3 = UseState(true);
+        var headerSwitchState4 = UseState(false);
+
+        var switchInHeaderExpandable1 = new Expandable(
+            Layout.Horizontal()
+            | headerSwitchState1.ToBoolInput(variant: BoolInputs.Switch)
+            | (Layout.Horizontal()
+               | Text.Block("Apps")
+               | new Icon(Icons.ChevronRight)
+               | new Icon(Icons.Paperclip)
+               | Text.Block("Attachments")),
+            Text.Block("This is the content for Attachments")
+        ).Disabled(true);
+
+        var switchInHeaderExpandable2 = new Expandable(
+            Layout.Horizontal()
+            | headerSwitchState2.ToBoolInput(variant: BoolInputs.Switch)
+            | (Layout.Horizontal()
+               | Text.Block("Apps")
+               | new Icon(Icons.ChevronRight)
+               | new Icon(Icons.MessageCircle)
+               | Text.Block("Comments")),
+            Text.Block("This is the content for Comments")
+        ).Disabled(true);
+
+        var switchInHeaderExpandable3 = new Expandable(
+            Layout.Horizontal()
+            | headerSwitchState3.ToBoolInput(variant: BoolInputs.Switch)
+            | (Layout.Horizontal()
+               | Text.Block("Apps")
+               | new Icon(Icons.ChevronRight)
+               | new Icon(Icons.Bug)
+               | Text.Block("Issues")),
+            Text.Block("This is the content for Issues")
+        );
+
+        var switchInHeaderExpandable4 = new Expandable(
+            Layout.Horizontal()
+            | headerSwitchState4.ToBoolInput(variant: BoolInputs.Switch)
+            | (Layout.Horizontal()
+               | Text.Block("Settings")
+               | new Icon(Icons.ChevronRight)
+               | new Icon(Icons.Users)
+               | Text.Block("Project Users")),
+            Text.Block("This is the content for Project Users")
+        ).Disabled(true);
+
+        return Layout.Vertical()
+            | Text.H2("Original Basic Expandable")
+            | basicExpandable
+            | Text.H2("Problematic Case - Switch in Header")
+            | Text.Block("This replicates the exact issue from your HTML - switches in the expandable header:")
+            | Text.Block($"Switch states: {headerSwitchState1.Value}, {headerSwitchState2.Value}, {headerSwitchState3.Value}, {headerSwitchState4.Value}")
+            | switchInHeaderExpandable1
+            | switchInHeaderExpandable2
+            | switchInHeaderExpandable3
+            | switchInHeaderExpandable4;
     }
 }

--- a/Ivy.Samples.Shared/Apps/Widgets/ExpandableApp.cs
+++ b/Ivy.Samples.Shared/Apps/Widgets/ExpandableApp.cs
@@ -64,7 +64,7 @@ public class ExpandableApp : SampleBase
             | Text.H2("Original Basic Expandable")
             | basicExpandable
             | Text.H2("Problematic Case - Switch in Header")
-            | Text.Block("This replicates the exact issue from your HTML - switches in the expandable header:")
+            | Text.Block("Nested switches should not be blocked by the expandable:")
             | Text.Block($"Switch states: {headerSwitchState1.Value}, {headerSwitchState2.Value}, {headerSwitchState3.Value}, {headerSwitchState4.Value}")
             | switchInHeaderExpandable1
             | switchInHeaderExpandable2

--- a/frontend/src/widgets/ExpandableWidget.tsx
+++ b/frontend/src/widgets/ExpandableWidget.tsx
@@ -23,9 +23,11 @@ export const ExpandableWidget: React.FC<ExpandableWidgetProps> = ({
 }) => {
   const [isOpen, setIsOpen] = React.useState(false);
 
-  if (disabled && isOpen) {
-    setIsOpen(false);
-  }
+  React.useEffect(() => {
+    if (disabled && isOpen) {
+      setIsOpen(false);
+    }
+  }, [disabled, isOpen]);
 
   return (
     <Collapsible
@@ -36,7 +38,7 @@ export const ExpandableWidget: React.FC<ExpandableWidgetProps> = ({
       data-disabled={disabled}
     >
       <div className="flex justify-between items-center space-x-4">
-        <div className="flex-1 ml-2 min-w-0">{slots?.Header}</div>
+        <div className="flex-1 min-w-0">{slots?.Header}</div>
         <CollapsibleTrigger asChild disabled={disabled}>
           <Button
             variant="ghost"

--- a/frontend/src/widgets/ExpandableWidget.tsx
+++ b/frontend/src/widgets/ExpandableWidget.tsx
@@ -35,12 +35,15 @@ export const ExpandableWidget: React.FC<ExpandableWidgetProps> = ({
       className="w-full rounded-md border border-border p-2 shadow-sm data-[disabled=true]:cursor-not-allowed data-[disabled=true]:opacity-50"
       data-disabled={disabled}
     >
-      <div className="flex justify-between space-x-4">
+      <div className="flex justify-between items-center space-x-4">
+        <div className="flex-1 ml-2 min-w-0">{slots?.Header}</div>
         <CollapsibleTrigger asChild disabled={disabled}>
-          <Button variant="ghost" className="w-full p-0 ">
-            <div className="ml-2">{slots?.Header}</div>
-            {!isOpen && <ChevronRight className="h-4 w-4 ml-auto mr-2" />}
-            {isOpen && <ChevronDown className="h-4 w-4 ml-auto mr-2" />}
+          <Button
+            variant="ghost"
+            className="p-0 h-9 w-9 shrink-0 hover:bg-accent"
+          >
+            {!isOpen && <ChevronRight className="h-4 w-4" />}
+            {isOpen && <ChevronDown className="h-4 w-4" />}
           </Button>
         </CollapsibleTrigger>
       </div>


### PR DESCRIPTION
This pull request introduces improvements to the `Expandable` widget in both the backend sample app and the frontend React component. The main focus is on handling cases where interactive elements (like switches) are present in the expandable header, ensuring they remain usable even when the expandable is disabled, and refining the UI layout for better usability.

**Frontend improvements:**

* Ensured that when the `ExpandableWidget` is disabled, it automatically closes if open, preventing interaction inconsistencies.
* Refactored the header layout in `ExpandableWidget.tsx` to allow embedded interactive elements (such as switches) to remain accessible and visually aligned, even when the expandable is disabled.

**Backend sample app enhancements:**

* Expanded the sample in `ExpandableApp.cs` to demonstrate problematic cases with switches embedded in expandable headers, including multiple variations and disabled states, to aid in testing and reproducing UI issues.