### PR TITLE
fix: errors sent by AppHub during connection are masked

### DIFF
--- a/Ivy/AppHub.cs
+++ b/Ivy/AppHub.cs
@@ -263,7 +263,9 @@ public class AppHub(
             {
                 await Clients.Caller.SendAsync("Error", new
                 {
-                    viewOverride = new NotFoundApp()
+                    title = "Internal Server Error",
+                    description = ex.Message,
+                    stackTrace = ex.StackTrace,
                 });
             }
             catch


### PR DESCRIPTION
#1560 introduced a change where if an Exception is caught during AppHub connection, we will try to serialize and send an Ivy app over the SignalR connection, instead of sending the error itself. This leads to the following unhelpful log message:
<img width="1236" height="297" alt="Screenshot 2025-12-05 at 10 44 04 PM" src="https://github.com/user-attachments/assets/bbf971ed-df04-4fe2-9a73-00be6173e28a" />
