### PR TITLE
[Docs]: fix dialog form width in few app examples in Forms

### DIFF
--- a/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/Forms.md
+++ b/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/Forms.md
@@ -686,7 +686,7 @@ public class DialogFormExample : ViewBase
             | user.ToForm()
                 .Required(m => m.FirstName, m => m.LastName, m => m.Email)
                 .ToDialog(isDialogOpen, "Create New User", "Please provide user information", 
-                         width: Size.Units(500));
+                         width: Size.Units(125));
     }
 }
 ```
@@ -789,7 +789,7 @@ public class CrudFormExample : ViewBase
                         }
                     })
                 )
-            ).Width(Size.Units(500))
+            ).Width(Size.Units(125))
             : null;
         
         // Create dialog content for editing product
@@ -816,7 +816,7 @@ public class CrudFormExample : ViewBase
                         }
                     })
                 )
-            ).Width(Size.Units(500))
+            ).Width(Size.Units(125))
             : null;
         
         return Layout.Vertical()


### PR DESCRIPTION
The issue arose because in some sample applications on the Forms page in Docs, the width `Size.Units(500)` was set for dialog forms, which actually looks like 2000 pixels.
To solve this, I set the value in units equal to 500 pixels, i.e. `Size.Units(125)`.

Now it looks as expected:
<img width="1366" height="601" alt="image" src="https://github.com/user-attachments/assets/ddffe6e5-28c7-4253-afdf-598a49195a5a" />
<img width="1366" height="595" alt="image" src="https://github.com/user-attachments/assets/5078fcb1-346a-4181-b807-617163112ee1" />
<img width="1366" height="604" alt="image" src="https://github.com/user-attachments/assets/43bda99e-9c2d-4dcf-87ad-621c754400bd" />
