### PR TITLE
Add UseRef hook and enhance UseAlert and UseTrigger logic

### DIFF
--- a/Ivy.Samples.Shared/Apps/Tests/HooksFix/AlertApp.cs
+++ b/Ivy.Samples.Shared/Apps/Tests/HooksFix/AlertApp.cs
@@ -1,0 +1,42 @@
+﻿using Ivy.Hooks;
+using Ivy.Views.Alerts;
+
+namespace Ivy.Samples.Shared.Apps.Tests.HooksFix;
+
+[App(isVisible: false)]
+public class AlertApp : ViewBase
+{
+    public override object? Build()
+    {
+        var (alertView, showAlert) = this.UseAlert();
+
+        var body = Layout.Vertical()
+                   | DateTime.Now.Ticks
+                   | new Button("Show Alert", () => showAlert("Hello", (x) =>
+                   {
+
+                   }))
+                   | new Button("WithConfirm").WithConfirm("Are you sure?")
+                   | new Button("WithPrompt").WithPrompt<int>((result) =>
+                   {
+
+                   }, defaultValue: 42)
+                   | new Button("WithSheet").WithSheet(() => new FooView(99), "", "")
+            ;
+
+        return Layout.Vertical()
+               | body
+               | alertView;
+    }
+
+    public class FooView(int someId) : ViewBase
+    {
+        public override object? Build()
+        {
+            return Layout.Vertical()
+                   | DateTime.Now.Ticks
+                   | someId;
+        }
+    }
+}
+

--- a/Ivy.Samples.Shared/Apps/Tests/HooksFix/TriggerApp.cs
+++ b/Ivy.Samples.Shared/Apps/Tests/HooksFix/TriggerApp.cs
@@ -1,0 +1,37 @@
+﻿using Ivy.Hooks;
+
+namespace Ivy.Samples.Shared.Apps.Tests.HooksFix;
+
+[App(isVisible: false)]
+public class TriggerApp : ViewBase
+{
+    public override object? Build()
+    {
+        var (triggerView, showTrigger) = this.UseTrigger((IState<bool> isOpen, int id) => new FooView(isOpen, id));
+
+        var body = Layout.Vertical()
+                   | DateTime.Now.Ticks
+                   | new Button("Show Trigger 1", () => showTrigger(1))
+                   | new Button("Show Trigger 2", () => showTrigger(2))
+            ;
+
+        return Layout.Vertical()
+               | body
+               | triggerView;
+    }
+
+    public class FooView(IState<bool> show, int someId) : ViewBase
+    {
+        public override object? Build()
+        {
+            if (!show.Value) return null;
+
+            return Layout.Vertical()
+                   | DateTime.Now.Ticks
+                   | new Button("Close", () => show.Set(false))
+                   | someId
+                   | "Hello";
+        }
+    }
+}
+

--- a/Ivy/Core/Hooks/IViewContext.cs
+++ b/Ivy/Core/Hooks/IViewContext.cs
@@ -12,6 +12,10 @@ public interface IViewContext : IDisposable
 
     IState<T> UseState<T>(Func<T> buildInitialValue, bool buildOnChange = true);
 
+    IState<T> UseRef<T>(T? initialValue = default) => UseState<T>(initialValue, buildOnChange: false);
+
+    IState<T> UseRef<T>(Func<T> buildInitialValue) => UseState<T>(buildInitialValue, buildOnChange: false);
+
     void UseEffect(Func<Task> handler, params IEffectTriggerConvertible[] triggers);
 
     void UseEffect(Func<Task<IDisposable>> handler, params IEffectTriggerConvertible[] triggers);

--- a/Ivy/Hooks/UseTrigger.cs
+++ b/Ivy/Hooks/UseTrigger.cs
@@ -1,5 +1,6 @@
 ﻿using Ivy.Core;
 using Ivy.Core.Hooks;
+using Ivy.Views;
 
 namespace Ivy.Hooks;
 
