### PR TITLE
[Auth]: allow user to logout even without user info

### DIFF
--- a/Ivy/Chrome/DefaultSidebarChrome.cs
+++ b/Ivy/Chrome/DefaultSidebarChrome.cs
@@ -394,24 +394,6 @@ public class DefaultSidebarChrome(ChromeSettings settings) : ViewBase
                 ..commonMenuItems, MenuItem.Default("Logout").Tag("$logout").Icon(Icons.LogOut).HandleSelect(onLogout)
             ], navigator));
         }
-        else if (isLoggedIn)
-        {
-            var trigger = new Button()
-                .Content(
-                    Layout.Horizontal().Align(Align.Left)
-                        | Icons.User.ToIcon()
-                        | Text.Muted("User")
-                    )
-                    .Variant(ButtonVariant.Ghost).Width(Size.Full());
-
-            footer = new DropDownMenu(
-                    DropDownMenu.DefaultSelectHandler(),
-                    trigger)
-                .Top()
-                .Items(settings.FooterMenuItemsTransformer([
-                    ..commonMenuItems, MenuItem.Default("Logout").Tag("$logout").Icon(Icons.LogOut).HandleSelect(onLogout)
-                ], navigator));
-        }
         else
         {
             var trigger = new Button("Settings")
@@ -422,12 +404,16 @@ public class DefaultSidebarChrome(ChromeSettings settings) : ViewBase
                     )
                     .Variant(ButtonVariant.Ghost).Width(Size.Full());
 
+            var footerMenuItems = isLoggedIn
+                ? [.. commonMenuItems, MenuItem.Default("Logout").Tag("$logout").Icon(Icons.LogOut).HandleSelect(onLogout)]
+                : commonMenuItems;
+
             footer = new DropDownMenu(
                     DropDownMenu.DefaultSelectHandler(),
                     trigger)
                 .Top()
                 .Items(
-                    settings.FooterMenuItemsTransformer(commonMenuItems, navigator)
+                    settings.FooterMenuItemsTransformer(footerMenuItems, navigator)
                 );
         }
 


### PR DESCRIPTION
## Problem

The `DefaultSidebarChrome` component conditionally displays the user footer based on the result of `GetUserInfoAsync()`. When user info is available, a full footer with avatar, name, and a **Logout** button is shown. However, when `GetUserInfoAsync()` returns `null` (due to an expired token, network issues, or provider errors), the code falls back to showing a generic "Settings" menu **without** the Logout option.

This creates a deadlock situation: the user is authenticated (has a valid session), but cannot log out because the UI doesn't provide that option. The user is effectively stuck and has no way to sign out through the application interface.

## Solution

Instead of creating a separate footer variant for the "logged in but no user info" scenario, I chose a simpler approach: add the **Logout** menu item directly to the existing Settings footer when the user has an active auth session.

The fix:
1. Check `auth.GetAuthSession()` to determine if the user is authenticated
2. In the Settings footer (the `else` branch), conditionally include the Logout menu item based on `isLoggedIn`

This approach keeps the code minimal and avoids UI duplication, while ensuring users can always log out regardless of whether their profile information could be fetched.

How it looks:
<img width="471" height="578" alt="image" src="https://github.com/user-attachments/assets/21a66b1f-2b6b-469f-a265-f5573e72c179" />
