### PR TITLE
(sidebar): Fixed so that Settings button and the dropdown menu in it uses --sidebar-accent

### DIFF
--- a/frontend/src/components/ui/sidebar/sidebar.tsx
+++ b/frontend/src/components/ui/sidebar/sidebar.tsx
@@ -224,7 +224,7 @@ const Sidebar = React.forwardRef<
         >
           <div
             data-sidebar="sidebar"
-            className="flex h-full w-full flex-col bg-sidebar group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow"
+            className="flex h-full w-full flex-col bg-sidebar group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:border-border group-data-[variant=floating]:shadow"
           >
             {children}
           </div>
@@ -276,7 +276,7 @@ const SidebarRail = React.forwardRef<
       onClick={toggleSidebar}
       title="Toggle Sidebar"
       className={cn(
-        'absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex',
+        'absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-border group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex',
         '[[data-side=left]_&]:cursor-w-resize [[data-side=right]_&]:cursor-e-resize',
         '[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize',
         'group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full group-data-[collapsible=offcanvas]:hover:bg-sidebar',
@@ -317,7 +317,7 @@ const SidebarInput = React.forwardRef<
       ref={ref}
       data-sidebar="input"
       className={cn(
-        'h-8 w-full bg-background shadow-none focus-visible:ring-2 focus-visible:ring-sidebar-ring',
+        'h-8 w-full bg-background shadow-none focus-visible:ring-2 focus-visible:ring-ring',
         className
       )}
       {...props}
@@ -364,7 +364,7 @@ const SidebarSeparator = React.forwardRef<
     <Separator
       ref={ref}
       data-sidebar="separator"
-      className={cn('mx-2 w-auto bg-sidebar-border', className)}
+      className={cn('mx-2 w-auto bg-border', className)}
       {...props}
     />
   );
@@ -415,7 +415,7 @@ const SidebarGroupLabel = React.forwardRef<
       ref={ref}
       data-sidebar="group-label"
       className={cn(
-        'duration-200 flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 outline-none ring-sidebar-ring transition-[margin,opa] ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
+        'duration-200 flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 outline-none ring-ring transition-[margin,opa] ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
         'group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0',
         className
       )}
@@ -436,7 +436,7 @@ const SidebarGroupAction = React.forwardRef<
       ref={ref}
       data-sidebar="group-action"
       className={cn(
-        'absolute right-3 top-3.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground outline-none ring-sidebar-ring transition-transform hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0 cursor-pointer',
+        'absolute right-3 top-3.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground outline-none ring-ring transition-transform hover:bg-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0 cursor-pointer',
         // Increases the hit area of the button on mobile.
         'after:absolute after:-inset-2 after:md:hidden',
         'group-data-[collapsible=icon]:hidden',
@@ -560,7 +560,7 @@ const SidebarMenuAction = React.forwardRef<
       ref={ref}
       data-sidebar="menu-action"
       className={cn(
-        'absolute right-1 top-1.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground outline-none ring-sidebar-ring transition-transform hover:bg-sidebar-accent focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0 cursor-pointer',
+        'absolute right-1 top-1.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground outline-none ring-ring transition-transform hover:bg-accent focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0 cursor-pointer',
         // Increases the hit area of the button on mobile.
         'after:absolute after:-inset-2 after:md:hidden',
         'peer-data-[size=sm]/menu-button:top-1',
@@ -643,7 +643,7 @@ const SidebarMenuSub = React.forwardRef<
     ref={ref}
     data-sidebar="menu-sub"
     className={cn(
-      'mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-l border-sidebar-border px-2.5 py-0.5',
+      'mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-l border-border px-2.5 py-0.5',
       'group-data-[collapsible=icon]:hidden',
       className
     )}
@@ -675,8 +675,8 @@ const SidebarMenuSubButton = React.forwardRef<
       data-size={size}
       data-active={isActive}
       className={cn(
-        'flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 text-sidebar-foreground outline-none ring-sidebar-ring hover:bg-sidebar-accent focus-visible:ring-2 active:bg-sidebar-accent disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 cursor-pointer',
-        'data-[active=true]:bg-sidebar-accent',
+        'flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 text-sidebar-foreground outline-none ring-ring hover:bg-accent focus-visible:ring-2 active:bg-accent disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 cursor-pointer',
+        'data-[active=true]:bg-accent',
         size === 'sm' && 'text-xs',
         size === 'md' && 'text-sm',
         'group-data-[collapsible=icon]:hidden',

--- a/frontend/src/components/ui/sidebar/variants.ts
+++ b/frontend/src/components/ui/sidebar/variants.ts
@@ -1,13 +1,13 @@
 import { cva } from 'class-variance-authority';
 
 export const sidebarMenuButtonVariants = cva(
-  'peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-none ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent focus-visible:ring-2 active:bg-sidebar-accent disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[state=open]:hover:bg-sidebar-accent group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:!p-2 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 cursor-pointer',
+  'peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-none ring-ring transition-[width,height,padding] hover:bg-accent focus-visible:ring-2 active:bg-accent disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-accent data-[active=true]:font-medium data-[state=open]:hover:bg-accent group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:!p-2 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 cursor-pointer',
   {
     variants: {
       variant: {
-        default: 'hover:bg-sidebar-accent',
+        default: 'hover:bg-accent',
         outline:
-          'bg-background shadow-[0_0_0_1px_var(--sidebar-border)] hover:bg-sidebar-accent hover:shadow-[0_0_0_1px_var(--sidebar-accent)]',
+          'bg-background shadow-[0_0_0_1px_var(--border)] hover:bg-accent hover:shadow-[0_0_0_1px_var(--accent)]',
       },
       size: {
         default: 'h-8 text-sm',

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -84,7 +84,7 @@
     --secondary-foreground: oklch(0 0 0);
     --muted: #f8f8f8;
     --muted-foreground: #8f8f8f;
-    --accent: #f8f8f8;
+    --accent: #eaebeb;
     --accent-foreground: oklch(0.33 0 0);
     --destructive: oklch(0.69 0.2 23.69);
     --destructive-foreground: oklch(0 0 0);
@@ -112,12 +112,6 @@
     --toolbox: #38363a;
     --sidebar: oklch(0.99 0 0);
     --sidebar-foreground: oklch(0.26 0 0);
-    --sidebar-primary: #00cc92;
-    --sidebar-primary-foreground: oklch(0.99 0 0);
-    --sidebar-accent: #eaebeb;
-    --sidebar-accent-foreground: oklch(0.33 0 0);
-    --sidebar-border: #d1d5db;
-    --sidebar-ring: oklch(0.77 0 0);
 
     /* Custom color palette with variants */
     --black: #000000;
@@ -330,10 +324,8 @@
     --sidebar-foreground: oklch(0.97 0 286.38);
     --sidebar-primary: oklch(0.49 0.22 264.39);
     --sidebar-primary-foreground: oklch(1 0 0);
-    --sidebar-accent: #26262b;
     --sidebar-accent-foreground: oklch(0.97 0 286.38);
     --sidebar-border: #26262b;
-    --sidebar-ring: oklch(0.87 0.01 286.29);
 
     /* Keep docs palette consistent in dark mode */
     --font-sans: 'Geist';
@@ -392,12 +384,6 @@
     --color-chart-5: var(--chart-5);
     --color-sidebar: var(--sidebar);
     --color-sidebar-foreground: var(--sidebar-foreground);
-    --color-sidebar-primary: var(--sidebar-primary);
-    --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
-    --color-sidebar-accent: var(--sidebar-accent);
-    --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-    --color-sidebar-border: var(--sidebar-border);
-    --color-sidebar-ring: var(--sidebar-ring);
     /* Custom color palette - using variables from :root */
     --color-black: var(--black);
     --color-white: var(--white);
@@ -464,17 +450,6 @@
 
   [data-sidebar='sidebar'] svg[fill='currentColor'] {
     color: var(--primary);
-  }
-
-  /* Make rounded buttons (Button components) use sidebar-accent when inside sidebar */
-  .bg-sidebar button.rounded-md:hover {
-    background-color: var(--sidebar-accent) !important;
-  }
-
-  /* Make dropdown menu items use sidebar-accent when opened from sidebar */
-  .dropdown-in-sidebar [role='menuitem']:focus,
-  .dropdown-in-sidebar [role='menuitem']:hover {
-    background-color: var(--sidebar-accent) !important;
   }
 }
 

--- a/frontend/src/widgets/DropDownMenuWidget.tsx
+++ b/frontend/src/widgets/DropDownMenuWidget.tsx
@@ -42,17 +42,6 @@ export const DropDownMenuWidget: React.FC<DropDownMenuWidgetProps> = ({
   const eventHandler = useEventHandler();
   const [open, setOpen] = useState(false);
   const triggerRef = useRef<HTMLButtonElement>(null);
-  const [isInSidebar, setIsInSidebar] = useState(false);
-
-  // Check if this dropdown is inside a sidebar
-  React.useEffect(() => {
-    if (triggerRef.current) {
-      const sidebar = triggerRef.current.closest(
-        '.bg-sidebar, [data-sidebar="sidebar"]'
-      );
-      setIsInSidebar(!!sidebar);
-    }
-  }, []);
 
   if (!slots?.Trigger) {
     return (
@@ -148,9 +137,7 @@ export const DropDownMenuWidget: React.FC<DropDownMenuWidgetProps> = ({
               )}
             </DropdownMenuSubTrigger>
             <DropdownMenuPortal>
-              <DropdownMenuSubContent
-                className={`m-2 ${isInSidebar ? 'dropdown-in-sidebar' : ''}`}
-              >
+              <DropdownMenuSubContent className="m-2">
                 {renderMenuItems(item.children)}
               </DropdownMenuSubContent>
             </DropdownMenuPortal>
@@ -185,7 +172,7 @@ export const DropDownMenuWidget: React.FC<DropDownMenuWidgetProps> = ({
         side={
           camelCase(side) as 'top' | 'right' | 'bottom' | 'left' | undefined
         }
-        className={`m-2 ${isInSidebar ? 'dropdown-in-sidebar' : ''}`}
+        className="m-2"
         alignOffset={alignOffset}
       >
         {slots.Header && <DropdownMenuLabel>{slots.Header}</DropdownMenuLabel>}

--- a/frontend/src/widgets/layouts/sidebar/SidebarLayoutWidget.tsx
+++ b/frontend/src/widgets/layouts/sidebar/SidebarLayoutWidget.tsx
@@ -181,7 +181,7 @@ export const SidebarLayoutWidget: React.FC<SidebarLayoutWidgetProps> = ({
       {showToggleButton && mainAppSidebar && (
         <button
           onClick={handleManualToggle}
-          className="absolute top-2 z-50 p-2 rounded-md bg-background hover:bg-sidebar-accent hover:text-accent-foreground cursor-pointer transition-all duration-200"
+          className="absolute top-2 z-50 p-2 rounded-md bg-background hover:bg-accent hover:text-accent-foreground cursor-pointer transition-all duration-200"
           style={{
             left: isSidebarOpen ? 'calc(16rem + 8px)' : '8px',
             transition: 'left 300ms ease-in-out',
@@ -270,7 +270,7 @@ const CollapsibleMenuItem: React.FC<{
         <li className="relative">
           <CollapsibleTrigger asChild>
             <button
-              className="flex w-full items-center gap-2 rounded-lg p-2 text-large-label hover:bg-sidebar-accent hover:text-accent-foreground cursor-pointer h-8"
+              className="flex w-full items-center gap-2 rounded-lg p-2 text-large-label hover:bg-accent hover:text-accent-foreground cursor-pointer h-8"
               onClick={() => {
                 // For items with children, toggle the collapsible state
                 // Only try to navigate if the item has a tag
@@ -303,7 +303,7 @@ const CollapsibleMenuItem: React.FC<{
     return (
       <li key={item.label}>
         <button
-          className="flex w-full items-center gap-2 rounded-lg p-2 text-large-label hover:bg-sidebar-accent hover:text-accent-foreground cursor-pointer h-8"
+          className="flex w-full items-center gap-2 rounded-lg p-2 text-large-label hover:bg-accent hover:text-accent-foreground cursor-pointer h-8"
           onClick={() => onItemClick(item)}
           onMouseDown={e => onCtrlRightMouseClick(e, item)}
         >
@@ -366,7 +366,7 @@ const renderMenuItems = (
         return (
           <li key={item.tag}>
             <button
-              className="flex w-full items-center gap-2 rounded-lg p-2 text-body hover:bg-sidebar-accent hover:text-accent-foreground cursor-pointer h-8"
+              className="flex w-full items-center gap-2 rounded-lg p-2 text-body hover:bg-accent hover:text-accent-foreground cursor-pointer h-8"
               onClick={() => onItemClick(item)}
               onMouseDown={e => onCtrlRightMouseClick(e, item)}
             >
@@ -379,7 +379,7 @@ const renderMenuItems = (
         return (
           <li key={item.tag}>
             <button
-              className="flex w-full items-center gap-2 rounded-lg p-2 text-body hover:bg-sidebar-accent hover:text-accent-foreground cursor-pointer h-8"
+              className="flex w-full items-center gap-2 rounded-lg p-2 text-body hover:bg-accent hover:text-accent-foreground cursor-pointer h-8"
               onClick={() => onItemClick(item)}
               onMouseDown={e => onCtrlRightMouseClick(e, item)}
             >
@@ -464,7 +464,7 @@ export const SidebarMenuWidget: React.FC<SidebarMenuWidgetProps> = ({
         return (
           <li key={item.tag}>
             <button
-              className={`flex w-full items-center gap-2 rounded-lg p-2 text-sm hover:bg-sidebar-accent hover:text-accent-foreground cursor-pointer h-8 ${
+              className={`flex w-full items-center gap-2 rounded-lg p-2 text-sm hover:bg-accent hover:text-accent-foreground cursor-pointer h-8 ${
                 isActive ? 'bg-accent text-accent-foreground' : ''
               }`}
               tabIndex={-1} // Not focusable


### PR DESCRIPTION
Issue #1342: Fixed where the Settings button in the sidebar footer was not using the --sidebar-accent color on hover, unlike other sidebar menu items.

# Changes Made

## Root Cause
The **Settings** button uses a `Button` component with `ButtonVariant.Ghost`, which applies  
`hover:bg-accent` instead of the `hover:bg-sidebar-accent` used by sidebar menu items.

## Solution

### CSS Changes (`index.css`)
- Added a CSS rule to make **rounded buttons** (`Button` components) in the sidebar use  
  `--sidebar-accent` on hover.
- Added a CSS rule for **dropdown menu items** to use `--sidebar-accent` when opened from the sidebar.
- Used the `.rounded-md` class selector to target `Button` components while **excluding plain text buttons**  
  (e.g., `"Dismiss"` in the `"Star on GitHub"` `MenuItem`).

### DropDownMenuWidget Changes (`DropDownMenuWidget.tsx`)
- Added logic to **detect if a dropdown is inside the sidebar**.
- Applied the `dropdown-in-sidebar` class to portal content when the dropdown is opened from the sidebar.
- This was necessary because dropdown menus **render in a portal** outside the sidebar’s DOM tree.

## Example

Before:

https://github.com/user-attachments/assets/24239fc2-e685-4f1d-acf8-573a992d25b6

After:

https://github.com/user-attachments/assets/6af5563f-c031-460d-888c-5d9eca6da515