### PR TITLE
(feat): (DBML): handle connection line and edges in different themes

### DIFF
--- a/frontend/src/widgets/internal/DbmlCanvasWidget.css
+++ b/frontend/src/widgets/internal/DbmlCanvasWidget.css
@@ -54,7 +54,7 @@
   background-color: var(--background) !important;
 }
 
-/* ReactFlow Edge styling - Simple connection line color */
+/* ReactFlow Edge styling */
 .react-flow__edge-path {
   stroke: var(--foreground) !important;
 }

--- a/frontend/src/widgets/internal/DbmlCanvasWidget.css
+++ b/frontend/src/widgets/internal/DbmlCanvasWidget.css
@@ -56,7 +56,7 @@
 
 /* ReactFlow Edge styling - Simple connection line color */
 .react-flow__edge-path {
-  stroke: var(--black) !important;
+  stroke: var(--foreground) !important;
 }
 
 .dark .react-flow__edge-path {
@@ -85,10 +85,14 @@
 
 /* ReactFlow Handle styling */
 .react-flow__handle {
-  background-color: var(--primary) !important;
+  background-color: var(--foreground) !important;
   border: 2px solid var(--background) !important;
   width: 8px !important;
   height: 8px !important;
+}
+
+.dark .react-flow__handle {
+  background-color: var(--primary) !important;
 }
 
 .react-flow__handle:hover {

--- a/frontend/src/widgets/internal/DbmlCanvasWidget.css
+++ b/frontend/src/widgets/internal/DbmlCanvasWidget.css
@@ -54,8 +54,12 @@
   background-color: var(--background) !important;
 }
 
-/* ReactFlow Edge styling */
+/* ReactFlow Edge styling - Simple connection line color */
 .react-flow__edge-path {
+  stroke: var(--black) !important;
+}
+
+.dark .react-flow__edge-path {
   stroke: var(--primary) !important;
 }
 
@@ -64,7 +68,6 @@
   font-size: 12px !important;
   font-weight: 500 !important;
 }
-
 .react-flow__edge-textbg {
   fill: var(--background) !important;
   stroke: var(--border) !important;

--- a/frontend/src/widgets/internal/DbmlCanvasWidget.tsx
+++ b/frontend/src/widgets/internal/DbmlCanvasWidget.tsx
@@ -17,6 +17,7 @@ import dagre from 'dagre';
 import 'reactflow/dist/style.css';
 import { Parser } from '@dbml/core';
 import { getWidth, getHeight } from '@/lib/styles';
+import { useTheme } from '@/components/theme-provider/hooks';
 import './DbmlCanvasWidget.css';
 
 interface DbmlCanvasWidgetProps {
@@ -301,6 +302,11 @@ export const DbmlCanvasWidget: React.FC<DbmlCanvasWidgetProps> = ({
   const [nodes, setNodes, onNodesChange] = useNodesState([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState([]);
   const [error, setError] = useState<DbmlError | null>(null);
+  const { theme } = useTheme();
+
+  const getConnectionLineColor = () => {
+    return theme === 'dark' ? 'var(--primary)' : 'var(--black)';
+  };
 
   const parseDbml = useCallback(() => {
     try {
@@ -394,13 +400,13 @@ export const DbmlCanvasWidget: React.FC<DbmlCanvasWidgetProps> = ({
           sourceHandle: `${ref.endpoints[0].fieldNames[0]}-right`,
           targetHandle: `${ref.endpoints[1].fieldNames[0]}-left`,
           type: 'smoothstep',
-          style: { stroke: 'var(--primary)' },
+          style: { stroke: getConnectionLineColor() },
           markerEnd: {
             type: MarkerType.ArrowClosed,
-            color: 'var(--primary)',
+            color: getConnectionLineColor(),
           },
           label: `${ref.endpoints[0].fieldNames[0]} → ${ref.endpoints[1].fieldNames[0]}`,
-          labelStyle: { fill: 'var(--primary)', fontWeight: 500 },
+          labelStyle: { fill: getConnectionLineColor(), fontWeight: 500 },
           labelBgStyle: { fill: 'var(--background)' },
         })
       );
@@ -448,7 +454,7 @@ export const DbmlCanvasWidget: React.FC<DbmlCanvasWidgetProps> = ({
 
       setError(errorInfo);
     }
-  }, [dbml, setNodes, setEdges]);
+  }, [dbml, setNodes, setEdges, theme]);
 
   useEffect(() => {
     parseDbml();
@@ -493,7 +499,7 @@ export const DbmlCanvasWidget: React.FC<DbmlCanvasWidgetProps> = ({
   }
 
   return (
-    <div style={styles}>
+    <div style={styles} className="dbml-canvas-widget">
       <ReactFlow
         nodes={nodes}
         edges={edges}
@@ -505,10 +511,10 @@ export const DbmlCanvasWidget: React.FC<DbmlCanvasWidgetProps> = ({
         maxZoom={1.5}
         defaultEdgeOptions={{
           type: 'smoothstep',
-          style: { stroke: 'var(--primary)' },
+          style: { stroke: getConnectionLineColor() },
           markerEnd: {
             type: MarkerType.ArrowClosed,
-            color: 'var(--primary)',
+            color: getConnectionLineColor(),
           },
         }}
       >

--- a/frontend/src/widgets/internal/DbmlCanvasWidget.tsx
+++ b/frontend/src/widgets/internal/DbmlCanvasWidget.tsx
@@ -305,7 +305,7 @@ export const DbmlCanvasWidget: React.FC<DbmlCanvasWidgetProps> = ({
   const { theme } = useTheme();
 
   const getConnectionLineColor = () => {
-    return theme === 'dark' ? 'var(--primary)' : 'var(--black)';
+    return theme === 'dark' ? 'var(--primary)' : 'var(--foreground)';
   };
 
   const parseDbml = useCallback(() => {


### PR DESCRIPTION
<img width="669" height="368" alt="Screenshot 2025-09-05 at 23 55 39" src="https://github.com/user-attachments/assets/92e2f69a-55ef-4480-b4e3-59d30e56dad1" />
<img width="670" height="340" alt="Screenshot 2025-09-05 at 23 55 56" src="https://github.com/user-attachments/assets/2cdf9f8f-4e10-46ca-89a3-687f6e80b67a" />
