### PR TITLE
(Fix): Reduced padding for child columns in DataTable

### DIFF
--- a/frontend/src/widgets/dataTables/DataTableEditor.tsx
+++ b/frontend/src/widgets/dataTables/DataTableEditor.tsx
@@ -101,7 +101,7 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
       borderColor: showVerticalBorders
         ? colors.border || (isDark ? '#404045' : '#d1d5db')
         : 'transparent',
-      cellHorizontalPadding: 16,
+      cellHorizontalPadding: 8,
       cellVerticalPadding: 8,
       headerIconSize: 20,
       // Add proper text colors for group headers and icons


### PR DESCRIPTION
closes #1281 

Before (lines to point out padding issue):
<img width="240" height="73" alt="ivy_groupheaders_not_aligned" src="https://github.com/user-attachments/assets/48857c55-7fb1-43af-8367-30b967422f88" />

After:
<img width="305" height="123" alt="ivy_groupheaders_aligned" src="https://github.com/user-attachments/assets/432672cd-d7cb-44a4-bf39-65c528ad077f" />
