### PR TITLE
(fix): Removed cropping from code snippets and edited copy button

### DIFF
--- a/frontend/src/components/CopyToClipboardButton.tsx
+++ b/frontend/src/components/CopyToClipboardButton.tsx
@@ -18,13 +18,13 @@ const copyIconVariants = cva('', {
 });
 
 const copyButtonSizeVariants = cva(
-  'p-1 rounded hover:bg-accent focus:outline-none cursor-pointer flex items-center',
+  'p-2 rounded hover:bg-accent focus:outline-none cursor-pointer flex items-center',
   {
     variants: {
       scale: {
-        Small: 'h-5',
-        Medium: 'h-6',
-        Large: 'h-7',
+        Small: 'h-6',
+        Medium: 'h-8',
+        Large: 'h-9',
       },
     },
     defaultVariants: {


### PR DESCRIPTION
Closes #1859 

Code shown in code snippets in Ivy.Docs is no longer cutoff by the padding the copy button had before.

https://github.com/user-attachments/assets/5f389bf7-40e0-49d6-9e2d-b11ececdea05
