### PR TITLE
[blades]: fixed spacing issue in blades header

### DIFF
--- a/frontend/src/components/ui/tabs.tsx
+++ b/frontend/src/components/ui/tabs.tsx
@@ -100,7 +100,7 @@ const TabsTrigger = React.forwardRef<HTMLButtonElement, TabsTriggerProps>(
           ref={ref as React.Ref<React.ElementRef<typeof TabsPrimitive.Trigger>>}
           value={value}
           className={cn(
-            'inline-flex items-center justify-center whitespace-nowrap -ml-px -mt-px px-10 py-2 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-card data-[state=active]:text-foreground data-[state=active]:shadow',
+            'inline-flex items-center justify-center whitespace-nowrap -ml-px -mt-px px-4 py-2 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-card data-[state=active]:text-foreground data-[state=active]:shadow',
             className
           )}
           role="tab"
@@ -122,7 +122,7 @@ const TabsTrigger = React.forwardRef<HTMLButtonElement, TabsTriggerProps>(
         aria-selected={isActive}
         data-state={isActive ? 'active' : 'inactive'}
         className={cn(
-          'inline-flex items-center justify-center whitespace-nowrap -ml-px -mt-px px-2 py-2 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+          'inline-flex items-center justify-center whitespace-nowrap -ml-px -mt-px px-4 py-2 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
           isActive && 'bg-card text-foreground shadow',
           className
         )}

--- a/frontend/src/widgets/layouts/sidebar/SidebarLayoutWidget.tsx
+++ b/frontend/src/widgets/layouts/sidebar/SidebarLayoutWidget.tsx
@@ -194,7 +194,7 @@ export const SidebarLayoutWidget: React.FC<SidebarLayoutWidgetProps> = ({
         {showToggleButton && mainAppSidebar && (
           <button
             onClick={handleManualToggle}
-            className="absolute top-0 left-2 z-50 p-2 rounded-md bg-background hover:bg-muted hover:text-accent-foreground cursor-pointer"
+            className="absolute top-0 left-1 z-50 p-2 rounded-md bg-background hover:bg-muted hover:text-accent-foreground cursor-pointer"
             style={{ marginTop: '3px' }}
             aria-label={isSidebarOpen ? 'Close sidebar' : 'Open sidebar'}
           >

--- a/frontend/src/widgets/layouts/tabs/components/Variants.tsx
+++ b/frontend/src/widgets/layouts/tabs/components/Variants.tsx
@@ -279,7 +279,7 @@ export const TabsVariant: React.FC<TabsVariantProps> = ({
     >
       <div className="flex-shrink-0" style={getWidth(width)}>
         <div
-          className="relative pl-12 pr-6 before:absolute before:inset-x-0 before:bottom-0 before:h-px before:bg-border before:z-0 overflow-hidden"
+          className="relative pl-10 pr-6 before:absolute before:inset-x-0 before:bottom-0 before:h-px before:bg-border before:z-0 overflow-hidden"
           ref={containerRef}
         >
           <DndContext


### PR DESCRIPTION
<img width="1226" height="698" alt="Screenshot 2025-12-15 at 07 57 20" src="https://github.com/user-attachments/assets/18b338cd-fdc2-492f-9b25-19de7d291d36" />

Evenly spaced around left, bottom and top to 18px from Issue #1694 . 

I think that there is also an issue with the right side of the header  (see pic above).
-Uneven spacing between search bar,  [+] and refresh button 
-Disproportionate balance between big green [+] and small refresh icon

I propose:
Evenly spacing between search, [+] and refresh and

1. Moving [+] button to left side of searchbar -or-
2. Adding a grey "badge" to the refresh button so that that elements are more balanced 


What do you think?
 