### PR TITLE
Test line chart visibility with strange data

### DIFF
--- a/Ivy.Samples.Shared/Apps/Widgets/Charts/LineChartApp.cs
+++ b/Ivy.Samples.Shared/Apps/Widgets/Charts/LineChartApp.cs
@@ -1,4 +1,4 @@
-﻿using Ivy.Charts;
+using Ivy.Charts;
 using Ivy.Shared;
 using Ivy.Views.Charts;
 
@@ -16,6 +16,12 @@ public class LineChartApp : ViewBase
             | new LineChart3View()
             | new LineChart4View()
             | new LineChart5View()
+            | new LineChartNegativeView()
+            | new LineChartZeroNullView()
+            | new LineChartExtremeRangeView()
+            | new LineChartSinglePointView()
+            | new LineChartIdenticalValuesView()
+            | new LineChartMixedEdgeCasesView()
         ;
     }
 }
@@ -155,6 +161,150 @@ public class LineChart5View : ViewBase
                 .Measure("Temperature", e => e.Sum(f => f.Temperature))
                 .Measure("Humidity", e => e.Sum(f => f.Humidity))
                 .Measure("Pressure", e => e.Sum(f => f.Pressure))
+        ;
+    }
+}
+
+// Test charts with edge cases and strange data
+public class LineChartNegativeView : ViewBase
+{
+    public override object? Build()
+    {
+        var data = new[]
+        {
+            new { Day = "Mon", Profit = -500, Loss = -1200, Net = -1700 },
+            new { Day = "Tue", Profit = 200, Loss = -800, Net = -600 },
+            new { Day = "Wed", Profit = -300, Loss = -400, Net = -700 },
+            new { Day = "Thu", Profit = 600, Loss = -200, Net = 400 },
+            new { Day = "Fri", Profit = -100, Loss = -1500, Net = -1600 },
+            new { Day = "Sat", Profit = 800, Loss = -100, Net = 700 },
+            new { Day = "Sun", Profit = -900, Loss = -300, Net = -1200 },
+        };
+
+        return new Card().Title("Test: Negative Values")
+            | data.ToLineChart(style: LineChartStyles.Default)
+                .Dimension("Day", e => e.Day)
+                .Measure("Profit", e => e.Sum(f => f.Profit))
+                .Measure("Loss", e => e.Sum(f => f.Loss))
+                .Measure("Net", e => e.Sum(f => f.Net))
+        ;
+    }
+}
+
+public class LineChartZeroNullView : ViewBase
+{
+    public override object? Build()
+    {
+        var data = new[]
+        {
+            new { Time = "00:00", Active = 0, Inactive = 0, Unknown = (int?)null },
+            new { Time = "04:00", Active = 0, Inactive = 5, Unknown = (int?)0 },
+            new { Time = "08:00", Active = (int?)null, Inactive = 0, Unknown = (int?)null },
+            new { Time = "12:00", Active = 10, Inactive = (int?)null, Unknown = 0 },
+            new { Time = "16:00", Active = 0, Inactive = 0, Unknown = 0 },
+            new { Time = "20:00", Active = (int?)null, Inactive = (int?)null, Unknown = (int?)null },
+            new { Time = "24:00", Active = 5, Inactive = 3, Unknown = 0 },
+        };
+
+        return new Card().Title("Test: Zero and Null Values")
+            | data.ToLineChart(style: LineChartStyles.Dashboard)
+                .Dimension("Time", e => e.Time)
+                .Measure("Active", e => e.Sum(f => f.Active ?? 0))
+                .Measure("Inactive", e => e.Sum(f => f.Inactive ?? 0))
+                .Measure("Unknown", e => e.Sum(f => f.Unknown ?? 0))
+        ;
+    }
+}
+
+public class LineChartExtremeRangeView : ViewBase
+{
+    public override object? Build()
+    {
+        var data = new[]
+        {
+            new { Period = "T1", Micro = 0.0001, Normal = 100, Huge = 999999999 },
+            new { Period = "T2", Micro = 0.0005, Normal = 150, Huge = 1500000000 },
+            new { Period = "T3", Micro = 0.0002, Normal = 80, Huge = 800000000 },
+            new { Period = "T4", Micro = 0.0008, Normal = 200, Huge = 2000000000 },
+            new { Period = "T5", Micro = 0.0003, Normal = 120, Huge = 1200000000 },
+            new { Period = "T6", Micro = 0.0009, Normal = 180, Huge = 1800000000 },
+        };
+
+        return new Card().Title("Test: Extreme Value Ranges")
+            | data.ToLineChart(style: LineChartStyles.Custom)
+                .Dimension("Period", e => e.Period)
+                .Measure("Micro Values", e => e.Sum(f => f.Micro))
+                .Measure("Normal Values", e => e.Sum(f => f.Normal))
+                .Measure("Huge Values", e => e.Sum(f => f.Huge))
+        ;
+    }
+}
+
+public class LineChartSinglePointView : ViewBase
+{
+    public override object? Build()
+    {
+        var data = new[]
+        {
+            new { Label = "Only Point", Value1 = 42, Value2 = 100, Value3 = -15 }
+        };
+
+        return new Card().Title("Test: Single Data Point")
+            | data.ToLineChart(style: LineChartStyles.Default)
+                .Dimension("Label", e => e.Label)
+                .Measure("Value1", e => e.Sum(f => f.Value1))
+                .Measure("Value2", e => e.Sum(f => f.Value2))
+                .Measure("Value3", e => e.Sum(f => f.Value3))
+        ;
+    }
+}
+
+public class LineChartIdenticalValuesView : ViewBase
+{
+    public override object? Build()
+    {
+        var data = new[]
+        {
+            new { Hour = "1h", Constant = 50, AlsoConstant = 50, StillConstant = 50 },
+            new { Hour = "2h", Constant = 50, AlsoConstant = 50, StillConstant = 50 },
+            new { Hour = "3h", Constant = 50, AlsoConstant = 50, StillConstant = 50 },
+            new { Hour = "4h", Constant = 50, AlsoConstant = 50, StillConstant = 50 },
+            new { Hour = "5h", Constant = 50, AlsoConstant = 50, StillConstant = 50 },
+            new { Hour = "6h", Constant = 50, AlsoConstant = 50, StillConstant = 50 },
+        };
+
+        return new Card().Title("Test: All Identical Values")
+            | data.ToLineChart(style: LineChartStyles.Dashboard)
+                .Dimension("Hour", e => e.Hour)
+                .Measure("Constant", e => e.Sum(f => f.Constant))
+                .Measure("AlsoConstant", e => e.Sum(f => f.AlsoConstant))
+                .Measure("StillConstant", e => e.Sum(f => f.StillConstant))
+        ;
+    }
+}
+
+public class LineChartMixedEdgeCasesView : ViewBase
+{
+    public override object? Build()
+    {
+        var data = new[]
+        {
+            new { Category = "A", Spike = 0.1, Drop = 10000, Zigzag = -500 },
+            new { Category = "B", Spike = 99999, Drop = 0.001, Zigzag = 1500 },
+            new { Category = "C", Spike = 0.5, Drop = 5000, Zigzag = -2000 },
+            new { Category = "D", Spike = 50000, Drop = 0.1, Zigzag = 3000 },
+            new { Category = "E", Spike = 1, Drop = 8000, Zigzag = -1000 },
+            new { Category = "F", Spike = 75000, Drop = 0.0001, Zigzag = 500 },
+            new { Category = "G", Spike = 0.01, Drop = 12000, Zigzag = -3500 },
+            new { Category = "H", Spike = 100000, Drop = 1, Zigzag = 4000 },
+        };
+
+        return new Card().Title("Test: Mixed Edge Cases (Spikes, Drops, Zigzags)")
+            | data.ToLineChart(style: LineChartStyles.Custom)
+                .Dimension("Category", e => e.Category)
+                .Measure("Spike Pattern", e => e.Sum(f => f.Spike))
+                .Measure("Drop Pattern", e => e.Sum(f => f.Drop))
+                .Measure("Zigzag Pattern", e => e.Sum(f => f.Zigzag))
         ;
     }
 }


### PR DESCRIPTION
Add 6 new line charts to `LineChartApp.cs` to test chart visibility and rendering with various edge-case data.

---
<a href="https://cursor.com/background-agent?bcId=bc-64651f0e-d6f1-4332-a5e0-6df8011a621b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-64651f0e-d6f1-4332-a5e0-6df8011a621b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

