### PR TITLE
(expandable): make full area clickable

### DIFF
--- a/frontend/src/widgets/ExpandableWidget.tsx
+++ b/frontend/src/widgets/ExpandableWidget.tsx
@@ -38,23 +38,25 @@ export const ExpandableWidget: React.FC<ExpandableWidgetProps> = ({
       data-disabled={disabled}
       role="details"
     >
-      <div className="flex justify-between items-center space-x-4">
+      <CollapsibleTrigger
+        disabled={disabled}
+        className="w-full flex justify-between items-center space-x-4 cursor-pointer hover:bg-accent/50 rounded-sm transition-colors data-[disabled=true]:cursor-not-allowed data-[disabled=true]:hover:bg-transparent"
+      >
         <div className="flex-1 ml-2 min-w-0" role="summary">
           {slots?.Header}
         </div>
-        <CollapsibleTrigger asChild disabled={disabled}>
-          <Button
-            variant="ghost"
-            className="p-0 h-9 w-9 shrink-0 hover:bg-accent"
-          >
-            <ChevronRight
-              className={`h-4 w-4 transition-transform duration-200 ease-in-out ${
-                isOpen ? 'rotate-90' : 'rotate-0'
-              }`}
-            />
-          </Button>
-        </CollapsibleTrigger>
-      </div>
+        <Button
+          variant="ghost"
+          className="p-0 h-9 w-9 shrink-0 hover:bg-transparent pointer-events-none"
+          tabIndex={-1}
+        >
+          <ChevronRight
+            className={`h-4 w-4 transition-transform duration-200 ease-in-out ${
+              isOpen ? 'rotate-90' : 'rotate-0'
+            }`}
+          />
+        </Button>
+      </CollapsibleTrigger>
       <CollapsibleContent className="overflow-hidden transition-all data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down">
         <div className="space-y-4 p-2">{slots?.Content}</div>
       </CollapsibleContent>


### PR DESCRIPTION
This pull request refactors the header section of the `ExpandableWidget` component to improve accessibility and user experience by restructuring how the collapsible trigger and header are rendered. The main changes focus on simplifying the component hierarchy and ensuring the trigger behaves correctly when disabled.

**Component structure and accessibility improvements:**

* The header area now uses `CollapsibleTrigger` directly instead of wrapping it in a separate `div`, streamlining the component structure and ensuring the entire header is clickable for expanding/collapsing.
* The trigger's styling is enhanced to provide visual feedback on hover and disabled states, improving usability and clarity for users.
* The expand/collapse button is now set to `pointer-events: none` and `tabIndex={-1}`, making it non-interactive and ensuring that only the main header area acts as the trigger, which prevents accidental interactions.
* The redundant wrapping `div` around the header and trigger is removed, further simplifying the component's DOM structure.