### PR TITLE
SelectInputs: vertically center checkbox/radio labels

### DIFF
--- a/frontend/src/widgets/inputs/SelectInputWidget.tsx
+++ b/frontend/src/widgets/inputs/SelectInputWidget.tsx
@@ -484,7 +484,7 @@ const RadioVariant: React.FC<SelectInputWidgetProps> = ({
                   <Label
                     htmlFor={`${id}-${option.value}`}
                     className={cn(
-                      'cursor-pointer',
+                      'cursor-pointer leading-none',
                       selectTextVariants[size],
                       stringValue === option.value.toString() && invalid
                         ? inputStyles.invalidInput


### PR DESCRIPTION
- Align label text with controls in List (Checkbox) and Radio variants by tightening label line-height.
- Frontend-only; no API or backend changes.
- Visually fixes misaligned “Yellow” (and others) in issue #1218  


<img width="1413" height="769" alt="Screenshot from 2025-10-28 17-38-14" src="https://github.com/user-attachments/assets/09ef29a1-f0fc-4b09-8afc-96a9843f706d" />

