### PR TITLE
chore: make chart toolboxes opt-in and clean up demos

### DIFF
--- a/Ivy.Docs.Shared/Docs/02_Widgets/06_Charts/AreaChart.md
+++ b/Ivy.Docs.Shared/Docs/02_Widgets/06_Charts/AreaChart.md
@@ -72,10 +72,11 @@ public class Covid19Demo : ViewBase
         };
 
         return new Card().Title("COVID-19 cases")
-            | data.ToAreaChart().Toolbox()
+            | data.ToAreaChart()
                 .Dimension("Month", e => e.Month)
                 .Measure("Cases", e => e.Sum(f => f.Cases))
                 .Measure("Deaths", e => e.Sum(f => f.Deaths))
+                .Toolbox()
         ;
     }
 }

--- a/Ivy.Docs.Shared/Docs/02_Widgets/06_Charts/BarChart.md
+++ b/Ivy.Docs.Shared/Docs/02_Widgets/06_Charts/BarChart.md
@@ -248,8 +248,8 @@ public class TiobeIndexDemo : ViewBase
                             .CartesianGrid(new CartesianGrid().Horizontal())
                             .Tooltip()
                             .XAxis(new XAxis("Language").TickLine(false).AxisLine(false))
-                                                    .Legend()
-                                                    .Toolbox();
+                            .Legend()
+                            .Toolbox();
     }
 }
 ```

--- a/Ivy.Docs.Shared/Docs/02_Widgets/06_Charts/LineChart.md
+++ b/Ivy.Docs.Shared/Docs/02_Widgets/06_Charts/LineChart.md
@@ -34,10 +34,10 @@ public class BasicLineChartDemo : ViewBase
         return Layout.Vertical()
                  | data.ToLineChart(
                         style: LineChartStyles.Default)
-                        .Toolbox()
                         .Dimension("Month", e => e.Month)
                         .Measure("Desktop", e => e.Sum(f => f.Desktop))
-                        .Measure("Mobile", e => e.Sum(f => f.Mobile));
+                        .Measure("Mobile", e => e.Sum(f => f.Mobile))
+                        .Toolbox();
     }
 }    
 ```
@@ -79,10 +79,10 @@ public class LineStylesDemo: ViewBase
                  | styleInput
                  | data.ToLineChart(
                         style: style)
-                        .Toolbox()
                         .Dimension("Month", e => e.Month)
                         .Measure("Desktop", e => e.Sum(f => f.Desktop))
-                        .Measure("Mobile", e => e.Sum(f => f.Mobile));
+                        .Measure("Mobile", e => e.Sum(f => f.Mobile))
+                        .Toolbox();
     }
 }
 ```
@@ -303,9 +303,9 @@ public class BitcoinChart : ViewBase
                  | Text.Html($"<i>From {bitcoinData.First().Date:yyyy-MM-dd} to {bitcoinData.Last().Date:yyyy-MM-dd}</i>")
                  | bitcoinData.ToLineChart(
                         style: LineChartStyles.Dashboard)
-                        .Toolbox()
                     .Dimension("Date", e => e.Date)
-                    .Measure("Price", e => e.Sum(f => f.Price));
+                    .Measure("Price", e => e.Sum(f => f.Price))
+                    .Toolbox();
     }
 }
 ```

--- a/Ivy.Docs.Shared/Docs/02_Widgets/06_Charts/PieChart.md
+++ b/Ivy.Docs.Shared/Docs/02_Widgets/06_Charts/PieChart.md
@@ -44,7 +44,7 @@ public class PieChartDemo : ViewBase
                     e => e.Sum(f => f.Mobile),
                     PieChartStyles.Dashboard
                 )
-                .Toolbox(toolbox => toolbox.MagicType(false)) // MagicType(true) is not supported for PieChart
+                .Toolbox(new Toolbox())
            | Text.Large("Desktop sales over Q1(January-March)")
            // Showing custom placement of the legend at the right bottom of the chart
            | data.ToPieChart

