### PR TITLE
(docs): (table): fix layouts usage in Integration with Other Widgets example

### DIFF
--- a/Ivy.Docs.Shared/Docs/02_Widgets/01_Common/Table.md
+++ b/Ivy.Docs.Shared/Docs/02_Widgets/01_Common/Table.md
@@ -304,10 +304,10 @@ public class TableIntegrationExample : ViewBase
             | new Card(
                 Layout.Vertical()
                     | products.Value.ToTable().Width(Size.Full())
-                    | Layout.Horizontal().Gap(2)
+                    | (Layout.Horizontal().Gap(2)
                         | new Button("Add Product", addProduct).Variant(ButtonVariant.Secondary)
-                        | new Button("Clear All", clearProducts).Variant(ButtonVariant.Destructive)
-                        | Text.Block($"Total Products: {products.Value.Length}")
+                        | new Button("Clear All", clearProducts).Variant(ButtonVariant.Destructive))
+                    | Text.Block($"Total Products: {products.Value.Length}")
             ).Title("Product List").Width(Size.Full());
     }
 }


### PR DESCRIPTION
Fixed:
<img width="529" height="354" alt="Screenshot 2025-09-02 at 12 01 53" src="https://github.com/user-attachments/assets/123ea7ed-4d1c-4b34-bdc9-b0e130098730" />

How it was:
<img width="464" height="354" alt="Screenshot 2025-09-02 at 12 01 44" src="https://github.com/user-attachments/assets/ade6ae94-2c7a-4c91-a1bc-245e9dd47fbd" />
