### PR TITLE
(inputs): update Scale property to explicitly delegate to base class 

### DIFF
--- a/Ivy/Widgets/Inputs/BoolInput.cs
+++ b/Ivy/Widgets/Inputs/BoolInput.cs
@@ -32,9 +32,16 @@ public abstract record BoolInputBase : WidgetBase<BoolInputBase>, IAnyBoolInput
 
     [Prop] public string? Invalid { get; set; }
 
-    [Prop] public new Scale? Scale { get; set; }
+
+    [Prop]
+    public new Scale? Scale
+    {
+        get => base.Scale;
+        set => base.Scale = value;
+    }
 
     [Prop] public string? Label { get; set; }
+
 
     [Prop] public string? Description { get; set; }
 

--- a/Ivy/Widgets/Inputs/CodeInput.cs
+++ b/Ivy/Widgets/Inputs/CodeInput.cs
@@ -25,9 +25,16 @@ public abstract record CodeInputBase : WidgetBase<CodeInputBase>, IAnyCodeInput
 
     [Prop] public string? Invalid { get; set; }
 
-    [Prop] public new Scale? Scale { get; set; }
+
+    [Prop]
+    public new Scale? Scale
+    {
+        get => base.Scale;
+        set => base.Scale = value;
+    }
 
     [Prop] public string? Placeholder { get; set; }
+
 
     [Prop] public CodeInputs Variant { get; set; }
 

--- a/Ivy/Widgets/Inputs/ColorInput.cs
+++ b/Ivy/Widgets/Inputs/ColorInput.cs
@@ -27,13 +27,20 @@ public abstract record ColorInputBase : WidgetBase<ColorInputBase>, IAnyColorInp
 
     [Prop] public string? Invalid { get; set; }
 
-    [Prop] public new Scale? Scale { get; set; }
 
     [Prop] public string? Placeholder { get; set; }
 
     [Prop] public bool Nullable { get; set; }
 
+    [Prop]
+    public new Scale? Scale
+    {
+        get => base.Scale;
+        set => base.Scale = value;
+    }
+
     [Prop] public ColorInputs Variant { get; set; } = ColorInputs.TextAndPicker;
+
 
     [Event] public Func<Event<IAnyInput>, ValueTask>? OnBlur { get; set; }
 

--- a/Ivy/Widgets/Inputs/DateRangeInput.cs
+++ b/Ivy/Widgets/Inputs/DateRangeInput.cs
@@ -24,9 +24,16 @@ public abstract record DateRangeInputBase : WidgetBase<DateRangeInputBase>, IAny
 
     [Prop] public string? Invalid { get; set; }
 
+    [Prop]
+    public new Scale? Scale
+    {
+        get => base.Scale;
+        set => base.Scale = value;
+    }
+
     [Prop] public bool Nullable { get; set; }
 
-    [Prop] public new Scale? Scale { get; set; }
+
 
     [Event] public Func<Event<IAnyInput>, ValueTask>? OnBlur { get; set; }
 

--- a/Ivy/Widgets/Inputs/DateTimeInput.cs
+++ b/Ivy/Widgets/Inputs/DateTimeInput.cs
@@ -34,9 +34,16 @@ public abstract record DateTimeInputBase : WidgetBase<DateTimeInputBase>, IAnyDa
 
     [Prop] public bool Disabled { get; set; }
 
+    [Prop]
+    public new Scale? Scale
+    {
+        get => base.Scale;
+        set => base.Scale = value;
+    }
+
     [Prop] public string? Invalid { get; set; }
 
-    [Prop] public new Scale? Scale { get; set; }
+
 
     [Event] public Func<Event<IAnyInput>, ValueTask>? OnBlur { get; set; }
 

--- a/Ivy/Widgets/Inputs/FeedbackInput.cs
+++ b/Ivy/Widgets/Inputs/FeedbackInput.cs
@@ -30,9 +30,16 @@ public abstract record FeedbackInputBase : WidgetBase<FeedbackInputBase>, IAnyFe
 
     [Prop] public string? Placeholder { get; set; }
 
+    [Prop]
+    public new Scale? Scale
+    {
+        get => base.Scale;
+        set => base.Scale = value;
+    }
+
     [Prop] public FeedbackInputs Variant { get; set; }
 
-    [Prop] public new Scale? Scale { get; set; }
+
 
     [Event] public Func<Event<IAnyInput>, ValueTask>? OnBlur { get; set; }
 

--- a/Ivy/Widgets/Inputs/FileInput.cs
+++ b/Ivy/Widgets/Inputs/FileInput.cs
@@ -37,9 +37,16 @@ public abstract record FileInputBase : WidgetBase<FileInputBase>, IAnyFileInput
 
     [Prop] public int? MaxFiles { get; set; }
 
+    [Prop]
+    public new Scale? Scale
+    {
+        get => base.Scale;
+        set => base.Scale = value;
+    }
+
     [Prop] public string? UploadUrl { get; set; }
 
-    [Prop] public new Scale? Scale { get; set; }
+
 
     [Event] public Func<Event<IAnyInput>, ValueTask>? OnBlur { get; set; }
 

--- a/Ivy/Widgets/Inputs/NumberInput.cs
+++ b/Ivy/Widgets/Inputs/NumberInput.cs
@@ -64,9 +64,16 @@ public abstract record NumberInputBase : WidgetBase<NumberInputBase>, IAnyNumber
 
     [Prop] public string? Currency { get; set; }
 
