### PR TITLE
(docs): fix UseMemo dependency array example

### DIFF
--- a/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/Memoization.md
+++ b/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/Memoization.md
@@ -91,7 +91,7 @@ public class ExpensiveCalculationView : ViewBase
             // Simulate expensive calculation
             Thread.Sleep(1000);
             return input.Value * input.Value;
-        }, input); // Only recompute when input changes
+        }, input.Value); // Only recompute when input changes
         
         return Layout.Vertical(
             Text.Inline("Number", value: input.Value, onChange: v => input.Set(v)),


### PR DESCRIPTION
Update UseMemo example to use input.Value instead of input in dependency array,
as the hook needs to track the actual value for proper memoization.

Fixes #942

🤖 Generated with [Claude Code](https://claude.ai/code)