### PR TITLE
(settings): implemented keybord access to settings menu

### DIFF
--- a/Ivy/Chrome/DefaultSidebarChrome.cs
+++ b/Ivy/Chrome/DefaultSidebarChrome.cs
@@ -374,7 +374,8 @@ public class DefaultSidebarChrome(ChromeSettings settings) : ViewBase
             footer = new DropDownMenu(
                     DropDownMenu.DefaultSelectHandler(),
                     trigger)
-                .Top();
+                .Top()
+                .KeyboardShortcut(",");
 
             var onLogout = new Action(async () =>
             {
@@ -409,6 +410,7 @@ public class DefaultSidebarChrome(ChromeSettings settings) : ViewBase
                     DropDownMenu.DefaultSelectHandler(),
                     trigger)
                 .Top()
+                .KeyboardShortcut(",")
                 .Items(
                     settings.FooterMenuItemsTransformer(commonMenuItems, navigator)
                 );

--- a/Ivy/Widgets/DropDownMenu.cs
+++ b/Ivy/Widgets/DropDownMenu.cs
@@ -76,6 +76,9 @@ public record DropDownMenu : WidgetBase<DropDownMenu>
     /// <summary>Offset distance from trigger in alignment direction. Default is 0 pixels.</summary>
     [Prop] public int AlignOffset { get; set; } = 0;
 
+    /// <summary>Keyboard shortcut key that triggers the dropdown when combined with Ctrl (Windows/Linux) or Cmd (Mac). For example, "," enables Ctrl+, or Cmd+,.</summary>
+    [Prop] public string? KeyboardShortcut { get; set; }
+
     /// <summary>Event handler for menu item selection.</summary>
     [Event] public Func<Event<DropDownMenu, object>, ValueTask> OnSelect { get; set; }
 
@@ -175,5 +178,13 @@ public static class DropDownMenuExtensions
     public static DropDownMenu HandleSelect(this DropDownMenu dropDownMenu, Action<object> onSelect)
     {
         return dropDownMenu with { OnSelect = @event => { onSelect(@event.Value); return ValueTask.CompletedTask; } };
+    }
+
+    /// <summary>Sets keyboard shortcut key that triggers the dropdown when combined with Ctrl (Windows/Linux) or Cmd (Mac).</summary>
+    /// <param name="dropDownMenu">The dropdown menu to configure.</param>
+    /// <param name="key">The key character, for example "," for Ctrl+, or "k" for Ctrl+K.</param>
+    public static DropDownMenu KeyboardShortcut(this DropDownMenu dropDownMenu, string key)
+    {
+        return dropDownMenu with { KeyboardShortcut = key };
     }
 }

--- a/frontend/src/widgets/DropDownMenuWidget.tsx
+++ b/frontend/src/widgets/DropDownMenuWidget.tsx
@@ -1,5 +1,5 @@
 import { useEventHandler } from '@/components/event-handler';
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import {
   DropdownMenu,
@@ -25,6 +25,11 @@ interface DropDownMenuWidgetProps {
   align?: 'Start' | 'Center' | 'End';
   side?: 'Top' | 'Right' | 'Bottom' | 'Left';
   alignOffset?: number;
+  /**
+   * Keyboard shortcut key that triggers the dropdown when combined with Ctrl (Windows/Linux) or Cmd (Mac).
+   * For example, "," enables Ctrl+, or Cmd+,
+   */
+  keyboardShortcut?: string;
   slots?: {
     Trigger?: React.ReactNode[];
     Header?: React.ReactNode[];
@@ -38,10 +43,26 @@ export const DropDownMenuWidget: React.FC<DropDownMenuWidgetProps> = ({
   align = 'Start',
   side = 'Bottom',
   alignOffset,
+  keyboardShortcut,
 }) => {
   const eventHandler = useEventHandler();
   const [open, setOpen] = useState(false);
   const triggerRef = useRef<HTMLButtonElement>(null);
+
+  // Add keyboard shortcut for dropdown (Ctrl+key or Cmd+key)
+  useEffect(() => {
+    if (!keyboardShortcut) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === keyboardShortcut && (event.metaKey || event.ctrlKey)) {
+        event.preventDefault();
+        setOpen((prevOpen: boolean) => !prevOpen);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [keyboardShortcut]);
 
   if (!slots?.Trigger) {
     return (


### PR DESCRIPTION
Users can now use ctrl + or cmd + comma sign to access the settings menu in the sidebar: The settings menu can then be navigated using the keyboard.

Made it so the KeyboardShortcut can be used with any key for future reuseablilty:

// Example 1: Settings menu with Ctrl+, or Cmd+,
footer = new DropDownMenu(
    DropDownMenu.DefaultSelectHandler(),
    trigger)
  .KeyboardShortcut(",");

// Example 2: Help menu with Ctrl+H or Cmd+H
var helpMenu = new DropDownMenu(
    DropDownMenu.DefaultSelectHandler(),
    helpTrigger)
  .KeyboardShortcut("h");


https://github.com/user-attachments/assets/263bb37d-e74e-44f8-91b1-cd3f1376e3a4