### PR TITLE
How to create a widget (DO NOT MERGE)

### DIFF
--- a/Ivy.Docs.Shared/Docs/02_Widgets/01_Common/Sparkles.md
+++ b/Ivy.Docs.Shared/Docs/02_Widgets/01_Common/Sparkles.md
@@ -1,0 +1,33 @@
+---
+searchHints:
+  - sparkle
+  - badge
+  - decoration
+---
+
+# Sparkles
+
+<Ingress>
+Decorative sparkles with optional text – a lightweight accent for titles and badges.
+</Ingress>
+
+## Basic Usage
+
+```csharp demo-tabs
+public class SparklesDemo : ViewBase
+{
+    public override object? Build()
+    {
+        return Layout.Horizontal().Gap(3)
+            | new Sparkles()
+            | new Sparkles().Text("Featured")
+            | new Sparkles().Color(Colors.Yellow).Size(Sizes.Large);
+    }
+}
+```
+
+## Properties
+
+- **Text(string?)**: Optional trailing text
+- **Color(Colors?)**: Optional color
+- **Size(Sizes)**: Small, Medium, Large

--- a/Ivy.Samples.Shared/Apps/Widgets/SparklesApp.cs
+++ b/Ivy.Samples.Shared/Apps/Widgets/SparklesApp.cs
@@ -1,0 +1,17 @@
+using Ivy.Shared;
+
+namespace Ivy.Samples.Shared.Apps.Widgets;
+
+[App(icon: Icons.Star, path: ["Widgets"], searchHints: ["sparkles", "badge", "decoration"])]
+public class SparklesApp : SampleBase
+{
+    protected override object? BuildSample()
+    {
+        return Layout.Vertical().Gap(4)
+            | new Sparkles()
+            | new Sparkles().Text("Shiny!")
+            | new Sparkles().Color(Colors.Yellow).Size(Sizes.Large);
+    }
+}
+
+

--- a/Ivy/Widgets/Sparkles.cs
+++ b/Ivy/Widgets/Sparkles.cs
@@ -1,0 +1,38 @@
+using Ivy.Core;
+using Ivy.Shared;
+
+// ReSharper disable once CheckNamespace
+namespace Ivy;
+
+/// <summary>
+/// Decorative sparkles indicator with optional text, color and size.
+/// Useful for accenting headings, badges or status labels.
+/// </summary>
+public record Sparkles : WidgetBase<Sparkles>
+{
+    /// <summary>Optional text displayed next to the sparkles icon.</summary>
+    [Prop] public string? Text { get; set; }
+
+    /// <summary>Optional foreground color token.</summary>
+    [Prop] public Colors? Color { get; set; }
+
+    /// <summary>Visual size of the sparkles icon.</summary>
+    [Prop] public Sizes Size { get; set; } = Sizes.Medium;
+}
+
+/// <summary>
+/// Fluent helpers for configuring <see cref="Sparkles"/>.
+/// </summary>
+public static class SparklesExtensions
+{
+    /// <summary>Sets the text.</summary>
+    public static Sparkles Text(this Sparkles w, string? text) => w with { Text = text };
+
+    /// <summary>Sets the color.</summary>
+    public static Sparkles Color(this Sparkles w, Colors color) => w with { Color = color };
+
+    /// <summary>Sets the size.</summary>
+    public static Sparkles Size(this Sparkles w, Sizes size) => w with { Size = size };
+}
+
+

--- a/frontend/src/widgets/SparklesWidget.tsx
+++ b/frontend/src/widgets/SparklesWidget.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { getColor } from '@/lib/styles';
+
+interface SparklesWidgetProps {
+  id?: string;
+  text?: string | null;
+  color?: string | null;
+  size?: 'Small' | 'Medium' | 'Large';
+}
+
+export function SparklesWidget({
+  text,
+  color,
+  size = 'Medium',
+}: SparklesWidgetProps) {
+  const dim =
+    size === 'Small' ? 'h-4 w-4' : size === 'Large' ? 'h-7 w-7' : 'h-5 w-5';
+  const colorToken = color ?? undefined;
+  const styles: React.CSSProperties = {
+    ...getColor(colorToken, 'color', 'foreground'),
+  };
+  return (
+    <span className="inline-flex items-center gap-2" style={styles}>
+      <svg
+        className={dim}
+        viewBox="0 0 20 20"
+        aria-hidden="true"
+        fill="currentColor"
+      >
+        <path d="M10 1l2 5 5 2-5 2-2 5-2-5-5-2 5-2 2-5z" />
+      </svg>
+      {text ? <span>{text}</span> : null}
+    </span>
+  );
+}

