### PR TITLE
(html): removing the Rendered result part and fix security formating

### DIFF
--- a/Ivy.Docs.Shared/Docs/02_Widgets/03_Primitives/Html.md
+++ b/Ivy.Docs.Shared/Docs/02_Widgets/03_Primitives/Html.md
@@ -188,8 +188,6 @@ public class ComplexLayoutView : ViewBase
 ```
 
 
-
-
 ## Security Features
 
 The Html widget includes robust security measures to protect against malicious content:


### PR DESCRIPTION
In the html doc there are a lot of parts called rendered result that are redondant with the demo, it's the only page in the doc where we have those rendered result parts, so I removed them, I also fixed the part on security that was badly formated