### PR TITLE
[Docs]: fix misalignment in demo elements

### DIFF
--- a/Ivy.Docs.Tools/MarkdownConverter.cs
+++ b/Ivy.Docs.Tools/MarkdownConverter.cs
@@ -596,7 +596,7 @@ StringBuilder viewBuilder, HashSet<string> usedClassNames, bool isNestedContent 
 
         void AppendDemoContent(StringBuilder cb, int tabs, string insert)
         {
-            cb.AppendTab(tabs).AppendLine($"{(isNestedContent ? ", " : "| ")}new Box().Content({insert})");
+            cb.AppendTab(tabs).AppendLine($"{(isNestedContent ? ", " : "| ")}new Box().Padding(4).Content({insert})");
         }
 
         void AppendTabbedDemo(StringBuilder cb, string code, string insert, string lang)


### PR DESCRIPTION
Increase Box padding from 2 to 4 units (8px → 16px) in demo blocks to match Code block's 1em padding, fixing visual alignment issue.
<img width="687" height="555" alt="image" src="https://github.com/user-attachments/assets/f59cd1bb-00fd-48ef-8b6a-ca8b7910f46f" />
