### PR TITLE
(async select): add search feature

### DIFF
--- a/Ivy.Samples.Shared/Apps/Widgets/Inputs/AsyncSelectInputApp.cs
+++ b/Ivy.Samples.Shared/Apps/Widgets/Inputs/AsyncSelectInputApp.cs
@@ -18,13 +18,13 @@ public class AsyncSelectInputApp : SampleBase
             await using var db = factory.CreateDbContext();
             var lowerQuery = query.ToLowerInvariant();
             return [.. (await db.Categories
+                    .Where(e => EF.Functions.Like(e.Name.ToLower(), $"%{lowerQuery}%"))
+                    .OrderBy(e => e.Name)
+                    .ThenBy(e => e.Id)
                     .Select(e => new { e.Id, e.Name })
+                    .Distinct()
+                    .Take(50)
                     .ToArrayAsync())
-                .Where(e => e.Name.ToLowerInvariant().Contains(lowerQuery))
-                .OrderBy(e => e.Name, StringComparer.OrdinalIgnoreCase)
-                .ThenBy(e => e.Id)
-                .DistinctBy(e => e.Name, StringComparer.OrdinalIgnoreCase)
-                .Take(50)
                 .Select(e => new Option<Guid?>(e.Name, e.Id))];
         }
 

--- a/Ivy/Widgets/Inputs/AsyncSelectInput.cs
+++ b/Ivy/Widgets/Inputs/AsyncSelectInput.cs
@@ -265,7 +265,7 @@ public class AsyncSelectListSheet<T>(RefreshToken refreshToken, AsyncSelectQuery
         });
 
         var items = records.Value.Select(option =>
-            new ListItem(title: option.Label, onClick: onItemClicked, tag: option));
+            new ListItem(title: option.Label, onClick: onItemClicked, tag: option)).ToArray();
 
         return Layout.Vertical().Gap(2)
             | filter.ToSearchInput().Placeholder("Search").Width(Size.Grow())


### PR DESCRIPTION
This pull request improves the search experience and performance of the async select input widget by making the search case-insensitive and implementing debounced filtering with loading state feedback. The main changes are focused on both backend query logic and frontend UI responsiveness.

<img width="1307" height="1009" alt="image" src="https://github.com/user-attachments/assets/ca4b1639-650f-4ae2-9cce-38f93a0d1958" />

**Search improvements:**

* Changed the category name filtering in `AsyncSelectInputApp` to be case-insensitive by converting both the query and the category names to lower case before comparison.

**UI/UX enhancements:**

* Replaced the previous list filtering mechanism in `AsyncSelectListSheet<T>` with a debounced filter input using `Throttle`, so queries are only sent after the user pauses typing, reducing unnecessary requests and improving performance.
* Added a loading state indicator to the async select list, showing "Loading..." while results are being fetched.
* Updated the UI to use a vertical layout with a search input and either a loading indicator or the filtered list results.

**Dependency update:**

* Added a missing `System.Reactive.Linq` import to support throttling/filtering logic in the async select input.