### PR TITLE
(sidebar): remove borders around main content

### DIFF
--- a/frontend/src/widgets/layouts/sidebar/SidebarLayoutWidget.tsx
+++ b/frontend/src/widgets/layouts/sidebar/SidebarLayoutWidget.tsx
@@ -157,7 +157,7 @@ export const SidebarLayoutWidget: React.FC<SidebarLayoutWidgetProps> = ({
         }`}
       >
         {hasContent(slots?.SidebarHeader) && (
-          <div className="flex flex-col shrink-0 border-b p-2 space-y-4">
+          <div className="flex flex-col shrink-0 p-2 space-y-4">
             {slots?.SidebarHeader}
           </div>
         )}
@@ -169,7 +169,7 @@ export const SidebarLayoutWidget: React.FC<SidebarLayoutWidgetProps> = ({
           </div>
         )}
         {hasContent(slots?.SidebarFooter) && (
-          <div className="flex flex-col shrink-0 border-t">
+          <div className="flex flex-col shrink-0">
             <div className="flex flex-col px-4 py-3 gap-4 min-h-0">
               {slots?.SidebarFooter}
             </div>


### PR DESCRIPTION
<img width="1160" height="774" alt="image" src="https://github.com/user-attachments/assets/7075cbae-5f64-4d38-a11f-492dc9fa3ac6" />

This pull request makes minor adjustments to the styling of the sidebar layout widget in the frontend. The changes remove the border styles from the sidebar header and footer sections for a cleaner appearance.