### PR TITLE
Allow custom submit title in toForm() method

### DIFF
--- a/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/Forms.md
+++ b/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/Forms.md
@@ -265,6 +265,25 @@ public class FieldManagementExample : ViewBase
 
 ## Validation
 
+### Custom Submit Text
+
+Change the text of the submit button by passing it as parameter of the `.toForm()` method
+
+```csharp demo-tabs
+public class CustomSubmitTitleFormExample : ViewBase
+{
+    public record UserModel(string Name, string Email, bool IsActive, int Age);
+
+    public override object? Build()
+    {
+        var user = UseState(() => new UserModel("", "", false, 25));
+        
+        return user.ToForm("Create new user");
+    }
+}
+```
+
+
 ### Custom Validation
 
 Add custom validation logic using `.Validate()` method.

--- a/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/Forms.md
+++ b/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/Forms.md
@@ -267,7 +267,7 @@ public class FieldManagementExample : ViewBase
 
 ### Custom Submit Text
 
-Change the text of the submit button by passing it as parameter of the `.toForm()` method
+Change the text of the submit button by passing it as a parameter of the `.toForm()` method
 
 ```csharp demo-tabs
 public class CustomSubmitTitleFormExample : ViewBase

--- a/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/Forms.md
+++ b/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/Forms.md
@@ -267,7 +267,7 @@ public class FieldManagementExample : ViewBase
 
 ### Custom Submit Text
 
-Change the text of the submit button by passing it as a parameter of the `.toForm()` method
+Change the text of the submit button by passing it as a parameter of the `.ToForm()` method
 
 ```csharp demo-tabs
 public class CustomSubmitTitleFormExample : ViewBase

--- a/Ivy/Views/Forms/FormBuilder.cs
+++ b/Ivy/Views/Forms/FormBuilder.cs
@@ -118,16 +118,18 @@ public class FormBuilder<TModel> : ViewBase
     private readonly IState<TModel> _model;
 
     /// <summary>The text displayed on the form's submit button.</summary>
-    public readonly string SubmitTitle = "Save";
+    public readonly string SubmitTitle;
 
     /// <summary>The list of group names that have been defined for organizing fields.</summary>
     private readonly List<string> _groups = new();
 
     /// <summary>Initializes form builder for specified model state with automatic field scaffolding.</summary>
     /// <param name="model">Reactive state containing model object to be edited by form.</param>
-    public FormBuilder(IState<TModel> model)
+    /// <param name="submitTitle">The text displayed on the form's submit button. Default is "Save".</param>
+    public FormBuilder(IState<TModel> model, string submitTitle = "Save")
     {
         _model = model;
+        SubmitTitle = submitTitle;
         _fields = new Dictionary<string, FormBuilderField<TModel>>();
         _Scaffold();
     }

--- a/Ivy/Views/Forms/FormExtensions.cs
+++ b/Ivy/Views/Forms/FormExtensions.cs
@@ -17,6 +17,7 @@ public static class FormExtensions
     /// </summary>
     /// <typeparam name="T">The type of the model object contained in the state.</typeparam>
     /// <param name="obj">The reactive state object containing the model to be edited by the form.</param>
+    /// <param name="submitTitle">The text displayed on the form's submit button. Default is "Save".</param>
     /// <returns>A new FormBuilder instance configured for the specified model type with automatic field discovery.</returns>
     /// <remarks>
     /// <para>This extension method provides a fluent entry point for form creation by converting
@@ -51,8 +52,8 @@ public static class FormExtensions
     /// maintaining the convenience of automatic scaffolding for rapid development.</para>
     /// </remarks>
     /// <seealso cref="FormBuilder{T}"/>
-    public static FormBuilder<T> ToForm<T>(this IState<T> obj)
+    public static FormBuilder<T> ToForm<T>(this IState<T> obj, string submitTitle = "Save")
     {
-        return new FormBuilder<T>(obj);
+        return new FormBuilder<T>(obj, submitTitle);
     }
 }


### PR DESCRIPTION
It allows the user to pass the text that is in the submit button directly in the toForm() method without having to do more work, I think it is usefull because other wise he would have to create the button himself and handle the click

Code example
<img width="731" height="445" alt="DOC 2" src="https://github.com/user-attachments/assets/514b39b6-e06f-4746-b41f-a7fb7ae187cc" />


Result:
<img width="735" height="520" alt="DOC 1" src="https://github.com/user-attachments/assets/3758c7e5-e15e-4e3b-abd5-3165c3e1fe02" />



