### PR TITLE
fix(sidebar): Lookup of menu item tags by value

### DIFF
--- a/Ivy/Shared/MenuItem.cs
+++ b/Ivy/Shared/MenuItem.cs
@@ -118,7 +118,7 @@ public static class MenuItemExtensions
                 return handler;
             }
 
-            if (item.Tag == value || item.Label == (string?)value)
+            if (Equals(item.Tag, value) || item.Label == (string?)value)
             {
                 if (item.OnSelect == null)
                 {


### PR DESCRIPTION
This PR looks up tags by value instead of by reference.

Fixes #1421