### PR TITLE
fix(tabs): prevent duplicate history entries when switching tabs

### DIFF
--- a/Ivy/Chrome/DefaultSidebarChrome.cs
+++ b/Ivy/Chrome/DefaultSidebarChrome.cs
@@ -249,12 +249,16 @@ public class DefaultSidebarChrome(ChromeSettings settings) : ViewBase
                 return;
             }
 
-            selectedIndex.Set(@event.Value);
+            // Only update and redirect if the selected index actually changes
+            if (selectedIndex.Value != @event.Value)
+            {
+                selectedIndex.Set(@event.Value);
 
-            // Update browser URL when tab is selected
-            var tab = tabs.Value[@event.Value];
-            var navigateArgs = new NavigateArgs(tab.AppId);
-            client.Redirect(navigateArgs.GetUrl(), tabId: tab.Id);
+                // Update browser URL when tab is selected
+                var tab = tabs.Value[@event.Value];
+                var navigateArgs = new NavigateArgs(tab.AppId);
+                client.Redirect(navigateArgs.GetUrl(), tabId: tab.Id);
+            }
         }
 
         void OnTabClose(Event<TabsLayout, int> @event)


### PR DESCRIPTION
**Root Cause:**
The OnTabSelect handler was calling client.Redirect() on every tab click 
event without checking if the selected index actually changed.

**Solution:**
Added a check to verify that selectedIndex.Value != @event.Value before 
updating the state and calling Redirect. This ensures browser history is 
only updated when the active tab actually changes.

**Result:**
- Tab switching now creates only one history entry per actual change
- Browser back/forward navigation works correctly
- No duplicate entries in browser history