### PR TITLE
[NumberInput]: restrict NumberInput to numeric characters only

### DIFF
--- a/frontend/src/components/NumberInput.tsx
+++ b/frontend/src/components/NumberInput.tsx
@@ -287,7 +287,7 @@ const NumberInput = React.forwardRef<HTMLInputElement, NumberInputProps>(
               ref.current = node;
             }
           }}
-          type="text"
+          type="number"
           inputMode="decimal"
           value={displayValueToUse}
           onChange={handleChange}


### PR DESCRIPTION
## Description

Changed `NumberInput` input type from `text` to `number` to restrict input to numeric characters only.

## Changes

- `NumberInput.tsx`: `type="text"` → `type="number"`

## Effect

- Browser automatically blocks non-numeric character input
- Mobile devices display numeric keypad
- Improved component semantics and accessibility