### PR TITLE
[FileInput]: make file input background transperent to fit different elements

### DIFF
--- a/frontend/src/widgets/inputs/FileInputWidget.tsx
+++ b/frontend/src/widgets/inputs/FileInputWidget.tsx
@@ -269,7 +269,7 @@ export const FileInputWidget: React.FC<FileInputWidgetProps> = ({
       <div
         key={file.id}
         data-file-item
-        className="flex items-center gap-3 p-3 border border-muted-foreground/25 rounded-md bg-background"
+        className="flex items-center gap-3 p-3 border border-muted-foreground/25 rounded-md bg-transparent"
       >
         <div className="flex-1 min-w-0">
           <p className="text-sm font-medium truncate">{file.fileName}</p>
@@ -289,7 +289,7 @@ export const FileInputWidget: React.FC<FileInputWidgetProps> = ({
             type="button"
             variant="ghost"
             size="icon"
-            className="h-8 w-8 flex-shrink-0"
+            className="h-8 w-8 shrink-0"
             onClick={e => {
               e.stopPropagation();
               handleCancel(file.id);


### PR DESCRIPTION
We had an issue where the file input had a black background even when it wasn’t placed inside an element with a dark background, which caused a strange-looking UI.

<img width="244" height="163" alt="Screenshot 2025-11-08 at 01 19 12" src="https://github.com/user-attachments/assets/6fc1c018-2cb8-421d-8417-31e7dabf533e" />

Fixed:
<img width="1164" height="664" alt="Screenshot 2025-11-08 at 01 19 51" src="https://github.com/user-attachments/assets/8a34c24d-0006-468d-b5bd-7c90e3cd5658" />

<img width="1068" height="280" alt="Screenshot 2025-11-08 at 01 20 17" src="https://github.com/user-attachments/assets/b181e23f-0dea-4a35-adb3-df890e928baa" />
