### PR TITLE
[datatable]: use stable connectionKey instead of object reference to prevent rerender

### DIFF
--- a/frontend/src/widgets/dataTables/dataTableContext/hooks/useDataLoading.ts
+++ b/frontend/src/widgets/dataTables/dataTableContext/hooks/useDataLoading.ts
@@ -48,6 +48,7 @@ export const useDataLoading = ({
   const loadingRef = useRef(false);
   const currentRowCountRef = useRef(0);
   const batchSize = config.batchSize ?? 20;
+  const connectionKey = `${connection.connectionId}-${connection.sourceId}`;
 
   // Reset currentRowCountRef when filter or sort changes
   useEffect(() => {
@@ -57,7 +58,7 @@ export const useDataLoading = ({
   // Reset row count when connection changes
   useEffect(() => {
     currentRowCountRef.current = 0;
-  }, [connection]);
+  }, [connectionKey]);
 
   // Load initial data
   useEffect(() => {
@@ -135,7 +136,7 @@ export const useDataLoading = ({
     };
     loadInitialData();
   }, [
-    connection,
+    connectionKey,
     activeFilter,
     activeSort,
     columnOrderLength,
@@ -195,7 +196,7 @@ export const useDataLoading = ({
       loadingRef.current = false;
     }
   }, [
-    connection,
+    connectionKey,
     hasMore,
     activeFilter,
     activeSort,

--- a/frontend/src/widgets/dataTables/dataTableContext/tableProvider.tsx
+++ b/frontend/src/widgets/dataTables/dataTableContext/tableProvider.tsx
@@ -45,10 +45,12 @@ export const TableProvider: React.FC<TableProviderProps> = ({
     allowSorting: allowSorting ?? true,
   });
 
+  const connectionKey = `${connection.connectionId}-${connection.sourceId}`;
+
   // Reset column widths when connection changes
   React.useEffect(() => {
     resetColumnWidths();
-  }, [connection, resetColumnWidths]);
+  }, [connectionKey, resetColumnWidths]);
 
   // Data loading
   const { isLoading, hasMore, loadMoreData } = useDataLoading({


### PR DESCRIPTION
### Problem
The DataTable component was unnecessarily reloading data when switching between tabs (Demo/Code) in the documentation or when opening the "Show Code" sheet in Samples. This happened because the useEffect hook in `useDataLoading.ts` depended on the connection object reference. When the parent component re-mounted (which happens during tab switches), React created a new connection object in memory — even though the actual connection values (connectionId, sourceId, port, path) remained the same. Since JavaScript compares objects by reference, React considered the connection "changed" and triggered data reload.

### Solution
Replaced the object reference dependency with a stable string key connectionKey composed of connectionId and sourceId. This ensures that the useEffect hooks only trigger when the connection actually changes logically, not when the object reference changes due to component re-mounting.

Current look - it works without rerender now