### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/backend-checks-windows.yml
+++ b/.github/workflows/backend-checks-windows.yml
@@ -1,4 +1,6 @@
 name: Backend Checks (Windows)
+permissions:
+  contents: read
 on:
   push:
     branches: [ main, master ]


### PR DESCRIPTION
Potential fix for [https://github.com/Ivy-Interactive/Ivy-Framework/security/code-scanning/2](https://github.com/Ivy-Interactive/Ivy-Framework/security/code-scanning/2)

To address the issue, we should set an explicit minimal permissions block for the job or the entire workflow. Based on the steps shown, the only permission strictly needed is `contents: read`, which allows actions/checkout to read repository contents and for subsequent build and test steps to function. No evidence is seen of steps that modify issues, pull requests, releases, or other resources requiring additional write permissions. To fix, add a `permissions:` block at the top level just below `name:` (for all jobs), or inside the `backend-checks` job (for that job only). The best practice is to add it at the workflow level unless finer granularity is required later.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
