### PR TITLE
(tabs): conditionally render close icon in dropdown menus

### DIFF
--- a/frontend/src/widgets/layouts/TabsLayoutWidget.tsx
+++ b/frontend/src/widgets/layouts/TabsLayoutWidget.tsx
@@ -116,11 +116,13 @@ function SortableDropdownMenuItem({
   children,
   onClick,
   isActive,
+  showClose,
 }: {
   id: string;
   children: React.ReactNode;
   onClick: () => void;
   isActive?: boolean;
+  showClose?: boolean;
 }) {
   const {
     attributes,
@@ -149,18 +151,20 @@ function SortableDropdownMenuItem({
       )}
     >
       <span className="truncate text-left">{children}</span>
-      <button
-        type="button"
-        className="ml-auto opacity-60 p-1 hover:opacity-100 invisible group-hover:visible cursor-pointer"
-        onClick={e => {
-          e.stopPropagation();
-          window.dispatchEvent(
-            new CustomEvent('tab-close', { detail: { id } })
-          );
-        }}
-      >
-        <X className="w-3 h-3" />
-      </button>
+      {showClose && (
+        <button
+          type="button"
+          className="ml-auto opacity-60 p-1 hover:opacity-100 invisible group-hover:visible cursor-pointer"
+          onClick={e => {
+            e.stopPropagation();
+            window.dispatchEvent(
+              new CustomEvent('tab-close', { detail: { id } })
+            );
+          }}
+        >
+          <X className="w-3 h-3" />
+        </button>
+      )}
     </div>
   );
 }
@@ -802,6 +806,7 @@ export const TabsLayoutWidget = ({
                         handleTabSelect(id);
                       }}
                       isActive={activeTabId === id}
+                      showClose={showClose}
                     >
                       {title}
                     </SortableDropdownMenuItem>


### PR DESCRIPTION
This pull request updates the `TabsLayoutWidget` component to improve the flexibility of tab items by allowing the close button to be conditionally shown or hidden. The main change is the addition of a `showClose` prop to the `SortableDropdownMenuItem` component, which controls whether the close button appears on each tab.

Enhancements to tab close button behavior:

* Added an optional `showClose` prop to the `SortableDropdownMenuItem` component, allowing the close button to be conditionally rendered. [[1]](diffhunk://#diff-ebe3cfd8584668aaed7504557c6c14cace5f3718eb7b9720ec4fcba94c0e873dR119-R125) [[2]](diffhunk://#diff-ebe3cfd8584668aaed7504557c6c14cace5f3718eb7b9720ec4fcba94c0e873dR154) [[3]](diffhunk://#diff-ebe3cfd8584668aaed7504557c6c14cace5f3718eb7b9720ec4fcba94c0e873dR167)
* Passed the `showClose` prop from `TabsLayoutWidget` to each `SortableDropdownMenuItem`, enabling parent-level control over the visibility of close buttons on tabs.