### PR TITLE
(docs): use more modern fields descriptions

### DIFF
--- a/Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/AsyncSelect.md
+++ b/Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/AsyncSelect.md
@@ -43,8 +43,9 @@ public class AsyncSelectBasicDemo : ViewBase
         }
 
         return Layout.Vertical()
-            | Text.Label("Select a category:")
             | selectedCategory.ToAsyncSelectInput(QueryCategories, LookupCategory, "Search categories...")
+                              .WithField()
+                              .Label("Select a category")
             | Text.Small($"Selected: {selectedCategory.Value ?? "None"}");
     }
 }
@@ -77,8 +78,9 @@ public class StringAsyncSelectDemo : ViewBase
         }
 
         return Layout.Vertical()
-            | Text.Label("Select a country:")
             | selectedCountry.ToAsyncSelectInput(QueryCountries, LookupCountry, placeholder: "Search countries...")
+                              .WithField()
+                              .Label("Select a country")
             | Text.Small($"Selected: {selectedCountry.Value ?? "None"}");
     }
 }
@@ -123,8 +125,9 @@ public class IntegerAsyncSelectDemo : ViewBase
         }
 
         return Layout.Vertical()
-            | Text.Label("Select a year:")
             | selectedYear.ToAsyncSelectInput(QueryYears, LookupYear, placeholder: "Search years...")
+                          .WithField()
+                          .Label("Select a year")
             | Text.Small($"Selected: {selectedYear.Value?.ToString() ?? "None"}");
     }
 }
@@ -185,8 +188,9 @@ public class EnumAsyncSelectDemo : ViewBase
         }
 
         return Layout.Vertical()
-            | Text.Label("Select a programming language:")
             | selectedLanguage.ToAsyncSelectInput(QueryLanguages, LookupLanguage, placeholder: "Search languages...")
+                              .WithField()
+                              .Label("Select a programming language")
             | Text.Small($"Selected: {selectedLanguage.Value.ToString()}");
     }
 }
@@ -270,8 +274,7 @@ public class AdvancedQueryDemo : ViewBase
         );
 
         return Layout.Vertical()
-            | Text.Label("Search and select a user:")
-            | customAsyncSelect
+            | customAsyncSelect.WithField().Label("Search and select a user")
             | Text.Small($"Selected: {selectedUserInfo.Value}");
     }
 }
@@ -325,8 +328,9 @@ public class ErrorHandlingDemo : ViewBase
         }
 
         return Layout.Vertical()
-            | Text.Label("AsyncSelect with error handling:")
             | selectedItem.ToAsyncSelectInput(QueryWithErrors, LookupWithErrors, placeholder: "Search items...")
+                          .WithField()
+                          .Label("AsyncSelect with error handling")
             | (errorMessage.Value != null ? Text.Block(errorMessage.Value) : null)
             | Text.Small($"Selected: {selectedItem.Value ?? "None"}");
     }
@@ -361,16 +365,19 @@ public class StylingDemo : ViewBase
         }
 
         return Layout.Vertical()
-            | Text.Label("Normal AsyncSelectInput:")
             | normalSelect.ToAsyncSelectInput(QueryOptions, LookupOption, placeholder: "Choose an option...")
+                          .WithField()
+                          .Label("Normal AsyncSelectInput")
             
-            | Text.Label("Invalid AsyncSelectInput:")
             | invalidSelect.ToAsyncSelectInput(QueryOptions, LookupOption, placeholder: "This has an error...")
                 .Invalid("This field is required")
+                .WithField()
+                .Label("Invalid AsyncSelectInput")
             
-            | Text.Label("Disabled AsyncSelectInput:")
             | disabledSelect.ToAsyncSelectInput(QueryOptions, LookupOption, placeholder: "This is disabled...")
-                .Disabled(true);
+                .Disabled(true)
+                .WithField()
+                .Label("Disabled AsyncSelectInput");
     }
 }
 ```

--- a/Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/Bool.md
+++ b/Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/Bool.md
@@ -77,9 +77,10 @@ public class NullableBoolDemo: ViewBase
         else 
             status.Set(going.Value == true ? "Yes!" : "No, not yet!");
         return Layout.Vertical()
-                | Text.Small("Have you booked return tickets?")
                 | Text.Html($"<i>{status}</i>")
-                | going.ToSwitchInput();        
+                | going.ToSwitchInput()
+                       .WithField()
+                       .Label("Have you booked return tickets?");        
     }    
 }
 ```
