### PR TITLE
(piechart): design rework to better display totals

### DIFF
--- a/Ivy.Samples.Shared/Apps/Demos/DashboardApp.cs
+++ b/Ivy.Samples.Shared/Apps/Demos/DashboardApp.cs
@@ -24,10 +24,11 @@ public class DashboardApp : ViewBase
                                     | new MetricView("System Health", Icons.Activity, () => Task.FromResult(new MetricRecord("99.9%", null, 0.99, "100% uptime")))
                                     )
 
-                                 | (Layout.Grid().Columns(3)
+                                 | (Layout.Grid().Columns(4)
                                     | new BrowsersView()
                                     | new MonthlyRevenueTrendView()
                                     | new MonthlyRevenueDistributionView()
+                                    | new DonutChartWithCustomLabelsView()
                                     )
 
                                  | (Layout.Grid().Columns(4)
@@ -121,5 +122,52 @@ public class BrowsersView : ViewBase
         };
 
         return new Card().Title("Browser Composition").Height("100%") | data.ToPieChart(e => e.Name, e => e.Sum(f => f.Value), PieChartStyles.Dashboard);
+    }
+}
+
+public class DonutChartWithCustomLabelsView : ViewBase
+{
+    public override object? Build()
+    {
+        var data = new[]
+        {
+            new PieChartData("Revenue", 1250000),
+            new PieChartData("Marketing", 450000),
+            new PieChartData("Operations", 320000),
+            new PieChartData("R&D", 280000),
+            new PieChartData("Admin", 150000),
+            new PieChartData("Sales", 380000),
+            new PieChartData("Customer Support", 220000),
+            new PieChartData("IT Infrastructure", 180000),
+            new PieChartData("Legal", 95000),
+            new PieChartData("HR", 120000),
+            new PieChartData("Finance", 160000),
+            new PieChartData("Quality Assurance", 140000)
+        };
+
+        var totalValue = data.Sum(d => d.Measure);
+
+        return new Card().Title("Donut Chart with Custom Labels").Height("100%")
+            | new PieChart(data)
+                .Pie(new Pie(nameof(PieChartData.Measure), nameof(PieChartData.Dimension))
+                    .InnerRadius("40%")
+                    .OuterRadius("90%")
+                    .Animated(true)
+                    .LabelList(new LabelList(nameof(PieChartData.Measure))
+                        .Position(Positions.Outside)
+                        .Fill(Colors.Blue)
+                        .FontSize(11)
+                        .NumberFormat("$0,0"))
+                    .LabelList(new LabelList(nameof(PieChartData.Dimension))
+                        .Position(Positions.Inside)
+                        .Fill(Colors.White)
+                        .FontSize(9)
+                        .FontFamily("Arial"))
+                )
+                .ColorScheme(ColorScheme.Default)
+                .Tooltip(new Ivy.Charts.Tooltip().Animated(true))
+                .Legend(new Legend().IconType(Legend.IconTypes.Rect))
+                .Total(totalValue, "Total Budget")
+        ;
     }
 }

--- a/frontend/src/widgets/charts/PieChartWidget.tsx
+++ b/frontend/src/widgets/charts/PieChartWidget.tsx
@@ -1,13 +1,5 @@
 import React from 'react';