--- a/Ivy.Samples.Shared/Apps/Widgets/Charts/AreaChartApp.cs
+++ b/Ivy.Samples.Shared/Apps/Widgets/Charts/AreaChartApp.cs
@@ -40,10 +40,11 @@ public class AreaChart0View : ViewBase
         };
 
         return new Card().Title("Basic Area Chart")
-            | data.ToAreaChart().Toolbox()
+            | data.ToAreaChart()
                 .Dimension("Month", e => e.Month)
                 .Measure("Desktop", e => e.Sum(f => f.Desktop))
                 .Measure("Mobile", e => e.Sum(f => f.Mobile))
+                .Toolbox()
         ;
     }
 }
@@ -63,11 +64,12 @@ public class AreaChart1View : ViewBase
         };
 
         return new Card().Title("Multi-Series Area Chart")
-            | data.ToAreaChart().Toolbox()
+            | data.ToAreaChart()
                 .Dimension("Month", e => e.Month)
                 .Measure("Desktop", e => e.Sum(f => f.Desktop))
                 .Measure("Mobile", e => e.Sum(f => f.Mobile))
                 .Measure("Tablet", e => e.Sum(f => f.Tablet))
+                .Toolbox()
         ;
     }
 }
@@ -87,10 +89,11 @@ public class AreaChart2View : ViewBase
         };
 
         return new Card().Title("Financial Overview")
-            | data.ToAreaChart().Toolbox()
+            | data.ToAreaChart()
                 .Dimension("Month", e => e.Month)
                 .Measure("Revenue", e => e.Sum(f => f.Revenue))
                 .Measure("Expenses", e => e.Sum(f => f.Expenses))
+                .Toolbox()
         ;
     }
 }
@@ -108,11 +111,12 @@ public class AreaChart3View : ViewBase
         };
 
         return new Card().Title("Product Sales by Quarter")
-            | data.ToAreaChart().Toolbox()
+            | data.ToAreaChart()
                 .Dimension("Quarter", e => e.Quarter)
                 .Measure("ProductA", e => e.Sum(f => f.ProductA))
                 .Measure("ProductB", e => e.Sum(f => f.ProductB))
                 .Measure("ProductC", e => e.Sum(f => f.ProductC))
+                .Toolbox()
         ;
     }
 }
@@ -131,12 +135,13 @@ public class AreaChart4View : ViewBase
         };
 
         return new Card().Title("Regional Growth Trends")
-            | data.ToAreaChart().Toolbox()
+            | data.ToAreaChart()
                 .Dimension("Year", e => e.Year)
                 .Measure("North", e => e.Sum(f => f.North))
                 .Measure("South", e => e.Sum(f => f.South))
                 .Measure("East", e => e.Sum(f => f.East))
                 .Measure("West", e => e.Sum(f => f.West))
+                .Toolbox()
         ;
     }
 }
@@ -156,11 +161,12 @@ public class AreaChart5View : ViewBase
         };
 
         return new Card().Title("Website Analytics")
-            | data.ToAreaChart().Toolbox()
+            | data.ToAreaChart()
                 .Dimension("Month", e => e.Month)
                 .Measure("Users", e => e.Sum(f => f.Users))
                 .Measure("Sessions", e => e.Sum(f => f.Sessions))
                 .Measure("Conversions", e => e.Sum(f => f.Conversions))
+                .Toolbox()
         ;
     }
 }
@@ -180,12 +186,13 @@ public class AreaChart6View : ViewBase
         };
 
         return new Card().Title("System Performance Metrics")
-            | data.ToAreaChart().Toolbox()
+            | data.ToAreaChart()
                 .Dimension("Week", e => e.Week)
                 .Measure("CPU Usage (%)", e => e.Sum(f => f.CPU))
                 .Measure("Memory Usage (%)", e => e.Sum(f => f.Memory))
                 .Measure("Disk Usage (%)", e => e.Sum(f => f.Disk))
                 .Measure("Network Usage (%)", e => e.Sum(f => f.Network))
+                .Toolbox()
         ;
     }
 }
@@ -211,12 +218,13 @@ public class AreaChart7View : ViewBase
         };
 
         return new Card().Title("Weather Data Trends (Annual)")
