### PR TITLE
refactor(tabs): remove stableChildren stabilization logic

### DIFF
--- a/frontend/src/widgets/layouts/tabs/TabsLayoutWidget.tsx
+++ b/frontend/src/widgets/layouts/tabs/TabsLayoutWidget.tsx
@@ -26,34 +26,9 @@ export const TabsLayoutWidget = ({
   width,
   addButtonText,
 }: TabsLayoutWidgetProps) => {
-  // Store stable children and only update when the actual tab IDs change
-  const [stableChildren, setStableChildren] = React.useState(children);
-  const [prevHash, setPrevHash] = React.useState('');
-
-  // Calculate hash of children IDs (sorted to ignore order changes)
-  const childrenHash = React.useMemo(() => {
-    const ids = React.Children.map(children, child => {
-      if (React.isValidElement(child)) {
-        return (child.props as { id?: string }).id || '';
-      }
-      return '';
-    });
-    // Sort IDs so that reordering doesn't change the hash
-    const sortedIds = ids ? [...ids].sort() : [];
-    return sortedIds.join(',');
-  }, [children]);
-
-  // Only update stableChildren when hash changes
-  React.useEffect(() => {
-    if (childrenHash !== prevHash) {
-      setStableChildren(children);
-      setPrevHash(childrenHash);
-    }
-  }, [children, childrenHash, prevHash]);
-
   const tabWidgets = React.useMemo(
-    () => filterTabWidgets(stableChildren),
-    [stableChildren]
+    () => filterTabWidgets(children),
+    [children]
   );
 
   // Centralized state management (includes synchronization logic)


### PR DESCRIPTION
Removing a fix for tabs re-rendering content, because it caused a bug in content tabs in Docs   