### PR TITLE
feat: make better chromeSettings doc section

### DIFF
--- a/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/Program.md
+++ b/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/Program.md
@@ -105,24 +105,39 @@ This automatically refreshes the browser when C# code changes during development
 
 ### Chrome Configuration
 
-Configure the application chrome (navigation, layout):
+You can add custom elements to both the header and footer sections of the sidebar using `ChromeSettings`:
 
 ```csharp
-// Basic chrome
-server.UseChrome();
-
-// Custom chrome settings
 var chromeSettings = new ChromeSettings()
     .Header(
-        Layout.Vertical().Padding(2)
+        Layout.Vertical().Gap(2)
         | new IvyLogo()
-        | Text.Muted("Version 1.0")
+        | Text.Lead("Enterprise Management System")
+        | Text.Muted("Comprehensive business application suite")
+    )
+    .Footer(
+        Layout.Vertical().Gap(2)
+        | new Button("Support")
+            .HandleClick(_ => { })
+        | Text.Small("Enterprise Application Framework")
     )
     .DefaultApp<MyApp>()
     .UseTabs(preventDuplicates: true);
 
 server.UseChrome(() => new DefaultSidebarChrome(chromeSettings));
 ```
+
+Additional ChromeSettings options:
+
+- **DefaultAppId(string? appId)** - Sets the default app to load by ID.
+
+- **DefaultApp<T>()** - Sets the default app using a type (recommended for compile-time safety).
+
+- **UseTabs(bool preventDuplicates)** - Enables tab navigation. When `preventDuplicates` is `true`, prevents duplicate tabs.
+
+- **UsePages()** - Switches to page navigation (replaces content instead of opening tabs).
+
+For more information about SideBar, check its [documentation](../../02_Widgets/04_Layouts/SidebarLayout.md)
 
 ## Authentication
 


### PR DESCRIPTION
<img width="1077" height="594" alt="Screenshot 2025-10-04 at 06 49 14" src="https://github.com/user-attachments/assets/c85bb599-39d2-46d6-bc98-fc792b3e09e6" />

Added some sidebar staff with headers and footers, some text, logo, button

This example I tested on our other Ivy Project, it works and looks fine

<img width="652" height="720" alt="Screenshot 2025-10-04 at 06 51 21" src="https://github.com/user-attachments/assets/94c5e661-ce4f-48ed-a43e-3e90d1fdc3ab" />
