### PR TITLE
[SearchBox]: fix highlighting of selected items

### DIFF
--- a/frontend/src/widgets/layouts/sidebar/SidebarLayoutWidget.tsx
+++ b/frontend/src/widgets/layouts/sidebar/SidebarLayoutWidget.tsx
@@ -468,9 +468,14 @@ export const SidebarMenuWidget: React.FC<SidebarMenuWidgetProps> = ({
                 isActive ? 'bg-accent text-accent-foreground' : ''
               }`}
               tabIndex={-1} // Not focusable
-              onClick={() =>
-                item.tag && eventHandler('OnSelect', id, [item.tag])
-              }
+              onClick={() => {
+                if (item.tag) {
+                  if (searchActive && flatIdx !== -1) {
+                    setSelectedIndex(flatIdx);
+                  }
+                  eventHandler('OnSelect', id, [item.tag]);
+                }
+              }}
               onMouseDown={e => onCtrlRightMouseClick(e, item)}
               onMouseEnter={() => {
                 if (searchActive) {


### PR DESCRIPTION
Had an issue where, when searching in the sidebar and clicking on any item other than the first one, both the clicked item (correctly) and the first search result were highlighted:

<img width="213" height="290" alt="Screenshot 2025-11-05 at 06 42 46" src="https://github.com/user-attachments/assets/336167b8-51b7-4b20-8682-fcbb4cd60d11" />

Another related issue was that after clicking, navigation with the Up and Down keys started from the first search result instead of the clicked one — causing a poor user experience.
Fixed:
<img width="190" height="276" alt="Screenshot 2025-11-05 at 06 45 24" src="https://github.com/user-attachments/assets/284f770d-9f53-41a2-a822-4cd58b20e642" />
