### PR TITLE
[FileInput]: enable tooltip for invalid icon

### DIFF
--- a/frontend/src/components/InvalidIcon.tsx
+++ b/frontend/src/components/InvalidIcon.tsx
@@ -15,7 +15,7 @@ export const InvalidIcon: React.FC<{ message: string; className?: string }> = ({
     <TooltipProvider>
       <Tooltip>
         <TooltipTrigger
-          className={cn(className, 'cursor-pointer')}
+          className={cn(className, 'cursor-pointer pointer-events-auto')}
           data-invalid-icon="true"
         >
           <InfoIcon className="h-4 w-4 text-red-900 hover:text-red-400 transition-colors duration-200" />

--- a/frontend/src/widgets/inputs/FileInputWidget.tsx
+++ b/frontend/src/widgets/inputs/FileInputWidget.tsx
@@ -381,9 +381,7 @@ export const FileInputWidget: React.FC<FileInputWidgetProps> = ({
       {/* Invalid icon in top right corner - only for required field validation */}
       {invalid && (
         <div className="absolute top-2 right-2 z-20 pointer-events-none">
-          <div className="pointer-events-auto">
-            <InvalidIcon message={invalid} />
-          </div>
+          <InvalidIcon message={invalid} />
         </div>
       )}
       <div

--- a/frontend/src/widgets/inputs/TextInputWidget/variants/DefaultVariant.tsx
+++ b/frontend/src/widgets/inputs/TextInputWidget/variants/DefaultVariant.tsx
@@ -117,7 +117,7 @@ export const DefaultVariant: React.FC<DefaultVariantProps> = ({
                 </div>
               )}
               {props.invalid && (
-                <div className="pointer-events-auto flex items-center h-6">
+                <div className="flex items-center h-6">
                   <InvalidIcon message={props.invalid} />
                 </div>
               )}

--- a/frontend/src/widgets/inputs/TextInputWidget/variants/PasswordVariant.tsx
+++ b/frontend/src/widgets/inputs/TextInputWidget/variants/PasswordVariant.tsx
@@ -132,7 +132,7 @@ export const PasswordVariant: React.FC<PasswordVariantProps> = ({
             </div>
           )}
           {props.invalid && (
-            <div className="pointer-events-auto flex items-center h-6 ml-2">
+            <div className="flex items-center h-6 ml-2">
               <InvalidIcon message={props.invalid} />
             </div>
           )}

--- a/frontend/src/widgets/inputs/TextInputWidget/variants/SearchVariant.tsx
+++ b/frontend/src/widgets/inputs/TextInputWidget/variants/SearchVariant.tsx
@@ -158,7 +158,7 @@ export const SearchVariant: React.FC<SearchVariantProps> = ({
           </div>
         )}
         {props.invalid && (
-          <div className="pointer-events-auto flex items-center h-6">
+          <div className="flex items-center h-6">
             <InvalidIcon message={props.invalid} />
           </div>
         )}

--- a/frontend/src/widgets/inputs/TextInputWidget/variants/TextareaVariant.tsx
+++ b/frontend/src/widgets/inputs/TextInputWidget/variants/TextareaVariant.tsx
@@ -87,7 +87,7 @@ export const TextareaVariant: React.FC<TextareaVariantProps> = ({
           </div>
         )}
         {props.invalid && (
-          <div className="pointer-events-auto flex items-center h-6">
+          <div className="flex items-center h-6">
             <InvalidIcon message={props.invalid} />
           </div>
         )}


### PR DESCRIPTION
## Problem

The validation icon tooltip in FileInput component was not working when hovering over the red invalid icon. The parent wrapper div had `pointer-events-none` CSS class which blocked all pointer interactions, preventing the tooltip from being triggered.

## Solution

Added an inner wrapper with `pointer-events-auto` around the InvalidIcon component to restore pointer events specifically for the icon. This allows the tooltip to work while keeping the surrounding area click-through for the file drop zone functionality.

How it looks now:
<img width="671" height="301" alt="image" src="https://github.com/user-attachments/assets/3e385130-8f2f-49d1-83ed-37d5f05afe93" />