### PR TITLE
[tabs]: move underline inside container bounds

### DIFF
--- a/frontend/src/widgets/layouts/tabs/components/Variants.tsx
+++ b/frontend/src/widgets/layouts/tabs/components/Variants.tsx
@@ -111,7 +111,11 @@ export const ContentVariant: React.FC<ContentVariantProps> = ({
         removeParentPadding && 'remove-parent-padding'
       )}
     >
-      <div ref={containerRef} className="relative" style={getWidth(width)}>
+      <div
+        ref={containerRef}
+        className="relative pb-[6px]"
+        style={getWidth(width)}
+      >
         {/* Hover Highlight */}
         <div
           className="absolute h-[26px] transition-all duration-300 ease-out bg-accent/20 rounded-[6px] flex items-center"
@@ -123,7 +127,7 @@ export const ContentVariant: React.FC<ContentVariantProps> = ({
         {/* Active Indicator */}
         <div
           className={cn(
-            'absolute bottom-[-6px] h-[2px] bg-foreground',
+            'absolute bottom-0 h-[2px] bg-foreground',
             !isInitialRender && 'transition-all duration-300 ease-out',
             activeTabId && !visibleTabs.includes(activeTabId) && 'opacity-0'
           )}


### PR DESCRIPTION
The underline indicator in Content variant was positioned outside the container (bottom: -6px), causing it to be overlapped.

Changes:
- Added pb-[6px] padding to tab container
- Changed underline position from bottom-[-6px] to bottom-0


<img width="342" height="127" alt="image" src="https://github.com/user-attachments/assets/818db1bf-2978-49fc-b944-2a650fdf4bd8" />
