### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/frontend-formatting-linting-checks.yml
+++ b/.github/workflows/frontend-formatting-linting-checks.yml
@@ -1,4 +1,6 @@
 name: Frontend Code Quality Checks
+permissions:
+  contents: read
 on:
   push:
     branches: [ main, master ]


### PR DESCRIPTION
Potential fix for [https://github.com/Ivy-Interactive/Ivy-Framework/security/code-scanning/5](https://github.com/Ivy-Interactive/Ivy-Framework/security/code-scanning/5)

The best way to fix the problem is to add a `permissions` block that restricts the GITHUB_TOKEN to read-only for repository contents, either at the workflow root (before `jobs:`) or at job level (beneath `jobs > frontend-checks`). Since there is only one job and all steps need at most read access (checkout, run code checks), we should add `permissions: contents: read` at the root level, just after the workflow `name` and before `jobs:`. This fixes the issue without impacting functionality, and implements the least privilege best practice.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
