### PR TITLE
[Docs]: refactor Upload docs

### DIFF
--- a/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/Uploads.md
+++ b/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/Uploads.md
@@ -121,7 +121,7 @@ public class ValidatedUploadView : ViewBase
         );
 
         return Layout.Vertical(
-            files.ToFileInput(uploadUrl, "Upload Image").Accept(".jpg,.jpeg,.png,.mp4,.mov,.avi,.wmv,.mpeg,.mpg"),
+            files.ToFileInput(uploadUrl, "Upload Image").Accept(".jpg,.jpeg,.png"),
             error.Value != null
                 ? new Callout(error.Value, variant: CalloutVariant.Error)
                 : null
@@ -161,7 +161,7 @@ public class ImageUploadView : ViewBase
                 // Create preview URL from uploaded bytes
                 preview.Set($"data:image/jpeg;base64,{Convert.ToBase64String(fileBytes)}");
                 // Process uploaded file bytes
-                client.Toast($"Image uploaded successfully", "Success");
+                client.Toast($"Image uploaded successfully ({fileBytes.Length} bytes)", "Success");
             },
             "image/jpeg",
             "uploaded-image"


### PR DESCRIPTION
1. Moved overview section under basic usage section
From:
<img width="1432" height="602" alt="Screenshot 2025-10-27 at 21 34 13" src="https://github.com/user-attachments/assets/d22ecc88-bae2-4d22-a1dc-afe1ce738edf" />
To:
<img width="1435" height="728" alt="Screenshot 2025-10-27 at 21 39 06" src="https://github.com/user-attachments/assets/6b079173-5d5e-49d8-a65b-4fc3adbfc825" />

2. Added How It Works section
<img width="1440" height="515" alt="Screenshot 2025-10-27 at 21 35 08" src="https://github.com/user-attachments/assets/5f6759a1-3cff-4dff-a5fd-caf86b74c416" />

3. Avoided error handling with Console.WriteLine(), used toasts instead

From: 
<img width="436" height="123" alt="Screenshot 2025-10-27 at 21 35 53" src="https://github.com/user-attachments/assets/b04131a8-de5f-4df3-85e3-00fe7b218b89" />

To:

<img width="522" height="123" alt="Screenshot 2025-10-27 at 21 36 12" src="https://github.com/user-attachments/assets/a637c751-990c-45fd-aac9-01c06450d51c" />

5. Removed Progress Tracking section, because we actually don't have this functionality (it actually wasn't working)

<img width="571" height="610" alt="Screenshot 2025-10-27 at 21 37 06" src="https://github.com/user-attachments/assets/f546809a-f36d-4568-a349-e6d80d7cfb10" />

6. Reduced max file size for File Validation from 5 to 2 mb to simplier testing of error handling
<img width="515" height="646" alt="Screenshot 2025-10-27 at 21 38 24" src="https://github.com/user-attachments/assets/32461e16-a7d6-4299-b373-bca276df3f68" />
