### PR TITLE
chore: forms allow full width elements

### DIFF
--- a/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/Forms.md
+++ b/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/Forms.md
@@ -184,6 +184,45 @@ public class LayoutControlExample : ViewBase
 }
 ```
 
+### Full-Width Fields
+
+Use `.PlaceFullWidth()` to make fields span the entire form width across all columns.
+
+```csharp demo-tabs
+public class FullWidthFieldsExample : ViewBase
+{
+    public record ProductModel(
+        string Name,
+        string Category,
+        decimal Price,
+        string Description,
+        string Tags,
+        string Notes
+    );
+
+    public override object? Build()
+    {
+        var product = UseState(() => new ProductModel("", "", 0.0m, "", "", ""));
+        
+        return product.ToForm()
+            .Place(m => m.Name)                      // First column
+            .Place(1, m => m.Category, m => m.Price) // Second column
+            .PlaceFullWidth(m => m.Description)      // Full width
+            .PlaceFullWidth(m => m.Tags)             // Full width
+            .PlaceFullWidth(m => m.Notes)            // Full width
+            .Builder(m => m.Description, s => s.ToTextAreaInput())
+            .Builder(m => m.Tags, s => s.ToTextAreaInput())
+            .Builder(m => m.Notes, s => s.ToTextAreaInput())
+            .Label(m => m.Name, "Product Name")
+            .Label(m => m.Category, "Category")
+            .Label(m => m.Price, "Price")
+            .Label(m => m.Description, "Product Description")
+            .Label(m => m.Tags, "Tags (comma-separated)")
+            .Label(m => m.Notes, "Additional Notes");
+    }
+}
+```
+
 ### Grouped Fields
 
 Organize related fields into logical groups using `.Group()`.

--- a/Ivy.Samples.Shared/Apps/Concepts/FormApp.cs
+++ b/Ivy.Samples.Shared/Apps/Concepts/FormApp.cs
@@ -71,6 +71,14 @@ public record DatabaseGeneratorModel(
 public record UserModel(
     string Name, string Password, bool IsAwesome, DateTime BirthDate, int Height, int UserId = 123, Gender Gender = Gender.Male, string Json = "{}", List<Fruits> FavoriteFruits = null!);
 
+public record ProductTestModel(
+    string Name,
+    string Category,
+    decimal Price,
+    string Description,
+    string Notes
+);
+
 [App(icon: Icons.Clipboard)]
 public class FormApp : SampleBase
 {
@@ -143,6 +151,34 @@ public class FormApp : SampleBase
             ).Width(1 / 2f)
         );
 
+        // Full-width field test
+        var productModel = UseState(() => new ProductTestModel("", "", 0.0m, "", ""));
+
+        FormBuilder<ProductTestModel> BuildProductForm(IState<ProductTestModel> x) =>
+            x.ToForm()
+                .Place(m => m.Name)                      // First column
+                .Place(1, m => m.Category, m => m.Price) // Second column
+                .PlaceFullWidth(m => m.Description)      // Full width
+                .PlaceFullWidth(m => m.Notes)            // Full width
+                .Builder(m => m.Description, s => s.ToTextAreaInput())
+                .Builder(m => m.Notes, s => s.ToTextAreaInput())
+                .Label(m => m.Name, "Product Name")
+                .Label(m => m.Category, "Category")
+                .Label(m => m.Price, "Price")
+                .Label(m => m.Description, "Product Description")
+                .Label(m => m.Notes, "Additional Notes");
+
+        var fullWidthForm = Layout.Horizontal(
+            new Card(
+                    BuildProductForm(productModel)
+                )
+                .Width(1 / 2f)
+                .Title("Full-Width Fields Test"),
+            new Card(
+                productModel.ToDetails()
+            ).Width(1 / 2f)
+        );
+
         return Layout.Vertical()
                | (Layout.Horizontal()
                   | new Button("Open in Sheet").ToTrigger((isOpen) => BuildForm(model).ToSheet(isOpen, "User Information", "Please fill in the form."))
@@ -152,6 +188,9 @@ public class FormApp : SampleBase
                | new Separator()
                | Text.H3("Database Generator Form Test")
                | databaseForm
+               | new Separator()
+               | Text.H3("Full-Width Fields Test")
+               | fullWidthForm
             ;
     }
 }

--- a/Ivy/Views/Forms/FormBuilder.cs
+++ b/Ivy/Views/Forms/FormBuilder.cs
@@ -472,6 +472,21 @@ public class FormBuilder<TModel> : ViewBase
     }
 
     /// <summary>
+    /// Places the specified fields to span the full width across all columns.
+    /// </summary>
+    /// <param name="fields">The fields to place at full width.</param>
+    /// <returns>The form builder instance for method chaining.</returns>
+    /// <remarks>
+    /// Full-width fields are rendered separately from the column layout and span the entire
+    /// form width. They are useful for fields like text areas, long descriptions, or other
+    /// content that benefits from maximum horizontal space.
+    /// </remarks>
+    public FormBuilder<TModel> PlaceFullWidth(params Expression<Func<TModel, object>>[] fields)
+    {
+        return _Place(-1, null, fields); // Use -1 to indicate full width
+    }
+
+    /// <summary>
     /// Groups the specified fields under a named section in the specified column.
     /// </summary>
     /// <param name="group">The name of the group for organizing related fields.</param>


### PR DESCRIPTION
This pull request adds support for full-width fields in forms, allowing certain fields to span the entire width of the form regardless of column layout. It introduces the `.PlaceFullWidth()` method for form builders, updates the rendering logic to handle these fields, and provides documentation and sample usage to demonstrate the feature.

### Full-width field support

* Added the `.PlaceFullWidth()` method to `FormBuilder<TModel>`, allowing developers to specify fields that should span all columns in a form.
* Updated the form rendering logic in `FormView<TModel>` to separate full-width fields from regular column fields and display them appropriately, including handling grouped full-width fields. [[1]](diffhunk://#diff-b3491b86e836d973fe9c87b136c57c96151656265fd9c2197ff6ee3292dc6485L228-R237) [[2]](diffhunk://#diff-b3491b86e836d973fe9c87b136c57c96151656265fd9c2197ff6ee3292dc6485L242-R286)
* Improved documentation comments in `FormView.cs` to reflect support for full-width fields.

### Documentation and sample usage

* Added a new section to the onboarding documentation (`Forms.md`) demonstrating how to use `.PlaceFullWidth()` with a sample form.
* Introduced a new `ProductTestModel` and corresponding sample in `FormApp.cs` to showcase full-width field usage in practice. [[1]](diffhunk://#diff-da1b703b4c32b55afabf60e2f510274db7282076aa1aaae07b420a2e2aa3de76R74-R81) [[2]](diffhunk://#diff-da1b703b4c32b55afabf60e2f510274db7282076aa1aaae07b420a2e2aa3de76R154-R181) [[3]](diffhunk://#diff-da1b703b4c32b55afabf60e2f510274db7282076aa1aaae07b420a2e2aa3de76R191-R193)