### PR TITLE
(image) Fix Image frontend to allow data uri src

### DIFF
--- a/frontend/src/widgets/primitives/ImageWidget.tsx
+++ b/frontend/src/widgets/primitives/ImageWidget.tsx
@@ -11,7 +11,11 @@ interface ImageWidgetProps {
 
 const getImageUrl = (url: string | undefined | null) => {
   if (!url) return '';
-  if (url.startsWith('http://') || url.startsWith('https://')) {
+  if (
+    url.startsWith('http://') ||
+    url.startsWith('https://') ||
+    url.startsWith('data:')
+  ) {
     return url;
   }
   return `${getIvyHost()}${url.startsWith('/') ? '' : '/'}${url}`;


### PR DESCRIPTION
Data uri src were not handled properly in ImageWidget.tsx

Result:
<img width="1116" height="567" alt="image" src="https://github.com/user-attachments/assets/c1f5f235-178d-4f00-a6a1-792895a87270" />
