### PR TITLE
(scrollbar): 0s delay by default for scroll areas

### DIFF
--- a/frontend/src/components/ui/scroll-area.tsx
+++ b/frontend/src/components/ui/scroll-area.tsx
@@ -4,7 +4,7 @@ import * as ScrollAreaPrimitive from '@radix-ui/react-scroll-area';
 import { cn } from '@/lib/utils';
 
 const ScrollArea = React.forwardRef<
-  React.ElementRef<typeof ScrollAreaPrimitive.Root>,
+  React.ComponentRef<typeof ScrollAreaPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
 >(({ className, children, scrollHideDelay = 0, ...props }, ref) => (
   <ScrollAreaPrimitive.Root
@@ -23,7 +23,7 @@ const ScrollArea = React.forwardRef<
 ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName;
 
 const ScrollBar = React.forwardRef<
-  React.ElementRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>,
+  React.ComponentRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>,
   React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>
 >(({ className, orientation = 'vertical', ...props }, ref) => (
   <ScrollAreaPrimitive.ScrollAreaScrollbar


### PR DESCRIPTION
This pull request updates the `ScrollArea` and `ScrollBar` components in `scroll-area.tsx` to improve type safety, flexibility, and code consistency. The main changes include updating type definitions, allowing customization of the scroll hide delay, and simplifying class names.

**Type and API improvements:**

* Changed the type definitions in both `ScrollArea` and `ScrollBar` to use `React.ComponentRef` instead of `React.ElementRef` for better alignment with React's type system. [[1]](diffhunk://#diff-ee3d547ec923ecc70049984a660f80c0d27e5a3881f0c6b1c34fecf65b1818dfL7-R13) [[2]](diffhunk://#diff-ee3d547ec923ecc70049984a660f80c0d27e5a3881f0c6b1c34fecf65b1818dfL26-R26)
* Made the `scrollHideDelay` prop configurable in `ScrollArea`, defaulting to `0` but allowing overrides for more flexible scroll behavior.

**Styling consistency:**

* Simplified padding class names from `p-[1px]` to `p-px` in `ScrollBar` for both vertical and horizontal orientations, improving code clarity and maintainability.


I did this so we have more consistent scrollbars