### PR TITLE
(login): logged in user UI is off

### DIFF
--- a/Ivy/Chrome/DefaultSidebarChrome.cs
+++ b/Ivy/Chrome/DefaultSidebarChrome.cs
@@ -367,7 +367,6 @@ public class DefaultSidebarChrome(ChromeSettings settings) : ViewBase
                            | Text.Label(user.Value.Email).Overflow(Overflow.Ellipsis))
                         .Grow()
                         .Size(Size.Full().Min(0))
-                        | Icons.ChevronsUpDown
                 ).Width(Size.Full());
 
             footer = new DropDownMenu(

--- a/frontend/src/widgets/layouts/sidebar/SidebarLayoutWidget.tsx
+++ b/frontend/src/widgets/layouts/sidebar/SidebarLayoutWidget.tsx
@@ -170,7 +170,7 @@ export const SidebarLayoutWidget: React.FC<SidebarLayoutWidgetProps> = ({
         )}
         {hasContent(slots?.SidebarFooter) && (
           <div className="flex flex-col shrink-0">
-            <div className="flex flex-col px-4 py-3 gap-4 min-h-0">
+            <div className="flex flex-col p-2 gap-4 min-h-0">
               {slots?.SidebarFooter}
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Removed the `Icons.ChevronsUpDown` icon from the sidebar user trigger to tighten the layout.
- Reduced the footer container padding in `SidebarLayoutWidget` from `px-4 py-3` to `p-2`, matching the intended spacing.

## Follow-up
I planned to shrink the user button padding via ButtonWidget, but that widget has no scoped way to override padding for just this instance, so a hardcoded change would impact every button. I suggest tracking a separate issue to introduce a targeted option (prop/variant/override) for button padding.