### PR TITLE
(select): resolve value mismatch 

### DIFF
--- a/Ivy.Samples.Shared/Apps/Widgets/Inputs/SelectInputApp.cs
+++ b/Ivy.Samples.Shared/Apps/Widgets/Inputs/SelectInputApp.cs
@@ -1,5 +1,6 @@
 #pragma warning disable IVYHOOK001
 
+using System.ComponentModel;
 using Ivy.Shared;
 
 namespace Ivy.Samples.Shared.Apps.Widgets.Inputs;
@@ -58,6 +59,8 @@ public class SelectInputApp : SampleBase
                | multiSelectVariants
                | Text.H2("Data Binding")
                | dataBinding
+               | Text.H2("Label/Value Edge Cases")
+               | CreateLabelValueEdgeCasesSection()
                ;
     }
 
@@ -413,6 +416,58 @@ public class SelectInputApp : SampleBase
                | nonNullableColorState
                     .ToSelectInput(colorOptions)
                     .Variant(SelectInputs.Toggle);
+    }
+
+    private enum DatabaseNamingConvention
+    {
+        [Description("PascalCase")]
+        PascalCase,
+        [Description("camelCase")]
+        CamelCase,
+        [Description("snake_case")]
+        SnakeCase,
+    }
+
+    private object CreateLabelValueEdgeCasesSection()
+    {
+        var namingConventionOptions = typeof(DatabaseNamingConvention).ToOptions();
+
+        var singleSelectState = UseState(DatabaseNamingConvention.PascalCase);
+        var multiSelectState = UseState<DatabaseNamingConvention[]>([DatabaseNamingConvention.PascalCase, DatabaseNamingConvention.SnakeCase]);
+
+        return Layout.Grid().Columns(4)
+               | Text.InlineCode("Description")
+               | Text.InlineCode("Select")
+               | Text.InlineCode("List")
+               | Text.InlineCode("Toggle")
+
+               | Text.InlineCode("Single Select")
+               | singleSelectState.ToSelectInput(namingConventionOptions)
+               | singleSelectState
+                    .ToSelectInput(namingConventionOptions)
+                    .Variant(SelectInputs.List)
+               | singleSelectState
+                    .ToSelectInput(namingConventionOptions)
+                    .Variant(SelectInputs.Toggle)
+
+               | Text.InlineCode("Multi Select")
+               | multiSelectState.ToSelectInput(namingConventionOptions)
+               | multiSelectState
+                    .ToSelectInput(namingConventionOptions)
+                    .Variant(SelectInputs.List)
+               | multiSelectState
+                    .ToSelectInput(namingConventionOptions)
+                    .Variant(SelectInputs.Toggle)
+
+               | Text.InlineCode("Current Single Value")
+               | Text.InlineCode($"'{singleSelectState.Value}'")
+               | Text.Block("Check browser console for any fallback warnings")
+               | Text.Block("Values should match enum value, not description")
+
+               | Text.InlineCode("Current Multi Values")
+               | Text.InlineCode($"[{string.Join(", ", multiSelectState.Value)}]")
+               | Text.Block("Frontend should send actual enum values to backend")
+               | Text.Block("Not descriptions, even if they contain underscores");
     }
 
     private static object FormatStateValue(string typeName, object? value, bool isNullable)

