### PR TITLE
(auth0): support direct JWT verification

### DIFF
--- a/Ivy.Auth.Auth0/Auth0AuthProvider.cs
+++ b/Ivy.Auth.Auth0/Auth0AuthProvider.cs
@@ -1,10 +1,15 @@
-﻿using System.Reflection;
+﻿using System.IdentityModel.Tokens.Jwt;
+using System.Reflection;
+using System.Security.Claims;
 using Auth0.AuthenticationApi;
 using Auth0.AuthenticationApi.Models;
 using Ivy.Hooks;
 using Ivy.Shared;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Tokens;
 
 namespace Ivy.Auth.Auth0;
 
@@ -24,6 +29,8 @@ public class Auth0AuthProvider : IAuthProvider
     private readonly string _audience;
     private readonly List<AuthOption> _authOptions = new();
 
+    private readonly ConfigurationManager<OpenIdConnectConfiguration> _configurationManager;
+
     public Auth0AuthProvider()
     {
         var configuration = new ConfigurationBuilder()
@@ -37,6 +44,15 @@ public class Auth0AuthProvider : IAuthProvider
         _audience = configuration.GetValue<string>("Auth0:Audience") ?? "";
 
         _authClient = new AuthenticationApiClient(_domain);
+
+        // Setup OpenID configuration manager for JWKS
+        var authority = $"https://{_domain}/";
+        var documentRetriever = new HttpDocumentRetriever { RequireHttps = true };
+        _configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
+            $"{authority}.well-known/openid-configuration",
+            new OpenIdConnectConfigurationRetriever(),
+            documentRetriever
+        );
     }
 
     public async Task<AuthToken?> LoginAsync(string email, string password)
@@ -160,40 +176,52 @@ public class Auth0AuthProvider : IAuthProvider
         }
     }
 
-    public async Task<bool> ValidateJwtAsync(string jwt)
+    private async Task<ClaimsPrincipal?> VerifyToken(string jwt)
     {
         try
         {
-            var userInfo = await _authClient.GetUserInfoAsync(jwt);
-            return userInfo != null;
-        }
-        catch (Exception)
-        {
-            return false;
-        }
-    }
+            var discoveryDocument = await _configurationManager.GetConfigurationAsync(CancellationToken.None);
+            var signingKeys = discoveryDocument.SigningKeys;
 
-    public async Task<UserInfo?> GetUserInfoAsync(string jwt)
-    {
-        try
-        {
-            var userInfo = await _authClient.GetUserInfoAsync(jwt);
-            if (userInfo == null)
+            var tokenValidationParameters = new TokenValidationParameters
             {
-                return null;
-            }
+                ValidateIssuer = true,
+                ValidIssuer = $"https://{_domain}/",
+                ValidateAudience = true,
+                ValidAudience = _audience,
+                ValidateIssuerSigningKey = true,
+                IssuerSigningKeys = signingKeys,
+                ValidateLifetime = true,
+            };
 
-            return new UserInfo(
-                userInfo.UserId,
-                userInfo.Email,
-                userInfo.FullName,
-                userInfo.Picture
-            );
+            var handler = new JwtSecurityTokenHandler();
+            return handler.ValidateToken(jwt, tokenValidationParameters, out SecurityToken validatedToken);
         }
         catch (Exception)
         {
             return null;
         }
+    }
+
+    public async Task<bool> ValidateJwtAsync(string jwt)
+    {
+        var claims = await VerifyToken(jwt);
+        return claims is not null;
+    }
+
+    public async Task<UserInfo?> GetUserInfoAsync(string jwt)
+    {
+        var claims = await VerifyToken(jwt);
+        if (claims is null)
+        {
+            return null;
+        }
+        return new UserInfo(
+            claims.FindFirst(ClaimTypes.NameIdentifier)?.Value ?? "",
+            claims.FindFirst(ClaimTypes.Email)?.Value ?? "",
+            claims.FindFirst(ClaimTypes.Name)?.Value ?? "",
+            claims.FindFirst("avatar")?.Value ?? ""
+        );
     }
 
     public AuthOption[] GetAuthOptions()

--- a/Ivy.Auth.Auth0/Auth0AuthProvider.cs
+++ b/Ivy.Auth.Auth0/Auth0AuthProvider.cs
@@ -43,7 +43,7 @@ public class Auth0AuthProvider : IAuthProvider
         _clientId = configuration.GetValue<string>("Auth0:ClientId") ?? throw new Exception("Auth0:ClientId is required");
         _clientSecret = configuration.GetValue<string>("Auth0:ClientSecret") ?? throw new Exception("Auth0:ClientSecret is required");
         _audience = configuration.GetValue<string>("Auth0:Audience") ?? "";
-        _namespace = configuration.GetValue<string>("Auth0:Namespace") ?? "";
+        _namespace = configuration.GetValue<string>("Auth0:Namespace") ?? "https://ivy.app/";
 
         _authClient = new AuthenticationApiClient(_domain);
 
