### PR TITLE
[async]: implement ellipsis overflow in selected value

### DIFF
--- a/Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/AsyncSelect.md
+++ b/Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/AsyncSelect.md
@@ -384,51 +384,6 @@ public class StylingDemo : ViewBase
 }
 ```
 
-### Long Option Names with Ellipsis
-
-AsyncSelectInput automatically handles long option names by truncating them with ellipsis and showing a tooltip on hover:
-
-```csharp demo-tabs
-public class LongOptionsDemo : ViewBase
-{
-    public override object? Build()
-    {
-        var selectedProduct = this.UseState<string?>(default(string));
-
-        Task<Option<string>[]> QueryProducts(string query)
-        {
-            var products = new[]
-            {
-                "Super Ultra Premium Deluxe Edition Professional Grade Enterprise Solution with Advanced Features Super Ultra Premium Deluxe Edition Professional Grade Enterprise Solution with Advanced Features Super Ultra Premium Deluxe Edition Professional Grade Enterprise Solution with Advanced Features Super Ultra Premium Deluxe Edition Professional Grade Enterprise Solution with Advanced Features",
-                "Standard Edition Basic Package for Small Businesses and Individual Users",
-                "Enterprise Edition Complete Suite with All Premium Features and 24/7 Support",
-                "Professional Edition Advanced Tools for Power Users and Development Teams",
-                "Starter Edition Essential Features for Beginners and Small Projects",
-                "Ultimate Edition Everything You Need Plus Exclusive Beta Access to New Features",
-                "Business Edition Comprehensive Solution for Medium to Large Organizations",
-                "Developer Edition Special Tools and APIs for Software Development Teams"
-            };
-            
-            return Task.FromResult(products
-                .Where(p => p.Contains(query, StringComparison.OrdinalIgnoreCase))
-                .Select(p => new Option<string>(p))
-                .ToArray());
-        }
-
-        Task<Option<string>?> LookupProduct(string product)
-        {
-            return Task.FromResult<Option<string>?>(new Option<string>(product));
-        }
-
-        return Layout.Vertical()
-            | selectedProduct.ToAsyncSelectInput(QueryProducts, LookupProduct, placeholder: "Search products...")
-                .WithField()
-                .Label("Select a product (hover to see full name):")
-            | Text.Small($"Selected: {selectedProduct.Value ?? "None"}");
-    }
-}
-```
-
 <Callout Type="tip">
 AsyncSelectInput automatically handles loading states and provides a smooth user experience. The query function is called as the user types, and the lookup function is called when displaying the selected value.
 </Callout>


### PR DESCRIPTION
How it was:
<img width="630" height="380" alt="Screenshot 2025-11-18 at 02 59 09" src="https://github.com/user-attachments/assets/1fb066e7-f6c2-4b72-8a1a-7e683b859ab6" />

How it's now:
<img width="604" height="361" alt="Screenshot 2025-11-18 at 02 56 38" src="https://github.com/user-attachments/assets/c149acce-70b8-45c9-bde8-9407ac425cba" />

Tooltip on hover:
<img width="605" height="351" alt="Screenshot 2025-11-18 at 02 56 46" src="https://github.com/user-attachments/assets/f19c90a1-0dd1-4927-a59c-39aa32caa96e" />
