### PR TITLE
[Docs] : Fixed added star on docs onchange of code

### DIFF
--- a/frontend/src/components/custom-emojis/emojiMap.tsx
+++ b/frontend/src/components/custom-emojis/emojiMap.tsx
@@ -4,6 +4,6 @@ export type EmojiEntry = {
 
 export const emojiMap: Record<string, EmojiEntry> = {
   ':ivy-branded-star:': {
-    src: './ivy-branded-star.svg',
+    src: '/ivy-branded-star.svg',
   },
 };


### PR DESCRIPTION
Fixes #986 

<img width="1034" height="415" alt="Screenshot from 2025-09-30 21-45-25" src="https://github.com/user-attachments/assets/aa90a70f-d82c-4d4f-85a0-8afee1a59080" />
Ivy branded star is not also visible in Docs with same code as sample one

Files Effected : **frontend/src/components/custom-emojis/emojiMap.tsx**
