### PR TITLE
(sidebar): fix embedded GitHub URL resource in Ivy package

### DIFF
--- a/Ivy/Ivy.csproj
+++ b/Ivy/Ivy.csproj
@@ -41,7 +41,7 @@
     <EmbeddedResource Update="Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-      <Culture>neutral</Culture>
+      <LogicalName>Ivy.Resources.resources</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
 


### PR DESCRIPTION
- Update `Ivy/Ivy.csproj` to set the logical name of `Resources.resx` to `Ivy.Resources.resources`.  
- Ensure the `ResXFileCodeGenerator` still produces `Resources.Designer.cs` for typed access.  
- After this change the resource is embedded into `Ivy.dll`, so `ResourceManager` can resolve `IvyGitHubUrl` without throwing `MissingManifestResourceException`.