@@ -262,18 +263,18 @@ public class SimpleFlightBooking : ViewBase
                 // Round Trip Switch
                 | isRoundTrip.ToSwitchInput().Label("Round Trip")
                 // Departure Date (always visible)
-                | (Layout.Vertical()
-                   | Text.Label("Departure Date:")
-                   | departureDate.ToDateTimeInput()
+                | departureDate.ToDateTimeInput()
                                   .Variant(DateTimeInputs.Date)
-                                  .Placeholder("Select departure date"))
+                                  .Placeholder("Select departure date")
+                                  .WithField()
+                                  .Label("Departure Date")
                 // Return Date (only visible when round trip is on)
-                | (Layout.Vertical()
-                       | Text.Label("Return Date:")
-                       | returnDate.ToDateTimeInput()
+                | returnDate.ToDateTimeInput()
                                    .Variant(DateTimeInputs.Date)
                                    .Placeholder("Select return date")
-                                   .Disabled(!isRoundTrip.Value))
+                                   .Disabled(!isRoundTrip.Value)
+                                   .WithField()
+                                   .Label("Return Date")
                 // Summary
                 | Text.Small($"Round trip: {departureDate.Value:MMM dd} → {returnDate.Value:MMM dd}")
                 | Text.Small($"One way: {departureDate.Value:MMM dd}");

--- a/Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/CodeInput.md
+++ b/Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/CodeInput.md
@@ -163,13 +163,14 @@ public class CodeInputWithValidation : ViewBase
         var isValid = !string.IsNullOrWhiteSpace(codeState.Value);
         
         return Layout.Vertical()
-            | Text.Label("Enter Code:")
             | codeState.ToCodeInput()
                     .Width(Size.Auto())
                     .Height(Size.Auto())
                     .Placeholder("Enter your code here...")
                     .Language(Languages.Javascript)
-                                | new Button("Execute Code")
+                    .WithField()
+                    .Label("Enter Code")
+            | new Button("Execute Code")
                 .Disabled(!isValid)
             | Text.Small(isValid 
                 ? "Ready to execute!" 

--- a/Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/Color.md
+++ b/Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/Color.md
@@ -71,24 +71,21 @@ public class ColorDemo : ViewBase
         var pickerColorState = UseState("#ff0000");
         var textAndPickerColorState = UseState("#ff0000");
         return Layout.Vertical()
-                | (Layout.Horizontal()
-                    | Text.Small("Just Text")
-                          .Width(25)
-                    | textColorState
+                | textColorState
                           .ToColorInput()
-                          .Variant(ColorInputs.Text))
-                | (Layout.Horizontal()
-                    | Text.Small("Just Picker")
-                          .Width(25)
-                    | pickerColorState
+                          .Variant(ColorInputs.Text)
+                          .WithField()
+                          .Label("Just Text")
+                | pickerColorState
                           .ToColorInput()
-                          .Variant(ColorInputs.Picker))
-                | (Layout.Horizontal()
-                    | Text.Small("Text and Picker")
-                          .Width(25)
-                    | textAndPickerColorState
+                          .Variant(ColorInputs.Picker)
+                          .WithField()
+                          .Label("Just Picker")
+                | textAndPickerColorState
                           .ToColorInput()
-                          .Variant(ColorInputs.TextAndPicker));
+                          .Variant(ColorInputs.TextAndPicker)
+                          .WithField()
+                          .Label("Text and Picker");
     }   
 }
 ```

--- a/Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/DateTime.md
+++ b/Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/DateTime.md
@@ -28,9 +28,10 @@ public class BasicDateTimeUsageDemo : ViewBase
         var dateState = UseState(DateTime.Today);
         var daysBetween = dateState.Value.Subtract(DateTime.Today).Days;
         return Layout.Vertical() 
-                | Text.Large("When is your birthday?")
                 | dateState.ToDateTimeInput()
                            .Variant(DateTimeInputs.Date)
+                           .WithField()
+                           .Label("When is your birthday?")
                 | Text.Html($"<i>That's <b>{daysBetween}</b> days from now!");
     }
 }    
@@ -82,20 +83,17 @@ public class DateTimeVariantsDemo : ViewBase
         var dateTimeState = UseState(DateTime.Today);
         
         return Layout.Vertical()
-                | (Layout.Horizontal()
-                    | Text.Small("Date")
-                          .Width(35)
-                    | dateState.ToDateInput()
-                           .Format("dd/MM/yyyy"))
-                | (Layout.Horizontal()
-                    | Text.Small("DateTime")
-                          .Width(35)
-                    | dateTimeState.ToDateTimeInput()
-                           .Format("dd/MM/yyyy HH:mm:ss"))
-                | (Layout.Horizontal()
-                    | Text.Small("Time")
-                          .Width(35)
-                    | timeState.ToTimeInput());
+                | dateState.ToDateInput()
+                           .Format("dd/MM/yyyy")
+                           .WithField()
+                           .Label("Date")
+                | dateTimeState.ToDateTimeInput()
+                           .Format("dd/MM/yyyy HH:mm:ss")
+                           .WithField()
+                           .Label("DateTime")
+                | timeState.ToTimeInput()
+                           .WithField()
+                           .Label("Time");
     }    
 }                
 ```