--- a/frontend/src/widgets/index.ts
+++ b/frontend/src/widgets/index.ts
@@ -17,3 +17,4 @@ export { TooltipWidget } from './TooltipWidget';
 
 export { PaginationWidget } from './PaginationWidget';
 export { KanbanWidget, KanbanColumnWidget, KanbanCardWidget } from './kanban';
+export { SparklesWidget } from './SparklesWidget';

--- a/frontend/src/widgets/widgetMap.ts
+++ b/frontend/src/widgets/widgetMap.ts
@@ -4,6 +4,7 @@ import {
   BadgeWidget,
   ButtonWidget,
   CardWidget,
+  SparklesWidget,
   ChatLoadingWidget,
   ChatMessageWidget,
   ChatStatusWidget,
@@ -117,6 +118,7 @@ export const widgetMap = {
   // Widgets
   'Ivy.Article': ArticleWidget,
   'Ivy.Button': ButtonWidget,
+  'Ivy.Sparkles': SparklesWidget,
   'Ivy.Progress': ProgressWidget,
   'Ivy.Tooltip': TooltipWidget,
   'Ivy.Slot': SlotWidget,


### PR DESCRIPTION
### Backend first: C# widget

- Create Ivy/Widgets/WidgetName.cs
- Define record WidgetName : WidgetBase<WidgetName>
- Add public props with [Prop] and minimal XML docs
- Add events with [Event] if needed
- Optional: add tiny fluent helpers as static extension methods
- Namespace must be namespace Ivy;

<img width="1140" height="691" alt="Screenshot 2025-10-30 at 06 20 10" src="https://github.com/user-attachments/assets/d6758716-1c95-46c0-a3d0-b124c74e723a" />

### Frontend component: React/TS

- Create frontend/src/widgets/WidgetNameWidget.tsx
- Props must mirror serialized backend props (names and types)
- Use Tailwind/shadcn only; ensure accessibility
- Prefer theme variables (e.g., via getColor) for colors

<img width="1138" height="697" alt="Screenshot 2025-10-30 at 06 21 54" src="https://github.com/user-attachments/assets/68e013fe-38a5-4c87-9463-57edae4184a4" />

### Wire it up

- In frontend/src/widgets/index.ts: export WidgetNameWidget if the pattern in that folder exports siblings
- In frontend/src/widgets/widgetMap.ts:
- Import WidgetNameWidget from @/widgets
- Add map entry 'Ivy.WidgetName': WidgetNameWidget
- Use the exact key format 'Ivy.WidgetName' to match backend WidgetName

<img width="1138" height="699" alt="Screenshot 2025-10-30 at 06 24 16" src="https://github.com/user-attachments/assets/806dfe1e-57fb-498e-8458-9a70ff12c2bc" />

<img width="1149" height="695" alt="Screenshot 2025-10-30 at 06 23 17" src="https://github.com/user-attachments/assets/18e20f56-b4b5-4107-b3c8-53f894dc20bf" />

### Test app

- Create Ivy.Samples.Shared/Apps/Widgets/WidgetNameApp.cs
- Decorate with [App(..., path: ["Widgets"], ...)] (or a subcategory if appropriate)
- Show 2–3 minimal examples (default, a variant, an edge-state)

<img width="1140" height="701" alt="Screenshot 2025-10-30 at 06 25 58" src="https://github.com/user-attachments/assets/fe123cec-7671-4f23-9258-28239227f362" />

### Documentation

- Create Ivy.Docs.Shared/Docs/02_Widgets/01_Common/WidgetName.md (or a better-fitting subfolder)
- Include: short ingress, “Basic Usage” demo, properties list, and a couple of examples
- Keep docs minimal but copy-pasteable

<img width="1144" height="705" alt="Screenshot 2025-10-30 at 06 29 05" src="https://github.com/user-attachments/assets/07742792-cea7-4572-a72e-486cc84e60b4" />

