### PR TITLE
(default-chrome): better gaps in header

### DIFF
--- a/Ivy/Chrome/DefaultSidebarChrome.cs
+++ b/Ivy/Chrome/DefaultSidebarChrome.cs
@@ -284,7 +284,7 @@ public class DefaultSidebarChrome(ChromeSettings settings) : ViewBase
         return new SidebarLayout(
             body ?? null!,
             sidebarMenu,
-            Layout.Vertical()
+            Layout.Vertical().Gap(2)
                 | settings.Header
                 | searchInput
             ,


### PR DESCRIPTION
This pull request introduces a minor UI improvement to the sidebar layout in `DefaultSidebarChrome.cs`. The change adds a small vertical gap between elements in the sidebar for better visual separation.

* UI enhancement: Added a `.Gap(2)` to the `Layout.Vertical()` call in the sidebar layout, which increases spacing between stacked components.