-            | data.ToAreaChart().Toolbox()
+            | data.ToAreaChart()
                 .Dimension("Month", e => e.Month)
                 .Measure("Temperature (°C)", e => e.Sum(f => f.Temperature))
                 .Measure("Humidity (%)", e => e.Sum(f => f.Humidity))
                 .Measure("Pressure (hPa)", e => e.Sum(f => f.Pressure))
                 .Measure("Wind Speed (km/h)", e => e.Sum(f => f.WindSpeed))
+                .Toolbox()
         ;
     }
 }
@@ -242,11 +250,12 @@ public class AreaChart8View : ViewBase
         };
 
         return new Card().Title("Temperature Trends (°C)")
-            | data.ToAreaChart().Toolbox()
+            | data.ToAreaChart()
                 .Dimension("Month", e => e.Month)
                 .Measure("High", e => e.Sum(f => f.High))
                 .Measure("Average", e => e.Sum(f => f.Average))
                 .Measure("Low", e => e.Sum(f => f.Low))
+                .Toolbox()
         ;
     }
 }
@@ -266,12 +275,13 @@ public class AreaChart9View : ViewBase
         };
 
         return new Card().Title("Market Share Analysis (%)")
-            | data.ToAreaChart().Toolbox()
+            | data.ToAreaChart()
                 .Dimension("Quarter", e => e.Quarter)
                 .Measure("CompanyA", e => e.Sum(f => f.CompanyA))
                 .Measure("CompanyB", e => e.Sum(f => f.CompanyB))
                 .Measure("CompanyC", e => e.Sum(f => f.CompanyC))
                 .Measure("Others", e => e.Sum(f => f.Others))
+                .Toolbox()
         ;
     }
 }

--- a/Ivy.Samples.Shared/Apps/Widgets/Charts/BarChartApp.cs
+++ b/Ivy.Samples.Shared/Apps/Widgets/Charts/BarChartApp.cs
@@ -155,7 +155,7 @@ public class BarChart4 : ViewBase
                 .Tooltip()
                 .XAxis(new XAxis("Quarter").TickLine(false).AxisLine(false))
                 .Legend()
-                 .Toolbox()
+                .Toolbox()
         ;
     }
 }

--- a/Ivy.Samples.Shared/Apps/Widgets/Charts/LineChartApp.cs
+++ b/Ivy.Samples.Shared/Apps/Widgets/Charts/LineChartApp.cs
@@ -41,10 +41,11 @@ public class LineChart0View : ViewBase
         };
 
         return new Card().Title("Basic Line Chart (Default Style)")
-            | data.ToLineChart(style: LineChartStyles.Default).Toolbox()
+            | data.ToLineChart(style: LineChartStyles.Default)
                 .Dimension("Month", e => e.Month)
                 .Measure("Desktop", e => e.Sum(f => f.Desktop))
                 .Measure("Mobile", e => e.Sum(f => f.Mobile))
+                .Toolbox()
         ;
     }
 }
@@ -64,11 +65,12 @@ public class LineChart1View : ViewBase
         };
 
         return new Card().Title("Department Performance (Dashboard Style)")
-            | data.ToLineChart(style: LineChartStyles.Dashboard).Toolbox()
+            | data.ToLineChart(style: LineChartStyles.Dashboard)
                 .Dimension("Month", e => e.Month)
                 .Measure("Sales", e => e.Sum(f => f.Sales))
                 .Measure("Marketing", e => e.Sum(f => f.Marketing))
                 .Measure("Development", e => e.Sum(f => f.Development))
+                .Toolbox()
         ;
     }
 }
@@ -87,10 +89,11 @@ public class LineChart2View : ViewBase
         };
 
         return new Card().Title("Financial Growth (Custom Style)")
-            | data.ToLineChart(style: LineChartStyles.Custom).Toolbox()
+            | data.ToLineChart(style: LineChartStyles.Custom)
                 .Dimension("Year", e => e.Year)
                 .Measure("Revenue", e => e.Sum(f => f.Revenue))
                 .Measure("Profit", e => e.Sum(f => f.Profit))
+                .Toolbox()
         ;
     }
 }
