### PR TITLE
[Text]: auto detect url links

### DIFF
--- a/frontend/src/widgets/primitives/TextBlockWidget.tsx
+++ b/frontend/src/widgets/primitives/TextBlockWidget.tsx
@@ -40,6 +40,8 @@ interface TextBlockWidgetProps {
   overflow?: Overflow;
 }
 
+type ProcessedContent = React.ReactNode;
+
 interface VariantMap {
   [key: string]: React.FC<{
     children: React.ReactNode;
@@ -215,6 +217,14 @@ const variantMap: VariantMap = {
   ),
 };
 
+// Enhanced URL regex that handles punctuation better and supports more protocols
+const URL_REGEX =
+  /(https?:\/\/[^\s<>"]+[^\s<>".,!;:?])|(ftp:\/\/[^\s<>"]+[^\s<>".,!;:?])|(mailto:[^\s<>"]+[^\s<>".,!;:?])|(tel:[^\s<>"]+[^\s<>".,!;:?])/gi;
+
+const isUrl = (text: string): boolean => {
+  return /^(https?:\/\/|ftp:\/\/|mailto:|tel:)/i.test(text);
+};
+
 export const TextBlockWidget: React.FC<TextBlockWidgetProps> = ({
   content,
   variant,
@@ -230,24 +240,28 @@ export const TextBlockWidget: React.FC<TextBlockWidgetProps> = ({
     ...getOverflow(overflow),
   };
 
-  // Auto-convert URLs to clickable links
-  const processedContent = content
-    .split(/(https?:\/\/[^\s]+)/gi)
-    .map((part, index) =>
-      /^https?:\/\//i.test(part) ? (
-        <a
-          key={index}
-          href={part}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-primary underline brightness-90 hover:brightness-100"
-        >
-          {part}
-        </a>
-      ) : (
-        part
-      )
-    );
+  // Memoized URL processing for performance optimization
+  const processedContent: ProcessedContent = React.useMemo(() => {
+    return content.split(URL_REGEX).map((part, index) => {
+      if (isUrl(part)) {
+        const isExternalLink = /^https?:\/\//i.test(part);
+
+        return (
+          <a
+            key={index}
+            href={part}
+            target={isExternalLink ? '_blank' : undefined}
+            rel={isExternalLink ? 'noopener noreferrer' : undefined}
+            className="text-primary underline brightness-90 hover:brightness-100 transition-all duration-150"
+            aria-label={isExternalLink ? `External link: ${part}` : undefined}
+          >
+            {part}
+          </a>
+        );
+      }
+      return part;
+    });
+  }, [content]);
 
   const Component = variantMap[variant];
   return (


### PR DESCRIPTION
Links are now automatically detected and retain the styling of the method used to create them.

Here’s an example:

<img width="616" height="423" alt="Screenshot 2025-10-16 at 01 35 31" src="https://github.com/user-attachments/assets/04720bc1-8dab-40ad-ab53-7e619566eacb" />

This change also enables copying links via right-click:

<img width="596" height="432" alt="Screenshot 2025-10-16 at 01 36 19" src="https://github.com/user-attachments/assets/fd5e1296-1ef8-40f4-8916-bf2bcac64007" />
