### PR TITLE
[Docs]: adjust Setters column width in Properties table

### DIFF
--- a/Ivy.Docs.Shared/Helpers/WidgetDocsView.cs
+++ b/Ivy.Docs.Shared/Helpers/WidgetDocsView.cs
@@ -98,6 +98,7 @@ public class WidgetDocsView(string typeName, string? extensionsTypeName, string?
         var propertySection = Layout.Vertical().Gap(2)
                               | Text.H3("Properties")
                               | properties.ToTable().Width(Size.Full())
+                                  .ColumnWidth(p => p.Setters, Size.Fraction(0.4f))
             ;
 
         var events = type.GetProperties()


### PR DESCRIPTION
Set 40% fraction for setters column width.
Now it looks more accurate:
<img width="602" height="381" alt="image" src="https://github.com/user-attachments/assets/4a44883e-5e1a-44db-950e-40609710e89d" />
