### PR TITLE
Unwrap `AggregateException`s in `Error{Teaser}View`

### DIFF
--- a/Ivy/Utils.cs
+++ b/Ivy/Utils.cs
@@ -590,6 +590,23 @@ public static class Utils
         return exception;
     }
 
+    /// <summary>
+    /// Unwraps an AggregateException to return the single inner exception if it contains only one.
+    /// If the exception is not an AggregateException or contains multiple inner exceptions,
+    /// it is returned as-is.
+    /// </summary>
+    /// <param name="e">The exception to unwrap.</param>
+    /// <returns>The unwrapped exception, or the original exception if it cannot be unwrapped.</returns>
+    public static Exception UnwrapAggregate(this Exception e)
+    {
+        if (e is AggregateException aggregateException && aggregateException.InnerExceptions.Count == 1)
+        {
+            e = aggregateException.InnerExceptions[0];
+        }
+
+        return e;
+    }
+
     public static void KillProcessUsingPort(int port)
     {
         if (Environment.OSVersion.Platform != PlatformID.Win32NT)

--- a/Ivy/Views/ErrorTeaserView.cs
+++ b/Ivy/Views/ErrorTeaserView.cs
@@ -18,10 +18,7 @@ public class ErrorTeaserView(Exception ex) : ViewBase
     /// to access full error details.</returns>
     public override object? Build()
     {
-        if (ex is AggregateException aggregateException && aggregateException.InnerExceptions.Count == 1)
-        {
-            ex = aggregateException.InnerExceptions[0];
-        }
+        ex = ex.UnwrapAggregate();
 
         return Layout.Vertical()
                | Text.Muted(ex.Message)

--- a/Ivy/Views/ErrorView.cs
+++ b/Ivy/Views/ErrorView.cs
@@ -16,10 +16,7 @@ public class ErrorView(System.Exception e) : ViewBase, IStateless
     /// <returns>An Error widget containing the exception type, message, and stack trace.</returns>
     public override object? Build()
     {
-        if (e is AggregateException aggregateException && aggregateException.InnerExceptions.Count == 1)
-        {
-            e = aggregateException.InnerExceptions[0];
-        }
+        e = e.UnwrapAggregate();
 
         return new Error(e.GetType().Name, e.Message, e.StackTrace);
     }


### PR DESCRIPTION
This PR displays single exceptions wrapped in `AggregateException` in a more useful way, by:
- showing the stack trace of the inner exception, instead of no stack trace
- showing the type and message of the inner exception, instead of `AggregateException` and "One or more errors occurred (actual error message here)", respectively