### PR TITLE
(fix): Email validation checks for dots after @ symbol now

### DIFF
--- a/Ivy/Views/Forms/Validators.cs
+++ b/Ivy/Views/Forms/Validators.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel.DataAnnotations;
+using System.Net.Mail;
 
 namespace Ivy.Views.Forms;
 
@@ -6,7 +6,6 @@ public static class Validators
 {
     public static Func<object?, (bool, string)> CreateEmailValidator(string fieldName)
     {
-        var emailValidator = new EmailAddressAttribute();
         return email =>
         {
             if (email is not string emailStr || string.IsNullOrWhiteSpace(emailStr))
@@ -14,17 +13,14 @@ public static class Validators
 
             try
             {
-                var validationContext = new ValidationContext(new { })
-                {
-                    MemberName = fieldName,
-                    DisplayName = fieldName
-                };
-                var result = emailValidator.GetValidationResult(emailStr, validationContext);
-                return result == ValidationResult.Success
-                    ? (true, "")
-                    : (false, result?.ErrorMessage ?? "Please enter a valid email address");
+                var addr = new MailAddress(emailStr);
+
+                if (!addr.Host.Contains('.'))
+                    return (false, "Please enter a valid email address");
+
+                return (true, "");
             }
-            catch
+            catch (FormatException)
             {
                 return (false, "Please enter a valid email address");
             }


### PR DESCRIPTION
Closes #1725 

Updated the validator to check for dot after the @ symbol.

Changed from System.ComponentModel.DataAnnotations to System.Net.Mail for the code to be smaller and easier to maintain. It also made it easier to add the dot check