### PR TITLE
[Docs]: implement mention of Sliplane deployment

### DIFF
--- a/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/05_Deploy.md
+++ b/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/05_Deploy.md
@@ -116,16 +116,7 @@ When you run `ivy deploy` without specifying options, Ivy will guide you through
 
 **Sliplane Services Used** - Container hosting and deployment, automated SSL/TLS certificates, load balancing and traffic routing, and automated health checks and monitoring.
 
-**Sliplane Setup Prerequisites** - Create a Sliplane account at [sliplane.io](https://sliplane.io), generate an API key from your Sliplane dashboard, and optionally create a server in your Sliplane dashboard (or let Ivy create one automatically).
-
-**Getting Your API Key**
-
-```terminal
-# 1. Login to your Sliplane dashboard
-# 2. Navigate to Settings > API Keys
-# 3. Click "Create API Key"
-# 4. Copy the generated key for use in deployment
-```
+**Sliplane Setup Prerequisites** - Create a Sliplane account, generate an API key from your Sliplane dashboard, and optionally create a server in your Sliplane dashboard (or let Ivy create one automatically).
 
 ### Deployment Process
 
@@ -273,7 +264,6 @@ ASPNETCORE_ENVIRONMENT="Production"
 ```terminal
 >ivy deploy
 # Select Sliplane
-# Enter your Sliplane API key
 # Configure server and deployment settings
 ```
 


### PR DESCRIPTION
Docs -> Deploy

1. Added Sliplane to Cloud Platforms list

<img width="1279" height="455" alt="Screenshot 2025-10-16 at 04 06 50" src="https://github.com/user-attachments/assets/45e9a99d-e419-4c47-872f-e38dacba1fee" />

2. Deployment Provider Configuration -> added mention about Sliplane deployment, terminal and base info similar to other clouds description

<img width="1286" height="708" alt="Screenshot 2025-10-16 at 04 08 29" src="https://github.com/user-attachments/assets/082e2c06-699c-45e4-9935-4180d779c3ea" />

3. Examples -> Sliplane Deployment terminal example

<img width="1284" height="611" alt="Screenshot 2025-10-16 at 04 10 14" src="https://github.com/user-attachments/assets/a9f53963-785f-47d7-ade8-eabab4bb6fd2" />

4. Cloud Provider Documentation -> added link to sliplane docs

<img width="1283" height="597" alt="Screenshot 2025-10-16 at 04 11 26" src="https://github.com/user-attachments/assets/d2ca4c39-3940-4d5c-8144-dd173eb39937" />
