### PR TITLE
chore: remove bg for currently active line

### DIFF
--- a/frontend/src/widgets/inputs/code/theme.ts
+++ b/frontend/src/widgets/inputs/code/theme.ts
@@ -60,10 +60,10 @@ export function createIvyCodeTheme(): Extension {
       borderColor: 'var(--ring)',
     },
     '.cm-activeLine': {
-      backgroundColor: 'var(--accent)',
+      backgroundColor: 'transparent',
     },
     '.cm-activeLineGutter': {
-      backgroundColor: 'var(--accent)',
+      backgroundColor: 'transparent',
     },
     '.cm-activeLineGutter .cm-gutterElement': {
       color: 'var(--foreground)',


### PR DESCRIPTION
This pull request makes a minor adjustment to the code editor theme by changing how the active line is highlighted. The background color for the active line and its gutter is now transparent instead of using the accent color.

* The `backgroundColor` for `.cm-activeLine` and `.cm-activeLineGutter` in `createIvyCodeTheme` was changed from `'var(--accent)'` to `'transparent'` in `frontend/src/widgets/inputs/code/theme.ts`.