### PR TITLE
Feature: Prevent tabs from overflowing on mobile

### DIFF
--- a/Ivy/Views/TabsView.cs
+++ b/Ivy/Views/TabsView.cs
@@ -15,6 +15,7 @@ public class TabView : ViewBase
     private TabsVariant _variant = TabsVariant.Content;
     private bool _removeParentPadding = false;
     private Thickness? _padding = new Thickness(4);
+    private bool _wrap = false;
 
     /// <summary>
     /// Internal constructor that initializes a TabView with predefined tabs.
@@ -242,6 +243,17 @@ public class TabView : ViewBase
     }
 
     /// <summary>
+    /// Sets whether the tabs will wrap to a new line when overflowing in x direction.
+    /// </summary>
+    /// <param name="wrap">Whether the tabs will wrap to a new line when overflowing in x direction.</param>
+    /// <returns>The current TabView instance for method chaining.</returns>
+    public TabView Wrap(bool wrap)
+    {
+        _wrap = wrap;
+        return this;
+    }
+
+    /// <summary>
     /// Builds the final tabbed layout widget with tab selection state management.
     /// </summary>
     /// <returns>A TabsLayout widget configured with the current settings and tab selection state.</returns>
@@ -256,6 +268,6 @@ public class TabView : ViewBase
 
         return new TabsLayout(OnTabSelect, null, null, null, selectedIndex.Value,
             _tabs.ToArray()
-        ).Variant(_variant).Width(_width).Height(_height).RemoveParentPadding(_removeParentPadding).Padding(_padding);
+        ).Variant(_variant).Width(_width).Height(_height).RemoveParentPadding(_removeParentPadding).Padding(_padding).Wrap(_wrap);
     }
 }

--- a/Ivy/Widgets/Layouts/TabsLayout.cs
+++ b/Ivy/Widgets/Layouts/TabsLayout.cs
@@ -2,6 +2,7 @@ using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Ivy.Core;
 using Ivy.Shared;
+using Ivy.Views;
 
 // ReSharper disable once CheckNamespace
 namespace Ivy;
@@ -52,8 +53,12 @@ public record TabsLayout : WidgetBase<TabsLayout>
 
     /// <summary> Gets or sets whether to remove any padding inherited from parent containers. </summary>
     [Prop] public bool RemoveParentPadding { get; set; }
+
     /// <summary> Gets or sets the padding around the tabs layout container. </summary>
     [Prop] public Thickness? Padding { get; set; } = new Thickness(4);
+
+    /// <summary> Gets or sets whether the tabs will wrap to a new line when overflowing in x direction. </summary>
+    [Prop] public bool Wrap { get; set; } = false;
 
     /// <summary> Gets or sets the event handler for tab selection events. </summary>
     [Event] public Func<Event<TabsLayout, int>, ValueTask>? OnSelect { get; set; }
@@ -144,6 +149,14 @@ public static class TabsLayoutExtensions
     public static TabsLayout Padding(this TabsLayout tabsLayout, int left, int top, int right, int bottom)
     {
         return tabsLayout with { Padding = new Thickness(left, top, right, bottom) };
+    }
+
+    /// <summary> Sets whether the tabs will wrap to a new line when overflowing in x direction. </summary>
+    /// <param name="tabsLayout">The TabsLayout to configure.</param>
+    /// <param name="wrap">Whether the tabs will wrap to a new line when overflowing in x direction.</param>
+    public static TabsLayout Wrap(this TabsLayout tabsLayout, bool wrap)
+    {
+        return tabsLayout with { Wrap = wrap };
     }
 }
 

