### PR TITLE
[Docs]: Sync docs with Release 1.0.114

### DIFF
--- a/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/03_DatabaseIntegration/01_Overview.md
+++ b/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/03_DatabaseIntegration/01_Overview.md
@@ -296,6 +296,27 @@ You can add multiple database connections to a single project:
 >ivy db add --provider ClickHouse --name AnalyticsDb
 ```
 
+## Default schema
+
+The ivy db add command includes a `--use-default-schema` parameter that automatically uses the database's default schema without prompting.
+
+```terminal
+>ivy db add --provider postgres --connection-string "..." --name MyDb --use-default-schema
+
+```
+
+The default schemas for each database provider are:
+
+- `PostgreSQL/Supabase` – public
+- `SQL Server` – dbo
+- `Oracle` – Uses the connected username as the default schema
+- `ClickHouse` – default
+- `Snowflake` – PUBLIC
+
+<Callout Type="Warning">
+You cannot use both --schema and --use-default-schema parameters together. Choose one based on whether you want to specify a custom schema or use the database default.
+</Callout>
+
 ## Related Commands
 
 - `ivy init` - Initialize a new Ivy project

--- a/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/03_DatabaseIntegration/01_Overview.md
+++ b/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/03_DatabaseIntegration/01_Overview.md
@@ -130,25 +130,6 @@ You can also use environment variables for connection strings (with the exceptio
 export ConnectionStrings__MY_DATABASE_CONNECTION_STRING="Host=localhost;Database=mydb;Username=user;Password=pass"
 ```
 
-### Entity Framework Migrations
-
-The generated DesignFactory allows you to use standard EF Core migration commands:
-
-```terminal
->dotnet ef migrations add InitialCreate
->dotnet ef database update
-```
-
-When you generate a new database project, the generator will automatically run:
-
-```terminal
->dotnet ef migrations add InitialCreate
-```
-
-<Callout Type="Warning">
-The migration is created with the connection string you provided during generation, ensuring it uses the correct database context.
-</Callout>
-
 ### Connection Structure
 
 Each database connection has its own a folder structure:

