### PR TITLE
(feat): Implement Size for DateTime Input type

### DIFF
--- a/Ivy.Samples.Shared/Apps/Widgets/Inputs/DateTimeInputApp.cs
+++ b/Ivy.Samples.Shared/Apps/Widgets/Inputs/DateTimeInputApp.cs
@@ -22,6 +22,73 @@ public class DateTimeInputApp : SampleBase
         var nullableTimeState = UseState<TimeOnly?>(() => null);
         var nullableDateOnlyState = UseState<DateOnly?>(() => null);
 
+        // Size examples
+        var sizeExamplesGrid = Layout.Grid().Columns(4)
+            | Text.InlineCode("Size")
+            | Text.InlineCode("Date Input")
+            | Text.InlineCode("DateTime Input")
+            | Text.InlineCode("Time Input")
+
+            | Text.InlineCode("Small")
+            | dateState
+                .ToDateTimeInput()
+                .Variant(DateTimeInputs.Date)
+                .Small()
+                .Placeholder("Small date")
+                .TestId("datetime-input-date-small")
+            | dateTimeState
+                .ToDateTimeInput()
+                .Variant(DateTimeInputs.DateTime)
+                .Small()
+                .Placeholder("Small datetime")
+                .TestId("datetime-input-datetime-small")
+            | timeState
+                .ToDateTimeInput()
+                .Variant(DateTimeInputs.Time)
+                .Small()
+                .Placeholder("Small time")
+                .TestId("datetime-input-time-small")
+
+            | Text.InlineCode("Medium")
+            | dateState
+                .ToDateTimeInput()
+                .Variant(DateTimeInputs.Date)
+                .Size(Sizes.Medium)
+                .Placeholder("Medium date")
+                .TestId("datetime-input-date-medium")
+            | dateTimeState
+                .ToDateTimeInput()
+                .Variant(DateTimeInputs.DateTime)
+                .Size(Sizes.Medium)
+                .Placeholder("Medium datetime")
+                .TestId("datetime-input-datetime-medium")
+            | timeState
+                .ToDateTimeInput()
+                .Variant(DateTimeInputs.Time)
+                .Size(Sizes.Medium)
+                .Placeholder("Medium time")
+                .TestId("datetime-input-time-medium")
+
+            | Text.InlineCode("Large")
+            | dateState
+                .ToDateTimeInput()
+                .Variant(DateTimeInputs.Date)
+                .Large()
+                .Placeholder("Large date")
+                .TestId("datetime-input-date-large")
+            | dateTimeState
+                .ToDateTimeInput()
+                .Variant(DateTimeInputs.DateTime)
+                .Large()
+                .Placeholder("Large datetime")
+                .TestId("datetime-input-datetime-large")
+            | timeState
+                .ToDateTimeInput()
+                .Variant(DateTimeInputs.Time)
+                .Large()
+                .Placeholder("Large time")
+                .TestId("datetime-input-time-large");
+
         // Variants grid
         var variantsGrid = Layout.Grid().Columns(6)
             | null!
@@ -242,6 +309,8 @@ public class DateTimeInputApp : SampleBase
 
         return Layout.Vertical()
             | Text.H1("DateTimeInput")
+            | Text.H2("Size Examples")
+            | sizeExamplesGrid
             | Text.H2("Variants")
             | variantsGrid
             | Text.H2("Data Binding")

--- a/Ivy/Widgets/Inputs/DateTimeInput.cs
+++ b/Ivy/Widgets/Inputs/DateTimeInput.cs
@@ -1,8 +1,10 @@
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Ivy.Core;
+using Ivy.Core.Docs;
 using Ivy.Core.Helpers;
 using Ivy.Core.Hooks;
+using Ivy.Shared;
 using Ivy.Widgets.Inputs;
 
 // ReSharper disable once CheckNamespace
@@ -50,6 +52,9 @@ public abstract record DateTimeInputBase : WidgetBase<DateTimeInputBase>, IAnyDa
 
     /// <summary>Gets or sets the date/time format string for displaying and parsing values.</summary>
     [Prop] public string? Format { get; set; }
