### PR TITLE
[SelectInput]: nullable when cleared should have no selected value

### DIFF
--- a/frontend/src/widgets/inputs/SelectInputWidget.tsx
+++ b/frontend/src/widgets/inputs/SelectInputWidget.tsx
@@ -356,7 +356,7 @@ const ToggleVariant: React.FC<SelectInputWidgetProps> = ({
           ) : (
             <ToggleGroup
               type="single"
-              value={selectedValues[0]?.toString()}
+              value={selectedValues[0]?.toString() ?? ''}
               onValueChange={handleValueChange}
               disabled={disabled}
               className="flex flex-wrap gap-2"


### PR DESCRIPTION

## Summary
This PR fixes how nullable select inputs behave when the value is cleared so that no option remains visually selected.

### Changes:

- **Radio variant**
  - Normalize the internal `stringValue` to an empty string (`''`) when the bound value is `null` / `undefined` / empty.
  - This keeps `RadioGroup` fully controlled and ensures that, after clearing, no radio item is selected and the checked indicator is removed.

- **Toggle variant**
  - For the single-select toggle (`type="single"`), always pass a string value to `ToggleGroup` and use `''` when there is no selection.
  - This ensures that after clearing, the toggle group also has no active (`data-state="on"`) item.

Together, these changes guarantee that for nullable select inputs, pressing the “Clear” button removes both the value and the visual selection in the Radio and Toggle variants.


https://github.com/user-attachments/assets/c8433ce1-c377-436b-aa71-df52b61ef5ed

