### PR TITLE
(code): remove hardcoded height

### DIFF
--- a/Ivy/Widgets/Primitives/Code.cs
+++ b/Ivy/Widgets/Primitives/Code.cs
@@ -27,7 +27,7 @@ public record Code : WidgetBase<Code>
         Content = content;
         Language = language;
         Width = Size.Full();
-        Height = Size.MaxContent().Max(Size.Px(800));
+        Height = Size.MaxContent();
     }
 
     [Prop] public string Content { get; set; }


### PR DESCRIPTION
<img width="1281" height="1295" alt="Screenshot 2025-12-17 at 16 33 00" src="https://github.com/user-attachments/assets/20221dc6-4a5b-44ab-afd7-8d79530f5505" />
<img width="1292" height="1292" alt="Screenshot 2025-12-17 at 16 32 52" src="https://github.com/user-attachments/assets/8d9ffe31-8f78-45cb-9528-f3eb9b7981ef" />