@@ -139,17 +137,15 @@ public class FormatDemo : ViewBase
          var yearMonthDate = UseState(DateTime.Today.Date);
          
          return Layout.Vertical()
-                 | (Layout.Horizontal()
-                     | Text.Small("MM/dd/yyyy")
-                           .Width(25) 
-                     | monthDateYear.ToDateInput()
-                                    .Format("MM/dd/yyyy"))
-                | (Layout.Horizontal()
-                    | Text.Small("yyyy/MMM/dd")
-                          .Width(25)
-                    | yearMonthDate.ToDateInput()
+                 | monthDateYear.ToDateInput()
+                                    .Format("MM/dd/yyyy")
+                                    .WithField()
+                                    .Label("MM/dd/yyyy")
+                | yearMonthDate.ToDateInput()
                                    .Placeholder("yyyy/MMM/dd")
-                                   .Format("yyyy/MMM/dd"));
+                                   .Format("yyyy/MMM/dd")
+                                   .WithField()
+                                   .Label("yyyy/MMM/dd");
     }
 }    
 ```
@@ -165,10 +161,10 @@ public class InvalidDateTimeDemo : ViewBase
     public override object? Build()
     {
         var thisDate = UseState(DateTime.Today.Date.AddDays(8));
-        return Layout.Vertical()
-                | Text.Large("Return date")
-                | thisDate.ToDateInput()
-                          .Invalid("Date is beyond the last approved date!");
+        return thisDate.ToDateInput()
+                          .Invalid("Date is beyond the last approved date!")
+                          .WithField()
+                          .Label("Return date");
     }
 }
 
@@ -225,14 +221,18 @@ public class LibraryBookReturnDemo : ViewBase
                 | Icons.Book    
                 | H3("Library Book Return")
                 | Text.Small("Library book returns must be within a week")
-                | Text.Large("Issue Date")
                 | issueDate.ToDateInput()
                            .Disabled()
-                | Text.Large("Return Date")
+                           .WithField()
+                           .Label("Issue Date")
                 | returnDate.ToDateInput()
                             .Disabled()
+                            .WithField()
+                            .Label("Return Date")
                 | actualReturnDate.ToDateInput()
-                                    .Invalid(invalidMessage.Value);
+                                    .Invalid(invalidMessage.Value)
+                                    .WithField()
+                                    .Label("Actual Return Date");
     }    
 }
 

--- a/Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/Feedback.md
+++ b/Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/Feedback.md
@@ -63,15 +63,18 @@ public class FeedbackDemo : ViewBase
         var emojiFeedback = UseState(4);
         return Layout.Vertical()
                 | H3 ("Simple movie review")
-                | Text.Block("Did you like the movie ?")
                 | new FeedbackInput<bool>(thumbsFeedback)
                       .Variant(FeedbackInputs.Thumbs)
-                | Text.Block("How would you like to rate the movie ?")
+                      .WithField()
+                      .Label("Did you like the movie?")
                 | new FeedbackInput<int>(starFeedback)
                       .Variant(FeedbackInputs.Stars)
-                | Text.Block("How do you feel after seeing the movie ?")
+                      .WithField()
+                      .Label("How would you like to rate the movie?")
                 | new FeedbackInput<int>(emojiFeedback)
-                      .Variant(FeedbackInputs.Emojis);
+                      .Variant(FeedbackInputs.Emojis)
+                      .WithField()
+                      .Label("How do you feel after seeing the movie?");
     }  
 }    
 ```

