### PR TITLE
[Docs]: add more info into Clients documentation

### DIFF
--- a/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/Clients.md
+++ b/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/Clients.md
@@ -116,8 +116,6 @@ Ivy automatically handles UI refreshes in most cases. You typically **don't need
 - **Sheet Dismissal**: Sheets are automatically closed by the framework when forms are submitted successfully
 - **Navigation**: Page navigation automatically refreshes the UI
 
-### When Manual Refresh is NOT Needed
-
 ❌ **Don't do this** - The framework handles it automatically:
 
 ```csharp


### PR DESCRIPTION
Had an issue that not all the methods had docs description, what caused pure user experience while working with Clients docs
<img width="684" height="568" alt="Screenshot 2025-10-18 at 07 20 39" src="https://github.com/user-attachments/assets/557ba580-0762-45d7-bff7-96b66882a74b" />

New:
1. Showing Toasts -> Toast with title example
<img width="1179" height="507" alt="Screenshot 2025-10-18 at 07 27 43" src="https://github.com/user-attachments/assets/14317986-739f-43e1-af96-ed977722b55d" />

2. Navigation section
<img width="1437" height="252" alt="Screenshot 2025-10-18 at 07 28 23" src="https://github.com/user-attachments/assets/a7fadf41-24c1-42e5-b3b6-ddb4f116d6a7" />

3. Downloading Files section 
<img width="560" height="183" alt="Screenshot 2025-10-18 at 07 28 52" src="https://github.com/user-attachments/assets/44a73ac6-58df-4921-8ebf-cb440fdccc59" />

4. Uploading Files section
<img width="584" height="417" alt="Screenshot 2025-10-18 at 07 29 16" src="https://github.com/user-attachments/assets/905f388b-5a1e-48bc-b034-8da52d50beb0" />

5. Clipboard Operations section
<img width="566" height="136" alt="Screenshot 2025-10-18 at 07 29 42" src="https://github.com/user-attachments/assets/4a740f82-cbb3-4445-8bac-ec19f3dd9f4e" />

6. Theme Customization section
<img width="542" height="241" alt="Screenshot 2025-10-18 at 07 30 01" src="https://github.com/user-attachments/assets/e5b5a205-77b1-479f-a4fb-752418fe508f" />

7. UI Refresh & State Management section
<img width="1440" height="521" alt="Screenshot 2025-10-18 at 07 33 55" src="https://github.com/user-attachments/assets/4ba251a2-21d0-4387-b6ef-f44951312e6c" />
