### PR TITLE
[Time]: style improvements

### DIFF
--- a/frontend/src/widgets/inputs/DateTimeInputWidget.tsx
+++ b/frontend/src/widgets/inputs/DateTimeInputWidget.tsx
@@ -478,7 +478,8 @@ const TimeVariant: React.FC<TimeVariantProps> = ({
         <Clock
           className={cn(
             'absolute left-3 top-1/2 -translate-y-1/2 shrink-0',
-            dateTimeInputIconVariants({ scale })
+            dateTimeInputIconVariants({ scale }),
+            disabled && 'opacity-50'
           )}
         />
         <Input


### PR DESCRIPTION
I found an issue with the time input’s background color. When the widget was placed inside an element with a different background, the time field kept its own background, which caused a visual mismatch:

<img width="362" height="95" alt="Screenshot 2025-11-26 at 04 36 23" src="https://github.com/user-attachments/assets/ec9dc14b-9479-4aa5-b3aa-398744254a4c" />

I also noticed that the time input had its icon positioned differently compared to the other date-related widgets. This made the layout feel inconsistent across the date/time components.

Both issues are now fixed:

<img width="1238" height="227" alt="Screenshot 2025-11-26 at 04 35 08" src="https://github.com/user-attachments/assets/8a48a0c3-77f4-42a6-8f21-9476be040df6" />

Fixed:
<img width="1228" height="222" alt="Screenshot 2025-11-26 at 04 33 57" src="https://github.com/user-attachments/assets/26cf3052-b917-4765-b392-fc22dbd08fd1" />

And the background color behaves correctly as well. The last screenshot is just a small test example I wrote for myself to verify everything visually.

<img width="1219" height="480" alt="Screenshot 2025-11-26 at 04 40 53" src="https://github.com/user-attachments/assets/e34318ba-56d5-40f3-b2d9-33acd485e99b" />
