### PR TITLE
[charts]: remove automatic alphabetical sorting in PivotTable

### DIFF
--- a/Ivy/Views/Charts/PivotTable.cs
+++ b/Ivy/Views/Charts/PivotTable.cs
@@ -112,8 +112,6 @@ public class PivotTable<T>
             calculation.Calculation(result);
         }
 
-        //sort by first dimension
-        result.Sort((a, b) => Comparer.Default.Compare(a[Dimensions[0].Name], b[Dimensions[0].Name]));
 
         return result.ToArray();
     }


### PR DESCRIPTION
## Problem

When using `.ToLineChart()` (and other chart builder methods), the x-axis values were sorted alphabetically instead of preserving the original data order. This caused months to appear in wrong order (e.g., "Apr → Feb → Jan → Mar" instead of "Jan → Feb → Mar → Apr"), breaking chronological visualization. The issue occurred because `PivotTable.ExecuteAsync()` applied `Comparer.Default.Compare` sorting on the first dimension, which performs lexicographic comparison on strings.

## Solution

Removed the automatic alphabetical sorting from `PivotTable.cs`. The data now preserves the order in which it was passed by the user, allowing proper chronological or custom ordering when using `.OrderBy()` before chart creation.

Before:
<img width="830" height="415" alt="image" src="https://github.com/user-attachments/assets/bc012275-4d22-45c5-a7bd-7a94e02cb4e6" />
After:
<img width="836" height="430" alt="image" src="https://github.com/user-attachments/assets/557331b7-d1fe-43b9-bfa9-2ab89b2671d7" />