+    [Prop]
+    public new Scale? Scale
+    {
+        get => base.Scale;
+        set => base.Scale = value;
+    }
+
     [Prop] public string? TargetType { get; set; }
 
-    [Prop] public new Scale? Scale { get; set; }
+
 
     [Event] public Func<Event<IAnyInput>, ValueTask>? OnBlur { get; set; }
 

--- a/Ivy/Widgets/Inputs/ReadOnlyInput.cs
+++ b/Ivy/Widgets/Inputs/ReadOnlyInput.cs
@@ -38,7 +38,15 @@ public record ReadOnlyInput<TValue> : WidgetBase<ReadOnlyInput<TValue>>, IInput<
 
     [Prop] public TValue Value { get; }
 
+    [Prop]
+    public new Scale? Scale
+    {
+        get => base.Scale;
+        set => base.Scale = value;
+    }
+
     [Prop] public bool Disabled { get; set; }
+
 
     [Prop] public string? Invalid { get; set; }
 
@@ -46,7 +54,6 @@ public record ReadOnlyInput<TValue> : WidgetBase<ReadOnlyInput<TValue>>, IInput<
 
     [Prop] public string? Placeholder { get; set; } //not really used but included to consistency with IAnyInput    
 
-    [Prop] public new Scale? Scale { get; set; }
 
     [Event] public Func<Event<IInput<TValue>, TValue>, ValueTask>? OnChange { get; }
 

--- a/Ivy/Widgets/Inputs/SelectInput.cs
+++ b/Ivy/Widgets/Inputs/SelectInput.cs
@@ -34,9 +34,16 @@ public abstract record SelectInputBase : WidgetBase<SelectInputBase>, IAnySelect
 
     [Prop] public bool SelectMany { get; set; } = false;
 
+    [Prop]
+    public new Scale? Scale
+    {
+        get => base.Scale;
+        set => base.Scale = value;
+    }
+
     [Prop] public char Separator { get; set; } = ';';
 
-    [Prop] public new Scale? Scale { get; set; }
+
 
     [Event] public Func<Event<IAnyInput>, ValueTask>? OnBlur { get; set; }
 

--- a/Ivy/Widgets/Inputs/TextInput.cs
+++ b/Ivy/Widgets/Inputs/TextInput.cs
@@ -43,9 +43,17 @@ public abstract record TextInputBase : WidgetBase<TextInputBase>, IAnyTextInput
 
     [Prop] public PrefixSuffix? Suffix { get; set; }
 
-    [Prop] public new Scale? Scale { get; set; }
+
+
+    [Prop]
+    public new Scale? Scale
+    {
+        get => base.Scale;
+        set => base.Scale = value;
+    }
 
     [Prop] public int? MaxLength { get; set; }
+
 
     [Event] public Func<Event<IAnyInput>, ValueTask>? OnBlur { get; set; }
 


### PR DESCRIPTION
This pull request refactors the handling of the `Scale` property across all input widget base classes in the `Ivy/Widgets/Inputs` directory. Instead of simply redeclaring the property, each input type now overrides the `Scale` property to directly delegate to the base class implementation using explicit getter and setter logic. This change ensures consistent behavior and allows for future extensibility.

**Refactoring of `Scale` property across input widgets:**

* For each input widget base class (e.g., `BoolInputBase`, `CodeInputBase`, `ColorInputBase`, `DateRangeInputBase`, `DateTimeInputBase`, `FeedbackInputBase`, `FileInputBase`, `NumberInputBase`, `ReadOnlyInput`, `SelectInputBase`, `TextInputBase`), the `Scale` property is now overridden with explicit getter and setter methods that delegate to the base class's `Scale` property. [[1]](diffhunk://#diff-112e300d6403f15983e12c7dfc77dcad6e19208040bcfbed4951f189a8864f56L35-R45) [[2]](diffhunk://#diff-f63c1fc1f3d43dabafd5c5cc120a87b10f8fcf1f02367d5a6e27b05c77210da8L28-R38) [[3]](diffhunk://#diff-a06e2abb78a638fc036d14ef94d5233fa96bd1d324f1f58d564fb87bbbf04a64L30-R44) [[4]](diffhunk://#diff-3618fd5024caeebde322e075ff340b1d4298bc19b8036556607e2c9e04898e3cR27-R36) [[5]](diffhunk://#diff-5ae8ce8d9d987ada29495b223d9085dc01c647786154bb7a7388babe1997dd66R37-R46) [[6]](diffhunk://#diff-efaf9d1ae819a35be465a41482d2513733ec4ac6c07f4c8a6778392fc4e74ee7R33-R42) [[7]](diffhunk://#diff-b39b80a9036a5039ab095080964e79c72d946014ed94cd8fb6572c62b6ae7921R40-R49) [[8]](diffhunk://#diff-e26cf8307f3c14c395a2a4317f6a3d5a0a96ff891b6f63cf58f954dc9b82875dR67-R76) [[9]](diffhunk://#diff-eacf935d57ea71a60a9d7f19b1a395b9b1c7de776b08d14362460b4644cc8548R41-L49) [[10]](diffhunk://#diff-3b6e53e44b801755cd8fcd561d96ebd0ad28ab6a249b1082a047918575054004R37-R46) [[11]](diffhunk://#diff-96d5a633ae7de8794a55e6c6c64651d443deea5611d0887fe928d296eaec521eL46-R57)

This update improves clarity and maintainability of the codebase by standardizing the property override pattern for all input widgets.