### PR TITLE
(number input): respect provided min/max instead of hard-coded 0/100

### DIFF
--- a/frontend/src/widgets/inputs/NumberInputWidget.tsx
+++ b/frontend/src/widgets/inputs/NumberInputWidget.tsx
@@ -168,8 +168,12 @@ const SliderVariant = memo(
           )}
           aria-hidden="true"
         >
-          <span>{min}</span>
-          <span>{max}</span>
+          {min !== undefined && max !== undefined && (
+            <>
+              <span>{min}</span>
+              <span>{max}</span>
+            </>
+          )}
         </span>
         {invalid && (
           <div className="absolute right-2.5 translate-y-1/2 -top-1.5">
@@ -187,8 +191,8 @@ const NumberVariant = memo(
   ({
     placeholder = '',
     value,
-    min = 0,
-    max = 100,
+    min,
+    max,
     step = 1,
     formatStyle = 'Decimal',
     precision = 2,
@@ -286,11 +290,14 @@ export const NumberInputWidget = memo(
       (newValue: number | null) => {
         // Apply bounds only if value is not null
         if (newValue !== null) {
-          // First apply component-level bounds (min/max props)
-          const boundedValue = Math.min(
-            Math.max(newValue, props.min ?? 0),
-            props.max ?? 100
-          );
+          // First apply component-level bounds (min/max props) only when provided
+          let boundedValue = newValue;
+          if (props.min !== undefined) {
+            boundedValue = Math.max(boundedValue, props.min);
+          }
+          if (props.max !== undefined) {
+            boundedValue = Math.min(boundedValue, props.max);
+          }
 
           // Then apply type-level validation to prevent overflow
           const validatedValue = validateAndCapValue(


### PR DESCRIPTION
Fixes : #912 

- Updated frontend/src/widgets/inputs/NumberInputWidget.tsx to remove hard-coded defaults min=0 and max=100 for the Number variant.

- The widget now clamps values only when min and/or max are explicitly provided via props.

- Preserved Slider variant defaults (min=0, max=100) to avoid breaking existing usage; slider end-labels now render only when both bounds are provided.

- Type-level bounds validation via validateAndCapValue() remains in place to prevent overflow for numeric target types.