### PR TITLE
[PieChart]: disable magicType in toolbox

### DIFF
--- a/frontend/src/widgets/charts/PieChartWidget.tsx
+++ b/frontend/src/widgets/charts/PieChartWidget.tsx
@@ -174,7 +174,7 @@ const PieChartWidget: React.FC<PieChartWidgetProps> = ({
       },
       series: series,
       toolbox: generateEChartToolbox(
-        toolbox ? { ...toolbox, magicType: false } : undefined
+        toolbox && { ...toolbox, magicType: false }
       ),
     }),
     [chartColors, legend, themeColors, tooltip, series, toolbox]


### PR DESCRIPTION
# Problem
The PieChart toolbox displayed "switch to line chart" and "switch to bar chart" buttons that didn't work when clicked.

# Cause
ECharts magicType feature only works for chart series with compatible data structures (cartesian coordinates with xAxis/yAxis). PieChart uses radial data without axes, so type conversion is not supported by the library.

# Solution
Disabled magicType in the toolbox for PieChart component.
<img width="361" height="313" alt="image" src="https://github.com/user-attachments/assets/25324fd3-2e56-4e37-944f-3f02eff9cbf0" />
