### PR TITLE
Add Language.Markdown support to CodeInputWidget

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "@codemirror/lang-html": "^6.4.9",
         "@codemirror/lang-javascript": "^6.2.4",
         "@codemirror/lang-json": "^6.0.2",
+        "@codemirror/lang-markdown": "^6.3.4",
         "@codemirror/lang-python": "^6.2.1",
         "@codemirror/lang-sql": "^6.9.1",
         "@dbml/core": "^3.13.9",
@@ -294,6 +295,21 @@
       "dependencies": {
         "@codemirror/language": "^6.0.0",
         "@lezer/json": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-markdown": {
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-markdown/-/lang-markdown-6.3.4.tgz",
+      "integrity": "sha512-fBm0BO03azXnTAsxhONDYHi/qWSI+uSEIpzKM7h/bkIc9fHnFp9y7KTMXKON0teNT97pFhc1a9DQTtWBYEZ7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.7.1",
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.3.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.2.1",
+        "@lezer/markdown": "^1.0.0"
       }
     },
     "node_modules/@codemirror/lang-python": {
@@ -1307,6 +1323,16 @@
       "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/markdown": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@lezer/markdown/-/markdown-1.4.3.tgz",
+      "integrity": "sha512-kfw+2uMrQ/wy/+ONfrH83OkdFNM0ye5Xq96cLlaCy7h5UT9FO54DU4oRoIc0CSBh5NWmWuiIJA7NGLMJbQ+Oxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0",
+        "@lezer/highlight": "^1.0.0"
       }
     },
     "node_modules/@lezer/python": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "@codemirror/lang-html": "^6.4.9",
     "@codemirror/lang-javascript": "^6.2.4",
     "@codemirror/lang-json": "^6.0.2",
+    "@codemirror/lang-markdown": "^6.3.4",
     "@codemirror/lang-python": "^6.2.1",
     "@codemirror/lang-sql": "^6.9.1",
     "@dbml/core": "^3.13.9",

--- a/frontend/src/widgets/inputs/code/CodeInputWidget.tsx
+++ b/frontend/src/widgets/inputs/code/CodeInputWidget.tsx
@@ -12,6 +12,7 @@ import { sql } from '@codemirror/lang-sql';
 import { html } from '@codemirror/lang-html';
 import { css } from '@codemirror/lang-css';
 import { json } from '@codemirror/lang-json';
+import { markdown } from '@codemirror/lang-markdown';
 import { useEventHandler } from '@/components/event-handler';
 import { cn } from '@/lib/utils';
 import { getHeight, getWidth, inputStyles } from '@/lib/styles';
@@ -48,6 +49,7 @@ const languageExtensions = {
   Css: css,
   Json: json,
   Dbml: dbml,
+  Markdown: markdown,
   Text: undefined,
 };
 


### PR DESCRIPTION
Adds Markdown language support to the CodeInputWidget by:

- Installing `@codemirror/lang-markdown` package
- Adding markdown import and extension to languageExtensions
- Enabling markdown syntax highlighting in CodeInputWidget

Fixes #884

Generated with [Claude Code](https://claude.ai/code)