### PR TITLE
(upload): fix clear button issue in document input

### DIFF
--- a/Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/File.md
+++ b/Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/File.md
@@ -50,7 +50,7 @@ public class FileDropDemo : ViewBase
     public override object? Build()
     {    
         var fileState = this.UseState((FileInput?)null);
-        var fileStates = this.UseState<IEnumerable<FileInput>?>(null);
+        var fileStates = this.UseState((IEnumerable<FileInput>?)null);
         return  Layout.Vertical()
                 | fileState.ToFileInput().Variant(FileInputs.Drop)
                 | fileStates.ToFileInput().Variant(FileInputs.Drop);


### PR DESCRIPTION
This pull request includes updates to documentation and project configuration to clarify multiple file selection behavior in the `FileInput` widget and to add a new worktree setup script. The most important changes are grouped below:

**Documentation improvements:**

* Updated the `FileDropDemo` example in `Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/File.md` to use `IEnumerable<FileInput>?` for the `fileStates` state, clarifying that multiple file selection is handled automatically by using a collection type. Added a tip callout to explicitly inform users that `.Multiple()` is not needed when using a collection.

**Project configuration:**

* Added a `.cursor/worktrees.json` file with a `setup-worktree` script to automate frontend setup by running `npm install` in the `frontend` directory.