--- a/Ivy.Test/JsonEnumConverterTests.cs
+++ b/Ivy.Test/JsonEnumConverterTests.cs
@@ -1,0 +1,193 @@
+using System.ComponentModel;
+using System.Text.Json;
+using Ivy.Core.Helpers;
+
+namespace Ivy.Test;
+
+public class JsonEnumConverterTests
+{
+    // Test enum with Description attributes (like DatabaseNamingConvention)
+    private enum TestEnum
+    {
+        [Description("PascalCase")]
+        PascalCase,
+
+        [Description("camelCase")]
+        CamelCase,
+
+        [Description("snake_case")]
+        SnakeCase,
+
+        // Enum without description to test fallback
+        NoDescription
+    }
+
+    private readonly JsonSerializerOptions _options;
+
+    public JsonEnumConverterTests()
+    {
+        _options = new JsonSerializerOptions
+        {
+            Converters = { new JsonEnumConverter() }
+        };
+    }
+
+    [Fact]
+    public void Write_ShouldSerializeEnumAsName_NotDescription()
+    {
+        // Arrange
+        var enumValue = TestEnum.SnakeCase;
+
+        // Act
+        var json = JsonSerializer.Serialize(enumValue, _options);
+
+        // Assert - Should serialize as enum name "SnakeCase", NOT description "snake_case"
+        Assert.Equal("\"SnakeCase\"", json);
+    }
+
+    [Fact]
+    public void Write_AllEnumValues_ShouldSerializeAsNames()
+    {
+        // Test all enum values to ensure they serialize as names, not descriptions
+        var testCases = new[]
+        {
+            (TestEnum.PascalCase, "\"PascalCase\""),
+            (TestEnum.CamelCase, "\"CamelCase\""),
+            (TestEnum.SnakeCase, "\"SnakeCase\""),
+            (TestEnum.NoDescription, "\"NoDescription\"")
+        };
+
+        foreach (var (enumValue, expectedJson) in testCases)
+        {
+            // Act
+            var json = JsonSerializer.Serialize(enumValue, _options);
+
+            // Assert
+            Assert.Equal(expectedJson, json);
+        }
+    }
+
+    [Fact]
+    public void Read_ShouldAcceptEnumName()
+    {
+        // Arrange
+        var json = "\"SnakeCase\"";
+
+        // Act
+        var result = JsonSerializer.Deserialize<TestEnum>(json, _options);
+
+        // Assert
+        Assert.Equal(TestEnum.SnakeCase, result);
+    }
+
+    [Fact]
+    public void Read_ShouldAcceptDescription_ForBackwardCompatibility()
+    {
+        // Arrange - JSON contains description, not enum name
+        var json = "\"snake_case\"";
+
+        // Act
+        var result = JsonSerializer.Deserialize<TestEnum>(json, _options);
+
+        // Assert - Should still parse correctly for backward compatibility
+        Assert.Equal(TestEnum.SnakeCase, result);
+    }
+
+    [Fact]
+    public void Read_ShouldAcceptBothDescriptionAndName()
+    {
+        var testCases = new[]
+        {
+            ("\"PascalCase\"", TestEnum.PascalCase),    // Enum name
+            ("\"PascalCase\"", TestEnum.PascalCase),    // Description (same as name)
+            ("\"CamelCase\"", TestEnum.CamelCase),      // Enum name  
+            ("\"camelCase\"", TestEnum.CamelCase),      // Description
+            ("\"SnakeCase\"", TestEnum.SnakeCase),      // Enum name
+            ("\"snake_case\"", TestEnum.SnakeCase),     // Description
+            ("\"NoDescription\"", TestEnum.NoDescription) // No description attribute
+        };
+
+        foreach (var (json, expectedEnum) in testCases)
+        {
+            // Act
+            var result = JsonSerializer.Deserialize<TestEnum>(json, _options);
+
+            // Assert
+            Assert.Equal(expectedEnum, result);
+        }
+    }
+
+    [Fact]
+    public void Read_InvalidValue_ShouldThrowJsonException()
+    {
+        // Arrange
+        var json = "\"InvalidEnumValue\"";
+
+        // Act & Assert
+        Assert.Throws<JsonException>(() =>
+            JsonSerializer.Deserialize<TestEnum>(json, _options));
+    }
+
+    [Fact]
+    public void RoundTrip_EnumValue_ShouldMaintainCorrectValue()
+    {
+        // This test proves the fix: enum should serialize as name and deserialize correctly
+
+        // Arrange
+        var originalValue = TestEnum.SnakeCase;
+
+        // Act - Serialize then deserialize
+        var json = JsonSerializer.Serialize(originalValue, _options);
+        var roundTripValue = JsonSerializer.Deserialize<TestEnum>(json, _options);
+
+        // Assert
+        Assert.Equal(originalValue, roundTripValue);
+        // Verify it serialized as enum name, not description
+        Assert.Equal("\"SnakeCase\"", json);
+    }
+
+    [Fact]
+    public void ProveTheBugWasFixed_DescriptionVsEnumName()
+    {
+        // This test specifically proves the bug that was causing the frontend issue
+
+        // Arrange
+        var enumValue = TestEnum.SnakeCase;
+
+        // Act
+        var serializedJson = JsonSerializer.Serialize(enumValue, _options);
+
+        // Assert - Before fix: would serialize as "snake_case" (description)
+        //         After fix: serializes as "SnakeCase" (enum name)
+        Assert.Equal("\"SnakeCase\"", serializedJson);
+        Assert.NotEqual("\"snake_case\"", serializedJson);
+
+        // Verify the frontend would receive the correct value
+        // Frontend expects: {label: "snake_case", value: "SnakeCase"}
+        // Before fix: backend sent {label: "snake_case", value: "snake_case"} ❌
+        // After fix: backend sends {label: "snake_case", value: "SnakeCase"} ✅
+    }
+
+    [Fact]
+    public void DatabaseNamingConvention_SimulateRealScenario()
+    {
+        // This simulates the exact DatabaseNamingConvention enum from SelectInputApp
+
+        // Arrange - Create enum similar to DatabaseNamingConvention
+        var testEnum = TestEnum.SnakeCase; // Represents DatabaseNamingConvention.SnakeCase
+
+        // Act - Simulate what happens when backend serializes current state
+        var currentStateJson = JsonSerializer.Serialize(testEnum, _options);
+
+        // Assert - This is what frontend receives as current value
+        Assert.Equal("\"SnakeCase\"", currentStateJson);
+
+        // Simulate frontend sending this back to backend
+        var backendReceives = JsonSerializer.Deserialize<TestEnum>(currentStateJson, _options);
+        Assert.Equal(TestEnum.SnakeCase, backendReceives);
+
+        // Before fix: frontend would receive "snake_case" and send it back,
+        // causing "Requested value 'snake_case' was not found" error
+        // After fix: frontend receives "SnakeCase" and sends it back successfully
+    }
+}