--- a/Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/Field.md
+++ b/Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/Field.md
@@ -11,11 +11,11 @@ searchHints:
 # Field
 
 <Ingress>
-Group any input with a label, description, and required indicator for a consistent, accessible form design.
+Group any input with a label, description, help text, and required indicator for a consistent, accessible form design.
 </Ingress>
 
 The `Field` widget acts as a **wrapper** around any input (such as `TextInput`, `Select`, `DateTime`, etc.).  
-It provides a standardized way to display a label, optional description, and visual cues like a required asterisk.  
+It provides a standardized way to display a label, optional description, help text tooltips, and visual cues like a required asterisk.  
 
 This makes forms easier to build and ensures inputs remain consistent in layout and accessibility.
 
@@ -50,6 +50,7 @@ A `Field` supports the following common properties:
 
 * **Label(string)** - The display label above the input.
 * **Description(string)** - An optional helper text shown below the input.
+* **HelpText(string)** - An optional help text displayed as a tooltip on an info icon next to the label.
 * **Required(bool)** - Marks the input as required (adds an asterisk or style cue).
 
 ## Examples
@@ -83,6 +84,26 @@ public class WithDescriptionDemo : ViewBase
             .WithField()
             .Label("Password")
             .Description("Must be at least 8 characters long and include a number");
+    }
+}
+```
+
+### Field With Help Text
+
+Use help text to provide contextual information without cluttering the interface:
+
+```csharp demo-below
+public class WithHelpTextDemo : ViewBase
+{
+    public override object? Build()
+    {
+        var username = UseState("");
+        return username.ToTextInput()
+            .Placeholder("Enter username")
+            .WithField()
+            .Label("Username")
+            .HelpText("Your username must be unique and contain only letters, numbers, and underscores")
+            .Required();
     }
 }
 ```

--- a/Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/Number.md
+++ b/Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/Number.md
@@ -60,7 +60,6 @@ public class NumberSliderInput : ViewBase
         var tapes = UseState(1.0);
         var cart = UseState("");
         return Layout.Vertical()
-                | Text.Block("Tapes")
                 | new NumberInput<double>(
                       tapes.Value,
                       e => {
@@ -72,6 +71,8 @@ public class NumberSliderInput : ViewBase
                      .Precision(2)
                      .Step(0.5)
                      .Variant(NumberInputs.Slider)
+                     .WithField()
+                     .Label("Tapes")
                 | Text.Block(cart);
     }
 }
@@ -100,7 +101,6 @@ public class MoneyInputDemo : ViewBase
         
         return Layout.Vertical()
                 | Text.H3("Simple Currency Converter")
-                | Text.Label("Enter EUR amount:")
                 | new NumberInput<decimal>(
                     moneyInEUR.Value,
                     e => {
@@ -112,16 +112,20 @@ public class MoneyInputDemo : ViewBase
                 .FormatStyle(NumberFormatStyle.Currency)
                 .Currency("EUR")
                 .Placeholder("€0.00")
+                .WithField()
+                .Label("Enter EUR amount")
                     
-                | Text.Label("USD:")
                 | moneyInUSD.ToMoneyInput()
                             .Currency("USD")
                             .Disabled()
+                            .WithField()
+                            .Label("USD")
                     
-                | Text.Label("GBP:")
                 | moneyInGBP.ToMoneyInput()
                             .Currency("GBP")
-                            .Disabled();
+                            .Disabled()
+                            .WithField()
+                            .Label("GBP");
     }
 }
 ```
