### PR TITLE
[Docs]: Sync docs with Release v1.0.120

### DIFF
--- a/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/Views.md
+++ b/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/Views.md
@@ -195,10 +195,6 @@ public class TextInputApp : ViewBase
 }
 ```
 
-<Callout Type="tip">
-For comprehensive documentation on sidebar navigation, app organization, and search functionality, see the [Sidebar documentation](./Sidebar.md).
-</Callout>
-
 ## Advanced Patterns
 
 ### Conditional Rendering


### PR DESCRIPTION
1) No need to be documented, because we have API section that mention width Prop
<img width="983" height="379" alt="Screenshot 2025-10-14 at 01 17 00" src="https://github.com/user-attachments/assets/0bc8dfec-1b02-4791-a4c5-2b101eb99354" />
<img width="1278" height="698" alt="Screenshot 2025-10-14 at 01 23 52" src="https://github.com/user-attachments/assets/77491c52-edcc-4f47-9256-83a804d81bab" />

2) Already implemented in docs
<img width="978" height="450" alt="Screenshot 2025-10-14 at 01 17 38" src="https://github.com/user-attachments/assets/8cf03379-4f3b-47b7-9c63-ac87a1cde856" />
<img width="1289" height="705" alt="Screenshot 2025-10-14 at 01 18 30" src="https://github.com/user-attachments/assets/3bf34b75-4230-4ff6-8f9b-b3a5c363d244" />

3) Added mention about search hints in existing section in Docs -> Views.md -> App Attribute
<img width="969" height="322" alt="Screenshot 2025-10-14 at 01 18 48" src="https://github.com/user-attachments/assets/fb1f467b-b59e-43c7-a6fd-b4792e133ca7" />
<img width="1290" height="710" alt="Screenshot 2025-10-14 at 01 22 28" src="https://github.com/user-attachments/assets/e9b9883e-6ebd-444b-9791-a7edb79659f2" />


