### PR TITLE
(chore): Readded Form app with scaffolding after compile errors

### DIFF
--- a/Ivy.Samples.Shared/Apps/Concepts/FormApp.cs
+++ b/Ivy.Samples.Shared/Apps/Concepts/FormApp.cs
@@ -6,8 +6,6 @@ using Ivy.Views.Forms;
 
 namespace Ivy.Samples.Shared.Apps.Concepts;
 
-#region Enums
-
 public enum Gender
 {
     Male,
@@ -55,10 +53,6 @@ public enum ViewState
     Success,
     Error
 }
-
-#endregion
-
-#region Models
 
 public record AppSpec(string Name, string Description);
 
@@ -135,10 +129,6 @@ public record UserModel(
     List<Fruits> FavoriteFruits = null!
 );
 
-#endregion
-
-#region Scaffolding Models
-
 public class DisplayExample
 {
     [Display(
@@ -210,10 +200,6 @@ public class StringsExample
     [Display(Description = "Must be between 5 and 10 characters long")]
     public string LengthString { get; set; } = "";
 }
-
-#endregion
-
-#region Validation Model
 
 public record FormValidationExamples
 {
@@ -306,8 +292,6 @@ public record FormValidationExamples
     [MaxLength(1000)]
     public string? Comments { get; init; }
 }
-
-#endregion
 
 [App(icon: Icons.Clipboard, path: ["Concepts"], searchHints: ["inputs", "fields", "validation", "submission", "data-entry", "controls", "scaffolding", "forms"])]
 public class FormApp : SampleBase


### PR DESCRIPTION
Closes #1593 

Compile errors occured when merging the new form app (with tab scaffolding). Probably because the old PR was dormant for to long and main was updated during that time. The Form Scaffolding tab had code example blocks that used example code that was removed between the last commit and the merge into main. It least I think that was the issue. I removed xml comments aswell.

Video for test (no need to watch it, just shows I did some tests):
https://github.com/user-attachments/assets/c2a71818-84d2-41e4-8828-95cea41dc332

Discovered that the invalid input still seem to have the old issue of being highlighted with grey and red on the outline. Maybe there is a issue on this problem already just wanted to point it out:
<img width="811" height="240" alt="image" src="https://github.com/user-attachments/assets/cb37fe58-86eb-49f3-89a1-0735d6e92195" />