### PR TITLE
[Widgets]: update file input example for widgets doc page

### DIFF
--- a/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/Widgets.md
+++ b/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/Widgets.md
@@ -153,8 +153,8 @@ public class InputWidgetsDemo : ViewBase
         var dateRangeState = UseState<(DateOnly?, DateOnly?)>((null, null));
         var colorState = UseState("#00cc92");
         var codeState = UseState("var x = 10;");
-        var fileState = UseState((FileUpload?)null);
-        var fileUpload = this.UseUpload((fileUpload, stream, cancellationToken) => System.Threading.Tasks.Task.CompletedTask);
+        var fileState = UseState<FileUpload<byte[]>?>();
+        var fileUpload = this.UseUpload(MemoryStreamUploadHandler.Create(fileState));
         var feedbackState = UseState(4);
         var selectState = UseState("");
         var asyncSelectState = UseState((string?)null);
@@ -193,10 +193,11 @@ public class InputWidgetsDemo : ViewBase
                 Layout.Vertical().Gap(2)
                     | new BoolInput(boolState).Label("Accept terms and conditions")
                     | boolState.ToSwitchInput().Label("Enable notifications")
-            ).Title("BoolInput").Description("Checkbox input").Height(Size.Units(60))
+            ).Title("BoolInput").Description("Checkbox input").Height(Size.Units(65))
             | new Card(
-                fileState.ToFileInput(fileUpload).Placeholder("Upload file")
-            ).Title("FileInput").Description("File upload").Height(Size.Units(60))
+                Layout.Vertical().Gap(2)
+                    | fileState.ToFileInput(fileUpload).Placeholder("Upload file")
+            ).Title("FileInput").Description("File upload").Height(Size.Units(65))
             | new Card(
                 dateRangeState.ToDateRangeInput().Placeholder("Select date range")
             ).Title("DateRange").Description("Date range picker").Height(Size.Units(40))


### PR DESCRIPTION
This one wasn't working, it was broken. Uploaded file hadn't feedback (it didn't appear in upload area)

<img width="1432" height="787" alt="Screenshot 2025-11-05 at 00 56 22" src="https://github.com/user-attachments/assets/c16730b4-84d0-4ee8-8c6a-55032cf780e3" />

Fixed:
<img width="517" height="198" alt="Screenshot 2025-11-05 at 01 20 03" src="https://github.com/user-attachments/assets/9475d79f-69ac-4e30-bd55-d247e0224d08" />

But now...I think we have an issue with uploaded file appearens. On the example there is a file input inside the card, and after uploading a file there is a name of file displayed with...black text block(?) . I think it causes pure user UI. @rorychatt , need your thoughts about this
<img width="170" height="120" alt="Screenshot 2025-11-05 at 01 24 02" src="https://github.com/user-attachments/assets/ad3f97a2-3577-4320-b41a-0b7b3b7071df" />
