### PR TITLE
(codex): fix remove parent padding

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -539,10 +539,6 @@
   padding: 0px !important;
 }
 
-:has(> DIV.remove-ancestor-padding) {
-  padding: 0 !important;
-}
-
 .invisible-scrollbar {
   opacity: 0 !important;
   pointer-events: none !important;

--- a/frontend/src/widgets/blades/BladeContainerWidget.tsx
+++ b/frontend/src/widgets/blades/BladeContainerWidget.tsx
@@ -34,7 +34,7 @@ export const BladeContainerWidget: React.FC<BladeContainerWidgetProps> = ({
   }, []);
 
   return (
-    <div className="bg-background remove-ancestor-padding h-full">
+    <div className="bg-background remove-parent-padding h-full">
       <ScrollArea
         ref={scrollRef}
         className="h-full w-full overflow-y-hidden"

--- a/frontend/src/widgets/layouts/FooterLayoutWidget.tsx
+++ b/frontend/src/widgets/layouts/FooterLayoutWidget.tsx
@@ -20,7 +20,7 @@ export const FooterLayoutWidget: React.FC<FooterLayoutWidgetProps> = ({
   }
 
   return (
-    <div className="h-full flex flex-col remove-ancestor-padding">
+    <div className="h-full flex flex-col remove-parent-padding">
       <div className="flex-1 min-h-0 overflow-hidden">
         <ScrollArea className="h-full">
           <div className="p-4">{slots.Content}</div>

--- a/frontend/src/widgets/layouts/HeaderLayoutWidget.tsx
+++ b/frontend/src/widgets/layouts/HeaderLayoutWidget.tsx
@@ -36,7 +36,7 @@ export const HeaderLayoutWidget: React.FC<HeaderLayoutWidgetProps> = ({
 
   return (
     <div
-      className="remove-ancestor-padding flex flex-col w-full h-full"
+      className="remove-parent-padding flex flex-col w-full h-full"
       style={styles}
     >
       <div

--- a/frontend/src/widgets/layouts/ResizeablePanelGroupWidget.tsx
+++ b/frontend/src/widgets/layouts/ResizeablePanelGroupWidget.tsx
@@ -49,7 +49,7 @@ export const ResizeablePanelGroupWidget: React.FC<
   );
 
   if (panelWidgets.length === 0)
-    return <div className="remove-ancestor-padding"></div>;
+    return <div className="remove-parent-padding"></div>;
 
   const style = {
     ...getWidth(width),
@@ -60,7 +60,7 @@ export const ResizeablePanelGroupWidget: React.FC<
     <ResizablePanelGroup
       style={style}
       direction={camelCase(direction) as 'horizontal' | 'vertical'}
-      className="remove-ancestor-padding"
+      className="remove-parent-padding"
       id={id}
     >
       {panelWidgets.map((panelWidget, index) => {

--- a/frontend/src/widgets/lists/ListWidget.css
+++ b/frontend/src/widgets/lists/ListWidget.css
@@ -1,5 +1,0 @@
-/* Component-specific CSS for ListWidget */
-/* Removes padding from parent element that contains .remove-parent-padding */
-:has(.remove-parent-padding) {
-  padding: 0px !important;
-}

--- a/frontend/src/widgets/lists/ListWidget.tsx
+++ b/frontend/src/widgets/lists/ListWidget.tsx
@@ -1,7 +1,6 @@
 import React, { useRef } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { cn } from '@/lib/utils';
-import './ListWidget.css';
 
 type ListWidgetProps = {
   children: React.ReactNode;


### PR DESCRIPTION
This pull request updates the way padding is removed from certain widget containers by replacing the `remove-ancestor-padding` class with a new `remove-parent-padding` class throughout the codebase. Additionally, it removes now-unnecessary global and component-specific CSS rules related to padding, streamlining the styling approach. These changes help ensure more predictable and maintainable padding behavior across widgets.

**Class name update for padding removal:**

* Replaced all usages of the `remove-ancestor-padding` class with `remove-parent-padding` in widget container components, including `BladeContainerWidget`, `FooterLayoutWidget`, `HeaderLayoutWidget`, and `ResizeablePanelGroupWidget`. [[1]](diffhunk://#diff-8a1811770d47c997351fab8a1548784ce234ace04a625932afdf8d8cef7a8904L37-R37) [[2]](diffhunk://#diff-f4a37af34ab0a7bcc106b6d59b3f700312015a6b337c22effaa64dab2cec7936L23-R23) [[3]](diffhunk://#diff-fa83ac7ba7a844bd18705f9f298a49a93f15b6c07afb165a4f3897fb0963d673L39-R39) [[4]](diffhunk://#diff-d418776c9beac6fa588b2d2fd8b2507b9be0bf1b7d4141e13330a7be2c2813e4L52-R52) [[5]](diffhunk://#diff-d418776c9beac6fa588b2d2fd8b2507b9be0bf1b7d4141e13330a7be2c2813e4L63-R63)

**CSS cleanup and simplification:**

* Removed global and component-specific CSS rules targeting `:has(.remove-parent-padding)` and `:has(> DIV.remove-ancestor-padding)` selectors from `index.css` and `ListWidget.css`, as these are no longer needed with the new class approach. [[1]](diffhunk://#diff-b6889d573bf684293ea3c3e654c123bd3502dd1f8155470375a1e5a906f0c236L542-L545) [[2]](diffhunk://#diff-0ea33b471449c10e67ede2b9dd3a769c56729f969158763762a915ccac38c608L1-L5)
* Removed the import of the now-deleted `ListWidget.css` from `ListWidget.tsx`.