### PR TITLE
(feat): Implement size for Date Range Input type

### DIFF
--- a/Ivy.Samples.Shared/Apps/Widgets/Inputs/DateRangeInputApp.cs
+++ b/Ivy.Samples.Shared/Apps/Widgets/Inputs/DateRangeInputApp.cs
@@ -17,6 +17,28 @@ public class DateRangeInputApp : SampleBase
         var nullableInvalidDateOnlyState = UseState<(DateOnly?, DateOnly?)>(() => (DateOnly.FromDateTime(DateTime.Today.AddDays(-7)), DateOnly.FromDateTime(DateTime.Today)));
         var nullableDisabledDateOnlyState = UseState<(DateOnly?, DateOnly?)>(() => (DateOnly.FromDateTime(DateTime.Today.AddDays(-7)), DateOnly.FromDateTime(DateTime.Today)));
 
+        // Size examples
+        var sizeExamplesGrid = Layout.Grid().Columns(4)
+            | Text.InlineCode("Size")
+            | Text.InlineCode("Normal")
+            | Text.InlineCode("Nullable")
+            | Text.InlineCode("Disabled")
+
+            | Text.InlineCode("Small")
+            | nullableDateOnlyState.ToDateRangeInput().Placeholder("Select date range").Format("yyyy-MM-dd").Small().TestId("daterange-input-dateonly-small")
+            | nullableDateOnlyState.ToDateRangeInput().Placeholder("Select date range").Format("yyyy-MM-dd").Small().TestId("daterange-input-dateonly-small-nullable")
+            | disabledNullableDateOnlyState.ToDateRangeInput().Placeholder("Select date range").Format("yyyy-MM-dd").Small().Disabled().TestId("daterange-input-dateonly-small-disabled")
+
+            | Text.InlineCode("Medium")
+            | nullableDateOnlyState.ToDateRangeInput().Placeholder("Select date range").Format("yyyy-MM-dd").Size(Sizes.Medium).TestId("daterange-input-dateonly-medium")
+            | nullableDateOnlyState.ToDateRangeInput().Placeholder("Select date range").Format("yyyy-MM-dd").Size(Sizes.Medium).TestId("daterange-input-dateonly-medium-nullable")
+            | disabledNullableDateOnlyState.ToDateRangeInput().Placeholder("Select date range").Format("yyyy-MM-dd").Size(Sizes.Medium).Disabled().TestId("daterange-input-dateonly-medium-disabled")
+
+            | Text.InlineCode("Large")
+            | nullableDateOnlyState.ToDateRangeInput().Placeholder("Select date range").Format("yyyy-MM-dd").Large().TestId("daterange-input-dateonly-large")
+            | nullableDateOnlyState.ToDateRangeInput().Placeholder("Select date range").Format("yyyy-MM-dd").Large().TestId("daterange-input-dateonly-large-nullable")
+            | disabledNullableDateOnlyState.ToDateRangeInput().Placeholder("Select date range").Format("yyyy-MM-dd").Large().Disabled().TestId("daterange-input-dateonly-large-disabled");
+
         // Variants grid
         var variantsGrid = Layout.Grid().Columns(5)
             // Header row (update last col)
@@ -54,6 +76,8 @@ public class DateRangeInputApp : SampleBase
 
         return Layout.Vertical()
             | Text.H1("DateRangeInput")
+            | Text.H2("Size Examples")
+            | sizeExamplesGrid
             | Text.H2("Variants")
             | variantsGrid
             | Text.H2("Data Binding")

--- a/Ivy/Widgets/Inputs/DateRangeInput.cs
+++ b/Ivy/Widgets/Inputs/DateRangeInput.cs
@@ -4,6 +4,7 @@ using Ivy.Core;
 using Ivy.Core.Helpers;
 using Ivy.Core.Hooks;
 using Ivy.Widgets.Inputs;
+using Ivy.Shared;
 
 // ReSharper disable once CheckNamespace
 namespace Ivy;
@@ -30,6 +31,9 @@ public abstract record DateRangeInputBase : WidgetBase<DateRangeInputBase>, IAny
 
     /// <summary>Gets or sets the date format string for displaying and parsing dates.</summary>
     [Prop] public string? Format { get; set; }
+
+    /// <summary>Gets or sets the size of the date range input.</summary>
+    [Prop] public Sizes Size { get; set; } = Sizes.Medium;
 
     /// <summary>Gets or sets whether the input is disabled.</summary>
     [Prop] public bool Disabled { get; set; }