--- a/frontend/src/widgets/layouts/TabsLayoutWidget.tsx
+++ b/frontend/src/widgets/layouts/TabsLayoutWidget.tsx
@@ -8,7 +8,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { cn } from '@/lib/utils';
-import { getPadding } from '@/lib/styles';
+import { getPadding, getWidth } from '@/lib/styles';
 import {
   DndContext,
   closestCenter,
@@ -52,6 +52,8 @@ interface TabsLayoutWidgetProps {
   children: React.ReactElement<TabWidgetProps>[];
   events: string[];
   padding?: string;
+  width?: string;
+  wrap: boolean;
 }
 
 function SortableTabTrigger({
@@ -170,6 +172,8 @@ export const TabsLayoutWidget = ({
   removeParentPadding,
   variant = 'Tabs',
   padding,
+  width,
+  wrap,
 }: TabsLayoutWidgetProps) => {
   const tabWidgets = React.Children.toArray(children).filter(
     child =>
@@ -210,6 +214,7 @@ export const TabsLayoutWidget = ({
   const [activeStyle, setActiveStyle] = React.useState({
     left: '0px',
     width: '0px',
+    top: '0px',
   });
   const [isInitialRender, setIsInitialRender] = React.useState(true);
 
@@ -230,10 +235,12 @@ export const TabsLayoutWidget = ({
     if (variant !== 'Content') return;
     const activeElement = tabRefs.current[activeIndex];
     if (activeElement) {
-      const { offsetLeft, offsetWidth } = activeElement;
+      const { offsetLeft, offsetWidth, offsetTop, clientHeight } =
+        activeElement;
       setActiveStyle({
         left: `${offsetLeft}px`,
         width: `${offsetWidth}px`,
+        top: `${clientHeight + offsetTop + 4}px`,
       });
 
       // After first position update, enable animations
@@ -730,35 +737,36 @@ export const TabsLayoutWidget = ({
           removeParentPadding && 'remove-parent-padding'
         )}
       >
-        <div className="relative">
-          {/* Hover Highlight */}
-          <div
-            className="absolute h-[26px] transition-all duration-300 ease-out bg-accent/20 rounded-[6px] flex items-center"
-            style={{
-              opacity: activeIndex !== null ? 1 : 0,
-              pointerEvents: 'none',
-            }}
-          />
-          {/* Active Indicator */}
-          <div
-            className={cn(
-              'absolute bottom-[-6px] h-[2px] bg-foreground',
-              !isInitialRender && 'transition-all duration-300 ease-out'
-            )}
-            style={activeStyle}
-          />
-          {/* Tabs */}
-          <div
-            className="relative flex space-x-[6px] items-center"
-            role="tablist"
-          >
-            {orderedTabWidgets.map((tabWidget, index) => {
-              if (!React.isValidElement(tabWidget)) return null;
-              const props = tabWidget.props as Partial<TabWidgetProps>;
-              if (!props.id) return null;
-              const { title, id } = props;
-              return (
-                <div
+        <div style={{ ...getWidth(width), scrollbarWidth: 'none' }} className="overflow-x-auto pb-[6px]">
+          <div className="relative">
+            {/* Hover Highlight */}
+            <div
+              className="absolute h-[26px] transition-all duration-300 ease-out bg-accent/20 rounded-[6px] flex items-center"
+              style={{
+                opacity: activeIndex !== null ? 1 : 0,
+                pointerEvents: 'none',
+              }}
+              />
+            {/* Active Indicator */}
+            <div
+              className={cn(
+                'absolute bottom-[-6px] h-[2px] bg-foreground',
+                !isInitialRender && 'transition-all duration-300 ease-out'
+              )}
+              style={activeStyle}
+              />
+            {/* Tabs */}
+            <div
+              className={cn("relative flex space-x-[6px] gap-y-[20px] items-center", wrap ? 'flex-wrap' : null)}
+              role="tablist"
+              >
+              {orderedTabWidgets.map((tabWidget, index) => {
+                if (!React.isValidElement(tabWidget)) return null;
+                const props = tabWidget.props as Partial<TabWidgetProps>;
+                if (!props.id) return null;
+                const { title, id } = props;
+                return (
+                  <div
                   key={id}
                   ref={el => {
                     tabRefs.current[index] = el;
@@ -768,26 +776,27 @@ export const TabsLayoutWidget = ({
                   tabIndex={0}
                   className={cn(
                     'px-3 py-1.5 cursor-pointer transition-colors duration-300 h-[26px]',
-                    index === activeIndex
+                      index === activeIndex
                       ? 'text-foreground'
                       : 'text-muted-foreground'
-                  )}
-                  onClick={() => {
-                    // Mark as user-initiated for Content variant
-                    isUserInitiatedChangeRef.current = true;
-                    const tabId = tabOrder[index];
-                    addToLoadedTabs(tabId);
-                    setActiveIndex(index);
-                    setActiveTabId(tabId);
-                    eventHandler('OnSelect', id, [index]);
-                  }}
-                >
-                  <div className="text-sm font-medium leading-4 whitespace-nowrap flex items-center justify-center h-full">
-                    {title}
+                    )}
+                    onClick={() => {
+                      // Mark as user-initiated for Content variant
+                      isUserInitiatedChangeRef.current = true;
+                      const tabId = tabOrder[index];
+                      addToLoadedTabs(tabId);
+                      setActiveIndex(index);
+                      setActiveTabId(tabId);
+                      eventHandler('OnSelect', id, [index]);
+                    }}
+                    >
+                    <div className="text-sm font-medium leading-4 whitespace-nowrap flex items-center justify-center h-full">
+                      {title}
+                    </div>
                   </div>
-                </div>
-              );
-            })}
+                );
+              })}
+            </div>
           </div>
         </div>
         <div className="flex-1 overflow-hidden">


### PR DESCRIPTION
This PR improves tabs (variant "Content") on mobile. The tabs widget will now respect the `width` prop, which by default is `Size.Full()`. There are two modes when width is restricted: Scroll in x-direction or wrapping.

By default scroll in x-direction is applied. Use `Layout.Tabs().Wrap(true)` to instead wrap.

To prevent both scroll and wrap and revert to the old behaviour use `Layout.Tabs().Width(Size.MaxContent())`.

Wrap visuals:

<img width="296" height="77" alt="Screenshot from 2025-10-03 23-26-38" src="https://github.com/user-attachments/assets/fb766380-5b1d-4428-b352-d0597a5e002b" />
<img width="230" height="105" alt="Screenshot from 2025-10-03 23-26-49" src="https://github.com/user-attachments/assets/6356804a-6bcf-4cb5-a03c-7eecf43a3e37" />
<img width="230" height="105" alt="Screenshot from 2025-10-03 23-26-54" src="https://github.com/user-attachments/assets/26a1f026-3904-45a3-a957-55fcc0dfddf4" />

An alternative way to solve overflow on mobile would be hamburger menus. Since one can opt out of scroll/wrap with Size.MaxContent() I don't think they exclude one another. Have a look and see what you think of this solution!