### PR TITLE
[Chat]: polish docs

### DIFF
--- a/Ivy.Docs.Shared/Docs/02_Widgets/07_Advanced/Chat.md
+++ b/Ivy.Docs.Shared/Docs/02_Widgets/07_Advanced/Chat.md
@@ -238,13 +238,17 @@ public class AdvancedChatDemo : ViewBase
                     }, 
                     "Value", 
                     "Month"
-                ).Height(Size.Units(50)),
+                ).Height(Size.Units(50))
+                 .Width(Size.Units(80)),
                 
                 "table data" => new Table(
-                    new TableRow(new TableCell("Name"), new TableCell("Age"), new TableCell("Role")).IsHeader(),
-                    new TableRow(new TableCell("John Doe"), new TableCell("30"), new TableCell("Developer")),
-                    new TableRow(new TableCell("Jane Smith"), new TableCell("25"), new TableCell("Designer"))
-                ),
+                    new TableRow(new TableCell("Name"), new TableCell("Age"), new TableCell("Role"), new TableCell("Department")).IsHeader(),
+                    new TableRow(new TableCell("John Doe"), new TableCell("30"), new TableCell("Developer"), new TableCell("Engineering")),
+                    new TableRow(new TableCell("Jane Smith"), new TableCell("25"), new TableCell("Designer"), new TableCell("Design")),
+                    new TableRow(new TableCell("Bob Johnson"), new TableCell("35"), new TableCell("Manager"), new TableCell("Product")),
+                    new TableRow(new TableCell("Alice Williams"), new TableCell("28"), new TableCell("Developer"), new TableCell("Engineering")),
+                    new TableRow(new TableCell("Charlie Brown"), new TableCell("32"), new TableCell("QA Engineer"), new TableCell("Quality Assurance"))
+                ).Width(Size.Units(100)),
                 
                 _ => $"You said: '{@event.Value}'. Try the commands: 'analyze code', 'create form', 'show chart', or 'table data'!"
             };


### PR DESCRIPTION
1. Removed hardcoded Max(400) value for chat width. It looks normal just with Width(Size.Full())
2. Removed exampel with custom placeholder. I moved custom placeholder to other example, but we don't need to show external example just to show its usage. 
Was:
<img width="1279" height="583" alt="Screenshot 2025-11-12 at 05 26 18" src="https://github.com/user-attachments/assets/63ecbc09-e1cc-4f79-a935-dfd2d9533045" />
Now:
<img width="1251" height="533" alt="Screenshot 2025-11-12 at 05 27 49" src="https://github.com/user-attachments/assets/5d86fbd7-37f2-4804-9aa5-162fbfe9f939" />

3. Fixed visibility for tables and charts in the "Advanced Chat with Commands" example:
Was: 
<img width="1289" height="685" alt="Screenshot 2025-11-12 at 05 29 40" src="https://github.com/user-attachments/assets/ed031ab1-8aa9-4939-bb7f-9e03c2eeedd9" />

Now: 
<img width="421" height="666" alt="Screenshot 2025-11-12 at 05 30 23" src="https://github.com/user-attachments/assets/e0360c12-ed14-4af6-b7df-a7bb534b0a6a" />

Small refactors. Other feauters work fine