@@ -218,5 +222,29 @@ public static class DateRangeInputExtensions
     public static DateRangeInputBase HandleBlur(this DateRangeInputBase widget, Action onBlur)
     {
         return widget.HandleBlur(_ => { onBlur(); return ValueTask.CompletedTask; });
+    }
+
+    /// <summary>Sets the size of the date range input.</summary>
+    /// <param name="widget">The date range input to configure.</param>
+    /// <param name="size">The size of the date range input.</param>
+    public static DateRangeInputBase Size(this DateRangeInputBase widget, Sizes size)
+    {
+        return widget with { Size = size };
+    }
+
+    /// <summary>Sets the date range input size to large for prominent display.</summary>
+    /// <param name="widget">The date range input to configure.</param>
+    /// <returns>A new DateRangeInputBase instance with large size applied.</returns>
+    public static DateRangeInputBase Large(this DateRangeInputBase widget)
+    {
+        return widget.Size(Sizes.Large);
+    }
+
+    /// <summary>Sets the date range input size to small for compact display.</summary>
+    /// <param name="widget">The date range input to configure.</param>
+    /// <returns>A new DateRangeInputBase instance with small size applied.</returns>
+    public static DateRangeInputBase Small(this DateRangeInputBase widget)
+    {
+        return widget.Size(Sizes.Small);
     }
 }

--- a/frontend/src/components/ui/input/date-range-input-variants.ts
+++ b/frontend/src/components/ui/input/date-range-input-variants.ts
@@ -1,0 +1,43 @@
+import { cva } from 'class-variance-authority';
+
+export const dateRangeInputVariants = cva(
+  'w-full justify-start text-left font-normal pr-20 cursor-pointer bg-transparent',
+  {
+    variants: {
+      size: {
+        Small: 'h-8 px-3',
+        Medium: 'h-9 px-4 py-2',
+        Large: 'h-10 px-5 py-2',
+      },
+    },
+    defaultVariants: {
+      size: 'Medium',
+    },
+  }
+);
+
+export const dateRangeInputIconVariants = cva('', {
+  variants: {
+    size: {
+      Small: 'h-3 w-3',
+      Medium: 'h-4 w-4',
+      Large: 'h-5 w-5',
+    },
+  },
+  defaultVariants: {
+    size: 'Medium',
+  },
+});
+
+export const dateRangeInputTextVariants = cva(' ', {
+  variants: {
+    size: {
+      Small: 'text-xs',
+      Medium: 'text-sm',
+      Large: 'text-base',
+    },
+  },
+  defaultVariants: {
+    size: 'Medium',
+  },
+});