@@ -108,11 +111,12 @@ public class LineChart3View : ViewBase
         };
 
         return new Card().Title("Product Sales Trends (Rainbow Colors)")
-            | data.ToLineChart(style: LineChartStyles.Default).Toolbox()
+            | data.ToLineChart(style: LineChartStyles.Default)
                 .Dimension("Quarter", e => e.Quarter)
                 .Measure("ProductA", e => e.Sum(f => f.ProductA))
                 .Measure("ProductB", e => e.Sum(f => f.ProductB))
                 .Measure("ProductC", e => e.Sum(f => f.ProductC))
+                .Toolbox()
         ;
     }
 }
@@ -132,11 +136,12 @@ public class LineChart4View : ViewBase
         };
 
         return new Card().Title("Website Analytics (Step Lines)")
-            | data.ToLineChart(style: LineChartStyles.Default).Toolbox()
+            | data.ToLineChart(style: LineChartStyles.Default)
                 .Dimension("Month", e => e.Month)
                 .Measure("Users", e => e.Sum(f => f.Users))
                 .Measure("Sessions", e => e.Sum(f => f.Sessions))
                 .Measure("Conversions", e => e.Sum(f => f.Conversions))
+                .Toolbox()
         ;
     }
 }
@@ -156,11 +161,12 @@ public class LineChart5View : ViewBase
         };
 
         return new Card().Title("Weather Monitoring (Mixed Styles)")
-            | data.ToLineChart(style: LineChartStyles.Default).Toolbox()
+            | data.ToLineChart(style: LineChartStyles.Default)
                 .Dimension("Week", e => e.Week)
                 .Measure("Temperature", e => e.Sum(f => f.Temperature))
                 .Measure("Humidity", e => e.Sum(f => f.Humidity))
                 .Measure("Pressure", e => e.Sum(f => f.Pressure))
+                .Toolbox()
         ;
     }
 }
@@ -177,11 +183,12 @@ public class LineChart6View : ViewBase
         };
 
         return new Card().Title("Extreme Values Test (Zero, Negative, Very Large)")
-            | data.ToLineChart(style: LineChartStyles.Default).Toolbox()
+            | data.ToLineChart(style: LineChartStyles.Default)
                 .Dimension("Period", e => e.Period)
                 .Measure("Normal", e => e.Sum(f => f.Value))
                 .Measure("Negative", e => e.Sum(f => f.Negative))
                 .Measure("Very Large", e => e.Sum(f => f.Large))
+                .Toolbox()
         ;
     }
 }
@@ -200,11 +207,12 @@ public class LineChart7View : ViewBase
         };
 
         return new Card().Title("Sparse Data Test (Many Zero Values)")
-            | data.ToLineChart(style: LineChartStyles.Dashboard).Toolbox()
+            | data.ToLineChart(style: LineChartStyles.Dashboard)
                 .Dimension("Day", e => e.Day)
                 .Measure("Sales", e => e.Sum(f => f.Sales))
                 .Measure("Marketing", e => e.Sum(f => f.Marketing))
                 .Measure("Support", e => e.Sum(f => f.Support))
+                .Toolbox()
         ;
     }
 }
@@ -219,9 +227,10 @@ public class LineChart8View : ViewBase
         };
 
         return new Card().Title("Single Data Point Test")
-            | data.ToLineChart(style: LineChartStyles.Custom).Toolbox()
+            | data.ToLineChart(style: LineChartStyles.Custom)
                 .Dimension("Point", e => e.Point)
                 .Measure("Value", e => e.Sum(f => f.Value))
+                .Toolbox()
         ;
     }
 }
@@ -240,9 +249,10 @@ public class LineChart9View : ViewBase
         };
 
         return new Card().Title("Long Labels & Special Characters Test")
-            | data.ToLineChart(style: LineChartStyles.Default).Toolbox()
+            | data.ToLineChart(style: LineChartStyles.Default)
                 .Dimension("Label", e => e.Label)
                 .Measure("Value", e => e.Sum(f => f.Value))
+                .Toolbox()
         ;
     }
 }
@@ -261,11 +271,12 @@ public class LineChart10View : ViewBase
         };
 
         return new Card().Title("Flat Lines Test (Identical Values)")
