### PR TITLE
[Table]: refactor example to display multilining of text

### DIFF
--- a/Ivy.Samples.Shared/Apps/Widgets/TableApp.cs
+++ b/Ivy.Samples.Shared/Apps/Widgets/TableApp.cs
@@ -26,7 +26,7 @@ public class TableApp : SampleBase
             new {Sku = "1235", Foo = true, Name = "Jeans", Price = 20.0, Url = "http://example.com/jeans"},
             new {Sku = "1236", Foo = true, Name = "Sneakers", Price = 30.0, Url = "http://example.com/sneakers"},
             new {Sku = "1237", Foo = true, Name = "Hat", Price = 5.0, Url = "http://example.com/hat"},
-            new {Sku = "1238", Foo = true, Name = "Multiline Example Multiline Example Multiline Example Multiline Example Multiline Example Multiline Example Multiline Example Multiline Example Multiline Example Multiline Example Multiline Example", Price = 2.0, Url = "http://example.com/socks"}
+            new {Sku = "1238", Foo = true, Name = "Premium Luxury Extra-Soft Organic Cotton Socks with Reinforced Heel and Toe - Perfect for All-Day Comfort and Athletic Performance - Available in Multiple Colors", Price = 2.0, Url = "http://example.com/socks"}
         };
 
         // Table with long headers to test overflow and tooltips


### PR DESCRIPTION
How it was:

<img width="787" height="476" alt="Screenshot 2025-10-16 at 01 48 08" src="https://github.com/user-attachments/assets/9fd7666d-d7c1-4947-9980-b3ca12cd67a2" />

How it's now:

<img width="1284" height="657" alt="Screenshot 2025-10-16 at 01 49 18" src="https://github.com/user-attachments/assets/97dd286b-bccc-4520-a66b-3c9454a10c49" />
