### PR TITLE
(ui/ux): (tabs): better align toggle button

### DIFF
--- a/frontend/src/widgets/layouts/TabsLayoutWidget.tsx
+++ b/frontend/src/widgets/layouts/TabsLayoutWidget.tsx
@@ -857,7 +857,7 @@ export const TabsLayoutWidget = ({
                 ref={tabsListRef}
                 useRadix={useRadix}
                 className="relative h-auto w-full gap-0.5 bg-transparent p-0 flex justify-start flex-nowrap"
-                style={{ marginTop: '15px' }}
+                style={{ marginTop: '16px' }}
               >
                 {orderedTabWidgets.map(tabWidget => {
                   if (!React.isValidElement(tabWidget)) return null;

--- a/frontend/src/widgets/layouts/TabsLayoutWidget.tsx
+++ b/frontend/src/widgets/layouts/TabsLayoutWidget.tsx
@@ -856,7 +856,8 @@ export const TabsLayoutWidget = ({
               <TabsList
                 ref={tabsListRef}
                 useRadix={useRadix}
-                className="relative h-auto w-full gap-0.5 mt-4 bg-transparent p-0 flex justify-start flex-nowrap"
+                className="relative h-auto w-full gap-0.5 bg-transparent p-0 flex justify-start flex-nowrap"
+                style={{ marginTop: '15px' }}
               >
                 {orderedTabWidgets.map(tabWidget => {
                   if (!React.isValidElement(tabWidget)) return null;

--- a/frontend/src/widgets/layouts/TabsLayoutWidget.tsx
+++ b/frontend/src/widgets/layouts/TabsLayoutWidget.tsx
@@ -856,7 +856,7 @@ export const TabsLayoutWidget = ({
               <TabsList
                 ref={tabsListRef}
                 useRadix={useRadix}
-                className="relative h-auto w-full gap-0.5 mt-2.5 bg-transparent p-0 flex justify-start flex-nowrap"
+                className="relative h-auto w-full gap-0.5 mt-4 bg-transparent p-0 flex justify-start flex-nowrap"
               >
                 {orderedTabWidgets.map(tabWidget => {
                   if (!React.isValidElement(tabWidget)) return null;

--- a/frontend/src/widgets/layouts/sidebar/SidebarLayoutWidget.tsx
+++ b/frontend/src/widgets/layouts/sidebar/SidebarLayoutWidget.tsx
@@ -181,9 +181,9 @@ export const SidebarLayoutWidget: React.FC<SidebarLayoutWidgetProps> = ({
       {showToggleButton && mainAppSidebar && (
         <button
           onClick={handleManualToggle}
-          className="absolute top-2 z-50 p-2 rounded-md bg-background hover:bg-sidebar-accent hover:text-accent-foreground cursor-pointer transition-all duration-200"
+          className="absolute top-3 z-50 p-2 rounded-md bg-background hover:bg-sidebar-accent hover:text-accent-foreground cursor-pointer transition-all duration-200"
           style={{
-            left: isSidebarOpen ? 'calc(16rem + 8px)' : '8px',
+            left: isSidebarOpen ? 'calc(16rem + 9px)' : '9px',
             transition: 'left 300ms ease-in-out',
             transform: 'translateX(0)', // Ensure button moves with its parent sidebar
           }}


### PR DESCRIPTION
This pull request makes minor UI adjustments to spacing and positioning in the tab and sidebar layouts to improve visual alignment.

*Tabs layout spacing:*
- Increased the top margin of the `TabsList` component in `TabsLayoutWidget.tsx` from `mt-2.5` to `mt-4` for improved spacing above the tabs.

*Sidebar toggle button positioning:*
- Adjusted the top margin of the sidebar toggle button from `top-2` to `top-3` and shifted its left position by 1px (from `8px`/`calc(16rem + 8px)` to `9px`/`calc(16rem + 9px)`) for better alignment with the sidebar.