@@ -10,17 +11,31 @@ public static class UseTriggerExtensions
 
     public static (object? triggerView, Action<T> triggerCallback) UseTrigger<T>(this IViewContext context, Func<IState<bool>, T, object?> factory)
     {
-        var open = context.UseState(false);
-        var triggerValue = context.UseState<T?>();
+        var open = context.UseRef(false);
+        var triggerValue = context.UseRef<T?>();
+
+        var view = new FuncView(context2 =>
+        {
+            var openInternal = context2.UseState(false);
+
+            context2.UseEffect(() =>
+            {
+                openInternal.Set(open.Value);
+            }, open);
+
+            return openInternal.Value && triggerValue.Value != null ? factory(open, triggerValue.Value) : null!;
+        });
 
         return (
-            open.Value && triggerValue.Value != null ? factory(open, triggerValue.Value) : null!,
-            value =>
-            {
-                open.Set(true);
-                triggerValue.Set(value);
-            }
+            view,
+            Callback
         );
+
+        void Callback(T? value)
+        {
+            triggerValue.Set(value);
+            open.Set(true);
+        }
     }
 
     public static (object? triggerView, Action triggerCallback) UseTrigger<TView>(this TView view, Func<IState<bool>, object?> viewFactory) where TView : ViewBase =>
@@ -28,13 +43,25 @@ public static class UseTriggerExtensions
 
     public static (object? triggerView, Action triggerCallback) UseTrigger(this IViewContext context, Func<IState<bool>, object?> factory)
     {
-        var open = context.UseState(false);
-        return (
-            open.Value ? factory(open) : null!,
-            () =>
+        var open = context.UseState(false, buildOnChange: false);
+
+        var view = new FuncView(context2 =>
+        {
+            var openInternal = context2.UseState(false);
+
+            context2.UseEffect(() =>
             {
-                open.Set(true);
-            }
-        );
+                openInternal.Set(open.Value);
+            }, open);
+
+            return openInternal.Value ? factory(open) : null!;
+        });
+
+        return (view, Callback);
+
+        void Callback()
+        {
+            open.Set(true);
+        }
     }
 }

--- a/Ivy/Views/Alerts/UseAlert.cs
+++ b/Ivy/Views/Alerts/UseAlert.cs
@@ -14,35 +14,37 @@ public static class UseAlertExtensions
 
     public static (IView? alertView, ShowAlertDelegate showAlert) UseAlert(this IViewContext context)
     {
-        var alertResult = context.UseState(AlertResult.Undecided);
-        var isOpen = context.UseState(false);
-        var alertOptions = context.UseState<AlertOptions?>();
-        var alertCallback = context.UseState<Action<AlertResult>?>();
-        var client = context.UseService<IClientProvider>();
+        var open = context.UseRef(false);
+        var alertResult = context.UseRef(AlertResult.Undecided);
+        var alertOptions = context.UseRef<AlertOptions?>();
+        var alertCallback = context.UseRef<Action<AlertResult>?>();
 
         context.UseEffect(() =>
         {
             if (alertResult.Value != AlertResult.Undecided && alertCallback.Value != null)
             {
-                try
-                {
-                    alertCallback.Value(alertResult.Value);
-                }
-                catch (Exception ex)
-                {
-                    client.Toast(ex);
-                }
+                alertCallback.Value(alertResult.Value);
             }
         }, [alertResult, alertCallback]);
 
-        var view = isOpen.Value && alertOptions.Value != null ? new AlertView(alertResult, isOpen, alertOptions.Value) : null;
+        var view = new FuncView(context2 =>
+        {
+            var openInternal = context2.UseState(false);
+
+            context2.UseEffect(() =>
+            {
+                openInternal.Set(open.Value);
+            }, open);
+
+            return openInternal.Value && alertOptions.Value != null ? new AlertView(alertResult, open, alertOptions.Value) : null;
+        });
 
         var showAlert = new ShowAlertDelegate((message, callback, title, buttonSet) =>
         {
             alertOptions.Set(new AlertOptions(title, message, buttonSet));
             alertResult.Set(AlertResult.Undecided);
             alertCallback.Set(callback);
-            isOpen.Set(true);
+            open.Set(true);
         });
 
         return (view, showAlert);

--- a/Ivy/Views/FuncView.cs
+++ b/Ivy/Views/FuncView.cs
@@ -12,3 +12,12 @@ public class FuncView(FuncViewBuilder viewFactory) : ViewBase
         return viewFactory(Context);
     }
 }
+public class MemoizedFuncView(FuncViewBuilder viewFactory, object[] memoValues) : ViewBase, IMemoized
+{
+    public override object? Build()
+    {
+        return viewFactory(Context);
+    }
+
+    public object[] GetMemoValues() => memoValues;
+}


### PR DESCRIPTION
## Overview

