### PR TITLE
[Docs]: fix Secrets doc placement in sidebar with apps

### DIFF
--- a/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/Secrets.md
+++ b/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/Secrets.md
@@ -1,4 +1,4 @@
-# Secrets Management
+# Secrets
 
 <Ingress>
 The Ivy Framework provides a comprehensive secrets management foundation that enables compile-time tracking of required application secrets, ensuring all necessary configuration is in place before deployment.

--- a/Ivy.Docs.Shared/Docs/04_Concepts/_index.md
+++ b/Ivy.Docs.Shared/Docs/04_Concepts/_index.md
@@ -1,3 +1,0 @@
----
-groupExpanded: false
----


### PR DESCRIPTION
https://github.com/Ivy-Interactive/Ivy-Framework/pull/925
"! We need to reorder this section in sidebar of doc page, because i didn't find where ordering of docs is defined"
I asked not to merge that PR until this doc won't have right placement with other docs
This PR is a small fix of its placement
Now it's with other concepts
Deleted created folder "04_Concepts" from mentioned PR
Also renamed file
<img width="1395" height="873" alt="Screenshot 2025-09-25 at 13 09 45" src="https://github.com/user-attachments/assets/781cb1eb-b503-4550-b19c-221115d30650" />
