### PR TITLE
(audio): implement audio recording widget

### DIFF
--- a/Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/Audio.md
+++ b/Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/Audio.md
@@ -1,0 +1,50 @@
+# AudioRecorder
+
+<Ingress>
+Enable audio recording with a flexible interface.
+</Ingress>
+
+The `AudioRecorder` widget allows users to record audio. It provides a audio recording interface with options for audio formats, audio upload endpoint, and upload chunking.
+
+## Basic Usage
+
+Here's a simple example of a `AudioRecorder` that allows users to record audio:
+
+```csharp demo-below
+public class BasicAudioRecorderDemo : ViewBase
+{
+    public override object? Build()
+    {
+        var uploadUrl = this.UseUpload(
+            fileBytes => {
+                // Process uploaded file bytes
+                Console.WriteLine($"Received {fileBytes.Length} bytes");
+            },
+            "application/octet-stream",
+            "uploaded-audio"
+        );
+
+        return new AudioRecorder("Start recording", "Recording audio..").UploadUrl(uploadUrl.Value).ChunkInterval(3000);
+   }     
+}    
+```
+
+## Styling
+
+`AudioRecorder` can be customized with various styling options:
+
+### Disabled
+
+To render a disabled `AudioRecorder` control, the `Disabled` function should be used.
+
+```csharp demo-below
+public class AudioRecorderDisabledDemo : ViewBase
+{
+    public override object? Build()
+    {
+        return new AudioRecorder("Disabled audio recorder", disabled: true);
+    }
+}    
+```
+
+<WidgetDocs Type="Ivy.AudioRecorder" ExtensionTypes="Ivy.AudioRecorderExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/AudioRecorder.cs"/>

--- a/Ivy.Samples.Shared/Apps/Widgets/Inputs/Audio.cs
+++ b/Ivy.Samples.Shared/Apps/Widgets/Inputs/Audio.cs
@@ -1,0 +1,17 @@
+using Ivy.Shared;
+
+namespace Ivy.Samples.Shared.Apps.Widgets;
+
+[App(icon: Icons.Mic, path: ["Widgets"])]
+public class AudioRecorderApp() : SampleBase
+{
+    protected override object? BuildSample()
+    {
+        return Layout.Vertical()
+               | Text.H1("Audio recorder")
+               | new AudioRecorder("Start recording", "Recording audio...")
+
+               | Text.H2("Disabled")
+               | new AudioRecorder("Start recording", "Recording audio...", disabled: true);
+    }
+}

