### PR TITLE
(fix): Fixed bug for AsyncSelect Icon placement

### DIFF
--- a/frontend/src/widgets/inputs/AsyncSelectInputWidget.tsx
+++ b/frontend/src/widgets/inputs/AsyncSelectInputWidget.tsx
@@ -48,12 +48,6 @@ const asyncSelectIconVariants = {
   Large: 'h-5 w-5',
 };
 
-const asyncSelectInvalidIconVariants = {
-  Small: 'right-5 top-1.5',
-  Medium: 'right-6 top-2.5',
-  Large: 'right-8 top-3.5',
-};
-
 interface AsyncSelectInputWidgetProps {
   id: string;
   placeholder?: string;
@@ -169,31 +163,27 @@ export const AsyncSelectInputWidget: React.FC<AsyncSelectInputWidgetProps> = ({
             {placeholder}
           </span>
         )}
-        <div
-          className={cn(
-            'absolute top-0 bottom-0 border-l flex items-center justify-end shrink-0',
-            'right-2.5',
-            asyncSelectIconContainerVariants[scale]
+        <div className="flex items-center gap-2 shrink-0 ml-2">
+          {invalid && (
+            <div className="flex items-center">
+              <InvalidIcon message={invalid} />
+            </div>
           )}
-        >
-          <ChevronRight
+          <div
             className={cn(
-              'opacity-50 shrink-0',
-              asyncSelectIconVariants[scale]
+              'border-l flex items-center justify-center pl-2',
+              asyncSelectIconContainerVariants[scale]
             )}
-          />
+          >
+            <ChevronRight
+              className={cn(
+                'opacity-50 shrink-0',
+                asyncSelectIconVariants[scale]
+              )}
+            />
+          </div>
         </div>
       </button>
-      {invalid && (
-        <div
-          className={cn(
-            'absolute h-4 w-4',
-            asyncSelectInvalidIconVariants[scale]
-          )}
-        >
-          <InvalidIcon message={invalid} />
-        </div>
-      )}
     </div>
   );
 };


### PR DESCRIPTION
Closes #1770 

Icon inside of AsyncSelect was pushed right:
<img width="657" height="356" alt="ivy-asyncselect-before" src="https://github.com/user-attachments/assets/71170d17-5b8c-47f9-9d2a-e6a78e70ac3e" />

I moved it more to the left and changed from absolute positioning to flex box positioning like TextInput in Ivy.Sample uses. Makes the code easier to maintain.

After:
<img width="836" height="444" alt="ivy-asyncselect-fix" src="https://github.com/user-attachments/assets/75cfe036-afdb-4fd7-b923-1fe35c951221" />