@@ -220,6 +220,10 @@ public class Auth0AuthProvider : IAuthProvider
         if (claims is null)
         {
             return null;
+        }
+        foreach (var claim in claims.Claims)
+        {
+            Console.WriteLine(claim.ToString());
         }
         return new UserInfo(
             claims.FindFirst("sub")?.Value ?? "",

--- a/Ivy.Auth.Auth0/Auth0AuthProvider.cs
+++ b/Ivy.Auth.Auth0/Auth0AuthProvider.cs
@@ -194,7 +194,10 @@ public class Auth0AuthProvider : IAuthProvider
                 ValidateLifetime = true,
             };
 
-            var handler = new JwtSecurityTokenHandler();
+            var handler = new JwtSecurityTokenHandler
+            {
+                InboundClaimTypeMap = new Dictionary<string, string>()
+            };
             return handler.ValidateToken(jwt, tokenValidationParameters, out SecurityToken validatedToken);
         }
         catch (Exception)
@@ -217,9 +220,9 @@ public class Auth0AuthProvider : IAuthProvider
             return null;
         }
         return new UserInfo(
-            claims.FindFirst(ClaimTypes.NameIdentifier)?.Value ?? "",
-            claims.FindFirst(ClaimTypes.Email)?.Value ?? "",
-            claims.FindFirst(ClaimTypes.Name)?.Value ?? "",
+            claims.FindFirst("sub")?.Value ?? "",
+            claims.FindFirst("email")?.Value ?? "",
+            claims.FindFirst("name")?.Value ?? "",
             claims.FindFirst("avatar")?.Value ?? ""
         );
     }

--- a/Ivy.Auth.Auth0/Auth0AuthProvider.cs
+++ b/Ivy.Auth.Auth0/Auth0AuthProvider.cs
@@ -27,6 +27,7 @@ public class Auth0AuthProvider : IAuthProvider
     private readonly string _clientId;
     private readonly string _clientSecret;
     private readonly string _audience;
+    private readonly string _namespace;
     private readonly List<AuthOption> _authOptions = new();
 
     private readonly ConfigurationManager<OpenIdConnectConfiguration> _configurationManager;
@@ -42,6 +43,7 @@ public class Auth0AuthProvider : IAuthProvider
         _clientId = configuration.GetValue<string>("Auth0:ClientId") ?? throw new Exception("Auth0:ClientId is required");
         _clientSecret = configuration.GetValue<string>("Auth0:ClientSecret") ?? throw new Exception("Auth0:ClientSecret is required");
         _audience = configuration.GetValue<string>("Auth0:Audience") ?? "";
+        _namespace = configuration.GetValue<string>("Auth0:Namespace") ?? "";
 
         _authClient = new AuthenticationApiClient(_domain);
 
@@ -221,9 +223,9 @@ public class Auth0AuthProvider : IAuthProvider
         }
         return new UserInfo(
             claims.FindFirst("sub")?.Value ?? "",
-            claims.FindFirst("email")?.Value ?? "",
-            claims.FindFirst("name")?.Value ?? "",
-            claims.FindFirst("avatar")?.Value ?? ""
+            claims.FindFirst(_namespace + "email")?.Value ?? "",
+            claims.FindFirst(_namespace + "name")?.Value ?? "",
+            claims.FindFirst(_namespace + "avatar")?.Value ?? ""
         );
     }
 

--- a/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/04_Authentication/02_Auth0.md
+++ b/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/04_Authentication/02_Auth0.md
@@ -164,8 +164,8 @@ To allow the Ivy application to properly display the users email, name and avata
 4. **Add the following code:**
 ```javascript
 exports.onExecutePostLogin = async (event, api) => {
-    api.accessToken.setCustomClaim('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/email', event.user.email);
-    api.accessToken.setCustomClaim('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name', event.user.name);
+    api.accessToken.setCustomClaim('email', event.user.email);
+    api.accessToken.setCustomClaim('name', event.user.name);
     api.accessToken.setCustomClaim('avatar', event.user.picture);
 };
 ```

--- a/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/04_Authentication/02_Auth0.md
+++ b/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/04_Authentication/02_Auth0.md
@@ -154,6 +154,28 @@ For more information on setting up Apple authentication, see Auth0's [Apple docu
 
 For more information on setting up Twitter/X authentication, see Auth0's [Twitter documentation](https://marketplace.auth0.com/integrations/twitter-social-connection).
 
+### Step 6: Add claims to JWT
+
+To allow the Ivy application to properly display the users email, name and avatar, these need to be added to the JWT. In Auth0, this is done using an action.
+
+1. **Go to Actions > Library** in the Auth0 Dashboard
+2. **Click "Create Action" > "Create Custom Action"**
+3. **Give it a name like "Add user claims to JWT" and choose "Login / Post Login" as the trigger.**
+4. **Add the following code:**
+```javascript
+exports.onExecutePostLogin = async (event, api) => {
+    api.accessToken.setCustomClaim('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/email', event.user.email);
+    api.accessToken.setCustomClaim('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name', event.user.name);
+    api.accessToken.setCustomClaim('avatar', event.user.picture);
+};
+```
+5. **Click Deploy**
+6. **Go to Actions > Triggers** in the Auth0 Dashboard
+7. **Click "post-login"**
+8. **Add your action** by dragging it from the right-hand panel between "Start" and "Complete".
+
+The user information email, name and picture will now be added to the JWT and consumed by Ivy in the `GetUserInfoAsync` function.
+
 ## Adding Authentication
 
 To set up Auth0 Authentication with Ivy, run the following command and choose `Auth0` when asked to select an auth provider:

