### PR TITLE
(fix): Added width inline style for number input

### DIFF
--- a/frontend/src/widgets/inputs/NumberInputWidget.tsx
+++ b/frontend/src/widgets/inputs/NumberInputWidget.tsx
@@ -3,7 +3,7 @@ import { useEventHandler, EventHandler } from '@/components/event-handler';
 import NumberInput from '@/components/NumberInput';
 import { Slider } from '@/components/ui/slider';
 import { cn } from '@/lib/utils';
-import { inputStyles } from '@/lib/styles';
+import { inputStyles, getWidth } from '@/lib/styles';
 import { InvalidIcon } from '@/components/InvalidIcon';
 import { X } from 'lucide-react';
 import React from 'react';
@@ -56,6 +56,7 @@ interface NumberInputWidgetProps
   extends Omit<NumberInputBaseProps, 'onValueChange'> {
   variant?: 'Default' | 'Slider';
   targetType?: string;
+  width?: string;
 }
 
 // Function to validate and cap values based on target type
@@ -278,6 +279,7 @@ export const NumberInputWidget = memo(
     id,
     variant = 'Default',
     nullable = false,
+    width,
     ...props
   }: NumberInputWidgetProps) => {
     const eventHandler = useEventHandler() as EventHandler;
@@ -314,21 +316,25 @@ export const NumberInputWidget = memo(
       [eventHandler, id, props.min, props.max, props.targetType]
     );
 
-    return variant === 'Slider' ? (
-      <SliderVariant
-        id={id}
-        {...props}
-        value={normalizedValue}
-        onValueChange={handleChange}
-      />
-    ) : (
-      <NumberVariant
-        id={id}
-        {...props}
-        value={normalizedValue}
-        nullable={nullable}
-        onValueChange={handleChange}
-      />
+    return (
+      <div style={{ ...getWidth(width) }}>
+        {variant === 'Slider' ? (
+          <SliderVariant
+            id={id}
+            {...props}
+            value={normalizedValue}
+            onValueChange={handleChange}
+          />
+        ) : (
+          <NumberVariant
+            id={id}
+            {...props}
+            value={normalizedValue}
+            nullable={nullable}
+            onValueChange={handleChange}
+          />
+        )}
+      </div>
     );
   }
 );


### PR DESCRIPTION
Closes #1800 

The user of the framework can now create number input with different widths simular to how Text input does it.

<img width="1634" height="615" alt="ivy-number-input-width" src="https://github.com/user-attachments/assets/61d2eb8a-7b4c-493b-acc4-0aa327342957" />
