### PR TITLE
(jobs): typography updates, smaller fonts

### DIFF
--- a/frontend/src/widgets/primitives/TextBlockWidget.tsx
+++ b/frontend/src/widgets/primitives/TextBlockWidget.tsx
@@ -118,7 +118,7 @@ const variantMap: VariantMap = {
   ),
   Muted: ({ children, className, style }) => (
     <div
-      className={cn('text-large-body text-muted-foreground', className)}
+      className={cn('text-sm text-muted-foreground', className)}
       style={style}
     >
       {children}


### PR DESCRIPTION
This pull request makes a small change to the `TextBlockWidget.tsx` component, updating the font size for the `Muted` text variant to use the `text-sm` class instead of `text-large-body`. This change ensures muted text appears smaller and more consistent with typical UI patterns.