### PR TITLE
fix: add top padding to async select sheet content

### DIFF
--- a/frontend/src/widgets/SheetWidget.tsx
+++ b/frontend/src/widgets/SheetWidget.tsx
@@ -66,7 +66,7 @@ export const SheetWidget: React.FC<SheetWidgetProps> = ({
             {description && <SheetDescription>{description}</SheetDescription>}
           </SheetHeader>
         )}
-        <div className="flex-1 pb-0 pt-0 pl-4 pr-4 mt-4 overflow-y-auto">
+        <div className="flex-1 pb-0 pt-1 pl-4 pr-4 mt-4 overflow-y-auto">
           {slots.Content}
         </div>
       </SheetContent>


### PR DESCRIPTION
Add a small top padding inside the async select sheet content to stop the sticky header from clipping the search input’s top border