### PR TITLE
[Field]: In the Field docs use WithField() as recommended

### DIFF
--- a/Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/Field.md
+++ b/Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/Field.md
@@ -116,9 +116,9 @@ public class MixedInputsDemo : ViewBase
 }
 ```
 
-## When to Use
-
-* Use `Field` whenever you want **consistent form layout** across your application with labels, description and required asterisk.
+<Callout Tip="Info">
+Use `Field` whenever you want **consistent form layout** across your application with labels, description and required asterisk.
+</Callout>
 
 <WidgetDocs Type="Ivy.Field" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Inputs/Field.cs"/>
 


### PR DESCRIPTION
<img width="1224" height="409" alt="Screenshot 2025-10-30 at 02 02 42" src="https://github.com/user-attachments/assets/23225437-3eba-449e-8948-fe671085412e" />

Same for other examples, except basic usage
Also refactored "When to use" section, which contained tip into callout

Was: 
<img width="1279" height="568" alt="Screenshot 2025-10-30 at 02 04 01" src="https://github.com/user-attachments/assets/8a84addb-281d-4ac5-9306-6e9dc5a02fb6" />

Now: 
<img width="1260" height="441" alt="Screenshot 2025-10-30 at 02 04 27" src="https://github.com/user-attachments/assets/a29e2a91-8067-4801-8d21-5b310e97175a" />
