### PR TITLE
[PieChart]: Redefine fill color for label list

### DIFF
--- a/frontend/src/widgets/charts/shared.ts
+++ b/frontend/src/widgets/charts/shared.ts
@@ -305,7 +305,7 @@ export const generateLabelListProps = (props: ExtendedLabelListProps) => {
   return {
     dataKey: camelCase(dataKey) as string,
     position: camelCase(position) as LabelListProps['position'],
-    fill: fill && `var(--${fill.toLowerCase()})`,
+    fill: fill && `var(--muted-foreground)`,
     formatter,
     ...labelListProps,
   };


### PR DESCRIPTION
Old one:
<img width="785" height="780" alt="Screenshot 2025-10-04 at 01 08 55" src="https://github.com/user-attachments/assets/a95dc787-6bd1-4b47-a5d2-32e463463a05" />

New one:
<img width="681" height="679" alt="Screenshot 2025-10-04 at 01 10 22" src="https://github.com/user-attachments/assets/92a73294-3f5e-45db-a50f-05773a702839" />

In light theme:
<img width="697" height="691" alt="Screenshot 2025-10-04 at 01 10 37" src="https://github.com/user-attachments/assets/61d16e45-feaf-41ab-8b80-cb7212477921" />
