### PR TITLE
[Options]: fix broken examples with forms and selects

### DIFF
--- a/Ivy/Widgets/Inputs/Option.cs
+++ b/Ivy/Widgets/Inputs/Option.cs
@@ -62,6 +62,7 @@ public static class OptionExtensions
                 typeof(Option<>).MakeGenericType(enumType),
                 description,
                 Convert.ChangeType(e, enumType),
+                null,
                 null
             )!;
         }


### PR DESCRIPTION
We had couple of broken examples:
Samples -> Forms, Docs -> Forms

<img width="627" height="635" alt="Screenshot 2025-11-20 at 01 17 40" src="https://github.com/user-attachments/assets/f916c890-7503-457b-b20f-cf9445e724de" />

Docs -> Select

<img width="575" height="665" alt="Screenshot 2025-11-20 at 01 20 10" src="https://github.com/user-attachments/assets/bcc48e3d-b4a3-4739-a827-4b9085ce2c35" />

Fixed 
The fix adds the 4th parameter (null for description), so the call matches the constructor signature:
description → label
Convert.ChangeType(e, enumType) → value
null → group
null → description
This resolves the MissingMethodException

<img width="1440" height="790" alt="Screenshot 2025-11-20 at 01 22 48" src="https://github.com/user-attachments/assets/03fe5cc9-db6c-4d86-9150-ba37788b26a5" />
<img width="1437" height="790" alt="Screenshot 2025-11-20 at 01 23 31" src="https://github.com/user-attachments/assets/13e90263-c95c-44b3-9c49-e4c65a2cead4" />
<img width="1436" height="790" alt="Screenshot 2025-11-20 at 01 24 35" src="https://github.com/user-attachments/assets/4003af34-c06d-4519-a5d9-c44410292314" />
