### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/frontend-unit-tests.yml
+++ b/.github/workflows/frontend-unit-tests.yml
@@ -1,4 +1,6 @@
 name: Frontend Unit Tests
+permissions:
+  contents: read
 on:
   push:
     branches: [ main, master ]


### PR DESCRIPTION
Potential fix for [https://github.com/Ivy-Interactive/Ivy-Framework/security/code-scanning/6](https://github.com/Ivy-Interactive/Ivy-Framework/security/code-scanning/6)

To fix this problem, you should explicitly add a `permissions` block to restrict the default permissions granted to the `GITHUB_TOKEN`. This can be done either at the workflow level (top-level, applies to all jobs) or at the job-level. Since this workflow is dedicated to running frontend unit tests which only need to check out code (for which `contents: read` is sufficient), you should add `permissions: contents: read` right after the `name:` and `on:` blocks, before `jobs:`. This enforces least privilege and does not affect functionality, as no steps in the workflow require write or admin access to the repository.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