--- a/Ivy/Core/Helpers/JsonEnumConverter.cs
+++ b/Ivy/Core/Helpers/JsonEnumConverter.cs
@@ -43,8 +43,7 @@ public class JsonEnumConverter : JsonConverterFactory
 
         public override void Write(Utf8JsonWriter writer, TEnum value, JsonSerializerOptions options)
         {
-            string description = GetEnumDescription(value);
-            writer.WriteStringValue(description);
+            writer.WriteStringValue(value.ToString());
         }
 
         private string GetEnumDescription(TEnum value)


### PR DESCRIPTION
This pull request addresses a serialization bug with enums that have `Description` attributes, ensuring that enum values are always serialized as their names (not their descriptions) and deserialized correctly. It also adds a new UI test section to demonstrate label/value edge cases for select inputs, and introduces comprehensive unit tests to verify the new serialization behavior.

**Enum Serialization Fixes and Tests:**

* Updated `JsonEnumConverter` so that enums are always serialized as their name (e.g., `"SnakeCase"`), not their `Description` attribute, fixing an issue where the frontend received the wrong value and could not round-trip enum values correctly.
* Added a new test suite `JsonEnumConverterTests` to verify that serialization and deserialization of enums work as intended, including round-trip scenarios, backward compatibility with descriptions, and error handling for invalid values.

**UI Demonstration Improvements:**

* Added a new section to the `SelectInputApp` UI demo called "Label/Value Edge Cases", which uses a `DatabaseNamingConvention` enum with `Description` attributes to visually demonstrate correct label/value handling in single and multi-select inputs. [[1]](diffhunk://#diff-b398f313c51699983c3bfa4900e2add78e465914611bf810812b23cf22f8e270R62-R63) [[2]](diffhunk://#diff-b398f313c51699983c3bfa4900e2add78e465914611bf810812b23cf22f8e270R421-R472)
* Introduced the `DatabaseNamingConvention` enum in the UI sample to provide realistic test data for the new demo section.

**Code Quality:**

* Added a missing `using System.ComponentModel;` directive to ensure `Description` attributes are recognized in the UI sample.