-import {
-  Legend,
-  LegendProps,
-  Pie,
-  PieChart,
-  Cell,
-  LabelList,
-  Label,
-} from 'recharts';
+import { Legend, LegendProps, Pie, PieChart, Cell, LabelList } from 'recharts';
 import {
   ChartConfig,
   ChartContainer,
@@ -65,72 +57,54 @@ const PieChartWidget: React.FC<PieChartWidgetProps> = ({
   const [colorGenerator] = getColorGenerator(colorScheme);
 
   return (
-    <ChartContainer config={chartConfig} style={styles}>
-      <PieChart
-        margin={{ top: 10, right: 10, bottom: 10, left: 10 }}
-        accessibilityLayer
-      >
-        {legend && <Legend {...generateLegendProps(legend)} />}
+    <div style={styles}>
+      {total && (
+        <div className="text-center">
+          <div className="text-xl font-bold text-foreground">
+            {total.formattedValue}
+          </div>
+          <div className="text-sm text-muted-foreground">{total.label}</div>
+        </div>
+      )}
+      <ChartContainer config={chartConfig}>
+        <PieChart
+          margin={{ top: 10, right: 10, bottom: 10, left: 10 }}
+          accessibilityLayer
+        >
+          {legend && <Legend {...generateLegendProps(legend)} />}
 
-        {tooltip && (
-          <ChartTooltip
-            cursor={false}
-            isAnimationActive={tooltip?.animated}
-            content={<ChartTooltipContent />}
-          />
-        )}
+          {tooltip && (
+            <ChartTooltip
+              cursor={false}
+              isAnimationActive={tooltip?.animated}
+              content={<ChartTooltipContent />}
+            />
+          )}
 
-        {pies?.map((props, pieIndex) => (
-          <Pie data={data} key={`pie${pieIndex}`} {...generatePieProps(props)}>
-            {data.map((_, dataIndex) => (
-              <Cell
-                key={`cell-${dataIndex}`}
-                fill={colorGenerator(dataIndex)}
-              />
-            ))}
+          {pies?.map((props, pieIndex) => (
+            <Pie
+              data={data}
+              key={`pie${pieIndex}`}
+              {...generatePieProps(props)}
+            >
+              {data.map((_, dataIndex) => (
+                <Cell
+                  key={`cell-${dataIndex}`}
+                  fill={colorGenerator(dataIndex)}
+                />
+              ))}
 
-            {props.labelLists?.map((labelList, labelListIndex) => (
-              <LabelList
-                key={`labelList-${labelListIndex}`}
-                {...generateLabelListProps(labelList)}
-              />
-            ))}
-
-            {pieIndex === 0 && total && (
-              <Label
-                content={({ viewBox }) => {
-                  if (viewBox && 'cx' in viewBox && 'cy' in viewBox) {
-                    return (
-                      <text
-                        x={viewBox.cx}
-                        y={viewBox.cy}
-                        textAnchor="middle"
-                        dominantBaseline="middle"
-                      >
-                        <tspan
-                          x={viewBox.cx}
-                          y={viewBox.cy}
-                          className="fill-foreground text-3xl font-bold"
-                        >
-                          {total.formattedValue}
-                        </tspan>
-                        <tspan
-                          x={viewBox.cx}
-                          y={(viewBox.cy || 0) + 24}
-                          className="fill-muted-foreground"
-                        >
-                          {total.label}
-                        </tspan>
-                      </text>
-                    );
-                  }
-                }}
-              />
-            )}
-          </Pie>
-        ))}
-      </PieChart>
-    </ChartContainer>
+              {props.labelLists?.map((labelList, labelListIndex) => (
+                <LabelList
+                  key={`labelList-${labelListIndex}`}
+                  {...generateLabelListProps(labelList)}
+                />
+              ))}
+            </Pie>
+          ))}
+        </PieChart>
+      </ChartContainer>
+    </div>
   );
 };
 


### PR DESCRIPTION
This pull request adds a new donut chart view to the dashboard and refactors the frontend pie chart widget to improve how the total value and label are displayed. The main changes are the introduction of a new chart component for displaying budget breakdowns with custom labels, and a frontend update to show the total value and label outside of the chart for better clarity and flexibility.

**Dashboard enhancements:**

* Added a new `DonutChartWithCustomLabelsView` to the dashboard, providing a detailed budget breakdown with custom inner and outer labels, color scheme, legend, and animated tooltip.
* Updated the dashboard layout to include the new donut chart, expanding the grid from 3 to 4 columns for better visual balance.

**Frontend chart widget improvements:**

* Refactored `PieChartWidget.tsx` to display the total value and label above the chart, outside the chart area, improving readability and layout flexibility.
* Removed the previous approach of rendering the total value and label inside the chart using a custom `<Label>`, and adjusted the chart rendering logic accordingly.
* Cleaned up imports in `PieChartWidget.tsx` by removing unused components for a more concise codebase.

**Other frontend adjustments:**

* Improved chart rendering by ensuring that pie props and label lists are correctly applied per pie, supporting more customization and future extensibility.