-            | data.ToLineChart(style: LineChartStyles.Dashboard).Toolbox()
+            | data.ToLineChart(style: LineChartStyles.Dashboard)
                 .Dimension("Time", e => e.Time)
                 .Measure("Flat Line", e => e.Sum(f => f.Flat))
                 .Measure("Identical", e => e.Sum(f => f.Identical))
                 .Measure("Same Value", e => e.Sum(f => f.Same))
+                .Toolbox()
         ;
     }
 }
@@ -282,12 +293,13 @@ public class LineChart11View : ViewBase
         };
 
         return new Card().Title("Mixed Scales Test (Very Different Ranges)")
-            | data.ToLineChart(style: LineChartStyles.Custom).Toolbox()
+            | data.ToLineChart(style: LineChartStyles.Custom)
                 .Dimension("Scale", e => e.Scale)
                 .Measure("Tiny (0.001-0.1)", e => e.Sum(f => f.Tiny))
                 .Measure("Small (1-100)", e => e.Sum(f => f.Small))
                 .Measure("Medium (1K-100K)", e => e.Sum(f => f.Medium))
                 .Measure("Large (1M-100M)", e => e.Sum(f => f.Large))
+                .Toolbox()
         ;
     }
 }

--- a/Ivy.Samples.Shared/Apps/Widgets/Charts/PieChartApp.cs
+++ b/Ivy.Samples.Shared/Apps/Widgets/Charts/PieChartApp.cs
@@ -45,7 +45,7 @@ public class PieChart0View : ViewBase
                     e => e.Sum(f => f.Value),
                     PieChartStyles.Default
                 )
-                .Toolbox(toolbox => toolbox.MagicType(false)) // MagicType(true) is not supported for PieChart
+                .Toolbox()
         ;
     }
 }
@@ -69,7 +69,7 @@ public class PieChart1View : ViewBase
                     e => e.Sum(f => f.Users),
                     PieChartStyles.Dashboard
                 )
-                .Toolbox(toolbox => toolbox.MagicType(false)) // MagicType(true) is not supported for PieChart
+                .Toolbox()
         ;
     }
 }
@@ -95,7 +95,7 @@ public class PieChart2View : ViewBase
                     e => e.Sum(f => f.Sales),
                     PieChartStyles.Default
                 )
-                .Toolbox(toolbox => toolbox.MagicType(false)) // MagicType(true) is not supported for PieChart
+                .Toolbox()
         ;
     }
 }
@@ -120,7 +120,7 @@ public class PieChart3View : ViewBase
                     e => e.Sum(f => f.Budget),
                     PieChartStyles.Dashboard
                 )
-                .Toolbox(toolbox => toolbox.MagicType(false)) // MagicType(true) is not supported for PieChart
+                .Toolbox()
         ;
     }
 }
@@ -144,7 +144,7 @@ public class PieChart4View : ViewBase
                     e => e.Sum(f => f.Revenue),
                     PieChartStyles.Default
                 )
-                .Toolbox(toolbox => toolbox.MagicType(false)) // MagicType(true) is not supported for PieChart
+                .Toolbox()
         ;
     }
 }
@@ -170,7 +170,7 @@ public class PieChart5View : ViewBase
                     e => e.Sum(f => f.Customers),
                     PieChartStyles.Dashboard
                 )
-                .Toolbox(toolbox => toolbox.MagicType(false)) // MagicType(true) is not supported for PieChart
+                .Toolbox()
         ;
     }
 }
@@ -198,7 +198,7 @@ public class PieChart6View : ViewBase
                     e => e.Sum(f => f.Users),
                     PieChartStyles.Donut
                 )
-                .Toolbox(toolbox => toolbox.MagicType(false)) // MagicType(true) is not supported for PieChart
+                .Toolbox()
         ;
     }
 }
@@ -224,7 +224,7 @@ public class PieChart7View : ViewBase
                     e => e.Sum(f => f.Budget),
                     PieChartStyles.Default
                 )
-                .Toolbox(toolbox => toolbox.MagicType(false)) // MagicType(true) is not supported for PieChart
+                .Toolbox()
         ;
     }
 }
