### PR TITLE
[Dependencies]: update Microsoft.Extensions.AI.OpenAI  dependencies

### DIFF
--- a/Ivy.Samples.Shared/Ivy.Samples.Shared.csproj
+++ b/Ivy.Samples.Shared/Ivy.Samples.Shared.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Bogus" Version="35.6.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.10" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
-    <PackageReference Include="OpenAI" Version="2.5.0" />
+    <PackageReference Include="OpenAI" Version="2.6.0" />
   </ItemGroup>
 
 </Project>

--- a/Ivy/Ivy.csproj
+++ b/Ivy/Ivy.csproj
@@ -55,11 +55,11 @@
     <PackageReference Include="ExcelNumberFormat" Version="1.1.0" />
     <PackageReference Include="Google.Protobuf" Version="3.33.0" />
     <PackageReference Include="Grpc.AspNetCore.Web" Version="2.71.0" />
-    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.10.0" />
+    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.10.2" />
     <PackageReference Include="Isopoh.Cryptography.Argon2" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.2.0" />
-    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="9.10.0-preview.1.25513.3" />
+    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="9.10.2-preview.1.25552.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.10" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.10" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.14.0" />

--- a/Ivy/Views/DataTables/DataTableService.cs
+++ b/Ivy/Views/DataTables/DataTableService.cs
@@ -5,8 +5,6 @@ using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
-using OpenAI;
-using OpenAI.Chat;
 
 //todo: Check for JWT
 


### PR DESCRIPTION
The issue was:
/usr/share/dotnet/sdk/9.0.306/Sdks/NuGet.Build.Tasks.Pack/build/NuGet.Build.Tasks.Pack.targets(221,5): warning NU5104: A stable release of a package should not have a prerelease dependency. Either modify the version spec of dependency "Microsoft.Extensions.AI.OpenAI [9.10.0-preview.1.25513.3, )" or update the version field in the nuspec. [/__w/Ivy/Ivy/Ivy-Framework/Ivy/Ivy.csproj]

I tried to find stable version of Microsoft.Extensions.AI.OpenAI [9.10.0-preview.1.25513.3, ) but there is no stable version. 
However, I updated some dependencies and removed redundant using from Ivy/Views/DataTables/DataTableService.cs
"OpenAI" Version="2.5.0" -> "OpenAI" Version="2.6.0"
"Microsoft.Extensions.AI.Abstractions" Version="9.10.0" -> "Microsoft.Extensions.AI.Abstractions" Version="9.10.2"
"Microsoft.Extensions.AI.OpenAI" Version="9.10.0-preview.1.25513.3" -> "Microsoft.Extensions.AI.OpenAI" Version="9.10.2-preview.1.25552.1"

I also don't have any NU warnings

<img width="794" height="187" alt="Screenshot 2025-11-04 at 01 03 53" src="https://github.com/user-attachments/assets/e28a78f3-c907-48bc-b7cc-416e852b79f4" />
<img width="233" height="100" alt="Screenshot 2025-11-04 at 01 04 15" src="https://github.com/user-attachments/assets/5be88b8d-3be2-413a-80e1-1242f65f3c54" />

Tested out datatables -> it works fine

