### PR TITLE
[Docs]: fix missing brackets in horizontal layout usage in forms

### DIFF
--- a/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/Forms.md
+++ b/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/Forms.md
@@ -349,10 +349,10 @@ public class FormSubmissionExample : ViewBase
         
         return Layout.Vertical()
             | formView
-            | Layout.Horizontal()
+            | (Layout.Horizontal()
                 | new Button("Send Message").HandleClick(_ => HandleSubmit())
                     .Loading(loading).Disabled(loading)
-                | validationView;
+                | validationView);
     }
 }
 ```
@@ -390,10 +390,10 @@ public class FormStatesExample : ViewBase
         
         return Layout.Vertical()
             | formView
-            | Layout.Horizontal()
+            | (Layout.Horizontal()
                 | new Button("Create Order").HandleClick(_ => HandleSubmit())
                     .Loading(loading).Disabled(loading)
-                | validationView
+                | validationView)
             | Text.Block($"Total: ${order.Value.Quantity * order.Value.UnitPrice:F2}");
     }
 }


### PR DESCRIPTION
In base usage, validationView renders for the right side of the save button, but with custom buttons of forms submission we need to put it in the layout. There were some missed brackets, that returned vertical layout instead of horizontal, how it supposed to be/

<img width="1480" height="682" alt="Screenshot 2025-09-24 at 00 10 24" src="https://github.com/user-attachments/assets/b1ccf5ff-948a-43f5-b81c-376e299dd0fc" />

<img width="1218" height="326" alt="Screenshot 2025-09-24 at 00 11 10" src="https://github.com/user-attachments/assets/4f7e8537-b8f4-4311-9622-0251bf77ffb3" />

<img width="984" height="382" alt="Screenshot 2025-09-24 at 00 12 18" src="https://github.com/user-attachments/assets/3d07a0f2-e9af-4e28-a598-cbbf4778fde8" />
