### PR TITLE
(tabs): Circle on hovers instead of square

### DIFF
--- a/frontend/src/widgets/layouts/tabs/components/TabContent.tsx
+++ b/frontend/src/widgets/layouts/tabs/components/TabContent.tsx
@@ -60,7 +60,7 @@ export const TabContentRenderer: React.FC<TabContentRendererProps> = ({
               isUserInitiatedChangeRef.current = true;
               safeEvent('OnRefresh', [tabOrder.indexOf(tabId)]);
             }}
-            className="opacity-60 p-1 rounded border border-transparent hover:border-border hover:bg-accent hover:opacity-100 transition-colors cursor-pointer"
+            className="opacity-60 p-1 rounded-full border border-transparent hover:border-border hover:bg-accent hover:opacity-100 transition-colors cursor-pointer"
           >
             <RotateCw className="w-3 h-3" />
           </a>
@@ -73,7 +73,7 @@ export const TabContentRenderer: React.FC<TabContentRendererProps> = ({
               safeEvent('OnClose', [tabOrder.indexOf(tabId)]);
             }}
             className={cn(
-              'opacity-60 p-1 rounded border border-transparent hover:border-border hover:bg-accent hover:opacity-100 transition-colors cursor-pointer',
+              'opacity-60 p-1 rounded-full border border-transparent hover:border-border hover:bg-accent hover:opacity-100 transition-colors cursor-pointer',
               !isActive && 'invisible group-hover:visible'
             )}
           >


### PR DESCRIPTION
Before:
<img width="479" height="182" alt="ivy_square_buttons" src="https://github.com/user-attachments/assets/2eb25574-f145-4281-bb39-ced22c17cfb6" />

After:
https://github.com/user-attachments/assets/81fa9d1d-3e03-4afd-be82-30a590c9efe0