+
+    /// <summary>Gets or sets the size of the date/time input.</summary>
+    [Prop] public Sizes Size { get; set; }
 
     /// <summary>Gets or sets whether the input is disabled.</summary>
     [Prop] public bool Disabled { get; set; }
@@ -371,5 +376,31 @@ public static class DateTimeInputExtensions
     public static DateTimeInputBase HandleBlur(this DateTimeInputBase widget, Action onBlur)
     {
         return widget.HandleBlur(_ => { onBlur(); return ValueTask.CompletedTask; });
+    }
+
+    /// <summary>Sets the size of the date/time input.</summary>
+    /// <param name="widget">The date/time input to configure.</param>
+    /// <param name="size">The size of the date/time input.</param>
+    public static DateTimeInputBase Size(this DateTimeInputBase widget, Sizes size)
+    {
+        return widget with { Size = size };
+    }
+
+    /// <summary>Sets the date/time input size to large for prominent display.</summary>
+    /// <param name="widget">The date/time input to configure.</param>
+    /// <returns>A new DateTimeInputBase instance with large size applied.</returns>
+    [RelatedTo(nameof(DateTimeInputBase.Size))]
+    public static DateTimeInputBase Large(this DateTimeInputBase widget)
+    {
+        return widget.Size(Sizes.Large);
+    }
+
+    /// <summary>Sets the date/time input size to small for compact display.</summary>
+    /// <param name="widget">The date/time input to configure.</param>
+    /// <returns>A new DateTimeInputBase instance with small size applied.</returns>
+    [RelatedTo(nameof(DateTimeInputBase.Size))]
+    public static DateTimeInputBase Small(this DateTimeInputBase widget)
+    {
+        return widget.Size(Sizes.Small);
     }
 }

--- a/frontend/src/components/ui/calendar/calendar-variants.ts
+++ b/frontend/src/components/ui/calendar/calendar-variants.ts
@@ -1,0 +1,81 @@
+import { cva } from 'class-variance-authority';
+
+export const calendarVariants = cva(
+  'bg-background group/calendar p-3 [[data-slot=card-content]_&]:bg-transparent [[data-slot=popover-content]_&]:bg-transparent',
+  {
+    variants: {
+      size: {
+        Small: '[--cell-size:--spacing(6)]',
+        Medium: '[--cell-size:--spacing(8)]',
+        Large: '[--cell-size:--spacing(10)]',
+      },
+    },
+    defaultVariants: {
+      size: 'Medium',
+    },
+  }
+);
+
+export const calendarButtonVariants = cva(
+  'aria-disabled:opacity-50 p-0 select-none',
+  {
+    variants: {
+      size: {
+        Small: 'size-(--cell-size) text-xs',
+        Medium: 'size-(--cell-size) text-sm',
+        Large: 'size-(--cell-size) text-base',
+      },
+    },
+    defaultVariants: {
+      size: 'Medium',
+    },
+  }
+);
+
+export const calendarCaptionVariants = cva(
+  'flex items-center justify-center w-full px-(--cell-size)',
+  {
+    variants: {
+      size: {
+        Small: 'h-(--cell-size) text-xs',
+        Medium: 'h-(--cell-size) text-sm',
+        Large: 'h-(--cell-size) text-base',
+      },
+    },
+    defaultVariants: {
+      size: 'Medium',
+    },
+  }
+);
+
+export const calendarWeekdayVariants = cva(
+  'text-muted-foreground rounded-md flex-1 font-normal select-none',
+  {
+    variants: {
+      size: {
+        Small: 'text-[0.7rem]',
+        Medium: 'text-[0.8rem]',
+        Large: 'text-[0.9rem]',
+      },
+    },
+    defaultVariants: {
+      size: 'Medium',
+    },
+  }
+);
+
+export const calendarDayVariants = cva(
+  'items-center justify-center whitespace-nowrap rounded-md transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 cursor-pointer hover:bg-accent data-[selected-single=true]:bg-primary data-[selected-single=true]:text-primary-foreground data-[range-middle=true]:bg-accent data-[range-middle=true]:text-accent-foreground data-[range-start=true]:bg-primary data-[range-start=true]:text-primary-foreground data-[range-end=true]:bg-primary data-[range-end=true]:text-primary-foreground group-data-[focused=true]/day:border-ring group-data-[focused=true]/day:ring-ring/50 dark:hover:text-accent-foreground flex aspect-square size-auto w-full min-w-(--cell-size) flex-col gap-1 leading-none font-normal group-data-[focused=true]/day:relative group-data-[focused=true]/day:z-10 group-data-[focused=true]/day:ring-[3px] data-[range-end=true]:rounded-md data-[range-end=true]:rounded-r-md data-[range-middle=true]:rounded-none data-[range-start=true]:rounded-md data-[range-start=true]:rounded-l-md',
+  {
+    variants: {
+      size: {
+        Small: 'text-xs [&>span]:text-[0.6rem]',
+        Medium: 'text-sm [&>span]:text-xs',
+        Large: 'text-base [&>span]:text-sm',
+      },
+    },
+    defaultVariants: {
+      size: 'Medium',
+    },
+  }
+);

