### PR TITLE
fix(docs): spaces in title "C L I Overview"

### DIFF
--- a/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/01_CLIOverview.md
+++ b/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/01_CLIOverview.md
@@ -1,4 +1,5 @@
 ---
+title: CLI Overview
 searchHints:
   - cli
   - command-line


### PR DESCRIPTION
### Before
<img width="250" height="72" alt="Screenshot 2025-12-15 at 11 37 33 PM" src="https://github.com/user-attachments/assets/146c47c0-1c5a-4942-9903-6d1b9df1f61b" />

### After
<img width="250" height="74" alt="Screenshot 2025-12-15 at 11 36 41 PM" src="https://github.com/user-attachments/assets/c7b127d3-8fce-4ec6-a40e-fff1976cc101" />
