### PR TITLE
fix: show user avatars in DefaultSidebarChrome

### DIFF
--- a/Ivy/Chrome/DefaultSidebarChrome.cs
+++ b/Ivy/Chrome/DefaultSidebarChrome.cs
@@ -359,7 +359,7 @@ public class DefaultSidebarChrome(ChromeSettings settings) : ViewBase
             var trigger = new Button().Variant(ButtonVariant.Ghost)
                 .Content(
                     Layout.Horizontal().Align(Align.Left).Width(Size.Full())
-                        | new Avatar(user.Value.Initials)
+                        | new Avatar(user.Value.Initials, user.Value.AvatarUrl)
                         | (Layout.Vertical().Gap(1)
                            | (user.Value.FullName != null
                                ? Text.Muted(user.Value.FullName!).Overflow(Overflow.Ellipsis)


### PR DESCRIPTION
Tested with Auth0 and it works.

<img width="2559" height="1272" alt="image" src="https://github.com/user-attachments/assets/77fc8bd1-f5f3-4d2a-bf85-fe96ecc371ac" />
<img width="1203" height="1004" alt="image" src="https://github.com/user-attachments/assets/f197da48-8086-43bc-846a-5fdc5e6233fb" />
<img width="1780" height="777" alt="image" src="https://github.com/user-attachments/assets/4c2f56ba-fd39-42e0-8e2f-289069d736be" />
<img width="1534" height="801" alt="image" src="https://github.com/user-attachments/assets/5da4aad6-ccee-4ec3-ba99-6fb3b85fd6eb" />
