### PR TITLE
(fix): Use `MigrateAsync()` instead of `EnsureCreatedAsync()`

### DIFF
--- a/Ivy.Database.Generator.Toolkit/DatabaseGenerator.cs
+++ b/Ivy.Database.Generator.Toolkit/DatabaseGenerator.cs
@@ -94,7 +94,7 @@ public class DatabaseGenerator
                     }
                 }
             }
-            await dbContext.Database.EnsureCreatedAsync();
+            await dbContext.Database.MigrateAsync();
         }, "Creating Tables", verbose);
 
         if (!seedDatabase && !yesToAll)


### PR DESCRIPTION
Supabase's builtin tables prevent `EnsureCreatedAsync()` from creating anything. Goes along with (and requires) the changes in [this Ivy PR](https://github.com/Ivy-Interactive/Ivy/pull/225).