### PR TITLE
fix: enable width and height support for field widget

### DIFF
--- a/frontend/src/widgets/inputs/FieldWidget.tsx
+++ b/frontend/src/widgets/inputs/FieldWidget.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Sizes } from '@/types/sizes';
+import { getWidth, getHeight } from '@/lib/styles';
 import Icon from '@/components/Icon';
 import {
   Tooltip,
@@ -16,6 +17,8 @@ interface FieldWidgetProps {
   help?: string;
   children?: React.ReactNode;
   size?: Sizes;
+  width?: string;
+  height?: string;
 }
 
 export const FieldWidget: React.FC<FieldWidgetProps> = ({
@@ -25,6 +28,8 @@ export const FieldWidget: React.FC<FieldWidgetProps> = ({
   help,
   children,
   size = Sizes.Medium,
+  width,
+  height,
 }) => {
   const labelSizeClass =
     size === Sizes.Small
@@ -42,8 +47,18 @@ export const FieldWidget: React.FC<FieldWidgetProps> = ({
   const gapClass =
     size === Sizes.Small ? 'gap-2' : size === Sizes.Large ? 'gap-4' : 'gap-3';
 
+  const styles: React.CSSProperties = {
+    ...getWidth(width),
+    ...getHeight(height),
+  };
+
+  const flexClass = width || height ? '' : 'flex-1';
+
   return (
-    <div className={`flex flex-col ${gapClass} flex-1 min-w-0`}>
+    <div
+      className={`flex flex-col ${gapClass} ${flexClass} min-w-0`}
+      style={styles}
+    >
       {label && (
         <div className="flex items-center gap-1.5">
           <label


### PR DESCRIPTION
- Fixed an issue where `Width` and `Height` properties on `Field` widgets were ignored by the frontend.
- Updated `FieldWidget.tsx` to accept and apply `width` and `height` props to the component's container.
- Modified the container styles to conditionally remove the `flex-1` class when explicit dimensions are provided, ensuring the specified size takes precedence.
- Added a verification case in `FieldApp.cs` to demonstrate a `Field` with a constrained width.

Without width and height:
<img width="799" height="457" alt="image" src="https://github.com/user-attachments/assets/f513696e-43a0-42bc-9a95-8b808155dea1" />

With width and height:
<img width="810" height="524" alt="image" src="https://github.com/user-attachments/assets/42002bce-6355-4337-b31e-a9af0a7d186e" />
