### PR TITLE
[Server]: add a callout about server.UseDefaultApp()

### DIFF
--- a/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/Program.md
+++ b/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/Program.md
@@ -147,6 +147,10 @@ Additional ChromeSettings options:
 
 - **UsePages()** - Switches to page navigation (replaces content instead of opening tabs).
 
+<Callout Type="tip">
+Use `server.UseDefaultApp(typeof(AppName))` instead of `UseChrome()` for single-purpose applications, embedded views, or minimal interfaces where sidebar navigation isn't needed.
+</Callout>
+
 For more information about SideBar, check its [documentation](../../02_Widgets/04_Layouts/SidebarLayout.md)
 
 ## Authentication


### PR DESCRIPTION
We already had mention about defaultApp usage, but I think a callout will do it a bit clearer

Docs -> Program -> Chrome Config

Also tested it on Ivy App, works fine

<img width="1278" height="699" alt="Screenshot 2025-10-25 at 02 27 02" src="https://github.com/user-attachments/assets/c6ee2c75-19fc-4f2f-8717-f65e6d7a97a5" />
<img width="742" height="390" alt="Screenshot 2025-10-25 at 02 27 17" src="https://github.com/user-attachments/assets/87455c4f-710d-4e56-99ab-b088baddbd2f" />
