### PR TITLE
Added doc on new colors used, removed unused colors

### DIFF
--- a/Ivy.Docs.Shared/Docs/01_Onboarding/01_GettingStarted/05_Architecture/01_FrontendArchitecture.md
+++ b/Ivy.Docs.Shared/Docs/01_Onboarding/01_GettingStarted/05_Architecture/01_FrontendArchitecture.md
@@ -249,70 +249,27 @@ export interface WidgetNode {
 
 ## Theming and Styling System
 
-The theming system uses CSS custom properties with comprehensive light and dark mode support. The system provides a complete design token set covering colors, typography, spacing, and animations. These default styles can be overridden at runtime using the Theming service, which allows applications to dynamically generate and apply custom CSS variables through `IThemeService.SetTheme()` and `IThemeService.GenerateThemeCss()`.
+The theming system uses CSS custom properties with comprehensive light and dark mode support, built on the **Ivy Design System** tokens. The system provides a complete design token set covering colors, typography, spacing, and animations. These default styles can be overridden at runtime using the Theming service, which allows applications to dynamically generate and apply custom CSS variables through `IThemeService.SetTheme()` and `IThemeService.GenerateThemeCss()`.
 
 **Theme Features:**
 
 - CSS custom properties for all design tokens
 - Automatic theme detection via `MutationObserver`
-- Extended color palette with light/dark variants
+- Semantic color palette with light/dark variants
 - Typography scales with Geist font family
 - Tailwind CSS integration for utility-first styling
+
+**Available Theme Colors:**
+
+| Category | Variables |
+|----------|-----------|
+| Main | `--primary`, `--primary-foreground`, `--secondary`, `--secondary-foreground`, `--background`, `--foreground` |
+| Semantic | `--destructive`, `--success`, `--warning`, `--info` (with `-foreground` variants) |
+| UI Elements | `--border`, `--input`, `--ring`, `--muted`, `--accent`, `--card`, `--popover` (with `-foreground` variants) |
 
 **Font System:** The application uses Geist and Geist Mono fonts with `font-display: swap` for optimal loading performance. Font files are served locally with multiple weights (400, 500, 600, 700).
 
 **Component Integration:** Radix UI components receive theme-aware styling through CSS custom properties, ensuring consistent appearance across light and dark modes.
-
-```css
-@import "tailwindcss";
-
-:root {
-  --background: 0 0% 100%;
-  --foreground: 222.2 84% 4.9%;
-  --card: 0 0% 100%;
-  --card-foreground: 222.2 84% 4.9%;
-  --popover: 0 0% 100%;
-  --popover-foreground: 222.2 84% 4.9%;
-  --primary: 222.2 47.4% 11.2%;
-  --primary-foreground: 210 40% 98%;
-  --secondary: 210 40% 96.1%;
-  --secondary-foreground: 222.2 47.4% 11.2%;
-  --muted: 210 40% 96.1%;
-  --muted-foreground: 215.4 16.3% 46.9%;
-  --accent: 210 40% 96.1%;
-  --accent-foreground: 222.2 47.4% 11.2%;
-  --destructive: 0 84.2% 60.2%;
-  --destructive-foreground: 210 40% 98%;
-  --border: 214.3 31.8% 91.4%;
-  --input: 214.3 31.8% 91.4%;
-  --ring: 222.2 84% 4.9%;
-  --radius: 0.5rem;
-}
-
-.dark {
-  --background: 222.2 84% 4.9%;
-  --foreground: 210 40% 98%;
-  --card: 222.2 84% 4.9%;
-  --card-foreground: 210 40% 98%;
-  --popover: 222.2 84% 4.9%;
-  --popover-foreground: 210 40% 98%;
-  --primary: 210 40% 98%;
-  --primary-foreground: 222.2 47.4% 11.2%;
-  --secondary: 217.2 32.6% 17.5%;
-  --secondary-foreground: 210 40% 98%;
-  --muted: 217.2 32.6% 17.5%;
-  --muted-foreground: 215 20.2% 65.1%;
-  --accent: 217.2 32.6% 17.5%;
-  --accent-foreground: 210 40% 98%;
-  --destructive: 0 62.8% 30.6%;
-  --destructive-foreground: 210 40% 98%;
-  --border: 217.2 32.6% 17.5%;
-  --input: 217.2 32.6% 17.5%;
-  --ring: 212.7 26.8% 83.9%;
-}
-
-// ... more theme definitions ...
-```
 
 ```css
 @font-face {

--- a/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/Theming.md
+++ b/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/Theming.md
@@ -121,20 +121,7 @@ var server = new Server()
                 Card = "#FFFFFF",
                 CardForeground = "#1A1A1A",
                 Popover = "#FFFFFF",
-                PopoverForeground = "#1A1A1A",
-                Chart1 = "#0077BE",
-                Chart2 = "#DC143C",
-                Chart3 = "#20B2AA",
-                Chart4 = "#FFD700",
-                Chart5 = "#4682B4",
-                Sidebar = "#E0E8F0",
-                SidebarForeground = "#1A1A1A",
-                SidebarPrimary = "#0077BE",
-                SidebarPrimaryForeground = "#FFFFFF",
-                SidebarAccent = "#87CEEB",
-                SidebarAccentForeground = "#1A1A1A",
-                SidebarBorder = "#B0C4DE",
-                SidebarRing = "#0077BE"
+                PopoverForeground = "#1A1A1A"
             },
             Dark = new ThemeColors
             {
@@ -162,20 +149,7 @@ var server = new Server()
                 Card = "#0F2A4A",
                 CardForeground = "#E8F4FD",
                 Popover = "#001122",
-                PopoverForeground = "#E8F4FD",
-                Chart1 = "#4A9EFF",
-                Chart2 = "#FF6B7D",
-                Chart3 = "#4ECDC4",
-                Chart4 = "#FFE066",
-                Chart5 = "#87CEEB",
-                Sidebar = "#0F2A4A",
-                SidebarForeground = "#E8F4FD",
-                SidebarPrimary = "#4A9EFF",
-                SidebarPrimaryForeground = "#001122",
-                SidebarAccent = "#1A3A5C",
-                SidebarAccentForeground = "#E8F4FD",
-                SidebarBorder = "#1A3A5C",
-                SidebarRing = "#4A9EFF"
+                PopoverForeground = "#E8F4FD"
             }
         };
     });


### PR DESCRIPTION
Not really sure how it should look.

These colors have now been removed from the Theming page:

Chart1
Chart2
Chart3
Chart4
Chart5
Sidebar
SidebarForeground
SidebarPrimary
SidebarPrimaryForeground
SidebarAccent
SidebarAccentForeground
SidebarBorder
SidebarRing

Old theme colors that are not used anymore:
<img width="923" height="586" alt="ivy_remove_colors1_old" src="https://github.com/user-attachments/assets/84074941-c48f-4eba-b0eb-01dc5af92bee" />
<img width="946" height="502" alt="ivy_remove_colors2_old" src="https://github.com/user-attachments/assets/7f53c4e1-4866-4441-8fa0-df87b18be37c" />

Removed light and dark themed colors:
<img width="902" height="487" alt="ivy_remove_colors" src="https://github.com/user-attachments/assets/506f2e74-b2b4-4fbb-a9ec-366cbe72103c" />
<img width="858" height="689" alt="ivy_remove_colors2" src="https://github.com/user-attachments/assets/e91d503b-5a17-4026-93a4-e0365af0f24f" />

Old frontend colors presented before:
<img width="917" height="739" alt="ivy_theme1_old" src="https://github.com/user-attachments/assets/36c51daf-ca75-4e6a-ac7b-eda5309b8f34" />

New frontend colors presented to the user:
<img width="815" height="768" alt="ivy_theme1" src="https://github.com/user-attachments/assets/a58fd332-b1cd-45ca-8109-6072be023b4b" />