### PR TITLE
(search) Improve search in the sidebar

### DIFF
--- a/Ivy.Samples.Shared/Apps/Widgets/Inputs/TextInputApp.cs
+++ b/Ivy.Samples.Shared/Apps/Widgets/Inputs/TextInputApp.cs
@@ -3,7 +3,7 @@ using Ivy.Shared;
 
 namespace Ivy.Samples.Shared.Apps.Widgets.Inputs;
 
-[App(icon: Icons.TextCursorInput, path: ["Widgets", "Inputs"], searchTags: ["password", "textarea", "search", "email"])]
+[App(icon: Icons.TextCursorInput, path: ["Widgets", "Inputs"], searchHints: ["password", "textarea", "search", "email"])]
 public class TextInputApp : SampleBase
 {
     protected override object? BuildSample()

--- a/Ivy/Apps/AppAttribute.cs
+++ b/Ivy/Apps/AppAttribute.cs
@@ -13,7 +13,7 @@ public class AppAttribute(
     int order = 0,
     bool groupExpanded = false,
     string? documentSource = null,
-    string[]? searchTags = null
+    string[]? searchHints = null
 )
     : System.Attribute
 {
@@ -35,5 +35,5 @@ public class AppAttribute(
 
     public string? DocumentSource { get; set; } = documentSource;
 
-    public string[]? SearchTags { get; set; } = searchTags;
+    public string[]? SearchHints { get; set; } = searchHints;
 }

--- a/Ivy/Apps/AppDescriptor.cs
+++ b/Ivy/Apps/AppDescriptor.cs
@@ -47,7 +47,7 @@ public class AppDescriptor : IAppRepositoryNode
 
     public string? DocumentSource { get; set; }
 
-    public string[]? SearchTags { get; set; }
+    public string[]? SearchHints { get; set; }
 
     public ViewBase CreateApp()
     {
@@ -71,6 +71,6 @@ public class AppDescriptor : IAppRepositoryNode
 
     public MenuItem GetMenuItem()
     {
-        return new MenuItem(Title, null, Icon, Id, SearchTags: SearchTags);
+        return new MenuItem(Title, null, Icon, Id, SearchHints: SearchHints);
     }
 }

--- a/Ivy/Apps/AppHelpers.cs
+++ b/Ivy/Apps/AppHelpers.cs
@@ -65,7 +65,7 @@ public static class AppHelpers
                 Order = appAttribute.Order,
                 GroupExpanded = appAttribute.GroupExpanded,
                 DocumentSource = appAttribute.DocumentSource,
-                SearchTags = appAttribute.SearchTags,
+                SearchHints = appAttribute.SearchHints,
             };
         }
         throw new InvalidOperationException($"Type '{type.FullName}' is missing the [App] attribute.");

--- a/Ivy/Chrome/DefaultSidebarChrome.cs
+++ b/Ivy/Chrome/DefaultSidebarChrome.cs
@@ -21,10 +21,9 @@ public class DefaultSidebarChrome(ChromeSettings settings) : ViewBase
     private bool itemMatchSearch(MenuItem item, string searchString)
     {
         bool matchSearch = (item.Label ?? "").Contains(searchString, StringComparison.OrdinalIgnoreCase);
-        for (int i = 0; !matchSearch && item.SearchTags != null && i < item.SearchTags.Length; i++)
+        if (!matchSearch)
         {
-            var tag = item.SearchTags[i];
-            matchSearch = tag.Contains(searchString, StringComparison.OrdinalIgnoreCase);
+            matchSearch = item.SearchHints?.Any(tag => tag.Contains(searchString, StringComparison.OrdinalIgnoreCase)) == true;
         }
         return matchSearch;
     }

--- a/Ivy/Shared/MenuItem.cs
+++ b/Ivy/Shared/MenuItem.cs
@@ -31,7 +31,7 @@ public enum MenuItemVariant
 /// <param name="Shortcut">Keyboard shortcut text to display.</param>
 /// <param name="Expanded">Whether child items are expanded in hierarchical menus.</param>
 /// <param name="OnSelect">Event handler called when item is selected.</param>
-/// <param name="SearchTags">Tags used for the search functionality.</param>
+/// <param name="SearchHints">Tags used for the search functionality.</param>
 public record MenuItem(
     string? Label = null,
     MenuItem[]? Children = null,
@@ -43,7 +43,7 @@ public record MenuItem(
     string? Shortcut = null,
     bool Expanded = false,
     Action<MenuItem>? OnSelect = null,
-    string[]? SearchTags = null)
+    string[]? SearchHints = null)
 {
 
     /// <summary>Creates a separator menu item for visual grouping.</summary>
@@ -181,8 +181,8 @@ public static class MenuItemExtensions
     }
 
     /// <summary>Sets the search tags for this app</summary>
-    public static MenuItem SearchTags(this MenuItem menuItem, string[] searchTags)
+    public static MenuItem SearchHints(this MenuItem menuItem, string[] searchHints)
     {
-        return menuItem with { SearchTags = searchTags };
+        return menuItem with { SearchHints = searchHints };
     }
 }


### PR DESCRIPTION
Feature [Issue 1015](https://github.com/Ivy-Interactive/Ivy-Framework/issues/1015)

 Add the possibility to add tags to apps to search them in the sidebar more easily, and add an example for textInput.

I also made a change so that we can search app name in the middle instead of only in the start. 