### PR TITLE
[Grid]: improve text contrast with opacity in dark mode

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -116,16 +116,12 @@
     --shadow-xl:
       0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 8px 10px -1px hsl(0 0% 0% / 0.1);
     --shadow-2xl: 0 1px 3px 0px hsl(0 0% 0% / 0.25);
-
-    --opacity-mix-color: white;
   }
 
   /* Dark theme variables now come from design system dark-flat.css import */
   .dark {
     /* Additional dark theme overrides not in design system yet */
     --toolbox: #edeaf1;
-
-    --opacity-mix-color: black;
   }
   @theme inline {
     /* Semantic color mappings for Tailwind utility classes */

--- a/frontend/src/lib/styles.ts
+++ b/frontend/src/lib/styles.ts
@@ -514,7 +514,7 @@ export const getColor = (
     color.toLowerCase() + (role === 'background' ? '' : '-foreground');
   if (percentage && percentage > -100 && percentage < 100) {
     return {
-      [cssProperty]: `color-mix(in srgb, var(--${varName}), var(--opacity-mix-color) ${Math.abs(percentage)}%)`,
+      [cssProperty]: `color-mix(in srgb, var(--${varName}), var(--background) ${Math.abs(percentage)}%)`,
     };
   }
   return {


### PR DESCRIPTION
<img width="1061" height="291" alt="image" src="https://github.com/user-attachments/assets/0718ab5e-45ee-4eb7-af99-aa914d1bac9c" />
<img width="1046" height="279" alt="image" src="https://github.com/user-attachments/assets/16323877-a544-4217-82e2-abe3e7b4120a" />

In dark mode, text was unreadable on boxes with opacity because `color-mix` always mixed towards white, making backgrounds lighter while text remained white. Added CSS variable `--opacity-mix-color` that switches between `white` (light mode) and `black` (dark mode), ensuring text stays readable in both themes.