### PR TITLE
(git) Fix: In the precommit script, remove git add .

### DIFF
--- a/frontend/.husky/pre-commit
+++ b/frontend/.husky/pre-commit
@@ -8,6 +8,6 @@ if [ -n "$CS_STAGED_FILES" ]; then
   echo "$CS_STAGED_FILES" | xargs git add
 fi
 
-#ts and js files are handled well by lint-staged
+# TS and JS files are handled well by lint-staged
 cd frontend
 npx lint-staged


### PR DESCRIPTION
Because of the husky precommit script it was impossible to keep unstaged files and I was often committing files that I didn't want to commit.

I removed the line `git add .` This line was usefull to stage the changes on the .cs files made by `dotnet format` but it also staged all the other unstaged changes

So I replace it by doing `git add` only on the .cs files that were already staged. 

I also do dotnet format only on those staged files because it's more efficient.