### PR TITLE
(blade): scroll fix for radix scrollarea with nested elements

### DIFF
--- a/Ivy.Samples.Shared/Apps/Demos/ProductsApp.cs
+++ b/Ivy.Samples.Shared/Apps/Demos/ProductsApp.cs
@@ -117,7 +117,7 @@ public class ProductDetailsBlade(Guid productId) : ViewBase
             .Width(Size.Grow())
             .ToTrigger((isOpen) => new ProductEditSheet(isOpen, productId, refreshToken));
 
-        return Layout.Vertical() | new Card(
+        var productCard = new Card(
             content: new
             {
                 // We include some of the interesting fields of the entity here
@@ -132,6 +132,15 @@ public class ProductDetailsBlade(Guid productId) : ViewBase
                 | deleteBtn
                 | editBtn
             ).Title("Product Details");
+
+        return Layout.Vertical().Gap(4) | new object[]
+        {
+            productCard,
+            productCard,
+            productCard,
+            productCard,
+            productCard
+        };
     }
 
     private void Delete(SampleDbContextFactory dbFactory)

--- a/frontend/src/widgets/blades/BladeWidget.tsx
+++ b/frontend/src/widgets/blades/BladeWidget.tsx
@@ -69,7 +69,7 @@ export function BladeWidget({
           )}
         </div>
       </div>
-      <div className="bg-background h-full">
+      <div className="bg-background flex-1 min-h-0">
         {/* radix scrollarea breaks the nested containers widths*/}
         <ScrollArea
           type="hover"


### PR DESCRIPTION
This pull request introduces a small frontend layout improvement and a significant change to the `ProductDetailsBlade` in the backend. The backend now returns a vertical layout containing multiple instances of the product details card, likely for demonstration or testing purposes.

Backend: Product details blade changes

* Refactored the `ProductDetailsBlade` to create a `productCard` variable and return a vertical layout containing five instances of the product card, each separated by a gap. [[1]](diffhunk://#diff-5277a8877c9dc966be0aaaeb22375ca70940fcf5b44d2275ec2d254ca42bd356L120-R120) [[2]](diffhunk://#diff-5277a8877c9dc966be0aaaeb22375ca70940fcf5b44d2275ec2d254ca42bd356R135-R143)

Frontend: Layout improvement

* Updated the `BladeWidget` container to use `flex-1 min-h-0` instead of a fixed height, improving layout flexibility and scroll behavior.