### PR TITLE
[Sheet]: Implement use case in docs to show sheet creation algorithm in complete layouts

### DIFF
--- a/Ivy.Docs.Shared/Docs/02_Widgets/07_Advanced/Sheet.md
+++ b/Ivy.Docs.Shared/Docs/02_Widgets/07_Advanced/Sheet.md
@@ -231,28 +231,29 @@ public class KanbanWithSheetExample : ViewBase
         var (sheetView, showEdit) = this.UseTrigger((IState<bool> isOpen, string taskId) =>
             new TaskFormSheet(isOpen, taskId, tasks, client));
         
-        return new Fragment(
-            tasks.Value
-                .ToKanban(
-                    groupBySelector: t => t.Status,
-                    idSelector: t => t.Id,
-                    orderSelector: t => t.Priority)
-                .CardBuilder(task => new Card(task.Title, task.Description)
-                    .HandleClick(() => showEdit(task.Id)))
-                .HandleMove(moveData =>
+        var kanban = tasks.Value
+            .ToKanban(
+                groupBySelector: t => t.Status,
+                idSelector: t => t.Id,
+                orderSelector: t => t.Priority)
+            .CardBuilder(task => new Card(task.Title, task.Description)
+                .HandleClick(() => showEdit(task.Id)))
+            .HandleMove(moveData =>
+            {
+                var taskId = moveData.CardId?.ToString();
+                var task = tasks.Value.FirstOrDefault(t => t.Id == taskId);
+                if (task != null)
                 {
-                    var taskId = moveData.CardId?.ToString();
-                    var task = tasks.Value.FirstOrDefault(t => t.Id == taskId);
-                    if (task != null)
-                    {
-                        tasks.Set(tasks.Value
-                            .Where(t => t.Id != taskId)
-                            .Append(task with { Status = moveData.ToColumn })
-                            .ToArray());
-                    }
-                }),
-            sheetView
-        );
+                    tasks.Set(tasks.Value
+                        .Where(t => t.Id != taskId)
+                        .Append(task with { Status = moveData.ToColumn })
+                        .ToArray());
+                }
+            });
+        
+        return new Fragment()
+            | kanban
+            | sheetView;
     }
 }
 


### PR DESCRIPTION
<img width="646" height="605" alt="Screenshot 2025-11-23 at 08 28 23" src="https://github.com/user-attachments/assets/fc133724-3e40-481a-8e77-9d90ab6b9007" />

<img width="723" height="765" alt="Screenshot 2025-11-23 at 08 29 43" src="https://github.com/user-attachments/assets/ea88e571-b517-40fa-8f3e-c997abe8adf1" />

<img width="841" height="237" alt="Screenshot 2025-11-23 at 08 31 45" src="https://github.com/user-attachments/assets/b377ddfe-f635-49dc-bea1-009b7494454a" />
Where in return body is a kanban widget.
Will close https://github.com/Ivy-Interactive/Ivy-Framework/issues/1489
Closed https://github.com/Ivy-Interactive/Ivy-Framework/pull/1528 because docs already contains at most effective way of sheet creation

SomeTrigger.WithSheet()