### PR TITLE
fix(DataTable): Remove cell selection border and improve filter dropdown

### DIFF
--- a/frontend/src/widgets/dataTables/DataTableEditor.tsx
+++ b/frontend/src/widgets/dataTables/DataTableEditor.tsx
@@ -91,9 +91,10 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
       textLight: colors.mutedForeground || (isDark ? '#71717a' : '#9ca3af'),
       // bgIconHeader is the background color for icon areas, should be subtle
       bgIconHeader: colors.muted || (isDark ? '#26262b' : '#f3f4f6'),
-      // accentColor affects icon foreground colors in headers
-      accentColor:
-        colors.primary || colors.accent || (isDark ? '#60a5fa' : '#3b82f6'),
+      // Set accentColor to transparent to remove cell selection border
+      accentColor: 'transparent',
+      // accentLight provides subtle background highlight for selected cells
+      accentLight: colors.accent || (isDark ? '#26262b' : '#f3f4f6'),
       horizontalBorderColor: colors.border || (isDark ? '#404045' : '#d1d5db'),
       linkColor:
         colors.primary || colors.accent || (isDark ? '#3b82f6' : '#2563eb'),

--- a/frontend/src/widgets/dataTables/styles/style.ts
+++ b/frontend/src/widgets/dataTables/styles/style.ts
@@ -81,7 +81,7 @@ export const tableStyles = {
         box-shadow: var(--shadow-md) !important;
         padding: 4px !important;
         font-family: var(--font-mono) !important;
-        font-size: 14px !important;
+        font-size: 12px !important;
         max-height: 300px !important;
         overflow-y: auto !important;
       }
@@ -99,6 +99,9 @@ export const tableStyles = {
         cursor: pointer !important;
         color: var(--foreground) !important;
         transition: background-color 0.15s ease-in-out !important;
+        display: flex !important;
+        justify-content: space-between !important;
+        align-items: center !important;
       }
 
       .cm-tooltip-autocomplete > ul > li[aria-selected="true"] {
@@ -118,7 +121,7 @@ export const tableStyles = {
 
       .cm-completionDetail {
         font-family: var(--font-mono) !important;
-        font-size: 12px !important;
+        font-size: 11px !important;
         color: var(--muted-foreground) !important;
         font-style: normal !important;
         margin-left: 8px !important;


### PR DESCRIPTION
## Summary
This PR improves the DataTable cell selection and filter dropdown UI by removing the distracting green border and improving the filter dropdown layout and sizing.

## Changes

### 1. Cell Selection Border Removal
- Set `accentColor` to `transparent` to remove the green border on cell selection
- Kept `accentLight` with theme colors to maintain a subtle background highlight for selected cells

### 2. Filter Dropdown Font Size
- Reduced `.cm-tooltip-autocomplete` font size from `14px` to `12px` to match placeholder text
- Reduced `.cm-completionDetail` font size from `12px` to `11px` for better visual hierarchy

### 3. Filter Dropdown Layout
- Added flexbox layout to dropdown items with `justify-content: space-between`
- Column name and type are now properly spaced apart

## Files Changed
- `frontend/src/widgets/dataTables/DataTableEditor.tsx`
- `frontend/src/widgets/dataTables/styles/style.ts`

## Testing
- ✅ Build passes with no TypeScript errors
- ✅ All linting and formatting checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)