### PR TITLE
[Icon]: update icon color from Muted to Neutral in CardExtensions

### DIFF
--- a/Ivy/Widgets/Card.cs
+++ b/Ivy/Widgets/Card.cs
@@ -73,7 +73,7 @@ public static class CardExtensions
     {
         if (icon is Icons iconsValue)
         {
-            icon = iconsValue.ToIcon().Color(Colors.Muted);
+            icon = iconsValue.ToIcon().Color(Colors.Neutral);
         }
         return card.Header(card.Title, card.Description, icon);
     }


### PR DESCRIPTION
## Description

Changed default icon color in card headers from `Muted` to `Neutral` for improved visibility.

## Changes

- `Card.cs` (line 76): `Colors.Muted` → `Colors.Neutral`

## Effect

Card icons set via `.Icon()` method now use `Neutral` color instead of `Muted`, providing better contrast and visibility.

### Before -->
<img width="1500" height="635" alt="image" src="https://github.com/user-attachments/assets/f3f9d9b2-9cf4-4536-b907-0374fc926fea" />

### After -->
<img width="1460" height="608" alt="image" src="https://github.com/user-attachments/assets/79bb32f1-57c3-4dc5-9a66-2d3d947c0dc2" />
