### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/backend-checks-linux.yml
+++ b/.github/workflows/backend-checks-linux.yml
@@ -1,4 +1,6 @@
 name: Backend Checks (Linux)
+permissions:
+  contents: read
 on:
   push:
     branches: [ main, master ]


### PR DESCRIPTION
Potential fix for [https://github.com/Ivy-Interactive/Ivy-Framework/security/code-scanning/1](https://github.com/Ivy-Interactive/Ivy-Framework/security/code-scanning/1)

To fix the problem, the workflow file `.github/workflows/backend-checks-linux.yml` should have a `permissions` block specifying the least privilege necessary for this job. Since all current steps only require reading repository contents (e.g., source code checkout), and do not write to issues, pull requests, or other resources, the minimal and recommended permissions are `contents: read`. This can be set either at the root of the workflow file (before `on:`), applying globally to all jobs, or at the job level just before `runs-on`. The most maintainable fix is to add the block after the `name` field, before the `on` field, so all jobs (including any future ones) are limited to this least privilege by default.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
