### PR TITLE
fix: adjust chart yaxis min when negative values are present

### DIFF
--- a/frontend/src/widgets/charts/sharedUtils.ts
+++ b/frontend/src/widgets/charts/sharedUtils.ts
@@ -257,7 +257,7 @@ export const generateYAxis = (
       ),
     },
     splitNumber: largeSpread ? 3 : 5,
-    min: largeSpread ? safeTransform(minValue) : 0,
+    min: largeSpread ? safeTransform(minValue) : Math.min(minValue, 0),
     ...(largeSpread && { max: safeTransform(maxValue) }),
     position: yAxis?.[0]?.orientation === 'Right' ? 'right' : 'left',
     axisLine: {


### PR DESCRIPTION
When negative values are present in the chart data we now use the minimum value as the y-axis minimum instead of 0. This makes negative values visible instead of clipping.