### PR TITLE
[Card]: fix text size overriding for default medium size

### DIFF
--- a/frontend/src/widgets/CardWidget.tsx
+++ b/frontend/src/widgets/CardWidget.tsx
@@ -86,7 +86,7 @@ export const CardWidget: React.FC<CardWidgetProps> = ({
       default:
         return {
           header: 'p-6',
-          content: 'p-6 pt-0 [&_*]:text-sm',
+          content: 'p-6 pt-0',
           footer: 'p-6 pt-0',
           title: 'text-base',
           description: 'text-sm mt-2',


### PR DESCRIPTION
Solution was just to remove text size setting for default card size
How it was:
<img width="1181" height="738" alt="Screenshot 2025-10-28 at 13 18 34" src="https://github.com/user-attachments/assets/926a3f13-54ca-425c-83ba-ee941d78ef9c" />
How it's now:
<img width="1180" height="739" alt="Screenshot 2025-10-28 at 13 18 56" src="https://github.com/user-attachments/assets/7ee3a8b4-68ee-4e14-a999-36df285b5a05" />

(From the issue): how it should look
<img width="753" height="690" alt="Screenshot 2025-10-28 at 13 19 56" src="https://github.com/user-attachments/assets/6badc5eb-7385-4d94-ab3d-c73b69fa0b53" />
