### PR TITLE
[Dashboard]: avoid using Text.H4 to avoid leaking headings into TOC

### DIFF
--- a/Ivy/Views/Dashboards/MetricView.cs
+++ b/Ivy/Views/Dashboards/MetricView.cs
@@ -69,13 +69,13 @@ public class MetricView(
         var x = data.Value;
 
         return new Card(
-                Layout.Vertical().Gap(2)
+                Layout.Vertical().Gap(6)
                 | (Layout.Horizontal().Gap(2)
                    | Text.Small(title).NoWrap().Overflow(Overflow.Ellipsis).Color(Colors.Gray)
                    | new Spacer().Width(Size.Grow())
                    | (icon?.ToIcon().Color(Colors.Gray)))
                 | (Layout.Horizontal().Align(Align.Left).Gap(2)
-                    | Text.H4(x.MetricFormatted).NoWrap().Overflow(Overflow.Clip)
+                    | Text.Large(x.MetricFormatted).NoWrap().Overflow(Overflow.Clip)
                     | (x.TrendComparedToPreviousPeriod != null
                         ? x.TrendComparedToPreviousPeriod >= 0
                             ? Icons.TrendingUp.ToIcon().Color(Colors.Success)


### PR DESCRIPTION
I tried to make it look as familiar as possible, the way it was before
How it was:

<img width="897" height="360" alt="Screenshot 2025-10-04 at 07 21 21" src="https://github.com/user-attachments/assets/971732f6-7572-4f84-a6c5-c6438f049a5c" />


How it now:
<img width="897" height="353" alt="Screenshot 2025-10-04 at 07 21 30" src="https://github.com/user-attachments/assets/a4c95773-44d7-4103-9ca3-0516df74358e" />

Changed, because: 
<img width="817" height="465" alt="Screenshot 2025-10-04 at 07 22 07" src="https://github.com/user-attachments/assets/71410dc8-0e0f-464f-9be3-ec7bb7fc037e" />
