### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/e2e-samples-tests.yml
+++ b/.github/workflows/e2e-samples-tests.yml
@@ -1,4 +1,6 @@
 name: E2E Samples Tests
+permissions:
+  contents: read
 on:
   push:
     branches: [ main, master ]


### PR DESCRIPTION
Potential fix for [https://github.com/Ivy-Interactive/Ivy-Framework/security/code-scanning/4](https://github.com/Ivy-Interactive/Ivy-Framework/security/code-scanning/4)

To fix this problem, add a `permissions` block to the workflow, specifying the least-privilege access required for its operation. For most read-only CI jobs—such as building, installing dependencies, running tests, and uploading artifacts—the minimal permission required is `contents: read`. This should be declared at the root of the workflow YAML file (i.e., above `jobs`), applying to all jobs within. If any jobs or steps require elevated permissions, those can be added more granularly later, but for this workflow (as shown), `contents: read` is sufficient. No additional methods or imports are needed; just a single YAML block addition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
