### PR TITLE
[CodeInput]: fix example in docs page

### DIFF
--- a/Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/CodeInput.md
+++ b/Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/CodeInput.md
@@ -170,11 +170,9 @@ public class CodeInputWithValidation : ViewBase
                     .Language(Languages.Javascript)
                     .WithField()
                     .Label("Enter Code:")
-            | new Button("Execute Code")
-                .Disabled(!isValid)
             | Text.Small(isValid 
-                ? "Ready to execute!" 
-                : "Enter code to enable the button");
+                ? "Entered code is valid ✅" 
+                : "Enter some code to validate");
     }
 }
 ```


### PR DESCRIPTION
Deleted useless button and added correct description under the code input
<img width="723" height="391" alt="image" src="https://github.com/user-attachments/assets/931c495f-ca64-4dbd-a252-938f7f58639f" />
<img width="713" height="373" alt="image" src="https://github.com/user-attachments/assets/7a95cbe9-fe14-45a7-8565-fde4633e4ea4" />