@@ -249,7 +249,7 @@ public class PieChart8View : ViewBase
                     e => e.Sum(f => f.Tasks),
                     PieChartStyles.Dashboard
                 )
-                .Toolbox(toolbox => toolbox.MagicType(false)) // MagicType(true) is not supported for PieChart
+                .Toolbox()
         ;
     }
 }
@@ -276,7 +276,7 @@ public class PieChart9View : ViewBase
                     e => e.Sum(f => f.Developers),
                     PieChartStyles.Default
                 )
-                .Toolbox(toolbox => toolbox.MagicType(false)) // MagicType(true) is not supported for PieChart
+                .Toolbox()
         ;
     }
 }
@@ -305,7 +305,7 @@ public class PieChart10View : ViewBase
                     e => e.Sum(f => f.Amount),
                     PieChartStyles.Donut
                 )
-                .Toolbox(toolbox => toolbox.MagicType(false)) // MagicType(true) is not supported for PieChart
+                .Toolbox()
         ;
     }
 }
@@ -331,7 +331,7 @@ public class PieChart11View : ViewBase
                     e => e.Sum(f => f.Users),
                     PieChartStyles.Dashboard
                 )
-                .Toolbox(toolbox => toolbox.MagicType(false)) // MagicType(true) is not supported for PieChart
+                .Toolbox()
         ;
     }
 }

--- a/Ivy/Views/Charts/AreaChartView.cs
+++ b/Ivy/Views/Charts/AreaChartView.cs
@@ -219,11 +219,6 @@ public class AreaChartBuilder<TSource>(
         return this;
     }
 
