### PR TITLE
feat(frontend): prefer public/favicon.ico with fallback to ivy.svg

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,6 +3,30 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/ivy.svg" />
+    <script>
+      (function () {
+        try {
+          var link = document.querySelector('link[rel="icon"]');
+          if (!link) {
+            link = document.createElement('link');
+            link.setAttribute('rel', 'icon');
+            document.head.appendChild(link);
+          }
+          fetch('/favicon.ico', { method: 'HEAD' })
+            .then(function (res) {
+              if (res && res.ok) {
+                link.setAttribute('href', '/favicon.ico');
+                link.setAttribute('type', 'image/x-icon');
+              }
+            })
+            .catch(function () {
+              /* ignore */
+            });
+        } catch (e) {
+          /* ignore */
+        }
+      })();
+    </script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Ivy</title>
   </head>


### PR DESCRIPTION
Fixes #867 

Summary
  - Prefer /favicon.ico when available; otherwise fall back to /ivy.svg.

Changes
  - Updated **frontend/index.html** to add a runtime check that swaps the favicon to /favicon.ico if it exists.

How to use
  - Add frontend/public/favicon.ico. No further configuration needed.
 
<img width="216" height="65" alt="Screenshot from 2025-09-28 16-43-51" src="https://github.com/user-attachments/assets/ed4f68a4-a95d-4607-aab4-53c24e38d540" />