--- a/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/03_DatabaseIntegration/01_Overview.md
+++ b/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/03_DatabaseIntegration/01_Overview.md
@@ -130,6 +130,25 @@ You can also use environment variables for connection strings (with the exceptio
 export ConnectionStrings__MY_DATABASE_CONNECTION_STRING="Host=localhost;Database=mydb;Username=user;Password=pass"
 ```
 
+### Entity Framework Migrations
+
+The generated DesignFactory allows you to use standard EF Core migration commands:
+
+```terminal
+>dotnet ef migrations add InitialCreate
+>dotnet ef database update
+```
+
+When you generate a new database project, the generator will automatically run:
+
+```terminal
+>dotnet ef migrations add InitialCreate
+```
+
+<Callout Type="Warning">
+The migration is created with the connection string you provided during generation, ensuring it uses the correct database context.
+</Callout>
+
 ### Connection Structure
 
 Each database connection has its own a folder structure:

--- a/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/03_DatabaseIntegration/02_SQLite.md
+++ b/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/03_DatabaseIntegration/02_SQLite.md
@@ -42,6 +42,31 @@ See [Database Integration Overview](Overview.md) for more information on adding 
 
 Ivy automatically configures the **Microsoft.EntityFrameworkCore.Sqlite** package for SQLite connections.
 
+## Database Initialization
+
+The Database Generator for SQLite projects includes automatic database initialization and improved logging capabilities:
+
+- **Automatic Database Creation**: The generated DbContextFactory automatically creates the SQLite database file on first use
+- **Thread-Safe Initialization**: Uses semaphore locking for safe concurrent access
+- **Flexible Storage**: Supports custom storage volumes with a default location in the user's local application data folder
+- **Better Logging**: Entity Framework logs are properly routed through the application's logging infrastructure
+
+The generated factory accepts optional volume and logger parameters for enhanced configuration:
+
+```csharp
+public MyDbContextFactory(
+    ServerArgs args,
+    IVolume? volume = null,
+    ILogger? logger = null
+)
+```
+
+<Callout Type="info">
+The `IVolume` parameter allows custom storage locations for your SQLite database, defaulting to the user's local application data folder. Inject your custom `IVolume` implementation through dependency injection for production deployments, containerized applications, or multi-tenant scenarios.
+</Callout>
+
+For more details on volume configuration, see the [Volume documentation](../../02_Concepts/Volume.md).
+
 ## SQLite-Specific Features
 
 Key advantages:

--- a/Ivy.Docs.Shared/Docs/02_Widgets/03_Primitives/Image.md
+++ b/Ivy.Docs.Shared/Docs/02_Widgets/03_Primitives/Image.md
@@ -10,4 +10,21 @@ The `Image` widget displays images in your app.
 new Image("https://api.images.cat/150/150")
 ```
 
+### Supported Image Sources
+
+The Image widget works with multiple source types:
+
+- **External URLs**: Images hosted on external servers
+- **Local files**: Images stored in your application's file system
+- **Data URIs**: Base64-encoded images embedded directly in the code
+
+```csharp
+var dataUri = "data:image/png;base64,iVBORw0KGgoAAAANS...";
+new Image(dataUri);
+
+new Image("https://example.com/image.jpg");  // External URL
+new Image("/images/logo.png");               // Local file
+new Image(dataUri);                          // Data URI
+```
+
 <WidgetDocs Type="Ivy.Image" ExtensionTypes="Ivy.ImageExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Primitives/Image.cs"/>

--- a/Ivy.Docs.Shared/Docs/02_Widgets/03_Primitives/Image.md
+++ b/Ivy.Docs.Shared/Docs/02_Widgets/03_Primitives/Image.md
@@ -24,7 +24,6 @@ new Image(dataUri);
 
 new Image("https://example.com/image.jpg");  // External URL
 new Image("/images/logo.png");               // Local file
-new Image(dataUri);                          // Data URI
 ```
 
 <WidgetDocs Type="Ivy.Image" ExtensionTypes="Ivy.ImageExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Primitives/Image.cs"/>


### PR DESCRIPTION
1. No need to be included in the documentation.

<img width="1321" height="751" alt="Screenshot 2025-09-30 at 00 26 25" src="https://github.com/user-attachments/assets/2aaa2476-d0b1-47d6-8405-0238c51c08f9" />

2. No need to be included in the documentation.

<img width="1325" height="163" alt="Screenshot 2025-09-30 at 00 27 49" src="https://github.com/user-attachments/assets/71f97819-7622-46ac-a55a-8d981dc2eb2e" />

3. Docs -> Cli -> Database Integration -> New section "Default Schema"
<img width="1326" height="520" alt="Screenshot 2025-09-30 at 00 28 14" src="https://github.com/user-attachments/assets/b73e8d93-a875-4dca-a7bb-8e8087d6fbb7" />

<img width="1353" height="738" alt="Screenshot 2025-09-30 at 00 31 16" src="https://github.com/user-attachments/assets/0fef3f5a-a9aa-40ba-94f6-961ac0f8e75e" />

4. Do we need to docement it externally? 

<img width="1340" height="282" alt="Screenshot 2025-09-30 at 00 38 52" src="https://github.com/user-attachments/assets/c2b1554c-a239-476a-b856-0c40bde28b45" />

5. Docs -> Cli -> Database Integration -> New section "Entity Framework Migrations"

<img width="1223" height="927" alt="Screenshot 2025-09-30 at 00 51 23" src="https://github.com/user-attachments/assets/4a6e3970-caec-46f8-901a-ebd4c7dc1636" />

<img width="1287" height="711" alt="Screenshot 2025-09-30 at 00 50 40" src="https://github.com/user-attachments/assets/1d6375e7-c66d-4eec-b84f-0596da2b88d8" />

6. No need to be included in the documentation(?)
SQLite has it's own documentation, but there is no code provided in doc, so it seems not to be there.
<img width="1333" height="638" alt="Screenshot 2025-09-30 at 00 52 17" src="https://github.com/user-attachments/assets/e11e898c-6c58-4b64-be20-d03a2dfbe5f0" />

7. No need to be included in the documentation.

In the most of input widgets we have API sections in docs with Size props.

<img width="1349" height="752" alt="Screenshot 2025-09-30 at 01 13 26" src="https://github.com/user-attachments/assets/1719ec9a-9fae-4cee-b49d-609a4cbbff16" />

<img width="1336" height="163" alt="Screenshot 2025-09-30 at 01 11 43" src="https://github.com/user-attachments/assets/6cb2825a-11e5-4116-950d-a4743d4c3613" />

8. This doesn't actually works? 
<img width="1331" height="349" alt="Screenshot 2025-09-30 at 01 23 11" src="https://github.com/user-attachments/assets/ae2ee413-82c2-4cde-a8a8-ffbfee25dc35" />
<img width="1309" height="451" alt="Screenshot 2025-09-30 at 01 32 47" src="https://github.com/user-attachments/assets/2e419b34-1bcd-4fd3-adf7-a843ca877d18" />

9. Docs -> Image -> new section "Supported Image Sources"
<img width="1334" height="384" alt="Screenshot 2025-09-30 at 01 34 53" src="https://github.com/user-attachments/assets/e0f51ea9-214b-46fa-b58f-a882c821af26" />

<img width="1314" height="752" alt="Screenshot 2025-09-30 at 01 49 26" src="https://github.com/user-attachments/assets/63bdeefc-ac8f-40cf-97cf-a1de111fbbca" />

10. Already in Docs, Pie chart -> Donut Chart with Custom Labels
<img width="1214" height="641" alt="Screenshot 2025-09-30 at 01 50 32" src="https://github.com/user-attachments/assets/d5980b56-ac3a-4043-8acf-7a7a76e76306" />
<img width="1286" height="711" alt="Screenshot 2025-09-30 at 01 51 27" src="https://github.com/user-attachments/assets/433700a0-66bb-4471-a956-ad6d424c21e2" />
11.  No need to be included in the documentation.
<img width="978" height="851" alt="Screenshot 2025-09-30 at 01 53 29" src="https://github.com/user-attachments/assets/5892a2d9-46bc-4bb7-b05a-4378c0426068" />
