### PR TITLE
[dropdown]: stop click propagation in DropdownMenuContent

### DIFF
--- a/frontend/src/widgets/dropDownMenuWidget.tsx
+++ b/frontend/src/widgets/dropDownMenuWidget.tsx
@@ -168,6 +168,7 @@ export const DropDownMenuWidget: React.FC<DropDownMenuWidgetProps> = ({
         <div>{slots.Trigger}</div>
       </DropdownMenuTrigger>
       <DropdownMenuContent
+        onClick={e => e.stopPropagation()}
         align={camelCase(align) as 'center' | 'end' | 'start' | undefined}
         side={
           camelCase(side) as 'top' | 'right' | 'bottom' | 'left' | undefined


### PR DESCRIPTION
## Problem

When clicking on a menu item inside a dropdown menu that is rendered within a card component (e.g., clicking "Delete" from the three-dot menu), the click event bubbles up to the parent card element, causing the card's `HandleClick` handler to trigger. This results in both the intended action (showing the delete confirmation dialog) and an unwanted side effect (opening the edit sheet) occurring simultaneously. This happens because Radix UI's `DropdownMenuContent` renders in a portal, but click events still propagate through the React event system to parent elements, even though the dropdown content is outside the DOM hierarchy.

## Solution

Added `onClick={(e) => e.stopPropagation()}` to the `DropdownMenuContent` component to prevent click events from bubbling up to parent elements. This ensures that clicks on dropdown menu items are handled exclusively by the dropdown's own event handlers and do not trigger click handlers on parent components like cards. The fix is minimal and targeted, addressing the root cause of event propagation without affecting other dropdown functionality.