@@ -178,15 +182,16 @@ public class MoneyPrecisionDemo : ViewBase
     public override object? Build()
     {
         var precValue = UseState(0.50M);
-        return Layout.Horizontal() 
-                | Text.Label("Min 0, Max 100, Step 0.5, Precision 2")
-                | new NumberInput<decimal>(precValue)
+        return new NumberInput<decimal>(precValue)
                      .Min(0.0)
                      .Max(100.0)
                      .Step(0.5)
                      .Precision(2)
                      .FormatStyle(NumberFormatStyle.Currency)
-                     .Currency("USD");
+                     .Currency("USD")
+                     .WithField()
+                     .Label("Price")
+                     .Description("Min 0, Max 100, Step 0.5, Precision 2");
     }
 }
 ```
@@ -249,21 +254,19 @@ public class GroceryAppDemo : ViewBase
         var eggCost = 3.45M;
         var breadCost = 6.13M;
         return Layout.Vertical()
-                | (Layout.Horizontal() 
-                   | Text.Label("Egg").Width(10)
-                   | eggs.ToNumberInput()
+                | eggs.ToNumberInput()
                          .Min(0)
                          .Max(12)
-                         .Width(10)
-                   | Text.Html("<i>Maximum 12</i>"))  
+                         .WithField()
+                         .Label("Egg")
+                         .Description("Maximum 12")
         
-                | (Layout.Horizontal()
-                   | Text.Label("Bread").Width(10)
-                   | breads.ToNumberInput()
+                | breads.ToNumberInput()
                               .Min(0)
                               .Max(5)
-                              .Width(10)
-                   | Text.Html("<i>Maximum 5</i>"))
+                              .WithField()
+                              .Label("Bread")
+                              .Description("Maximum 5")
                 | Text.Large($"{eggs} eggs and {breads} breads")
                 | (Layout.Horizontal()
                    | Text.Large("Bill : ")

--- a/Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/Select.md
+++ b/Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/Select.md
@@ -29,9 +29,10 @@ public class SelectVariantDemo : ViewBase
         var langs = new string[]{"C#","Java","Go","JavaScript","F#","Kotlin","VB.NET","Rust"};
         
         var favLang = UseState("C#");
-        return Layout.Vertical() 
-                | Text.Label("Select your favourite programming language")
-                | favLang.ToSelectInput(langs.ToOptions()).Variant(SelectInputs.Select);
+        return favLang.ToSelectInput(langs.ToOptions())
+                      .Variant(SelectInputs.Select)
+                      .WithField()
+                      .Label("Select your favourite programming language");
     }    
 }
 ```
@@ -109,13 +110,12 @@ public class EventHandlingDemo : ViewBase
         var skillOptions = CategoryOptions[selectedCategory.Value].ToOptions();
         
         return Layout.Vertical()
-            | Layout.Grid().Columns(2)
-                | Text.Label("Category:")
-                | selectedCategory.ToSelectInput(categoryOptions)
+            | selectedCategory.ToSelectInput(categoryOptions)
                     .Placeholder("Choose a category...")
+                    .WithField()
+                    .Label("Category")
                 