-    /// <summary>
-    /// Configures the toolbox for the resulting area chart using a predefined toolbox instance.
-    /// </summary>
-    /// <param name="toolbox">The toolbox configuration to apply.</param>
-    /// <returns>The builder instance for method chaining.</returns>
     public AreaChartBuilder<TSource> Toolbox(Toolbox toolbox)
     {
         ArgumentNullException.ThrowIfNull(toolbox);
@@ -232,11 +227,6 @@ public class AreaChartBuilder<TSource>(
         return this;
     }
 
-    /// <summary>
-    /// Configures the toolbox for the resulting area chart using a customization delegate.
-    /// </summary>
-    /// <param name="configure">Delegate that accepts the current toolbox (or a new instance) and returns the updated toolbox.</param>
-    /// <returns>The builder instance for method chaining.</returns>
     public AreaChartBuilder<TSource> Toolbox(Func<Toolbox, Toolbox> configure)
     {
         ArgumentNullException.ThrowIfNull(configure);
@@ -245,10 +235,6 @@ public class AreaChartBuilder<TSource>(
         return this;
     }
 
-    /// <summary>
-    /// Enables the default toolbox with standard configuration.
-    /// </summary>
-    /// <returns>The builder instance for method chaining.</returns>
     public AreaChartBuilder<TSource> Toolbox()
     {
         return Toolbox(_ => new Toolbox());

--- a/Ivy/Views/Charts/BarChartView.cs
+++ b/Ivy/Views/Charts/BarChartView.cs
@@ -230,11 +230,6 @@ public class BarChartBuilder<TSource>(
         return this;
     }
 
-    /// <summary>
-    /// Configures the toolbox for the resulting bar chart using a predefined toolbox instance.
-    /// </summary>
-    /// <param name="toolbox">The toolbox configuration to apply.</param>
-    /// <returns>The builder instance for method chaining.</returns>
     public BarChartBuilder<TSource> Toolbox(Toolbox toolbox)
     {
         ArgumentNullException.ThrowIfNull(toolbox);
@@ -243,11 +238,6 @@ public class BarChartBuilder<TSource>(
         return this;
     }
 
-    /// <summary>
-    /// Configures the toolbox for the resulting bar chart using a customization delegate.
-    /// </summary>
-    /// <param name="configure">Delegate that accepts the current toolbox (or a new instance) and returns the updated toolbox.</param>
-    /// <returns>The builder instance for method chaining.</returns>
     public BarChartBuilder<TSource> Toolbox(Func<Toolbox, Toolbox> configure)
     {
         ArgumentNullException.ThrowIfNull(configure);
@@ -256,10 +246,6 @@ public class BarChartBuilder<TSource>(
         return this;
     }
 
-    /// <summary>
-    /// Enables the default toolbox with standard configuration.
-    /// </summary>
-    /// <returns>The builder instance for method chaining.</returns>
     public BarChartBuilder<TSource> Toolbox()
     {
         return Toolbox(_ => new Toolbox());

--- a/Ivy/Views/Charts/LineChartView.cs
+++ b/Ivy/Views/Charts/LineChartView.cs
@@ -278,11 +278,6 @@ public class LineChartBuilder<TSource>(
         return this;
     }
 
-    /// <summary>
-    /// Configures the toolbox for the resulting line chart using a predefined toolbox instance.
-    /// </summary>
-    /// <param name="toolbox">The toolbox configuration to apply.</param>
-    /// <returns>The builder instance for method chaining.</returns>
     public LineChartBuilder<TSource> Toolbox(Toolbox toolbox)
     {
         ArgumentNullException.ThrowIfNull(toolbox);
@@ -291,11 +286,6 @@ public class LineChartBuilder<TSource>(
         return this;
     }
 
-    /// <summary>
-    /// Configures the toolbox for the resulting line chart using a customization delegate.
-    /// </summary>
-    /// <param name="configure">Delegate that accepts the current toolbox (or a new instance) and returns the updated toolbox.</param>
-    /// <returns>The builder instance for method chaining.</returns>
     public LineChartBuilder<TSource> Toolbox(Func<Toolbox, Toolbox> configure)
     {
         ArgumentNullException.ThrowIfNull(configure);
@@ -304,10 +294,6 @@ public class LineChartBuilder<TSource>(
         return this;
     }
 
-    /// <summary>
-    /// Enables the default toolbox with standard configuration.
-    /// </summary>
-    /// <returns>The builder instance for method chaining.</returns>
     public LineChartBuilder<TSource> Toolbox()
     {
         return Toolbox(_ => new Toolbox());

--- a/Ivy/Views/Charts/PieChartView.cs
+++ b/Ivy/Views/Charts/PieChartView.cs
@@ -236,11 +236,6 @@ public class PieChartBuilder<TSource>(
         return polish?.Invoke(configuredChart) ?? configuredChart;
     }
 
-    /// <summary>
-    /// Configures the toolbox for the resulting pie chart using a predefined toolbox instance.
-    /// </summary>
-    /// <param name="toolbox">The toolbox configuration to apply.</param>
-    /// <returns>The builder instance for method chaining.</returns>
     public PieChartBuilder<TSource> Toolbox(Toolbox toolbox)
     {
         ArgumentNullException.ThrowIfNull(toolbox);
@@ -249,11 +244,6 @@ public class PieChartBuilder<TSource>(
         return this;
     }
 
-    /// <summary>
-    /// Configures the toolbox for the resulting pie chart using a customization delegate.
-    /// </summary>
-    /// <param name="configure">Delegate that accepts the current toolbox (or a new instance) and returns the updated toolbox.</param>
-    /// <returns>The builder instance for method chaining.</returns>
     public PieChartBuilder<TSource> Toolbox(Func<Toolbox, Toolbox> configure)
     {
         ArgumentNullException.ThrowIfNull(configure);
@@ -262,10 +252,6 @@ public class PieChartBuilder<TSource>(
         return this;
     }
 
-    /// <summary>
-    /// Enables the default toolbox with standard configuration.
-    /// </summary>
-    /// <returns>The builder instance for method chaining.</returns>
     public PieChartBuilder<TSource> Toolbox()
     {
         return Toolbox(_ => new Toolbox());


### PR DESCRIPTION
## Summary
- Make chart toolboxes opt-in across all styles so they only render when explicitly requested  
- Update docs and samples to call the new builder helpers, disabling `MagicType` for pie charts where it does not apply  
- Align Seamless widgets with documentation by enabling the toolbox through `polish`/`.Toolbox()` in every demo  
- Toolbox actions are now enabled manually in all widgets so the panel is consistently visible to users.