### PR TITLE
Log current Ivy framework version and build info in console at app startup

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -2,6 +2,13 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';
 import { App } from './components/App';
+import { logger } from '@/lib/logger';
+import {
+  getIvyVersion,
+  getIvyCommit,
+  getIvyBuild,
+  getIvyHost,
+} from '@/lib/utils';
 
 const container = document.getElementById('root');
 if (!container) throw new Error('Failed to find root element');
@@ -14,6 +21,20 @@ let root = (window as WindowWithReactRoot).__reactRoot;
 if (!root) {
   root = createRoot(container);
   (window as WindowWithReactRoot).__reactRoot = root;
+}
+
+try {
+  const info = {
+    framework: 'Ivy',
+    version: getIvyVersion() ?? 'unknown',
+    commit: getIvyCommit() ?? undefined,
+    build: getIvyBuild() ?? undefined,
+    host: getIvyHost(),
+    mode: import.meta.env.MODE,
+  } as const;
+  logger.info('Using framework:', info);
+} catch (e) {
+  console.info('Ivy: failed to log version info', e);
 }
 
 root.render(

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -55,6 +55,29 @@ export function getIvyHost(): string {
   return window.location.origin;
 }
 
+/**
+ * Returns the content of a meta tag named with the given key.
+ * Example: getIvyMeta('ivy-version') -> "1.0.118"
+ */
+export function getIvyMeta(name: string): string | null {
+  return (
+    document.querySelector(`meta[name="${name}"]`)?.getAttribute('content') ??
+    null
+  );
+}
+
+export function getIvyVersion(): string | null {
+  return getIvyMeta('ivy-version');
+}
+
+export function getIvyCommit(): string | null {
+  return getIvyMeta('ivy-commit');
+}
+
+export function getIvyBuild(): string | null {
+  return getIvyMeta('ivy-build');
+}
+
 export function camelCase(titleCase: unknown): unknown {
   if (typeof titleCase !== 'string') {
     return titleCase;


### PR DESCRIPTION
1. Logs the currently loaded Ivy framework version, commit, build, host, and mode to the browser console as soon as the 
    frontend boots.
3. Helps diagnose crashes and “blank screen” cases by exposing the attempted version in dev tools.


What’s changed:

  - frontend/src/lib/utils.ts
      - Added helpers to read ivy-* meta tags:
          - getIvyMeta(name), getIvyVersion(), getIvyCommit(), getIvyBuild()
          
Screenshot: 

<img width="2229" height="1196" alt="Screenshot from 2025-10-08 14-38-12" src="https://github.com/user-attachments/assets/e6bba30e-b54a-42f5-8ca6-c489b2b21d49" />

Checklist :

-  Linked to issue #1063
-  Tested locally with and without meta tags
-  No UI changes
-  No additional dependencies

Fixes : #1063 
