### PR TITLE
[code]: Add XML syntax highlighting support for code blocks

### DIFF
--- a/Ivy.Docs.Tools/MarkdownConverter.cs
+++ b/Ivy.Docs.Tools/MarkdownConverter.cs
@@ -499,6 +499,7 @@ public static partial class MarkdownConverter
             "css" => "Languages.Css",
             "json" => "Languages.Json",
             "dbml" => "Languages.Dbml",
+            "xml" => "Languages.Xml",
             "text" => "Languages.Text",
             _ => "Languages.Text"
         };

--- a/Ivy.Samples.Shared/Apps/Widgets/Primitives/CodeApp.cs
+++ b/Ivy.Samples.Shared/Apps/Widgets/Primitives/CodeApp.cs
@@ -157,6 +157,18 @@ public class CodeApp : SampleBase
                     result bigint [not null]
                     calculated_at timestamp [default: `now()`]
                 }
+                """,
+
+            [Languages.Xml] = """
+                <!-- Project file for Fibonacci console application -->
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>net9.0</TargetFramework>
+                    <ImplicitUsings>enable</ImplicitUsings>
+                    <Nullable>enable</Nullable>
+                  </PropertyGroup>
+                </Project>
                 """
         };
 

--- a/Ivy/Widgets/Primitives/Code.cs
+++ b/Ivy/Widgets/Primitives/Code.cs
@@ -17,6 +17,7 @@ public enum Languages
     Dbml,
     Markdown,
     Text,
+    Xml,
 }
 
 public record Code : WidgetBase<Code>

--- a/frontend/src/widgets/primitives/CodeWidget.tsx
+++ b/frontend/src/widgets/primitives/CodeWidget.tsx
@@ -30,6 +30,7 @@ const languageMap: Record<string, string> = {
   Json: 'json',
   Dbml: 'sql',
   Text: 'text',
+  Xml: 'xml',
 };
 
 const mapLanguageToPrism = (language: string): string | undefined => {


### PR DESCRIPTION
## Summary
Adds XML syntax highlighting support to the Code widget, enabling proper color highlighting for XML code blocks in documentation.

## Problem
XML code blocks in markdown documentation (e.g., `.csproj` files) were being rendered as plain text without syntax highlighting, making them harder to read and less visually distinct from other code examples.

## Solution
- Added `Xml` to the `Languages` enum in `Code.cs`
- Added XML language mapping in `MarkdownConverter.MapLanguageToEnum()` to recognize `xml` code fences
- Added XML language mapping in `CodeWidget.tsx` to map `Languages.Xml` to Prism's `xml` highlighter
- Added XML example to `CodeApp.cs` demonstrating XML syntax highlighting

## Changes
- **Ivy/Widgets/Primitives/Code.cs**: Added `Xml` to `Languages` enum
- **Ivy.Docs.Tools/MarkdownConverter.cs**: Added `"xml" => "Languages.Xml"` mapping
- **frontend/src/widgets/primitives/CodeWidget.tsx**: Added `Xml: 'xml'` to language map
- **Ivy.Samples.Shared/Apps/Widgets/Primitives/CodeApp.cs**: Added XML example with .csproj file

## Before -->
<img width="2347" height="560" alt="image" src="https://github.com/user-attachments/assets/33e5c30e-8433-488a-bfba-6a4557eaaf66" />

## After -->
<img width="1485" height="444" alt="image" src="https://github.com/user-attachments/assets/b718b50b-ed71-4ac8-8db5-7a2dd188b143" />
