### PR TITLE
[CodeInput]: fix copy button background visibility in different elements

### DIFF
--- a/Ivy.Samples.Shared/Apps/Widgets/Inputs/CodeInputApp.cs
+++ b/Ivy.Samples.Shared/Apps/Widgets/Inputs/CodeInputApp.cs
@@ -159,6 +159,32 @@ public class CodeInputApp : SampleBase
 
         var dataBinding = CreateStringTypeTests();
 
+        var cardCode = UseState(
+            """
+            public class Example
+            {
+                public void DoWork()
+                {
+                    Console.WriteLine("Code inside Card");
+                }
+            }
+            """);
+
+        // Links with copy functionality using one Code block inside Card
+        var socialMediaLinksContent = """
+            discord.gg: https://discord.gg/62DYrqEX
+            github.com: https://github.com/Ivy-Interactive/Ivy-Framework
+            linkedin.com: https://www.linkedin.com/company/ivy-interactive/posts/?feedView=all
+            discord.gg: https://discord.gg/rVcUVZPG
+            youtube.com: https://www.youtube.com/@IvyInteractive
+            github.com: https://github.com/Ivy-Interactive/Ivy-Framework
+            x.com: https://x.com/ivy_interactive
+            """;
+
+        var socialMediaLinks = new Card(
+            new Code(socialMediaLinksContent, Languages.Text).ShowCopyButton().ShowBorder(false)
+        );
+
         return Layout.Vertical()
                | Text.H2("Sizes")
                | sizeGrid
@@ -169,6 +195,11 @@ public class CodeInputApp : SampleBase
                | thirdGrid
                | Text.H2("Data Binding")
                | dataBinding
+               | Text.H2("CodeInput in Card")
+               | new Card(
+                   cardCode.ToCodeInput().Language(Languages.Csharp).ShowCopyButton().Height(Size.Auto())
+               ).Title("Code Example").Description("Testing copy button visibility with card background")
+               | socialMediaLinks
                ;
     }
 

--- a/frontend/src/components/CopyToClipboardButton.tsx
+++ b/frontend/src/components/CopyToClipboardButton.tsx
@@ -34,7 +34,7 @@ const CopyToClipboardButton: React.FC<CopyToClipboardButtonProps> = ({
         'hover:bg-accent hover:shadow-sm border-0',
         copied
           ? 'bg-primary text-primary-foreground'
-          : 'bg-background text-muted-foreground hover:text-foreground'
+          : 'bg-transparent text-muted-foreground hover:text-foreground'
       )}
     >
       <span className="relative w-4 h-4">

--- a/frontend/src/widgets/inputs/code/CodeInputWidget.tsx
+++ b/frontend/src/widgets/inputs/code/CodeInputWidget.tsx
@@ -141,7 +141,7 @@ export const CodeInputWidget: React.FC<CodeInputWidgetProps> = ({
   return (
     <div style={styles} className="relative w-full h-full overflow-hidden">
       {showCopyButton && (
-        <div className="absolute top-2 right-2 z-10 rounded-md hover:bg-accent transition-colors duration-200">
+        <div className="absolute top-2 right-2 z-10 rounded-md">
           <CopyToClipboardButton
             textToCopy={localValue}
             aria-label="Copy to clipboard"


### PR DESCRIPTION
Had an issue:
<img width="766" height="238" alt="Screenshot 2025-11-04 at 00 11 14" src="https://github.com/user-attachments/assets/0e4886ca-a7a4-4b70-96b9-0a10918e178b" />

@rorychatt , before mergind, tell me if it's good, I think it will be better to remove these new examples form CodeInputApp.cs, it seems to be redundant there. Before approving of PR, I won't remove it for case if we want some more changes about it

Fixed: 

<img width="940" height="138" alt="Screenshot 2025-11-04 at 00 11 59" src="https://github.com/user-attachments/assets/39bb9949-2351-4bdb-8e06-df8858d680c3" />

<img width="96" height="59" alt="Screenshot 2025-11-04 at 00 12 17" src="https://github.com/user-attachments/assets/e017d551-d1aa-47ef-87e7-88526da9bc05" />

On hover:

<img width="68" height="56" alt="Screenshot 2025-11-04 at 00 12 37" src="https://github.com/user-attachments/assets/26e32ebf-e9a0-480b-a314-f8da9924ef91" />

When clicked:

<img width="73" height="58" alt="Screenshot 2025-11-04 at 00 12 53" src="https://github.com/user-attachments/assets/b3308654-668a-4468-a21e-06bcf0b42c1c" />


With basic black background:

<img width="53" height="38" alt="Screenshot 2025-11-04 at 00 13 43" src="https://github.com/user-attachments/assets/9edf5387-acea-4a83-aa79-846ad335c55d" />


On hover:

<img width="57" height="43" alt="Screenshot 2025-11-04 at 00 13 59" src="https://github.com/user-attachments/assets/0bec8016-0040-4f70-8104-e07c7c93e273" />

When clicked:

<img width="71" height="52" alt="Screenshot 2025-11-04 at 00 14 45" src="https://github.com/user-attachments/assets/5e078d3c-2187-4b58-8d65-0bcbd1753fc3" />