--- a/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/04_Authentication/02_Auth0.md
+++ b/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/04_Authentication/02_Auth0.md
@@ -164,9 +164,16 @@ To allow the Ivy application to properly display the users email, name and avata
 4. **Add the following code:**
 ```javascript
 exports.onExecutePostLogin = async (event, api) => {
-    api.accessToken.setCustomClaim('email', event.user.email);
-    api.accessToken.setCustomClaim('name', event.user.name);
-    api.accessToken.setCustomClaim('avatar', event.user.picture);
+    // Choose a claims namespace - typically your own domain
+    let namespace = "https://your-domain.com/";
+
+    if (namespace && !namespace.endsWith('/')) {
+        namespace += '/';
+    }
+
+    api.accessToken.setCustomClaim(namespace + 'email', event.user.email);
+    api.accessToken.setCustomClaim(namespace + 'name', event.user.name);
+    api.accessToken.setCustomClaim(namespace + 'avatar', event.user.picture);
 };
 ```
 5. **Click Deploy**
@@ -190,6 +197,7 @@ You will be prompted to provide the following Auth0 configuration:
 - **Client ID**: Your Auth0 application's client ID
 - **Client Secret**: Your Auth0 application's client secret
 - **Audience**: API identifier for securing API access
+- **Namespace**: Namespace used for custom JWT claims, as chosen earlier on this page
 
 Your credentials will be stored securely in .NET user secrets. You will then be prompted to choose one or more authentication options to support, from the following list:
 
@@ -215,7 +223,7 @@ Ivy then finishes configuring your application automatically:
 To skip the interactive prompts, you can provide configuration via a connection string:
 
 ```terminal
->ivy auth add --provider Auth0 --connection-string "Auth0:Domain=your-domain.auth0.com;Auth0:ClientId=your-client-id;Auth0:ClientSecret=your-client-secret"
+>ivy auth add --provider Auth0 --connection-string "Auth0:Domain=your-domain.auth0.com;Auth0:ClientId=your-client-id;Auth0:ClientSecret=your-client-secret;Auth0:Namespace=https://your-domain.com/"
 ```
 
 For a list of connection string parameters, see [Configuration Parameters](#configuration-parameters) below.
@@ -236,6 +244,7 @@ The following parameters are supported via connection string, environment variab
 - **Auth0:ClientId**: Required. Your Auth0 application's client ID.
 - **Auth0:ClientSecret**: Required. Your Auth0 application's client secret.
 - **Auth0:Audience**: Required. API identifier for securing API access.
+- **Auth0:Namespace**: Optional. Your JWT claims namespace, as chosen earlier in this guide.
 
 ## Authentication Flow
 

--- a/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/04_Authentication/02_Auth0.md
+++ b/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/04_Authentication/02_Auth0.md
@@ -164,8 +164,8 @@ To allow the Ivy application to properly display the users email, name and avata
 4. **Add the following code:**
 ```javascript
 exports.onExecutePostLogin = async (event, api) => {
-    // Choose a claims namespace - typically your own domain
-    let namespace = "https://your-domain.com/";
+    // You can change this if you want - but then also update the "Auth0:Namespace" configuration in your Ivy project
+    let namespace = "https://ivy.app/";
 
     if (namespace && !namespace.endsWith('/')) {
         namespace += '/';
@@ -197,7 +197,6 @@ You will be prompted to provide the following Auth0 configuration:
 - **Client ID**: Your Auth0 application's client ID
 - **Client Secret**: Your Auth0 application's client secret
 - **Audience**: API identifier for securing API access
-- **Namespace**: Namespace used for custom JWT claims, as chosen earlier on this page
 
 Your credentials will be stored securely in .NET user secrets. You will then be prompted to choose one or more authentication options to support, from the following list:
 
@@ -244,7 +243,7 @@ The following parameters are supported via connection string, environment variab
 - **Auth0:ClientId**: Required. Your Auth0 application's client ID.
 - **Auth0:ClientSecret**: Required. Your Auth0 application's client secret.
 - **Auth0:Audience**: Required. API identifier for securing API access.
-- **Auth0:Namespace**: Optional. Your JWT claims namespace, as chosen earlier in this guide.
+- **Auth0:Namespace**: Optional. Your JWT claims namespace, as chosen earlier in this guide. If left empty "https://ivy.app/" will be used.
 
 ## Authentication Flow
 


### PR DESCRIPTION
This PR changes how the Auth0 provider handles JWTs, and how it gets the user info. Instead of using the Auth0 Authentication API, the JWT is verified using the Auth0 JWKS, and user info (id, email, name, etc.) is read straight from the JWT claims.

Issue #988 