### PR TITLE
(forms): better use cases of Place

### DIFF
--- a/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/Forms.md
+++ b/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/Forms.md
@@ -172,9 +172,9 @@ public class LayoutControlExample : ViewBase
         var address = UseState(() => new AddressModel("", "", "", "", ""));
         
         return address.ToForm()
-            .Place(m => m.Street)                    // First column
-            .Place(1, m => m.City, m => m.State)    // Second column, same row
-            .Place(1, m => m.ZipCode, m => m.Country) // Second column, same row
+            .Place(m => m.Street)                    // Single field spans full width
+            .Place(true, m => m.City, m => m.State)  // Two fields side-by-side, sharing row width
+            .Place(true, m => m.ZipCode, m => m.Country) // Two fields side-by-side, sharing row width
             .Label(m => m.Street, "Street Address")
             .Label(m => m.City, "City")
             .Label(m => m.State, "State/Province")

--- a/Ivy/Views/Forms/FormBuilder.cs
+++ b/Ivy/Views/Forms/FormBuilder.cs
@@ -348,36 +348,36 @@ public class FormBuilder<TModel> : ViewBase
         return this;
     }
 
-    /// <summary>Places specified fields in given column with automatic vertical ordering.</summary>
+    /// <summary>Places specified fields vertically in the given column with automatic ordering.</summary>
     /// <param name="col">Zero-based column index where fields should be placed.</param>
-    /// <param name="fields">Fields to place in specified column.</param>
+    /// <param name="fields">Fields to place vertically in the specified column.</param>
     /// <returns>Form builder instance for method chaining.</returns>
     public FormBuilder<TModel> Place(int col, params Expression<Func<TModel, object>>[] fields)
     {
         return _Place(col, null, fields);
     }
 
-    /// <summary>Places specified fields in first column (column 0) with automatic vertical ordering.</summary>
-    /// <param name="fields">Fields to place in first column.</param>
+    /// <summary>Places specified fields vertically in the first column (column 0) with automatic ordering.</summary>
+    /// <param name="fields">Fields to place vertically in the first column.</param>
     /// <returns>Form builder instance for method chaining.</returns>
     public FormBuilder<TModel> Place(params Expression<Func<TModel, object>>[] fields)
     {
         return _Place(0, null, fields);
     }
 
-    /// <summary>Places specified fields with optional horizontal row grouping.</summary>
-    /// <param name="row">Whether to group fields in same horizontal row.</param>
-    /// <param name="fields">Fields to place, optionally in same row.</param>
+    /// <summary>Places specified fields horizontally side-by-side when row is true, or vertically when false.</summary>
+    /// <param name="row">True to arrange fields side-by-side in the same row; false to stack vertically.</param>
+    /// <param name="fields">Fields to arrange. When row is true, fields will be distributed evenly across the row width.</param>
     /// <returns>Form builder instance for method chaining.</returns>
     public FormBuilder<TModel> Place(bool row, params Expression<Func<TModel, object>>[] fields)
     {
         return _Place(0, row ? Guid.NewGuid() : null, fields);
     }
 
-    /// <summary>Places specified fields in specific column with optional horizontal row grouping.</summary>
+    /// <summary>Places specified fields in a specific column, optionally arranging them horizontally side-by-side.</summary>
     /// <param name="col">Zero-based column index where fields should be placed.</param>
-    /// <param name="row">Whether to group fields in same horizontal row.</param>
-    /// <param name="fields">Fields to place in specified column and optional row.</param>
+    /// <param name="row">True to arrange fields side-by-side in the same row; false to stack vertically in the column.</param>
+    /// <param name="fields">Fields to place in the specified column. When row is true, fields will share the same row.</param>
     /// <returns>Form builder instance for method chaining.</returns>
     public FormBuilder<TModel> Place(int col, bool row, params Expression<Func<TModel, object>>[] fields)
     {

--- a/frontend/src/widgets/forms/FormFieldWidget.tsx
+++ b/frontend/src/widgets/forms/FormFieldWidget.tsx
@@ -14,7 +14,7 @@ export const FormFieldWidget: React.FC<FormFieldWidgetProps> = ({
   required,
   children,
 }) => (
-  <div className="flex flex-col gap-2">
+  <div className="flex flex-col gap-2 flex-1 min-w-0">
     {label && (
       <label className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
         {label} {required && <span className="font-mono text-primary">*</span>}


### PR DESCRIPTION
This pull request updates the form layout logic and documentation to clarify and improve how fields are arranged in forms, both in backend form builder methods and frontend rendering. The changes make the intent of horizontal and vertical field placement more explicit, improve code comments, and enhance the flexibility of form layouts.

**Form layout API improvements:**

* Updated the documentation and method signatures in `FormBuilder.cs` to clarify the difference between vertical stacking and horizontal side-by-side arrangement of fields using the `Place` methods. The new comments make it clear when fields are distributed across a row or stacked in a column.

**Form layout usage and examples:**

* Changed the example usage in `Forms.md` to use the new `Place(true, ...)` syntax for arranging fields side-by-side in the same row, replacing the previous column-based approach. This makes the example align with the updated API and better demonstrates horizontal field grouping.

**Frontend layout rendering:**

* Modified the container `div` in `FormFieldWidget.tsx` to include `flex-1 min-w-0`, allowing form fields to better share available space and prevent overflow issues when fields are arranged side-by-side.