### PR TITLE
fix(Download): resolve download button opening in new tab instead of downloading files

### DIFF
--- a/frontend/src/routing-constants.json
+++ b/frontend/src/routing-constants.json
@@ -4,6 +4,7 @@
     "/webhook",
     "/auth",
     "/upload",
+    "/download",
     "/assets",
     "/fonts",
     "/_framework",

--- a/frontend/src/widgets/ButtonWidget.tsx
+++ b/frontend/src/widgets/ButtonWidget.tsx
@@ -115,6 +115,9 @@ export const ButtonWidget: React.FC<ButtonWidgetProps> = ({
   const hasChildren = !!children;
   const hasUrl = !!(effectiveUrl && !disabled);
 
+  // Check if URL is a download link (starts with /download/)
+  const isDownloadUrl = effectiveUrl?.startsWith('/download/') ?? false;
+
   const buttonContent = (
     <>
       {!hasChildren && (
@@ -177,8 +180,9 @@ export const ButtonWidget: React.FC<ButtonWidgetProps> = ({
       {hasUrl ? (
         <a
           href={getUrl(effectiveUrl!)}
-          target="_blank"
-          rel="noopener noreferrer"
+          {...(isDownloadUrl
+            ? {}
+            : { target: '_blank', rel: 'noopener noreferrer' })}
         >
           {buttonContent}
         </a>


### PR DESCRIPTION
## Problem

1. **Download URLs opening in new tab**: When using `Button.Url()` with download URLs (e.g., `/download/{connectionId}/{downloadId}`), the button was opening the URL in a new tab (`target="_blank"`) instead of triggering a file download.

2. **Routing conflicts**: Download paths were being intercepted by `PathToAppIdMiddleware` and converted to `appId` query parameters, causing:
   - Download endpoints to be treated as app routes
   - Infinite redirect loops when accessing download pages
   - Files not being downloaded properly

## Solution

1. **Added `/download` to excluded paths**: Updated `routing-constants.json` to exclude `/download` paths from being converted to appId parameters by `PathToAppIdMiddleware`.

2. **Fixed ButtonWidget download handling**: Modified `ButtonWidget.tsx` to detect download URLs (starting with `/download/`) and avoid using `target="_blank"` for these links, allowing files to download directly.

## Changes

- `frontend/src/routing-constants.json`: Added `/download` to `excludedPaths` array
- `frontend/src/widgets/ButtonWidget.tsx`: Added logic to detect download URLs and conditionally apply `target="_blank"` only for non-download links
