### PR TITLE
[CodeWidget]: Update copy to clipboard button styling

### DIFF
--- a/frontend/src/components/CopyToClipboardButton.tsx
+++ b/frontend/src/components/CopyToClipboardButton.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Copy, Check } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { buttonVariants } from '@/components/ui/button/variants';
 
 interface CopyToClipboardButtonProps {
   textToCopy?: string;
@@ -25,16 +26,21 @@ const CopyToClipboardButton: React.FC<CopyToClipboardButtonProps> = ({
     }
   };
 
+  const isIconOnly = !label;
+
   return (
     <button
       onClick={handleCopy}
       aria-label={ariaLabel || 'Copy to clipboard'}
       className={cn(
-        'flex items-center gap-1 px-3 py-2 rounded-lg transition-all duration-200 ease-in-out cursor-pointer',
-        'hover:bg-accent hover:shadow-sm border-0',
-        copied
-          ? 'bg-primary text-primary-foreground'
-          : 'bg-transparent text-muted-foreground hover:text-foreground'
+        isIconOnly
+          ? buttonVariants({ variant: 'ghost', size: 'icon' })
+          : 'flex items-center gap-1 px-3 py-2 rounded-lg transition-all duration-200 ease-in-out cursor-pointer hover:bg-accent hover:shadow-sm border-0',
+        !isIconOnly &&
+          (copied
+            ? 'bg-primary text-primary-foreground'
+            : 'bg-transparent text-muted-foreground hover:text-foreground'),
+        copied && isIconOnly && 'bg-primary text-primary-foreground'
       )}
     >
       <span className="relative w-4 h-4">
@@ -44,7 +50,7 @@ const CopyToClipboardButton: React.FC<CopyToClipboardButtonProps> = ({
             copied ? 'scale-0' : 'scale-100'
           )}
         >
-          <Copy size={16} />
+          <Copy className="h-4 w-4" />
         </span>
         <span
           className={cn(
@@ -52,7 +58,7 @@ const CopyToClipboardButton: React.FC<CopyToClipboardButtonProps> = ({
             copied ? 'scale-100' : 'scale-0'
           )}
         >
-          <Check size={16} />
+          <Check className="h-4 w-4" />
         </span>
       </span>
       {label && (


### PR DESCRIPTION
Updated styling for the reference of other buttons presented in framework
Default:
<img width="440" height="480" alt="Screenshot 2025-11-12 at 22 44 26" src="https://github.com/user-attachments/assets/9a4b3cb5-9df0-40d2-a510-6c53edf60834" />
OnHover:
<img width="425" height="432" alt="Screenshot 2025-11-12 at 22 44 46" src="https://github.com/user-attachments/assets/c445d205-dae0-429d-ab65-9f02dd6d2082" />
Click and onHover:
<img width="361" height="423" alt="Screenshot 2025-11-12 at 22 45 23" src="https://github.com/user-attachments/assets/10aacad9-ecb2-42bc-8f28-e30bd4fb100c" />
Click and unHover:
<img width="446" height="523" alt="Screenshot 2025-11-12 at 22 45 36" src="https://github.com/user-attachments/assets/0dc5c208-2e3e-4ac9-868a-a76c798e9274" />

For a reference I grap refresh and close buttons from blades widget (sizes, paddings):
<img width="443" height="266" alt="Screenshot 2025-11-12 at 22 47 17" src="https://github.com/user-attachments/assets/c331fb38-e0ad-4682-9637-173e627eebee" />

