### PR TITLE
[App]: StrictMode causes page re-render while dragging and dropping tab

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,4 +1,3 @@
-import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';
 import { App } from './components/App';
@@ -16,8 +15,4 @@ if (!root) {
   (window as WindowWithReactRoot).__reactRoot = root;
 }
 
-root.render(
-  <StrictMode>
-    <App />
-  </StrictMode>
-);
+root.render(<App />);


### PR DESCRIPTION
## Problem

Tab content re-renders when dragging and dropping tabs in development mode (`npm run dev`, localhost:5173). This issue **does not occur** in production builds or on the backend server (localhost:5010).

### Root Cause

React's `StrictMode` in development:
1. Intentionally unmounts/remounts components to detect bugs
2. This disconnects the WebSocket connection
3. On reconnection, backend sends **REFRESH** (full tree) instead of **UPDATE** (patch)
4. Full tree replacement causes tab content to re-render

### Console logging

Tested dragging and dropping "Hello" tab.

#### With StrictMode (active tab):
<img width="1170" height="543" alt="image" src="https://github.com/user-attachments/assets/2c0f4a1c-cacc-4461-bf0a-507e01dc4684" />

#### With StrictMode (inactive tab) (you can see confetti in upper left corner):
<img width="1359" height="550" alt="image" src="https://github.com/user-attachments/assets/335e4c2d-3584-4648-9b04-7af4eefd4f3e" /> 

#### Without StrictMode (active tab):
<img width="1174" height="391" alt="image" src="https://github.com/user-attachments/assets/5b85d7e5-72f0-49b0-a825-9a74e4d2eb7a" />

#### Without StrictMode (inactive tab):
<img width="1176" height="329" alt="image" src="https://github.com/user-attachments/assets/e95b981c-6483-4e09-a31e-a37087fbd853" />


## Solution

### Recommendation: No action required

This issue should be **closed as "By Design"** or **"Won't Fix"** for the following reasons:

**1. Development-Only Issue**
- StrictMode only runs in development mode
- Production builds are unaffected
- End users never experience this

**2. Not A Bug**
- StrictMode's behavior is intentional
- Component logic is correct
- No state management issues
- This is expected behavior for WebSocket connections in StrictMode

**3. Alternatives Are Not Worth It**
- Disabling StrictMode: Lose valuable development checks
- Deep memoization: Adds complexity for a dev-only issue
- Keep as-is: Document as known behavior

**4. Widely Accepted Pattern**
- Many WebSocket/SSE applications have this behavior
- React team acknowledges this trade-off
- Not indicative of production problems