### PR TITLE
(contributing): add link to a good PR

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -243,6 +243,10 @@ Before submitting your widget PR, ensure you have:
    - Screenshots for UI changes
    - Test results
 
+### Example of a Good Pull Request
+
+For a reference on what constitutes a well-structured pull request, see [#1285](https://github.com/Ivy-Interactive/Ivy-Framework/issues/1285).
+
 ## Code Style and Standards
 
 ### Linting and Formatting


### PR DESCRIPTION
This pull request updates the `CONTRIBUTING.md` documentation to help contributors submit better pull requests by providing an example of a well-structured PR.

Documentation improvement:

* Added a section with a link to an example of a good pull request, giving contributors a concrete reference for best practices.