### PR TITLE
(fix): Version 0 in docs, samples

### DIFF
--- a/Ivy/Ivy.csproj
+++ b/Ivy/Ivy.csproj
@@ -6,7 +6,6 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <PackageId>Ivy</PackageId>
     <Company>Ivy</Company>


### PR DESCRIPTION
Fixes #752 by re-enabling GenerateAssemblyInfo

@nielsbosma Would like your input in case you have a good reason to leave this disabled.