### PR TITLE
[Docs]: fix leaking headings from examples to the TOC

### DIFF
--- a/frontend/src/widgets/article/TableOfContents.tsx
+++ b/frontend/src/widgets/article/TableOfContents.tsx
@@ -76,16 +76,16 @@ export const TableOfContents: React.FC<TableOfContentsProps> = ({
         return;
       }
 
-      // Get all headings, but exclude those inside example boxes (divs with border class)
+      // Get all headings, but exclude those inside example boxes (DemoBoxWidget)
       const allHeadings = Array.from(
         articleElement.querySelectorAll('h1, h2, h3, h4, h5, h6')
       );
 
       // Filter out headings that are inside example boxes
       const elements = allHeadings.filter(heading => {
-        // Check if the heading is inside a div with border class (example box)
-        const isInsideExampleBox = heading.closest('div.border');
-        return !isInsideExampleBox;
+        // Check if the heading is inside a demo box (DemoBoxWidget)
+        const isInsideDemoBox = heading.closest('div[data-demo-box]');
+        return !isInsideDemoBox;
       });
 
       // If no headings found but content might still be loading, retry
@@ -204,9 +204,9 @@ export const TableOfContents: React.FC<TableOfContentsProps> = ({
 
     // Filter out headings that are inside example boxes
     const elements = allHeadings.filter(heading => {
-      // Check if the heading is inside a div with border class (example box)
-      const isInsideExampleBox = heading.closest('div.border');
-      return !isInsideExampleBox;
+      // Check if the heading is inside a demo box (DemoBoxWidget)
+      const isInsideDemoBox = heading.closest('div[data-demo-box]');
+      return !isInsideDemoBox;
     });
 
     const observer = new IntersectionObserver(

--- a/frontend/src/widgets/internal/DemoBoxWidget.tsx
+++ b/frontend/src/widgets/internal/DemoBoxWidget.tsx
@@ -56,7 +56,7 @@ const DemoBoxWidget: React.FC<DemoBoxWidgetProps> = ({
   };
 
   return (
-    <div className={cn('border')} style={styles}>
+    <div className={cn('border')} style={styles} data-demo-box>
       {children}
     </div>
   );


### PR DESCRIPTION
First of all, issue was opened about leaked number in card documentation, metric view example, because it renders as Text.H4
<img width="1004" height="526" alt="Screenshot 2025-10-09 at 00 46 00" src="https://github.com/user-attachments/assets/cef5f716-d0da-4c05-bf05-451f78e9e583" />

Fixed by adding filtering Text.H* which presented in examples (csharp demo-tabs, demo-below etc)

<img width="1281" height="439" alt="Screenshot 2025-10-09 at 00 47 52" src="https://github.com/user-attachments/assets/88297ac7-145d-4b67-a048-b3b71940706d" />

We have a lot of these problems in docs. For example, in HTML docs from release:

<img width="1277" height="482" alt="Screenshot 2025-10-09 at 00 50 00" src="https://github.com/user-attachments/assets/0789b974-4a6c-4aa0-98c7-fe4ff8dfe1a1" />

And this page with fix:
<img width="1284" height="557" alt="Screenshot 2025-10-09 at 00 51 29" src="https://github.com/user-attachments/assets/5af6df87-e092-4678-99ae-ccfc4ac35677" />
