### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/e2e-docs-tests.yml
+++ b/.github/workflows/e2e-docs-tests.yml
@@ -4,6 +4,8 @@ on:
     branches: [ main, master ]
   pull_request:
     branches: [ main, master ]
+permissions:
+  contents: read
 jobs:
   test:
     timeout-minutes: 60


### PR DESCRIPTION
Potential fix for [https://github.com/Ivy-Interactive/Ivy-Framework/security/code-scanning/3](https://github.com/Ivy-Interactive/Ivy-Framework/security/code-scanning/3)

To fix this problem, we should add a `permissions:` block to the workflow (either at the root level or per-job). The minimal safe starting point is specifying `contents: read`, which allows the workflow to checkout code and read the repository contents, but not write to it or perform other privileged actions. If later analysis reveals a need for additional permissions, those can be added, but the initial step is to add explicit least-privilege permissions. For the provided code, this permissions block should be added immediately after the `name:` or `on:` fields, above the `jobs:` key.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