--- a/frontend/src/components/ui/calendar/calendar.tsx
+++ b/frontend/src/components/ui/calendar/calendar.tsx
@@ -8,6 +8,14 @@ import { DayButton, DayPicker, getDefaultClassNames } from 'react-day-picker';
 
 import { cn } from '@/lib/utils';
 import { Button, buttonVariants } from '@/components/ui/button';
+import {
+  calendarVariants,
+  calendarButtonVariants,
+  calendarCaptionVariants,
+  calendarWeekdayVariants,
+  calendarDayVariants,
+} from './calendar-variants';
+import { Sizes } from '@/types/sizes';
 
 export function Calendar({
   className,
@@ -17,9 +25,11 @@ export function Calendar({
   buttonVariant = 'ghost',
   formatters,
   components,
+  size = Sizes.Medium,
   ...props
 }: React.ComponentProps<typeof DayPicker> & {
   buttonVariant?: React.ComponentProps<typeof Button>['variant'];
+  size?: Sizes;
 }) {
   const defaultClassNames = getDefaultClassNames();
 
@@ -27,7 +37,7 @@ export function Calendar({
     <DayPicker
       showOutsideDays={showOutsideDays}
       className={cn(
-        'bg-background group/calendar p-3 [--cell-size:--spacing(8)] [[data-slot=card-content]_&]:bg-transparent [[data-slot=popover-content]_&]:bg-transparent',
+        calendarVariants({ size }),
         String.raw`rtl:**:[.rdp-button\_next>svg]:rotate-180`,
         String.raw`rtl:**:[.rdp-button\_previous>svg]:rotate-180`,
         className
@@ -51,16 +61,16 @@ export function Calendar({
         ),
         button_previous: cn(
           buttonVariants({ variant: buttonVariant }),
-          'size-(--cell-size) aria-disabled:opacity-50 p-0 select-none',
+          calendarButtonVariants({ size }),
           defaultClassNames.button_previous
         ),
         button_next: cn(
           buttonVariants({ variant: buttonVariant }),
-          'size-(--cell-size) aria-disabled:opacity-50 p-0 select-none',
+          calendarButtonVariants({ size }),
           defaultClassNames.button_next
         ),
         month_caption: cn(
-          'flex items-center justify-center h-(--cell-size) w-full px-(--cell-size)',
+          calendarCaptionVariants({ size }),
           defaultClassNames.month_caption
         ),
         dropdowns: cn(
@@ -82,7 +92,7 @@ export function Calendar({
         table: 'w-full border-collapse',
         weekdays: cn('flex', defaultClassNames.weekdays),
         weekday: cn(
-          'text-muted-foreground rounded-md flex-1 font-normal text-[0.8rem] select-none',
+          calendarWeekdayVariants({ size }),
           defaultClassNames.weekday
         ),
         week: cn('flex w-full mt-2', defaultClassNames.week),
@@ -150,7 +160,7 @@ export function Calendar({
             <ChevronDownIcon className={cn('size-4', className)} {...props} />
           );
         },
-        DayButton: CalendarDayButton,
+        DayButton: props => <CalendarDayButton {...props} size={size} />,
         WeekNumber: ({ children, ...props }) => {
           return (
             <td {...props}>
@@ -171,8 +181,11 @@ function CalendarDayButton({
   className,
   day,
   modifiers,
+  size = Sizes.Medium,
   ...props
-}: React.ComponentProps<typeof DayButton>) {
+}: React.ComponentProps<typeof DayButton> & {
+  size?: Sizes;
+}) {
   const defaultClassNames = getDefaultClassNames();
 
   const ref = React.useRef<HTMLButtonElement>(null);
@@ -196,7 +209,7 @@ function CalendarDayButton({
       data-range-end={modifiers.range_end}
       data-range-middle={modifiers.range_middle}
       className={cn(
-        'data-[selected-single=true]:bg-primary data-[selected-single=true]:text-primary-foreground data-[range-middle=true]:bg-accent data-[range-middle=true]:text-accent-foreground data-[range-start=true]:bg-primary data-[range-start=true]:text-primary-foreground data-[range-end=true]:bg-primary data-[range-end=true]:text-primary-foreground group-data-[focused=true]/day:border-ring group-data-[focused=true]/day:ring-ring/50 dark:hover:text-accent-foreground flex aspect-square size-auto w-full min-w-(--cell-size) flex-col gap-1 leading-none font-normal group-data-[focused=true]/day:relative group-data-[focused=true]/day:z-10 group-data-[focused=true]/day:ring-[3px] data-[range-end=true]:rounded-md data-[range-end=true]:rounded-r-md data-[range-middle=true]:rounded-none data-[range-start=true]:rounded-md data-[range-start=true]:rounded-l-md [&>span]:text-xs [&>span]:opacity-70',
+        calendarDayVariants({ size }),
         defaultClassNames.day,
         className
       )}

--- a/frontend/src/components/ui/input/date-time-input-variants.ts
+++ b/frontend/src/components/ui/input/date-time-input-variants.ts
@@ -29,7 +29,7 @@ export const dateTimeInputIconVariants = cva('', {
   },
 });
 
-export const dateTimeInputTextVariants = cva('font-normal', {
+export const dateTimeInputTextVariants = cva(' ', {
   variants: {
     size: {
       Small: 'text-xs',

--- a/frontend/src/components/ui/input/date-time-input-variants.ts
+++ b/frontend/src/components/ui/input/date-time-input-variants.ts
@@ -1,0 +1,43 @@
+import { cva } from 'class-variance-authority';
+
+export const dateTimeInputVariants = cva(
+  'w-full justify-start text-left font-normal pr-20 cursor-pointer bg-transparent',
+  {
+    variants: {
+      size: {
+        Small: 'h-8 px-3 text-xs',
+        Medium: 'h-9 px-4 py-2 text-sm',
+        Large: 'h-10 px-5 py-2 text-base',
+      },
+    },
+    defaultVariants: {
+      size: 'Medium',
+    },
+  }
+);
+
+export const dateTimeInputIconVariants = cva('', {
+  variants: {
+    size: {
+      Small: 'h-3 w-3',
+      Medium: 'h-4 w-4',
+      Large: 'h-5 w-5',
+    },
+  },
+  defaultVariants: {
+    size: 'Medium',
+  },
+});
+
+export const dateTimeInputTextVariants = cva('font-normal', {
+  variants: {
+    size: {
+      Small: 'text-xs',
+      Medium: 'text-sm',
+      Large: 'text-base',
+    },
+  },
+  defaultVariants: {
+    size: 'Medium',
+  },
+});

--- a/frontend/src/widgets/inputs/DateTimeInputWidget.tsx
+++ b/frontend/src/widgets/inputs/DateTimeInputWidget.tsx
@@ -151,6 +151,7 @@ const DateVariant: React.FC<DateVariantProps> = ({
             selected={date}
             onSelect={handleSelect}
             initialFocus
+            size={size}
           />
         </PopoverContent>
       </Popover>
@@ -336,6 +337,7 @@ const DateTimeVariant: React.FC<DateTimeVariantProps> = ({
               selected={date}
               onSelect={handleDateSelect}
               initialFocus
+              size={size}
             />
             <div className="flex items-center gap-2">
               <Clock

--- a/frontend/src/widgets/inputs/DateTimeInputWidget.tsx
+++ b/frontend/src/widgets/inputs/DateTimeInputWidget.tsx
@@ -14,6 +14,12 @@ import { cn } from '@/lib/utils';
 import { useEventHandler } from '@/components/event-handler';
 import { inputStyles } from '@/lib/styles';
 import { InvalidIcon } from '@/components/InvalidIcon';
+import { Sizes } from '@/types/sizes';
+import {
+  dateTimeInputVariants,
+  dateTimeInputIconVariants,
+  dateTimeInputTextVariants,
+} from '@/components/ui/input/date-time-input-variants';
 
 type VariantType = 'Date' | 'DateTime' | 'Time';
 
@@ -26,6 +32,7 @@ interface DateTimeInputWidgetProps {
   nullable?: boolean;
   invalid?: string;
   format?: string;
+  size?: Sizes;
   'data-testid'?: string;
 }
 
@@ -37,6 +44,7 @@ interface BaseVariantProps {
   nullable?: boolean;
   invalid?: string;
   format?: string;
+  size?: Sizes;
   'data-testid'?: string;
 }
 
@@ -61,6 +69,7 @@ const DateVariant: React.FC<DateVariantProps> = ({
   invalid,
   onDateChange,
   format: formatProp,
+  size = Sizes.Medium,
   'data-testid': dataTestId,
 }) => {
   const [open, setOpen] = useState(false);
@@ -89,14 +98,16 @@ const DateVariant: React.FC<DateVariantProps> = ({
             disabled={disabled}
             variant="outline"
             className={cn(
-              'w-full justify-start text-left font-normal pr-20 cursor-pointer bg-transparent', // pr-20 for clear+icon, bg-transparent to match other inputs
+              dateTimeInputVariants({ size }),
               !date && 'text-muted-foreground',
               invalid && inputStyles.invalidInput,
               disabled && 'cursor-not-allowed'
             )}
             data-testid={dataTestId}
           >
-            <CalendarIcon className="mr-2 h-4 w-4" />
+            <CalendarIcon
+              className={cn('mr-2', dateTimeInputIconVariants({ size }))}
+            />
             {date ? (
               format(date, formatProp || 'yyyy-MM-dd')
             ) : (
@@ -121,7 +132,12 @@ const DateVariant: React.FC<DateVariantProps> = ({
                     className="p-1 rounded hover:bg-accent focus:outline-none cursor-pointer"
                     style={{ pointerEvents: 'auto' }}
                   >
-                    <X className="h-4 w-4 text-muted-foreground hover:text-foreground" />
+                    <X
+                      className={cn(
+                        dateTimeInputIconVariants({ size }),
+                        'text-muted-foreground hover:text-foreground'
+                      )}
+                    />
                   </span>
                 )}
                 {invalid && <InvalidIcon message={invalid} />}
@@ -151,6 +167,7 @@ const DateTimeVariant: React.FC<DateTimeVariantProps> = ({
   onDateChange,
   onTimeChange,
   format: formatProp,
+  size = Sizes.Medium,
   'data-testid': dataTestId,
 }) => {
   const [open, setOpen] = useState(false);
@@ -272,14 +289,16 @@ const DateTimeVariant: React.FC<DateTimeVariantProps> = ({
             disabled={disabled}
             variant="outline"
             className={cn(
-              'w-full justify-start text-left font-normal pr-20 cursor-pointer bg-transparent', // pr-20 for clear+icon, bg-transparent to match other inputs
+              dateTimeInputVariants({ size }),
               !date && 'text-muted-foreground',
               invalid && inputStyles.invalidInput,
               disabled && 'cursor-not-allowed'
             )}
             data-testid={dataTestId}
           >
-            <CalendarIcon className="mr-2 h-4 w-4" />
+            <CalendarIcon
+              className={cn('mr-2', dateTimeInputIconVariants({ size }))}
+            />
             {date ? (
               format(date, formatProp || 'yyyy-MM-dd')
             ) : (
@@ -297,7 +316,12 @@ const DateTimeVariant: React.FC<DateTimeVariantProps> = ({
                     className="p-1 rounded hover:bg-accent focus:outline-none cursor-pointer"
                     style={{ pointerEvents: 'auto' }}
                   >
-                    <X className="h-4 w-4 text-muted-foreground hover:text-foreground" />
+                    <X
+                      className={cn(
+                        dateTimeInputIconVariants({ size }),
+                        'text-muted-foreground hover:text-foreground'
+                      )}
+                    />
                   </button>
                 )}
                 {invalid && <InvalidIcon message={invalid} />}
@@ -314,7 +338,12 @@ const DateTimeVariant: React.FC<DateTimeVariantProps> = ({
               initialFocus
             />
             <div className="flex items-center gap-2">
-              <Clock className="h-4 w-4 text-muted-foreground" />
+              <Clock
+                className={cn(
+                  dateTimeInputIconVariants({ size }),
+                  'text-muted-foreground'
+                )}
+              />
               <Input
                 type="time"
                 step="1"
@@ -326,6 +355,7 @@ const DateTimeVariant: React.FC<DateTimeVariantProps> = ({
                 disabled={disabled}
                 className={cn(
                   'bg-background appearance-none [&::-webkit-calendar-picker-indicator]:hidden',
+                  dateTimeInputTextVariants({ size }),
                   invalid && inputStyles.invalidInput
                 )}
                 data-testid={dataTestId ? `${dataTestId}-time` : undefined}
@@ -345,6 +375,7 @@ const TimeVariant: React.FC<TimeVariantProps> = ({
   nullable,
   invalid,
   onTimeChange,
+  size = Sizes.Medium,
   'data-testid': dataTestId,
 }) => {
   // Use local state for the input value to make it uncontrolled
@@ -426,7 +457,12 @@ const TimeVariant: React.FC<TimeVariantProps> = ({
 
   return (
     <div className="relative flex items-center gap-2" data-testid={dataTestId}>
-      <Clock className="h-4 w-4 text-muted-foreground" />
+      <Clock
+        className={cn(
+          dateTimeInputIconVariants({ size }),
+          'text-muted-foreground'
+        )}
+      />
       <div className="relative w-full">
         <Input
           type="time"
@@ -439,6 +475,7 @@ const TimeVariant: React.FC<TimeVariantProps> = ({
           placeholder={placeholder || 'Select time'}
           className={cn(
             'bg-background appearance-none [&::-webkit-calendar-picker-indicator]:hidden pr-20 cursor-pointer', // pr-20 for clear+icon
+            dateTimeInputTextVariants({ size }),
             invalid && inputStyles.invalidInput,
             disabled && 'cursor-not-allowed'
           )}
@@ -454,7 +491,12 @@ const TimeVariant: React.FC<TimeVariantProps> = ({
                 className="p-1 rounded hover:bg-accent focus:outline-none cursor-pointer"
                 style={{ pointerEvents: 'auto' }}
               >
-                <X className="h-4 w-4 text-muted-foreground hover:text-foreground" />
+                <X
+                  className={cn(
+                    dateTimeInputIconVariants({ size }),
+                    'text-muted-foreground hover:text-foreground'
+                  )}
+                />
               </button>
             )}
             {invalid && <InvalidIcon message={invalid} />}
@@ -480,6 +522,7 @@ export const DateTimeInputWidget: React.FC<DateTimeInputWidgetProps> = ({
   nullable = false,
   invalid,
   format: formatProp,
+  size = Sizes.Medium,
   'data-testid': dataTestId,
 }) => {
   const eventHandler = useEventHandler();
@@ -526,6 +569,7 @@ export const DateTimeInputWidget: React.FC<DateTimeInputWidgetProps> = ({
       nullable={nullable}
       invalid={invalid}
       format={formatProp}
+      size={size}
       onDateChange={handleDateChange}
       onTimeChange={handleTimeChange}
       data-testid={dataTestId}


### PR DESCRIPTION
<img width="1085" height="302" alt="image" src="https://github.com/user-attachments/assets/eda13d13-d91f-4d9e-bc3e-07cb76553220" />

## Small Size Calendar Dropdown - >
<img width="276" height="477" alt="image" src="https://github.com/user-attachments/assets/9eab2b58-2ddc-46cf-9788-15a2abd2689f" />

## Large Size Calendar Dropdown ->
<img width="441" height="734" alt="image" src="https://github.com/user-attachments/assets/43e59813-482c-48d9-989e-e89f93cde0d8" />
