### PR TITLE
(rechart): fix support for react 19

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -78,7 +78,7 @@
         "react-resizable-panels": "^3.0.4",
         "react-syntax-highlighter": "^15.6.6",
         "reactflow": "^11.11.4",
-        "recharts": "^3.1.2",
+        "recharts": "^3.2.1",
         "rehype-katex": "^7.0.1",
         "rehype-raw": "^7.0.0",
         "rehype-slug": "^6.0.0",
@@ -10123,9 +10123,9 @@
       }
     },
     "node_modules/recharts": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.1.2.tgz",
-      "integrity": "sha512-vhNbYwaxNbk/IATK0Ki29k3qvTkGqwvCgyQAQ9MavvvBwjvKnMTswdbklJpcOAoMPN/qxF3Lyqob0zO+ZXkZ4g==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.2.1.tgz",
+      "integrity": "sha512-0JKwHRiFZdmLq/6nmilxEZl3pqb4T+aKkOkOi/ZISRZwfBhVMgInxzlYU9D4KnCH3KINScLy68m/OvMXoYGZUw==",
       "license": "MIT",
       "dependencies": {
         "@reduxjs/toolkit": "1.x.x || 2.x.x",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -85,7 +85,7 @@
     "react-resizable-panels": "^3.0.4",
     "react-syntax-highlighter": "^15.6.6",
     "reactflow": "^11.11.4",
-    "recharts": "^3.1.2",
+    "recharts": "^3.2.1",
     "rehype-katex": "^7.0.1",
     "rehype-raw": "^7.0.0",
     "rehype-slug": "^6.0.0",

--- a/frontend/src/widgets/charts/PieChartWidget.tsx
+++ b/frontend/src/widgets/charts/PieChartWidget.tsx
@@ -112,7 +112,7 @@ const PieChartWidget: React.FC<PieChartWidgetProps> = ({
               {props.labelLists
                 ?.filter(ll => {
                   // For donuts, drop inside labels; keep outside only.
-                  const pos = (ll.position as unknown as string) || '';
+                  const pos = ll.position || '';
                   return !isDonut || pos.toString().toLowerCase() !== 'inside';
                 })
                 .map((labelList, labelListIndex) => (

--- a/frontend/src/widgets/charts/shared.ts
+++ b/frontend/src/widgets/charts/shared.ts
@@ -122,7 +122,7 @@ export interface ExtendedLabelProps extends LabelProps {
   color?: string;
 }
 
-export interface ExtendedLineProps extends LineProps {
+export interface ExtendedLineProps extends Omit<LineProps, 'label'> {
   animated: boolean;
   curveType: CurveType;
   strokeDashArray?: string;
@@ -294,17 +294,17 @@ export interface FormatterDefinitions {
 }
 
 export interface ExtendedLabelListProps
-  extends LabelListProps<Record<string, unknown>>,
-    FormatterDefinitions {}
+  extends Omit<LabelListProps, 'position'>,
+    FormatterDefinitions {
+  position?: string;
+}
 
 export const generateLabelListProps = (props: ExtendedLabelListProps) => {
   const { fill, position, dataKey, ...labelListProps } = props;
   const formatter = getFormatter(props);
   return {
     dataKey: camelCase(dataKey) as string,
-    position: camelCase(position) as LabelListProps<
-      Record<string, unknown>
-    >['position'],
+    position: camelCase(position) as LabelListProps['position'],
     fill: fill && `var(--${fill.toLowerCase()})`,
     formatter,
     ...labelListProps,

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -73,6 +73,9 @@ export default defineConfig(({ mode }) => ({
       input: {
         main: path.resolve(__dirname, 'index.html'),
       },
+      external: () => {
+        return false;
+      },
       output: {
         entryFileNames: 'assets/[name].[hash].js',
         chunkFileNames: 'assets/[name].[hash].js',
@@ -80,8 +83,13 @@ export default defineConfig(({ mode }) => ({
         // Fine-grained vendor chunking to keep initial payloads small and improve caching
         manualChunks(id) {
           if (id.includes('node_modules')) {
-            if (id.includes('react') || id.includes('@radix-ui'))
+            if (
+              id.includes('react') &&
+              !id.includes('recharts') &&
+              !id.includes('@radix-ui')
+            )
               return 'vendor-react';
+            if (id.includes('@radix-ui')) return 'vendor-react';
             if (
               id.includes('codemirror') ||
               id.includes('@uiw/react-codemirror')
@@ -95,8 +103,6 @@ export default defineConfig(({ mode }) => ({
             )
               return 'vendor-markdown';
             if (id.includes('mermaid')) return 'vendor-mermaid';
-            if (id.includes('recharts') || id.includes('d3'))
-              return 'vendor-charts';
             if (id.includes('reactflow')) return 'vendor-reactflow';
             if (id.includes('framer-motion')) return 'vendor-motion';
             if (id.includes('katex')) return 'vendor-katex';

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -73,9 +73,6 @@ export default defineConfig(({ mode }) => ({
       input: {
         main: path.resolve(__dirname, 'index.html'),
       },
-      external: () => {
-        return false;
-      },
       output: {
         entryFileNames: 'assets/[name].[hash].js',
         chunkFileNames: 'assets/[name].[hash].js',
@@ -83,13 +80,8 @@ export default defineConfig(({ mode }) => ({
         // Fine-grained vendor chunking to keep initial payloads small and improve caching
         manualChunks(id) {
           if (id.includes('node_modules')) {
-            if (
-              id.includes('react') &&
-              !id.includes('recharts') &&
-              !id.includes('@radix-ui')
-            )
+            if (id.includes('react') && !id.includes('recharts'))
               return 'vendor-react';
-            if (id.includes('@radix-ui')) return 'vendor-react';
             if (
               id.includes('codemirror') ||
               id.includes('@uiw/react-codemirror')


### PR DESCRIPTION
This pull request updates the `recharts` charting library to version 3.2.1 and makes several related improvements and fixes to chart widget typings and build configuration. The changes ensure better compatibility with the new `recharts` version and optimize how chart-related code is bundled.

**Dependency update and compatibility adjustments:**

- Upgraded `recharts` from version 3.1.2 to 3.2.1 in both `package.json` and `package-lock.json` for improved features and bug fixes. [[1]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655L88-R88) [[2]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aL81-R81) [[3]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aL10126-R10128)

**Type and props improvements for chart widgets:**

- Updated `ExtendedLineProps` to omit the `label` property from `LineProps` to avoid type conflicts with the latest `recharts` types.
- Modified `ExtendedLabelListProps` to omit the `position` property from `LabelListProps` and reintroduce it as an optional string, aligning with new `recharts` expectations. Updated `generateLabelListProps` to handle the change.
- Simplified type handling for label positions in `PieChartWidget.tsx` by removing unnecessary casting, since `position` is now always a string.

**Build and bundling configuration:**

- Updated Vite config to prevent `recharts` from being bundled with the main React vendor chunk, ensuring it is handled separately for better caching and load performance.
- Removed the vendor chunk rule for `recharts` and `d3` to further optimize code splitting.