--- a/Ivy/Widgets/AudioRecorder.cs
+++ b/Ivy/Widgets/AudioRecorder.cs
@@ -52,17 +52,17 @@ public record AudioRecorder : WidgetBase<AudioRecorder>
 /// </summary>
 public static class AudioRecorderExtensions
 {
-    /// <summary>Sets the label text for the audio recorder.</summary>
+    /// <summary>Sets the label text to display when no audio is recording.</summary>
     /// <param name="widget">The audio recorder to configure.</param>
-    /// <param name="label">The label text to display when no audio is recording.</param>
+    /// <param name="label">The label text.</param>
     public static AudioRecorder Label(this AudioRecorder widget, string label)
     {
         return widget with { Label = label };
     }
 
-    /// <summary>Sets the placeholder text for the audio recorder.</summary>
+    /// <summary>Sets the label text to display when audio is recording.</summary>
     /// <param name="widget">The audio recorder to configure.</param>
-    /// <param name="label">The label text to display when audio is recording.</param>
+    /// <param name="label">The label text.</param>
     public static AudioRecorder RecordingLabel(this AudioRecorder widget, string label)
     {
         return widget with { RecordingLabel = label };
@@ -84,7 +84,7 @@ public static class AudioRecorderExtensions
         return widget with { MimeType = mimeType };
     }
 
-    /// <summary>Sets the mime type used for recorded audio.</summary>
+    /// <summary>Sets the chunk size, in milliseconds, for continuous chunked uploads.</summary>
     /// <param name="widget">The audio recorder to configure.</param>
     /// <param name="chunkInterval">Chunk size to use, in milliseconds. If null, audio will only be uploaded when recording stops.</param>
     public static AudioRecorder ChunkInterval(this AudioRecorder widget, int? chunkInterval)

--- a/Ivy/Widgets/AudioRecorder.cs
+++ b/Ivy/Widgets/AudioRecorder.cs
@@ -14,7 +14,7 @@ public record AudioRecorder : WidgetBase<AudioRecorder>
     /// Initializes a new instance with basic configuration.
     /// </summary>
     /// <param name="placeholder">Optional placeholder text displayed when no audio is recording.</param>
-    /// <param name="mimeType">The mime type of the recorded audio data (e.g., "audio/webm" or "audio/mp3").</param>
+    /// <param name="mimeType">The mime type of the recorded audio data (e.g., "audio/webm").</param>
     /// <param name="chunkInterval">The chunk size, in milliseconds, for continuous chunked uploads. If null, audio will be uploaded once recording stops.</param>
     /// <param name="uploadUrl">The upload URL for automatic audio file uploads.</param>
     /// <param name="disabled">Whether the widget should be disabled initially.</param>
@@ -78,7 +78,7 @@ public static class AudioRecorderExtensions
 
     /// <summary>Sets the mime type used for recorded audio.</summary>
     /// <param name="widget">The audio recorder to configure.</param>
-    /// <param name="mimeType">Mime type to use (e.g., "audio/webm", "audio/mp3").</param>
+    /// <param name="mimeType">Mime type to use (e.g., "audio/webm").</param>
     public static AudioRecorder MimeType(this AudioRecorder widget, string mimeType)
     {
         return widget with { MimeType = mimeType };

--- a/Ivy/Widgets/AudioRecorder.cs
+++ b/Ivy/Widgets/AudioRecorder.cs
@@ -1,0 +1,102 @@
+using Ivy.Core;
+
+// ReSharper disable once CheckNamespace
+namespace Ivy;
+
+/// <summary>
+/// An audio recorder control that allows users to upload audio using their
+/// microphone. Audio is uploaded either when recording stops, or continuously
+/// with a specific chunk interval.
+/// </summary>
+public record AudioRecorder : WidgetBase<AudioRecorder>
+{
+    /// <summary>
+    /// Initializes a new instance with basic configuration.
+    /// </summary>
+    /// <param name="placeholder">Optional placeholder text displayed when no audio is recording.</param>
+    /// <param name="mimeType">The mime type of the recorded audio data (e.g., "audio/webm" or "audio/mp3").</param>
+    /// <param name="chunkInterval">The chunk size, in milliseconds, for continuous chunked uploads. If null, audio will be uploaded once recording stops.</param>
+    /// <param name="uploadUrl">The upload URL for automatic audio file uploads.</param>
+    /// <param name="disabled">Whether the widget should be disabled initially.</param>
+    public AudioRecorder(string? label = null, string? recordingLabel = null, string mimeType = "audio/webm", int? chunkInterval = null, string? uploadUrl = null, bool disabled = false)
+    {
+        Label = label;
+        RecordingLabel = recordingLabel;
+        MimeType = mimeType;
+        ChunkInterval = chunkInterval;
+        UploadUrl = uploadUrl;
+        Disabled = disabled;
+    }
+
+    /// <summary>Gets or sets whether the widget is disabled.</summary>
+    [Prop] public bool Disabled { get; set; }
+
+    /// <summary>Gets or sets the label text displayed when no audio is recording.</summary>
+    [Prop] public string? Label { get; set; }
+
+    /// <summary>Gets or sets the label text displayed when audio is recording.</summary>
+    [Prop] public string? RecordingLabel { get; set; }
+
+    /// <summary>Gets or sets the mime type used for recorded audio.</summary>
+    [Prop] public string MimeType { get; set; }
+
+    /// <summary>Gets or sets the chunk size, in milliseconds, for continuous chunked uploads.</summary>
+    [Prop] public int? ChunkInterval { get; set; }
+
+    /// <summary>Gets or sets the upload URL for automatic audio file uploads.</summary>
+    [Prop] public string? UploadUrl { get; set; }
+}
+
+/// <summary>
+/// Provides extension methods for configuring audio recorders.
+/// </summary>
+public static class AudioRecorderExtensions
+{
+    /// <summary>Sets the label text for the audio recorder.</summary>
+    /// <param name="widget">The audio recorder to configure.</param>
+    /// <param name="label">The label text to display when no audio is recording.</param>
+    public static AudioRecorder Label(this AudioRecorder widget, string label)
+    {
+        return widget with { Label = label };
+    }
+
+    /// <summary>Sets the placeholder text for the audio recorder.</summary>
+    /// <param name="widget">The audio recorder to configure.</param>
+    /// <param name="label">The label text to display when audio is recording.</param>
+    public static AudioRecorder RecordingLabel(this AudioRecorder widget, string label)
+    {
+        return widget with { RecordingLabel = label };
+    }
+
+    /// <summary>Sets the disabled state of the audio recorder.</summary>
+    /// <param name="widget">The audio recorder to configure.</param>
+    /// <param name="disabled">Whether the recorder should be disabled.</param>
+    public static AudioRecorder Disabled(this AudioRecorder widget, bool disabled = true)
+    {
+        return widget with { Disabled = disabled };
+    }
+
+    /// <summary>Sets the mime type used for recorded audio.</summary>
+    /// <param name="widget">The audio recorder to configure.</param>
+    /// <param name="mimeType">Mime type to use (e.g., "audio/webm", "audio/mp3").</param>
+    public static AudioRecorder MimeType(this AudioRecorder widget, string mimeType)
+    {
+        return widget with { MimeType = mimeType };
+    }
+
+    /// <summary>Sets the mime type used for recorded audio.</summary>
+    /// <param name="widget">The audio recorder to configure.</param>
+    /// <param name="chunkInterval">Chunk size to use, in milliseconds. If null, audio will only be uploaded when recording stops.</param>
+    public static AudioRecorder ChunkInterval(this AudioRecorder widget, int? chunkInterval)
+    {
+        return widget with { ChunkInterval = chunkInterval };
+    }
+
+    /// <summary>Sets the upload URL for automatic audio file uploads.</summary>
+    /// <param name="widget">The audio recorder to configure.</param>
+    /// <param name="uploadUrl">The upload URL where audio chunks should automatically be uploaded.</param>
+    public static AudioRecorder UploadUrl(this AudioRecorder widget, string? uploadUrl)
+    {
+        return widget with { UploadUrl = uploadUrl };
+    }
+}

--- a/frontend/src/widgets/AudioRecorderWidget.tsx
+++ b/frontend/src/widgets/AudioRecorderWidget.tsx
@@ -1,0 +1,232 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { Mic, Square } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { getWidth } from '@/lib/styles';
+import { logger } from '@/lib/logger';
+
+interface AudioRecorderWidgetProps {
+  label?: string;
+  recordingLabel?: string;
+  mimeType: string
+  disabled: boolean;
+  events: string[];
+  width?: string;
+  uploadUrl: string;
+  chunkInterval: number;
+}
+
+export const AudioRecorderWidget: React.FC<AudioRecorderWidgetProps> = ({
+  label,
+  recordingLabel,
+  mimeType,
+  disabled,
+  width,
+  uploadUrl,
+  chunkInterval,
+}) => {
+  const uploadChunk = useCallback(
+    async (chunk: Blob): Promise<void> => {
+      if (!uploadUrl) return;
+
+      // Get the correct host from meta tag or use relative URL
+      const getUploadUrl = () => {
+        const ivyHostMeta = document.querySelector('meta[name="ivy-host"]');
+        if (ivyHostMeta) {
+          const host = ivyHostMeta.getAttribute('content');
+          return host + uploadUrl;
+        }
+        // If no meta tag, use relative URL (should work in production)
+        return uploadUrl;
+      };
+
+      const formData = new FormData();
+      formData.append('file', chunk);
+
+      try {
+        const response = await fetch(getUploadUrl(), {
+          method: 'POST',
+          body: formData,
+        });
+
+        if (!response.ok) {
+          throw new Error(`Upload failed: ${response.statusText}`);
+        }
+      } catch (error) {
+        logger.error('File upload error:', error);
+      }
+    },
+    [uploadUrl]
+  );
+
+  const [recording, setRecording] = useState(false);
+  const [error, setError] = useState(false);
+
+  const [recordingStartedAt, setRecordingStartedAt] = useState<number | null>(
+    null
+  );
+  const [recordingStoppedAt, setRecordingStoppedAt] = useState<number | null>(
+    null
+  );
+
+  const [volume, setVolume] = useState(0);
+
+  useEffect(() => {
+    if (!recording) {
+      return;
+    }
+    setRecordingStartedAt(null);
+    setRecordingStoppedAt(null);
+
+    let cancelled = false;
+    let onCancel = () => {};
+    (async () => {
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({
+          audio: true,
+        });
+        if (cancelled) {
+          return;
+        }
+        const mediaRecorder = new MediaRecorder(stream, {
+          mimeType,
+        });
+
+        mediaRecorder.ondataavailable = async event => {
+          if (event.data.size > 0) {
+            await uploadChunk(event.data);
+          }
+        };
+
+        mediaRecorder.start(chunkInterval);
+        setRecordingStartedAt(Date.now());
+
+        const audioContext = new AudioContext();
+        const source = audioContext.createMediaStreamSource(stream);
+        const analyser = audioContext.createAnalyser();
+        analyser.fftSize = 256;
+        source.connect(analyser);
+        const dataArray = new Uint8Array(analyser.frequencyBinCount);
+        const updateVolume = () => {
+          if (cancelled) return;
+          analyser.getByteFrequencyData(dataArray);
+          const avg = dataArray.reduce((a, b) => a + b, 0) / dataArray.length;
+          setVolume(avg); // Range: 0 - 255
+          requestAnimationFrame(updateVolume);
+        };
+        updateVolume();
+
+        onCancel = () => {
+          mediaRecorder.stop();
+          stream.getTracks().forEach(track => track.stop());
+          audioContext.close();
+        };
+      } catch (err) {
+        logger.error('Error accessing microphone:', err);
+        setError(true);
+        setRecording(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+      onCancel();
+      setRecordingStoppedAt(Date.now());
+    };
+  }, [recording, chunkInterval, uploadChunk]);
+
+  const volumePercent = recording ? Math.min(volume / 255, 1) * 100 : 0;
+
+  return (
+    <div className="relative" style={{ ...getWidth(width) }}>
+      <div
+        className={cn(
+          'relative rounded-md border-2 border-dashed transition-colors border-muted-foreground/25 p-4 w-30',
+          disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'
+        )}
+        onClick={
+          disabled
+            ? undefined
+            : e => {
+                e.stopPropagation();
+                if (recording) {
+                  setRecording(false);
+                } else {
+                  setRecording(true);
+                  setError(false);
+                }
+              }
+        }
+      >
+        <div
+          className="absolute bottom-0 left-0 w-full transition-all duration-100 ease-linear"
+          style={{
+            backgroundColor: 'rgba(255,0,0,0.075)',
+            height: `${volumePercent}%`,
+            pointerEvents: 'none',
+            transition: 'height 50ms',
+          }}
+        />
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="mt-2 h-6 w-fit z-10 mx-auto block"
+        >
+          {recording ? (
+            <Square className="h-4 w-4" />
+          ) : (
+            <Mic className="h-4 w-4" />
+          )}
+        </Button>
+        <SecondsCounter
+          start={recordingStartedAt}
+          stopped={recordingStoppedAt}
+        />
+        {(label || recordingLabel) && (
+          <p className="text-sm text-center mt-1 text-muted-foreground">
+            {recording ? recordingLabel : label}
+          </p>
+        )}
+        {error && (
+          <p className="text-sm text-muted-foreground text-center">
+            Failed to record. Check your settings.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+function SecondsCounter(props: {
+  start: number | null;
+  stopped: number | null;
+}) {
+  const [seconds, setSeconds] = useState(0);
+  useEffect(() => {
+    if (typeof props.start !== 'number') {
+      setSeconds(0);
+      return;
+    }
+    if (typeof props.stopped === 'number') {
+      setSeconds(Math.floor((props.stopped - props.start) / 1000));
+      return;
+    }
+    const start = props.start;
+    const interval = setInterval(() => {
+      setSeconds(Math.floor((Date.now() - start) / 1000));
+    }, 100);
+    return () => {
+      clearInterval(interval);
+    };
+  }, [props.start, props.stopped]);
+  return (
+    <p className="text-center">
+      {Math.floor(seconds / 60)
+        .toString()
+        .padStart(2, '0')}
+      :{(seconds % 60).toString().padStart(2, '0')}
+    </p>
+  );
+}
+
+export default AudioRecorderWidget;

--- a/frontend/src/widgets/AudioRecorderWidget.tsx
+++ b/frontend/src/widgets/AudioRecorderWidget.tsx
@@ -8,7 +8,7 @@ import { logger } from '@/lib/logger';
 interface AudioRecorderWidgetProps {
   label?: string;
   recordingLabel?: string;
-  mimeType: string
+  mimeType: string;
   disabled: boolean;
   events: string[];
   width?: string;

--- a/frontend/src/widgets/widgetMap.ts
+++ b/frontend/src/widgets/widgetMap.ts
@@ -89,6 +89,9 @@ export const widgetMap = {
   'Ivy.CodeInput': React.lazy(
     () => import('@/widgets/inputs/code/CodeInputWidget')
   ),
+  'Ivy.AudioRecorder': React.lazy(
+    () => import('@/widgets/AudioRecorderWidget')
+  ),
 
   // Forms
   'Ivy.Form': Forms.FormWidget,


### PR DESCRIPTION
Implements an audio recorder widget, for #769.

The widget supports streaming uploads so that if client is at any point disconnected the so-far uploaded data can still be played.

When recording, the widget displays the volume input to give feedback to the user that the microphone is picking up the audio.

<img width="298" height="300" alt="Screenshot from 2025-09-09 19-32-48" src="https://github.com/user-attachments/assets/142b9353-3b22-4fea-82ac-0a06058df317" />
<img width="298" height="300" alt="Screenshot from 2025-09-09 19-32-57" src="https://github.com/user-attachments/assets/2e3d6066-dd57-4f4b-8841-6ad739c9e215" />
