### PR TITLE
[Docs]: In the Text Input doc change shortcut to Ctrl+J from Ctrl+F

### DIFF
--- a/Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/Text.md
+++ b/Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/Text.md
@@ -301,10 +301,10 @@ public class ShortCutDemo : ViewBase
         var message = UseState("");
         return Layout.Vertical()
                 | Text.Inline("Keyboard Shortcuts Demo")
-                | Text.Inline("Ctrl+F - Focus Name, Ctrl+E - Focus Email, Ctrl+M - Focus Message")  
+                | Text.Inline("Ctrl+J - Focus Name, Ctrl+E - Focus Email, Ctrl+M - Focus Message")  
                 | new TextInput(name)
-                      .Placeholder("Name (Ctrl+F)")
-                      .ShortcutKey("Ctrl+F")    
+                      .Placeholder("Name (Ctrl+J)")
+                      .ShortcutKey("Ctrl+J")    
                 | new TextInput(email)
                       .Placeholder("Email (Ctrl+E)")
                       .ShortcutKey("Ctrl+E")


### PR DESCRIPTION
We had pure user experience on trying to search something on the page with default browser search(ctrl+F), because this shortcut was binded for text input.

How it was:

<img width="420" height="172" alt="Screenshot 2025-10-28 at 01 32 41" src="https://github.com/user-attachments/assets/0ee6c317-b759-46eb-b284-39c5f3a781cf" />

How it is now:

<img width="538" height="212" alt="Screenshot 2025-10-28 at 01 32 07" src="https://github.com/user-attachments/assets/2dcc95ef-b54d-408f-9b01-50c7625a2b66" />
