### PR TITLE
[DropDownMenu]: fix subcontent overlay

### DIFF
--- a/frontend/src/components/ui/dropdown-menu.tsx
+++ b/frontend/src/components/ui/dropdown-menu.tsx
@@ -45,7 +45,7 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      'z-[50] min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+      'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
       className
     )}
     sideOffset={8}


### PR DESCRIPTION
Here is how it was: 
<img width="743" height="630" alt="Screenshot 2025-09-19 at 22 25 15" src="https://github.com/user-attachments/assets/6245c6fd-ee5a-4e68-8eef-bbfce39d8019" />

Fixed one:

<img width="788" height="506" alt="Screenshot 2025-09-19 at 22 54 22" src="https://github.com/user-attachments/assets/af1f1e93-eae9-43b6-991a-1bc6e5809e10" />


Was trying to use minimum of changes to handle it right. 
In the dropdown-menu we already use sideoffset, so I think that's ok to add it as a part of a solution for subcontent.

To check it, go to Ivy.Docs -> DropDown Menu -> Nested Menu Items section