### PR TITLE
[GridView]: add Height

### DIFF
--- a/Ivy/Views/GridView.cs
+++ b/Ivy/Views/GridView.cs
@@ -52,6 +52,12 @@ public class GridView : ViewBase, IStateless
         return this;
     }
 
+    public GridView Height(Size height)
+    {
+        _definition.Height = height;
+        return this;
+    }
+
     public GridView ColumnWidths(params Size[] widths)
     {
         _definition.ColumnWidths = widths;


### PR DESCRIPTION
What I mentioned in example that Artem provided in issue:
1 - you set 3 values for .RowHeights, but actually you have 4 rows
2 - without setting .Height() for layout, fraction won't work at all and this is correct behaviour (it don't know from what value fraction has to be taken)

About 2 punct, GridView don't have height at all, so I added it in this PR. Now fractions will work.

Here you can see the correct one:
<img width="675" height="395" alt="image" src="https://github.com/user-attachments/assets/4ccda079-abae-4214-9093-b240aae10da7" />
<img width="667" height="375" alt="image" src="https://github.com/user-attachments/assets/31710050-24a8-4d41-8df1-691db8cc2429" />

