### PR TITLE
(docs): made alert buttons horizontal layout

### DIFF
--- a/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/Alerts.md
+++ b/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/Alerts.md
@@ -59,7 +59,7 @@ public class AlertButtonSetsDemo : ViewBase
         var (alertView, showAlert) = this.UseAlert();
         var client = UseService<IClientProvider>();
 
-        return Layout.Vertical(
+        return Layout.Horizontal(
             new Button("Ok Only", _ => 
                 showAlert("This is an info message", _ => {}, "Information", AlertButtonSet.Ok)
             ),
@@ -97,7 +97,7 @@ public class BasicToastDemo : ViewBase
     {
         var client = UseService<IClientProvider>();
 
-        return Layout.Vertical(
+        return Layout.Horizontal(
             new Button("Success Toast", _ => 
                 client.Toast("Operation completed successfully!", "Success")
             ),
@@ -121,7 +121,7 @@ public class ToastExceptionDemo : ViewBase
     {
         var client = UseService<IClientProvider>();
 
-        return Layout.Vertical(
+        return Layout.Horizontal(
             new Button("Simulate Error", _ => {
                 try {
                     throw new InvalidOperationException("Something went wrong!");


### PR DESCRIPTION
Switched orientation of all demo alert buttons from vertical to horizontal


<img width="1024" height="418" alt="Screenshot 2025-12-03 at 10 57 36" src="https://github.com/user-attachments/assets/9bb1cb6b-3f18-4001-be72-5a606fc6bd2e" />

<img width="1180" height="762" alt="Screenshot 2025-12-03 at 10 57 46" src="https://github.com/user-attachments/assets/8d83fcfb-7ccb-4157-be04-13df9cf94f0f" />
