### PR TITLE
Reverse order of TerminalWidget stoplight buttons

### DIFF
--- a/frontend/src/widgets/internal/TerminalWidget.tsx
+++ b/frontend/src/widgets/internal/TerminalWidget.tsx
@@ -29,9 +29,9 @@ const TerminalWidget = ({ lines, title, showHeader }: TerminalWidgetProps) => {
             {title}
           </div>
           <div className="flex gap-1">
-            <div className="w-3 h-3 bg-red-500 rounded-full"></div>
-            <div className="w-3 h-3 bg-yellow-500 rounded-full"></div>
             <div className="w-3 h-3 bg-green-500 rounded-full"></div>
+            <div className="w-3 h-3 bg-yellow-500 rounded-full"></div>
+            <div className="w-3 h-3 bg-red-500 rounded-full"></div>
           </div>
         </div>
       )}


### PR DESCRIPTION
Nitpick: I think the red "button" should be in the corner of the widget

Before:
<img width="726" height="108" alt="Screenshot 2025-09-26 at 3 47 24 PM" src="https://github.com/user-attachments/assets/24d4f275-9a1f-4eb1-bd14-5b5a67458a58" />

After:
<img width="730" height="106" alt="Screenshot 2025-09-26 at 4 21 57 PM" src="https://github.com/user-attachments/assets/73f7e1ba-3ebe-437f-8351-4573fed16d1c" />
