### PR TITLE
[TerminalWidget]: fix ">" placement

### DIFF
--- a/Ivy.Samples.Shared/Apps/Demos/TerminalApp.cs
+++ b/Ivy.Samples.Shared/Apps/Demos/TerminalApp.cs
@@ -13,11 +13,6 @@ public class TerminalApp : ViewBase
                    .AddCommand("echo Hello, world!")
                    .AddOutput("Hello, world!")
                    .Title("Your first Ivy app!")
-                 | new Terminal()
-                   .AddCommand("ivy db add --provider postgres --connection-string \"...\" --name MyDb --use-default-schema!")
-                   .AddOutput("Hello, world!")
-                   .Title("Your first Ivy app!")
-
             ;
     }
 }


### PR DESCRIPTION
Had a problem with multilined commands. ">" symbol took place between lines, at the center.
<img width="1018" height="162" alt="Screenshot 2025-10-01 at 00 07 26" src="https://github.com/user-attachments/assets/648348ca-7ab7-40fc-922f-1045d74a9452" />

Fixed.
<img width="606" height="103" alt="Screenshot 2025-10-01 at 00 04 08" src="https://github.com/user-attachments/assets/1a52ec8b-28c2-432f-8be6-b251465dec43" />
Also saved alighning of > symbol as it was before.
<img width="211" height="40" alt="Screenshot 2025-10-01 at 00 04 27" src="https://github.com/user-attachments/assets/fa7fd254-d800-4ab7-bdc7-685be6d9c630" />
<img width="604" height="91" alt="Screenshot 2025-10-01 at 00 04 05" src="https://github.com/user-attachments/assets/1a574d9c-52d7-445a-820c-9df8568d6779" />
<img width="1247" height="277" alt="Screenshot 2025-10-01 at 00 09 32" src="https://github.com/user-attachments/assets/fe23141c-69c5-460f-a5b2-478ed893839e" />