--- a/frontend/src/widgets/inputs/DateRangeInputWidget.tsx
+++ b/frontend/src/widgets/inputs/DateRangeInputWidget.tsx
@@ -196,7 +196,10 @@ export const DateRangeInputWidget: React.FC<DateRangeInputWidgetProps> = ({
                     <Button
                       variant="ghost"
                       size="sm"
-                      className="w-full justify-start cursor-pointer"
+                      className={cn(
+                        'w-full justify-start cursor-pointer',
+                        dateRangeInputTextVariants({ size })
+                      )}
                       onClick={() => {
                         handleChange({
                           from: today,
@@ -211,7 +214,10 @@ export const DateRangeInputWidget: React.FC<DateRangeInputWidgetProps> = ({
                     <Button
                       variant="ghost"
                       size="sm"
-                      className="w-full justify-start cursor-pointer"
+                      className={cn(
+                        'w-full justify-start cursor-pointer',
+                        dateRangeInputTextVariants({ size })
+                      )}
                       onClick={() => {
                         handleChange(yesterday);
                         setMonth(yesterday.to);
@@ -223,7 +229,10 @@ export const DateRangeInputWidget: React.FC<DateRangeInputWidgetProps> = ({
                     <Button
                       variant="ghost"
                       size="sm"
-                      className="w-full justify-start cursor-pointer"
+                      className={cn(
+                        'w-full justify-start cursor-pointer',
+                        dateRangeInputTextVariants({ size })
+                      )}
                       onClick={() => {
                         handleChange(last7Days);
                         setMonth(last7Days.to);
@@ -235,7 +244,10 @@ export const DateRangeInputWidget: React.FC<DateRangeInputWidgetProps> = ({
                     <Button
                       variant="ghost"
                       size="sm"
-                      className="w-full justify-start cursor-pointer"
+                      className={cn(
+                        'w-full justify-start cursor-pointer',
+                        dateRangeInputTextVariants({ size })
+                      )}
                       onClick={() => {
                         handleChange(last30Days);
                         setMonth(last30Days.to);
@@ -247,7 +259,10 @@ export const DateRangeInputWidget: React.FC<DateRangeInputWidgetProps> = ({
                     <Button
                       variant="ghost"
                       size="sm"
-                      className="w-full justify-start cursor-pointer"
+                      className={cn(
+                        'w-full justify-start cursor-pointer',
+                        dateRangeInputTextVariants({ size })
+                      )}
                       onClick={() => {
                         handleChange(monthToDate);
                         setMonth(monthToDate.to);
@@ -259,7 +274,10 @@ export const DateRangeInputWidget: React.FC<DateRangeInputWidgetProps> = ({
                     <Button
                       variant="ghost"
                       size="sm"
-                      className="w-full justify-start cursor-pointer"
+                      className={cn(
+                        'w-full justify-start cursor-pointer',
+                        dateRangeInputTextVariants({ size })
+                      )}
                       onClick={() => {
                         handleChange(lastMonth);
                         setMonth(lastMonth.to);
@@ -271,7 +289,10 @@ export const DateRangeInputWidget: React.FC<DateRangeInputWidgetProps> = ({
                     <Button
                       variant="ghost"
                       size="sm"
-                      className="w-full justify-start cursor-pointer"
+                      className={cn(
+                        'w-full justify-start cursor-pointer',
+                        dateRangeInputTextVariants({ size })
+                      )}
                       onClick={() => {
                         handleChange(yearToDate);
                         setMonth(yearToDate.to);
@@ -283,7 +304,10 @@ export const DateRangeInputWidget: React.FC<DateRangeInputWidgetProps> = ({
                     <Button
                       variant="ghost"
                       size="sm"
-                      className="w-full justify-start cursor-pointer"
+                      className={cn(
+                        'w-full justify-start cursor-pointer',
+                        dateRangeInputTextVariants({ size })
+                      )}
                       onClick={() => {
                         handleChange(lastYear);
                         setMonth(lastYear.to);

--- a/frontend/src/widgets/inputs/DateRangeInputWidget.tsx
+++ b/frontend/src/widgets/inputs/DateRangeInputWidget.tsx
@@ -23,6 +23,12 @@ import {
 } from 'date-fns';
 import { useEventHandler } from '@/components/event-handler';
 import { InvalidIcon } from '@/components/InvalidIcon';
+import { Sizes } from '@/types/sizes';
+import {
+  dateRangeInputVariants,
+  dateRangeInputIconVariants,
+  dateRangeInputTextVariants,
+} from '@/components/ui/input/date-range-input-variants';
 
 interface DateRangeInputWidgetProps {
   id: string;
@@ -35,6 +41,7 @@ interface DateRangeInputWidgetProps {
   format?: string;
   invalid?: string;
   nullable?: boolean;
+  size?: Sizes;
   events: string[];
   'data-testid'?: string;
 }
@@ -47,6 +54,7 @@ export const DateRangeInputWidget: React.FC<DateRangeInputWidgetProps> = ({
   format: formatProp,
   invalid,
   nullable = false,
+  size = Sizes.Medium,
   events,
   'data-testid': dataTestId,
 }) => {
@@ -143,7 +151,7 @@ export const DateRangeInputWidget: React.FC<DateRangeInputWidgetProps> = ({
             disabled={disabled}
             data-testid={dataTestId}
             className={cn(
-              'w-full justify-start text-left font-normal cursor-pointer bg-transparent', // bg-transparent to match other inputs
+              dateRangeInputVariants({ size }),
               !date && 'text-muted-foreground',
               invalid && 'border-destructive focus-visible:ring-destructive',
               showClear && invalid
@@ -153,18 +161,29 @@ export const DateRangeInputWidget: React.FC<DateRangeInputWidgetProps> = ({
                   : ''
             )}
           >
-            <CalendarIcon className="mr-2 h-4 w-4" />
+            <CalendarIcon
+              className={cn('mr-2', dateRangeInputIconVariants({ size }))}
+            />
             {date?.from ? (
               date.to ? (
-                <>
+                <span className={dateRangeInputTextVariants({ size })}>
                   {format(date.from, displayFormat)} -{' '}
                   {format(date.to, displayFormat)}
-                </>
+                </span>
               ) : (
-                format(date.from, displayFormat)
+                <span className={dateRangeInputTextVariants({ size })}>
+                  {format(date.from, displayFormat)}
+                </span>
               )
             ) : (
-              <span>{placeholder}</span>
+              <span
+                className={cn(
+                  dateRangeInputTextVariants({ size }),
+                  'text-muted-foreground'
+                )}
+              >
+                {placeholder}
+              </span>
             )}
           </Button>
         </PopoverTrigger>
@@ -290,6 +309,7 @@ export const DateRangeInputWidget: React.FC<DateRangeInputWidgetProps> = ({
                   numberOfMonths={2}
                   className="p-2 bg-background"
                   disabled={[{ after: today }]}
+                  size={size}
                 />
               </div>
             </div>
@@ -307,7 +327,12 @@ export const DateRangeInputWidget: React.FC<DateRangeInputWidgetProps> = ({
               onClick={handleClear}
               className="p-1 rounded hover:bg-accent focus:outline-none cursor-pointer"
             >
-              <X className="h-4 w-4 text-muted-foreground hover:text-foreground" />
+              <X
+                className={cn(
+                  dateRangeInputIconVariants({ size }),
+                  'text-muted-foreground hover:text-foreground'
+                )}
+              />
             </button>
           )}
           {invalid && <InvalidIcon message={invalid} />}


### PR DESCRIPTION
<img width="1569" height="372" alt="image" src="https://github.com/user-attachments/assets/afdce5e9-667f-4148-828d-d45dafbdfd6f" />

## Small Size Calendar Dropdown - >
<img width="737" height="516" alt="image" src="https://github.com/user-attachments/assets/123d83f3-7d19-4691-a679-104d7b684f3b" />

## Medium Size Calendar Dropdown - >
<img width="846" height="461" alt="image" src="https://github.com/user-attachments/assets/18c3e86e-67e6-47a3-8631-d01d69da67d7" />

## Large Size Calendar Dropdown - >
<img width="1001" height="524" alt="image" src="https://github.com/user-attachments/assets/d5e00f88-2b9f-41bd-96a9-5a15e26b7794" />
