### PR TITLE
[Color]: In color doc refactor event handling example to fix visibility

### DIFF
--- a/Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/Color.md
+++ b/Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/Color.md
@@ -106,7 +106,7 @@ public class ColorChangedDemo : ViewBase
     public override object? Build()
     {    
         var colorState = this.UseState("#ff0000");
-        var colorName = UseState("");
+        var colorName = UseState(colorState.Value);
         var onChangeHandler = (Event<IInput<string>, string> e) =>
         {
             colorName.Set(e.Value);
@@ -114,12 +114,13 @@ public class ColorChangedDemo : ViewBase
         };
         return Layout.Vertical() 
                 | H3("Hex Color Picker")
+                | (Layout.Horizontal()
                 | new ColorInput<string>
                        (colorState.Value, onChangeHandler)
                       .Variant(ColorInputs.Picker) 
                 | new Code(colorName.Value)
-                     .ShowCopyButton()
-                     .ShowBorder();
+                    .ShowCopyButton()
+                    .ShowBorder());
     }    
 }    
 ```


### PR DESCRIPTION
How it was: 
<img width="1280" height="632" alt="Screenshot 2025-10-30 at 23 11 58" src="https://github.com/user-attachments/assets/f235a922-2418-4715-8513-e4eb0d25b742" />

How it's now:
<img width="1288" height="670" alt="Screenshot 2025-10-30 at 23 12 57" src="https://github.com/user-attachments/assets/6397b3ab-fa36-4cb5-9c38-c45ebc4fdcdc" />
