### PR TITLE
(docs): fix incorrect paths for docs regen instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,14 +69,14 @@ If you want to work on the framework itself, you need to set up the following:
    **Windows (PowerShell):**
 
    ```powershell
-   cd Ivy.Docs
+   cd Ivy.Docs.Shared
    .\Regenerate.ps1
    ```
 
    **Mac/Linux (Bash):**
 
    ```bash
-   cd Ivy.Docs
+   cd Ivy.Docs.Shared
    sh ./Regenerate.sh
    ```
 


### PR DESCRIPTION
Updated the path from `cd Ivy.Docs` to `cd Ivy.Docs.Shared` in the documentation generation instructions.

This change ensures that users follow the correct steps when generating documentation files.