### PR TITLE
[Chat]: refactor docs

### DIFF
--- a/Ivy.Docs.Shared/Docs/02_Widgets/07_Advanced/Chat.md
+++ b/Ivy.Docs.Shared/Docs/02_Widgets/07_Advanced/Chat.md
@@ -50,7 +50,9 @@ public class BasicChatDemo : ViewBase
 
 A chat that simulates AI processing with loading indicators.
 
-This example shows how to implement async message handling, display loading states using ChatStatus, and manage message updates during processing.
+First, the handler appends the user's message so the transcript updates immediately. It then pushes a `ChatStatus` entry that renders the animated "thinking" indicator while the asynchronous work (a delay in this demo, your AI call in production) runs. When the task completes, the status message is removed and replaced by the assistant's final response so the user never sees an empty gap.
+
+This example shows how to implement async message handling, display loading states using `ChatStatus`, and manage message updates during processing.
 
 ```csharp demo-tabs 
 public class LoadingChatDemo : ViewBase


### PR DESCRIPTION
### Summary

- Fix chat docs to show user messages before responses. Updated each demo’s handler so the user’s message is added to state immediately, guaranteeing it renders in the transcript before any assistant response or status indicator.
- Clarify the async loading flow. Expanded the loading-state description to outline how the chat appends the user message, inserts a ChatStatus “thinking” indicator during async work, and then swaps that status for the assistant’s final answer once processing completes

<img width="1917" height="913" alt="image" src="https://github.com/user-attachments/assets/53c16459-1873-4795-bda4-133df3488534" />

<img width="1919" height="912" alt="image" src="https://github.com/user-attachments/assets/c516deb4-bb85-4338-a758-235070aac1a3" />

<img width="1919" height="912" alt="image" src="https://github.com/user-attachments/assets/643d8502-bbba-4c04-8125-42bb84162c57" />
