### PR TITLE
(codex): resolve duplicate file inclusion errors in Language Server

### DIFF
--- a/Ivy.Docs.Shared/Ivy.Docs.Shared.csproj
+++ b/Ivy.Docs.Shared/Ivy.Docs.Shared.csproj
@@ -32,6 +32,7 @@
   <Target Name="TransformMarkdown" BeforeTargets="CoreCompile">
     <Exec Command="dotnet run --project ../Ivy.Docs.Tools/Ivy.Docs.Tools.csproj -- convert $(MSBuildProjectDirectory)/Docs/*.md $(MSBuildProjectDirectory)/Generated --skip-if-not-changed" />
     <ItemGroup>
+      <Compile Remove="Generated/**/*.g.cs" />
       <Compile Include="Generated/**/*.g.cs" />
     </ItemGroup>
   </Target>

--- a/Ivy/Ivy.csproj
+++ b/Ivy/Ivy.csproj
@@ -48,6 +48,10 @@
   <ItemGroup>
     <Protobuf Include="Protos\datatable.proto" GrpcServices="Server" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="obj/**/*.cs;bin/**/*.cs" />
+  </ItemGroup>
   
   <ItemGroup>
     <PackageReference Include="Grpc.AspNetCore" Version="2.64.0" />


### PR DESCRIPTION
Prevent Generated/**/*.g.cs and Protobuf-generated files from being
included multiple times during Language Server project evaluation.

Tested out starting project, npm ci, npm run dev, dotnet build,  dotnet watch, sh Regenerate.sh , any new warnings