-                | Text.Label("Skill:")
-                | new SelectInput<string>(
+            | new SelectInput<string>(
                     value: selectedSkill.Value,
                     onChange: e =>
                     {
@@ -124,6 +124,8 @@ public class EventHandlingDemo : ViewBase
                     },
                     skillOptions)
                     .Placeholder("Select a skill...")
+                    .WithField()
+                    .Label("Skill")
             
             | (showInfo.Value 
                 ? Text.Block($"Selected: {selectedCategory.Value} → {selectedSkill.Value}") 
@@ -152,19 +154,22 @@ public class SelectStylingDemo : ViewBase
         var options = new[]{"Option 1", "Option 2", "Option 3"}.ToOptions();
         
         return Layout.Vertical()
-            | Text.Label("Normal SelectInput:")
             | normalSelect.ToSelectInput(options)
                 .Placeholder("Choose an option...")
+                .WithField()
+                .Label("Normal SelectInput")
             
-            | Text.Label("Invalid SelectInput:")
             | invalidSelect.ToSelectInput(options)
                 .Placeholder("This has an error...")
                 .Invalid("This field is required")
+                .WithField()
+                .Label("Invalid SelectInput")
             
-            | Text.Label("Disabled SelectInput:")
             | disabledSelect.ToSelectInput(options)
                 .Placeholder("This is disabled...")
-                .Disabled(true);
+                .Disabled(true)
+                .WithField()
+                .Label("Disabled SelectInput");
     }
 }
 ```
@@ -184,14 +189,16 @@ public class NullableSelectDemo : ViewBase
         var options = new[]{"Red", "Green", "Blue"}.ToOptions();
         
         return Layout.Vertical()
-            | Text.Label("Nullable Single Select:")
             | nullableString.ToSelectInput(options)
                 .Placeholder("Choose a color (optional)")
+                .WithField()
+                .Label("Nullable Single Select")
             
-            | Text.Label("Nullable Multi-Select:")
             | nullableArray.ToSelectInput(options)
                 .Variant(SelectInputs.List)
                 .Placeholder("Choose colors (optional)")
+                .WithField()
+                .Label("Nullable Multi-Select")
             
             | Text.Small($"Single: {nullableString.Value ?? "None"}")
             | Text.Small($"Multiple: {nullableArray.Value?.Length ?? 0} selected");
@@ -266,15 +273,17 @@ public class CoffeeShopDemo: ViewBase
         var orderSummary = BuildOrderSummary(coffee.Value, coffeeSize.Value, selectedCondiments.Value);
         
         return Layout.Vertical()
-                | Layout.Grid().Columns(2)
-                    | Text.Label("Coffee Type:")
-                    | coffee.ToSelectInput(CoffeeAccompaniments.Keys.ToOptions())
+                | coffee.ToSelectInput(CoffeeAccompaniments.Keys.ToOptions())
+                        .WithField()
+                        .Label("Coffee Type")
                     
-                    | Text.Label("Size:")
-                    | coffeeSizeMenu
+                | coffeeSizeMenu
+                        .WithField()
+                        .Label("Size")
                     
-                    | Text.Label("Condiments:")
-                    | condimentMenu
+                | condimentMenu
+                        .WithField()
+                        .Label("Condiments")
                     
                 | new Icon(Icons.Coffee) 
                 | Text.Block(orderSummary);

--- a/Ivy.Samples.Shared/Apps/Widgets/Inputs/FieldApp.cs
+++ b/Ivy.Samples.Shared/Apps/Widgets/Inputs/FieldApp.cs
@@ -1,4 +1,4 @@
-﻿using Ivy.Shared;
+using Ivy.Shared;
 using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Generic;
@@ -34,21 +34,23 @@ public class FieldApp : SampleBase
                 .Description("Your full name")
                 .Required()
 
-                // Using .WithField() shortcut
+                // Using .WithField() shortcut with help text
                 | emailState.ToTextInput()
                     .Placeholder("Enter your email")
                     .WithField()
                     .Label("Email")
                     .Description("Required for contact")
+                    .HelpText("We will never share your email with third parties")
                     .Required()
 
-                // Password field, disabled if name is empty
+                // Password field, disabled if name is empty, with help text
                 | passwordState.ToPasswordInput()
                     .Placeholder("Enter password")
                     .Disabled(string.IsNullOrWhiteSpace(nameState.Value))
                     .WithField()
                     .Label("Password")
                     .Description("At least 8 characters")
+                    .HelpText("Use a mix of letters, numbers, and symbols for better security")
 
                 // Checkbox wrapped with .WithField()
                 | acceptedTerms.ToSelectInput(options.ToOptions())

--- a/Ivy/Widgets/Inputs/Field.cs
+++ b/Ivy/Widgets/Inputs/Field.cs
@@ -1,4 +1,4 @@
-﻿using Ivy.Core;
+using Ivy.Core;
 using Ivy.Shared;
 using Ivy.Widgets.Inputs;
 using System;
@@ -18,7 +18,8 @@ public record Field : WidgetBase<Field>
     /// <param name="label">Optional label text.</param>
     /// <param name="description">Optional description.</param>
     /// <param name="required">Whether field is required.</param>
-    public Field(IAnyInput input, string? label = null, string? description = null, bool required = false) : base([input])
+    /// <param name="helpText">Optional help text displayed as tooltip on info icon.</param>
+    public Field(IAnyInput input, string? label = null, string? description = null, bool required = false, string? helpText = null) : base([input])
     {
         var labelProp = input.GetType().GetProperty("Label");
         if (labelProp != null && labelProp.PropertyType == typeof(string))
@@ -40,6 +41,7 @@ public record Field : WidgetBase<Field>
         Label = label;
         Description = description;
         Required = required;
+        HelpText = helpText;
     }
 
     /// <summary>Label text displayed for field.</summary>
@@ -50,6 +52,9 @@ public record Field : WidgetBase<Field>
 
     /// <summary>Whether field is required. Default is false.</summary>
     [Prop] public bool Required { get; set; }
+
+    /// <summary>Help text displayed as tooltip on info icon next to label.</summary>
+    [Prop] public string? HelpText { get; set; }
 
     /// <summary>The size of the field affecting label and input sizing. Default is Medium.</summary>
     [Prop] public Sizes Size { get; set; } = Sizes.Medium;
@@ -81,6 +86,10 @@ public static class FieldExtensions
     /// <param name="description">The description text to display for the child input.</param>
     public static Field Description(this Field field, string description) => field with { Description = description };
 
+    /// <summary>Sets the help text displayed as tooltip on info icon next to label.</summary>
+    /// <param name="field">The field to configure.</param>
+    /// <param name="helpText">The help text to display in tooltip.</param>
+    public static Field HelpText(this Field field, string helpText) => field with { HelpText = helpText };
 
     /// <summary>Make the input child required</summary>
     /// <param name="field">The field to configure.</param>

--- a/frontend/src/widgets/inputs/FieldWidget.tsx
+++ b/frontend/src/widgets/inputs/FieldWidget.tsx
@@ -1,11 +1,19 @@
 import React from 'react';
 import { Sizes } from '@/types/sizes';
+import Icon from '@/components/Icon';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
 
 interface FieldWidgetProps {
   id: string;
   label: string;
   description?: string;
   required: boolean;
+  helpText?: string;
   children?: React.ReactNode;
   size?: Sizes;
 }
@@ -14,6 +22,7 @@ export const FieldWidget: React.FC<FieldWidgetProps> = ({
   label,
   description,
   required,
+  helpText,
   children,
   size = Sizes.Medium,
 }) => {
@@ -36,12 +45,35 @@ export const FieldWidget: React.FC<FieldWidgetProps> = ({
   return (
     <div className={`flex flex-col ${gapClass} flex-1 min-w-0`}>
       {label && (
-        <label
-          className={`${labelSizeClass} font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70`}
-        >
-          {label}{' '}
-          {required && <span className="font-mono text-primary">*</span>}
-        </label>
+        <div className="flex items-center gap-1.5">
+          <label
+            className={`${labelSizeClass} font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70`}
+          >
+            {label}{' '}
+            {required && <span className="font-mono text-primary">*</span>}
+          </label>
+          {helpText && (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    className="inline-flex items-center justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
+                  >
+                    <Icon
+                      name="Info"
+                      size="14"
+                      className="text-muted-foreground hover:text-foreground transition-colors"
+                    />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent className="bg-popover text-popover-foreground shadow-md">
+                  {helpText}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          )}
+        </div>
       )}
       {children}
       {description && (


### PR DESCRIPTION
This pull request updates documentation examples to consistently use the `.WithField().Label(...)` pattern for form inputs, replacing previous usages of separate label widgets. It also adds support and documentation for the `HelpText` property in the `Field` component, improving clarity and accessibility in form design. The changes ensure all input widgets across the docs demonstrate best practices for labeling, help text, and field grouping.

**Standardization of input labeling and field grouping:**

* Updated all input examples in `AsyncSelect.md`, `Bool.md`, `CodeInput.md`, `Color.md`, `DateTime.md`, `Feedback.md`, and `Number.md` to use `.WithField().Label(...)` instead of separate label widgets, ensuring consistent and accessible labeling for form fields. [[1]](diffhunk://#diff-c0de2647c03cada2a06a0a2223a531926a02d8d1e792d9e16bc960b7c2d2912bL46-R48) [[2]](diffhunk://#diff-c0de2647c03cada2a06a0a2223a531926a02d8d1e792d9e16bc960b7c2d2912bL80-R83) [[3]](diffhunk://#diff-c0de2647c03cada2a06a0a2223a531926a02d8d1e792d9e16bc960b7c2d2912bL126-R130) [[4]](diffhunk://#diff-c0de2647c03cada2a06a0a2223a531926a02d8d1e792d9e16bc960b7c2d2912bL188-R193) [[5]](diffhunk://#diff-c0de2647c03cada2a06a0a2223a531926a02d8d1e792d9e16bc960b7c2d2912bL273-R277) [[6]](diffhunk://#diff-c0de2647c03cada2a06a0a2223a531926a02d8d1e792d9e16bc960b7c2d2912bL328-R333) [[7]](diffhunk://#diff-c0de2647c03cada2a06a0a2223a531926a02d8d1e792d9e16bc960b7c2d2912bL364-R380) [[8]](diffhunk://#diff-a704fdb0af62cedf0a97c533ec5aae337f26964ccbbab53adbad357f13146a86L80-R83) [[9]](diffhunk://#diff-a704fdb0af62cedf0a97c533ec5aae337f26964ccbbab53adbad357f13146a86L265-R277) [[10]](diffhunk://#diff-74462dc700309369918a9ca3fc9590e9d229d3830116d7c5315c663bc111909bL166-R172) [[11]](diffhunk://#diff-7ca01e37a088fff0aec083e9aa45ee302b51b04e7fd46edf02ca2805248452ebL74-R88) [[12]](diffhunk://#diff-d1367597be32ac171e2d59d822c9f02f3048bd7039e13e76f248ec1b3122deb7L31-R34) [[13]](diffhunk://#diff-d1367597be32ac171e2d59d822c9f02f3048bd7039e13e76f248ec1b3122deb7L85-R96) [[14]](diffhunk://#diff-d1367597be32ac171e2d59d822c9f02f3048bd7039e13e76f248ec1b3122deb7L142-R148) [[15]](diffhunk://#diff-d1367597be32ac171e2d59d822c9f02f3048bd7039e13e76f248ec1b3122deb7L168-R167) [[16]](diffhunk://#diff-d1367597be32ac171e2d59d822c9f02f3048bd7039e13e76f248ec1b3122deb7L228-R235) [[17]](diffhunk://#diff-1cfdaad8fb8894a88268e850e45ccb00224cf7e67654cc97a9df74d82548cdd0L66-R77) [[18]](diffhunk://#diff-af8d04dc19153c744aa546e3b18bab74d0cc03f05a7906a1d9fe211a7b44aae6L63) [[19]](diffhunk://#diff-af8d04dc19153c744aa546e3b18bab74d0cc03f05a7906a1d9fe211a7b44aae6R74-R75) [[20]](diffhunk://#diff-af8d04dc19153c744aa546e3b18bab74d0cc03f05a7906a1d9fe211a7b44aae6L103) [[21]](diffhunk://#diff-af8d04dc19153c744aa546e3b18bab74d0cc03f05a7906a1d9fe211a7b44aae6R115-R128)

**Enhancements to Field documentation:**

* Expanded the description of the `Field` component to mention support for help text via tooltips, and updated the list of supported properties to include `HelpText`. [[1]](diffhunk://#diff-c9005ab9c8616f2f717af5652238660dced881a502f90c959d15a95e2441166fL14-R18) [[2]](diffhunk://#diff-c9005ab9c8616f2f717af5652238660dced881a502f90c959d15a95e2441166fR53)
* Added a new example demonstrating usage of the `HelpText` property in the `Field` component.