### PR TITLE
[Color-Input]: add automatic validation for invalid hex values

### DIFF
--- a/Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/Color.md
+++ b/Ivy.Docs.Shared/Docs/02_Widgets/02_Inputs/Color.md
@@ -145,15 +145,16 @@ public class DisabledColorInput : ViewBase
 
 ### Invalid
 
-To represent that there is something wrong with a `ColorInput` the `Invalid` function
-should be used.
+`ColorInput` automatically validates color values. If an invalid color format is entered,
+the input will display an error state.
 
 ```csharp demo-below
 public class InvalidStyleDemo : ViewBase
 { 
     public override object? Build()
     {    
-        return new ColorInput<string>("#ff0000").Invalid("This is not used now");
+        var colorState = UseState("#invalid-color");
+        return colorState.ToColorInput();
     }
 }
 

--- a/Ivy/Widgets/Inputs/ColorInput.cs
+++ b/Ivy/Widgets/Inputs/ColorInput.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Ivy.Core;
 using Ivy.Core.Helpers;
@@ -106,12 +107,38 @@ public record ColorInput : ColorInput<string>
 
 public static class ColorInputExtensions
 {
+    private static readonly Regex HexColorPattern = new(
+        @"^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6}|[0-9A-Fa-f]{8})$",
+        RegexOptions.Compiled);
+
+    private static string? ValidateColorFormat(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+
+        if (value.StartsWith("#"))
+            return HexColorPattern.IsMatch(value) ? null : "Invalid color format";
+
+        if (Enum.TryParse<Colors>(value, ignoreCase: true, out _))
+            return null;
+
+        return "Invalid color format";
+    }
+
     public static ColorInputBase ToColorInput(this IAnyState state, string? placeholder = null, bool disabled = false, ColorInputs variant = ColorInputs.TextAndPicker)
     {
         var type = state.GetStateType();
         Type genericType = typeof(ColorInput<>).MakeGenericType(type);
         ColorInputBase input = (ColorInputBase)Activator.CreateInstance(genericType, state, placeholder, disabled, variant)!;
         input.Nullable = type.IsNullableType();
+
+        var currentValue = state.As<object>().Value?.ToString();
+        var validationError = ValidateColorFormat(currentValue);
+        if (validationError != null)
+        {
+            input = input with { Invalid = validationError };
+        }
+
         return input;
     }
 


### PR DESCRIPTION
## Problem

The `ColorInput` component did not display an invalid state when users entered malformed hex color values (e.g., `#FF002!R3I2!3I3`). The component would silently accept any input without visual feedback, making it difficult for users to identify input errors.

## Solution

Added automatic client-side validation in `ColorInputWidget.tsx` that:

1. **Validates hex formats**: Accepts `#RGB`, `#RRGGBB`, and `#RRGGBBAA` patterns
2. **Validates named colors**: Accepts color names from the backend `Colors` enum (e.g., `green`, `blue`, `primary`, `destructive`) using the existing `enumColorsToCssVar` mapping
3. **Shows visual feedback**: Displays a red border and error icon with "Invalid color format" message for invalid values
<img width="414" height="122" alt="image" src="https://github.com/user-attachments/assets/cef52a63-99cb-4346-86b1-aa4ac2eebbf7" />
