### PR TITLE
(onboarding): remove unneccessary numbers in list in docs

### DIFF
--- a/Ivy.Docs.Shared/Docs/01_Onboarding/01_GettingStarted/02_Installation.md
+++ b/Ivy.Docs.Shared/Docs/01_Onboarding/01_GettingStarted/02_Installation.md
@@ -23,7 +23,7 @@ For information about core Ivy concepts like Views and state management, see [Co
 
 The easiest way to set up an Ivy project is using the Ivy CLI. This will automatically create the project structure, configuration files, and necessary setup.
 
-### 1. Install Ivy Globally
+### Install Ivy Globally
 
 Run the following command in your terminal to install Ivy as a global tool:
 
@@ -36,7 +36,7 @@ If you're using a specific operating system, read the instructions in your termi
 You can always see all available commands by using `ivy --help`.
 </Callout>
 
-### 2. Create a New Ivy Project
+### Create a New Ivy Project
 
 Use the Ivy CLI to scaffold a new project:
 


### PR DESCRIPTION
Removed numbers (1 & 2) from list on installation instructions to match rest of page

<img width="1306" height="674" alt="Screenshot 2025-12-02 at 10 56 11" src="https://github.com/user-attachments/assets/1545f8e9-20e0-4cac-a6fc-6f52500a3798" />
