### PR TITLE
(codex): provide xml docs in build

### DIFF
--- a/Ivy.Analyser/Ivy.Analyser.csproj
+++ b/Ivy.Analyser/Ivy.Analyser.csproj
@@ -19,6 +19,7 @@
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <NoWarn>$(NoWarn);RS2007;RS2008</NoWarn>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Ivy.Auth.Auth0/Ivy.Auth.Auth0.csproj
+++ b/Ivy.Auth.Auth0/Ivy.Auth.Auth0.csproj
@@ -14,6 +14,7 @@
     <RepositoryUrl>https://github.com/Ivy-Interactive/Ivy</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Ivy.Auth.Authelia/Ivy.Auth.Authelia.csproj
+++ b/Ivy.Auth.Authelia/Ivy.Auth.Authelia.csproj
@@ -14,6 +14,7 @@
     <RepositoryUrl>https://github.com/Ivy-Interactive/Ivy</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Ivy.Auth.MicrosoftEntra/Ivy.Auth.MicrosoftEntra.csproj
+++ b/Ivy.Auth.MicrosoftEntra/Ivy.Auth.MicrosoftEntra.csproj
@@ -14,6 +14,7 @@
     <RepositoryUrl>https://github.com/Ivy-Interactive/Ivy</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Ivy.Auth.Supabase/Ivy.Auth.Supabase.csproj
+++ b/Ivy.Auth.Supabase/Ivy.Auth.Supabase.csproj
@@ -14,6 +14,7 @@
     <RepositoryUrl>https://github.com/Ivy-Interactive/Ivy</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Ivy.Database.Generator.Toolkit/Ivy.Database.Generator.Toolkit.csproj
+++ b/Ivy.Database.Generator.Toolkit/Ivy.Database.Generator.Toolkit.csproj
@@ -15,6 +15,7 @@
     <RepositoryUrl>https://github.com/Ivy-Interactive/Ivy</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Ivy/Ivy.csproj
+++ b/Ivy/Ivy.csproj
@@ -14,6 +14,7 @@
     <RepositoryUrl>https://github.com/Ivy-Interactive/Ivy</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
This pull request updates several project files to enable XML documentation generation for their respective assemblies. This change will ensure that documentation files are produced during builds, which can be useful for consumers of the libraries and for maintaining code quality.

Documentation generation:

* Added `<GenerateDocumentationFile>true</GenerateDocumentationFile>` to the project files for `Ivy.Analyser`, `Ivy.Auth.Auth0`, `Ivy.Auth.Authelia`, `Ivy.Auth.MicrosoftEntra`, `Ivy.Auth.Supabase`, `Ivy.Database.Generator.Toolkit`, and `Ivy` to enable XML documentation output. [[1]](diffhunk://#diff-72338ace5c0f4dd75ffeae758a4723b4d74fab6d852336a3838431e34a9ae95aR22) [[2]](diffhunk://#diff-f793d99e40c229c1370241b775fd0f8360f0d5e653550247929e738aff0e9386R17) [[3]](diffhunk://#diff-4b4c6594e057ad81b6e4445c297eef55c535e26bf0af46cb9b7211663edae72bR17) [[4]](diffhunk://#diff-8d458cd6cb7c0d8f5c0e83e5dce066630f8c537980dec7f742aee6fe554aaecfR17) [[5]](diffhunk://#diff-25f62689bb32d55b03cfef6c923613da1427bda71f264466f8c4d89ad30700f3R17) [[6]](diffhunk://#diff-31fe8c7172d12c9cdd41782d4d1217a4ffdc6b3b7d84443d95f54ac63a2bfb80R18) [[7]](diffhunk://#diff-597c71914330918d12614084047603f14e52ae382240e6f033a722c81fc7b272R17)