### PR TITLE
[fonts]: prevent font flicker by changing font-display to fallback

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -6,7 +6,7 @@
   src: url('/fonts/Geist/webfonts/Geist-Regular.woff2') format('woff2');
   font-weight: 400;
   font-style: normal;
-  font-display: fallback;
+  font-display: swap;
 }
 
 @font-face {
@@ -14,7 +14,7 @@
   src: url('/fonts/Geist/webfonts/Geist-Medium.woff2') format('woff2');
   font-weight: 500;
   font-style: normal;
-  font-display: fallback;
+  font-display: swap;
 }
 
 @font-face {
@@ -22,7 +22,7 @@
   src: url('/fonts/Geist/webfonts/Geist-SemiBold.woff2') format('woff2');
   font-weight: 600;
   font-style: normal;
-  font-display: fallback;
+  font-display: swap;
 }
 
 @font-face {
@@ -30,7 +30,7 @@
   src: url('/fonts/Geist/webfonts/Geist-Bold.woff2') format('woff2');
   font-weight: 700;
   font-style: normal;
-  font-display: fallback;
+  font-display: swap;
 }
 
 /* Geist Mono Font Family */
@@ -39,7 +39,7 @@
   src: url('/fonts/GeistMono/webfonts/GeistMono-Regular.woff2') format('woff2');
   font-weight: 400;
   font-style: normal;
-  font-display: fallback;
+  font-display: swap;
 }
 
 @font-face {
@@ -47,7 +47,7 @@
   src: url('/fonts/GeistMono/webfonts/GeistMono-Medium.woff2') format('woff2');
   font-weight: 500;
   font-style: normal;
-  font-display: fallback;
+  font-display: swap;
 }
 
 @font-face {
@@ -55,7 +55,7 @@
   src: url('/fonts/GeistMono/webfonts/GeistMono-SemiBold.woff2') format('woff2');
   font-weight: 600;
   font-style: normal;
-  font-display: fallback;
+  font-display: swap;
 }
 
 @font-face {
@@ -63,7 +63,7 @@
   src: url('/fonts/GeistMono/webfonts/GeistMono-Bold.woff2') format('woff2');
   font-weight: 700;
   font-style: normal;
-  font-display: fallback;
+  font-display: swap;
 }
 
 @theme {


### PR DESCRIPTION
## Problem

When loading pages, text initially renders with a fallback font (typically Times New Roman) before switching to the Geist font family, causing a visible "flicker" effect. This issue occurs because `font-display: swap` instructs the browser to immediately display the fallback font while the custom font loads in the background, then swap to the custom font once it's available. This creates a noticeable visual transition that degrades the user experience, especially on slower network connections where the font loading delay is more pronounced.

## Solution

Changed `font-display` from `swap` to `fallback` for all Geist font family definitions in `index.css`. The `fallback` strategy provides a short blocking period (~100ms) for the font to load. If the font loads within this window, it's displayed immediately without any flicker. If it doesn't load in time, the fallback font is used for the current page load, but subsequent navigations will use the cached font. This approach eliminates the visible font switching while maintaining good performance characteristics.

Testing with network throttling confirmed that `fallback` eliminates the flicker:

https://github.com/user-attachments/assets/d150c3c9-83a0-4002-b5df-3fdd079b41bc