### PR TITLE
[Sheet]: remove focus outline on sheet container

### DIFF
--- a/frontend/src/components/ui/sheet.tsx
+++ b/frontend/src/components/ui/sheet.tsx
@@ -30,19 +30,22 @@ const SheetOverlay = React.forwardRef<
 ));
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
 
-const sheetVariants = cva('fixed z-50 gap-4 bg-background p-6 shadow-lg', {
-  variants: {
-    side: {
-      top: 'inset-x-0 top-0 border-b',
-      bottom: 'inset-x-0 bottom-0 border-t',
-      left: 'inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm',
-      right: 'inset-y-0 right-0 h-full w-3/4 border-l',
+const sheetVariants = cva(
+  'fixed z-50 gap-4 bg-background p-6 shadow-lg outline-none',
+  {
+    variants: {
+      side: {
+        top: 'inset-x-0 top-0 border-b',
+        bottom: 'inset-x-0 bottom-0 border-t',
+        left: 'inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm',
+        right: 'inset-y-0 right-0 h-full w-3/4 border-l',
+      },
     },
-  },
-  defaultVariants: {
-    side: 'right',
-  },
-});
+    defaultVariants: {
+      side: 'right',
+    },
+  }
+);
 
 interface SheetContentProps
   extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,


### PR DESCRIPTION
## Description
Fixes the unwanted black focus outline that appears on the Sheet container when it receives focus (e.g., when doing Shift+LMB on Sheet).

## Changes
Added outline-none to the base styles of sheetVariants in `sheet.tsx`

## Result
No focus outline on the Sheet container