### PR TITLE
[Docs]: implement docs for Jobs

### DIFF
--- a/Ivy.Docs.Shared/Docs/03_ApiReference/IvyShared/JobScheduler.md
+++ b/Ivy.Docs.Shared/Docs/03_ApiReference/IvyShared/JobScheduler.md
@@ -194,16 +194,136 @@ public class DynamicChildrenDemo : ViewBase
 }
 ```
 
+### Fluent Job Chaining
+
+Use `Then()` to chain dependent jobs fluently:
+
+```csharp demo-tabs
+public class FluentChainingDemo : ViewBase
+{
+    public override object? Build()
+    {
+        var scheduler = this.UseStatic(BuildScheduler);
+        var refresh = this.UseRefreshToken();
+
+        UseEffect(() => scheduler.Subscribe(_ => refresh.Refresh()));
+
+        return Layout.Vertical()
+            | new Button("Run Pipeline", onClick: async _ => await scheduler.RunAsync())
+            | scheduler.ToView();
+    }
+
+    private static JobScheduler BuildScheduler()
+    {
+        var scheduler = new JobScheduler(maxParallelJobs: 1);
+
+        scheduler.CreateJob("Step 1: Extract")
+            .WithAction(async (_, _, progress, token) =>
+            {
+                await Task.Delay(300, token);
+                progress.Report(1);
+            })
+            .Then("Step 2: Transform", async (_, _, progress, token) =>
+            {
+                await Task.Delay(300, token);
+                progress.Report(1);
+            })
+            .Then("Step 3: Load", async (_, _, progress, token) =>
+            {
+                await Task.Delay(300, token);
+                progress.Report(1);
+            })
+            .Build();
+
+        return scheduler;
+    }
+}
+```
+
+### Multiple Children with Progress
+
+Create complex job hierarchies with multiple children that report progress:
+
+```csharp demo-tabs
+public class MultipleChildrenDemo : ViewBase
+{
+    public override object? Build()
+    {
+        var scheduler = this.UseStatic(BuildScheduler);
+        var refresh = this.UseRefreshToken();
+
+        UseEffect(() => scheduler.Subscribe(_ => refresh.Refresh()));
+
+        return Layout.Vertical()
+            | new Button("Start Processing", onClick: async _ => await scheduler.RunAsync())
+            | scheduler.ToView();
+    }
+
+    private static JobScheduler BuildScheduler()
+    {
+        var scheduler = new JobScheduler(maxParallelJobs: 3);
+
+        Job jobA = scheduler.CreateJob("Job A")
+            .WithAction(async (job, sched, _, token) =>
+            {
+                // Create multiple children with progress reporting
+                for (int i = 1; i <= 5; i++)
+                {
+                    var child = sched.CreateJob($"Child A-{i}")
+                        .WithAction(async (_, _, progress, childToken) =>
+                        {
+                            for (int j = 0; j <= 100; j++)
+                            {
+                                await Task.Delay(30, childToken);
+                                progress.Report(j / 100.0);
+                            }
+                        })
+                        .Build();
+
+                    sched.AddChild(job, child);
+                }
+
+                await Task.Delay(500, token);
+            })
+            .Build();
+
+        // Job B depends on Job A
+        scheduler.CreateJob("Job B")
+            .DependsOn(jobA)
+            .WithAction(async (_, _, progress, token) =>
+            {
+                await Task.Delay(400, token);
+                progress.Report(1);
+            })
+            .Build();
+
+        // Job C is independent
+        scheduler.CreateJob("Job C")
+            .WithAction(async (_, _, progress, token) =>
+            {
+                await Task.Delay(600, token);
+                progress.Report(1);
+            })
+            .Build();
+
+        return scheduler;
+    }
+}
+```
+
 ## Reference
 
 | Method | Description |
 |--------|-------------|
 | `JobScheduler(int maxParallelJobs)` | Constructor that controls concurrency and lifecycle. |
 | `JobScheduler.CreateJob(string title)` | Creates a new job builder. Returns `JobBuilder`. |
+| `JobBuilder.WithTitle(string title)` | Sets or updates the job title. |
 | `JobBuilder.WithAction(...)` | Registers job logic. Supports multiple overloads. |
 | `JobBuilder.DependsOn(params Job[] jobs)` | Sets job prerequisites. |
 | `JobBuilder.WithContinueOnChildFailure(bool)` | Keeps parents alive when children fail. |
 | `JobBuilder.Then(...)` | Chains dependent jobs fluently. |
+| `JobBuilder.Build()` | Builds and registers the job with the scheduler. |
+| `Job.SetDisplay(object? display)` | Attaches custom status UI to the job. |
 | `JobScheduler.AddChild(Job parent, Job child)` | Links dynamic child work to a parent job. |
 | `JobSchedulerExtensions.ToView()` | Renders the scheduler state using Ivy components. |
 | `JobScheduler.RunAsync(CancellationToken?)` | Starts scheduling and waits until all jobs settle. |


### PR DESCRIPTION
Docs -> Ivy.Shared -> Job Scheduler

<img width="1435" height="796" alt="Screenshot 2025-11-12 at 03 09 28" src="https://github.com/user-attachments/assets/a3cdeb42-c8b5-463f-9f7f-176a1233db2b" />
<img width="1436" height="793" alt="Screenshot 2025-11-12 at 03 09 38" src="https://github.com/user-attachments/assets/6457f8bf-2baa-45d1-af09-6f2ba5c74f65" />
<img width="1436" height="794" alt="Screenshot 2025-11-12 at 03 09 47" src="https://github.com/user-attachments/assets/bd16a17a-ff09-41ac-a605-8b8dd2d872e7" />
<img width="1435" height="618" alt="Screenshot 2025-11-12 at 03 09 58" src="https://github.com/user-attachments/assets/835b5beb-4799-49e8-b47a-c6df5a3e6894" />
<img width="1434" height="791" alt="Screenshot 2025-11-12 at 03 10 06" src="https://github.com/user-attachments/assets/4f50fdeb-5914-4f7b-b489-94be2220aa67" />

About Reference section with table -> We don't have auto generated API section for jobs, so...yes, it's hardcoded in doc. I can remove it, but we still need to document all that methods, don't we? 
* We can place it, but that's all we have in it
<img width="789" height="309" alt="Screenshot 2025-11-12 at 03 14 34" src="https://github.com/user-attachments/assets/daa1236a-ae6b-4baf-98f9-b3382fabe303" />