This pull request introduces significant improvements to the Ivy Hooks system, focusing on the addition of a new `UseRef` hook, and major enhancements to the logic and usability of `UseAlert` and `UseTrigger`. These improvements provide more flexible state management for scenarios where triggering a re-render on value change is not desired (e.g., storing mutable references), and make it easier to implement modal, alert, and trigger-driven UI patterns in Ivy-based applications. The PR also adds new sample apps demonstrating the improved hooks.

---

## Changes

### 1. **New: `UseRef` Hook**

- **Purpose:**  
  Provides a hook for referencing mutable values that do **not** trigger a re-render when updated. This is useful for scenarios similar to React's `useRef`, such as holding DOM references or storing transient state.

- **API:**
    ```csharp
    // In IViewContext:
    IState<T> UseRef<T>(T? initialValue = default)
    IState<T> UseRef<T>(Func<T> buildInitialValue)
    ```

- **Implementation:**  
  Internally, `UseRef` delegates to `UseState` but sets `buildOnChange: false` to avoid triggering a rebuild when the value changes.

---

### 2. **Enhanced: `UseAlert` Logic**

- **Refactored to use `UseRef`** for internal state storage instead of `UseState`, preventing unnecessary re-renders.
- **Alert view rendering** is now managed by a `FuncView` that syncs its own visible state to the alert's open flag. This ensures the alert dialog's UI is correctly shown/hidden in sync with imperative triggers.
- **Callback invocation** is streamlined, and exception handling is simplified.

---

### 3. **Enhanced: `UseTrigger` Logic**

- **Refactored to use `UseRef`** for "open" and "trigger value" states.
- **Trigger view rendering** uses a `FuncView` with internal synchronization, ensuring the trigger's open/close state is properly handled and isolated.
- **Callback logic** is improved for clarity and reliability.

---

### 4. **New: `MemoizedFuncView` Class**

- **Purpose:**  
  Enables creation of function-based views that can be memoized based on input values, paving the way for future performance optimizations and fine-grained control over view updates.

- **API:**
    ```csharp
    public class MemoizedFuncView : ViewBase, IMemoized
    {
        public MemoizedFuncView(FuncViewBuilder viewFactory, object[] memoValues);
        public override object? Build();
        public object[] GetMemoValues();
    }
    ```

---

### 5. **New Sample Apps**

- **`AlertApp`**  
  Demonstrates usage and improvements of `UseAlert` for showing alerts, confirmations, prompts, and sheets.

- **`TriggerApp`**  
  Demonstrates usage and improvements of `UseTrigger` for showing dynamic, triggerable content.

---

## Code Examples

### 1. **UseRef Hook**

```csharp
// Store a mutable reference (doesn't trigger re-renders)
var myRef = context.UseRef(42);

// Read or mutate the value without causing a rebuild
myRef.Value = 100;
```

### 2. **UseAlert Usage**

```csharp
var (alertView, showAlert) = context.UseAlert();

return Layout.Vertical()
       | new Button("Show Alert", () => showAlert("Hello!", result => { /* handle result */ }))
       | alertView;
```

### 3. **UseTrigger Usage**

```csharp
var (triggerView, showTrigger) = context.UseTrigger((isOpen, param) => 
    new SomeModalView(isOpen, param));

return Layout.Vertical()
       | new Button("Open Modal", () => showTrigger(123))
       | triggerView;
```

### 4. **MemoizedFuncView**

```csharp
var view = new MemoizedFuncView(ctx => BuildSomething(ctx), new object[] { dependency1, dependency2 });
```

---

## Notes

- **No breaking changes** to existing public APIs, but the internal implementation of `UseAlert` and `UseTrigger` is now more robust and less prone to unnecessary re-renders.
- `UseRef` is now the recommended way to manage mutable references or state that should not trigger view updates.
- `MemoizedFuncView` is a foundation for further optimization; it's not yet integrated into higher-level APIs but is available for advanced use.
- Exception handling in `UseAlert` callbacks is now the responsibility of the callback itself. If you need toast/error reporting, handle exceptions in your alert callbacks.

---

## Summary

- **Added:** `UseRef` hook for non-re-rendering state.
- **Improved:** `UseAlert` and `UseTrigger` logic and rendering, now more efficient and robust.
- **Added:** `MemoizedFuncView` for future performance and composability enhancements.
- **Added:** Sample apps demonstrating new/updated hooks.
- **Internal:** Cleanup and modernization of hook logic for clarity and maintainability.
