### PR TITLE
(icons): to button common styling within a blade

### DIFF
--- a/frontend/src/widgets/blades/BladeWidget.tsx
+++ b/frontend/src/widgets/blades/BladeWidget.tsx
@@ -74,7 +74,7 @@ export function BladeWidget({
         {/* radix scrollarea breaks the nested containers widths*/}
         <ScrollArea
           type="hover"
-          className="blade-container h-full [&>div>div[style]]:!block"
+          className="blade-container h-full [&>div>div[style]]:block!"
         >
           <div className="p-4">{children}</div>
         </ScrollArea>


### PR DESCRIPTION
This pull request updates the `BladeWidget` component to use a more consistent button styling approach and makes a minor adjustment to a CSS utility class. The most important changes are:

**UI Consistency Improvements:**

* Updated the refresh and close buttons in `BladeWidget` to use the `buttonVariants` utility with `variant: 'outline'` and `size: 'icon'` for consistent styling across the app, replacing the previous hardcoded class names.
* Imported `buttonVariants` from `@/components/ui/button/variants` to support the new button styling approach.

**CSS Utility Adjustment:**

* Modified the `ScrollArea` component's class to use `block!` instead of `!block` for the targeted nested divs, likely to improve specificity or fix a styling issue.