### PR TITLE
(codex): rename `NavigationPurpose` to `HistoryOp`

### DIFF
--- a/Ivy/AppHub.cs
+++ b/Ivy/AppHub.cs
@@ -542,7 +542,7 @@ public class AppHub(
                 _ => new NavigateSignal()
             );
 
-            await navigateSignal.Send(new NavigateArgs(appId, TabId: state?.TabId, Purpose: NavigationPurpose.HistoryTraversal));
+            await navigateSignal.Send(new NavigateArgs(appId, TabId: state?.TabId, HistoryOp: HistoryOp.Pop));
 
             logger.LogInformation("Navigate signal sent: {ConnectionId} to [{AppId}]", Context.ConnectionId, appId);
         }

--- a/Ivy/Chrome/DefaultSidebarChrome.cs
+++ b/Ivy/Chrome/DefaultSidebarChrome.cs
@@ -89,7 +89,7 @@ public class DefaultSidebarChrome(ChromeSettings settings) : ViewBase
 
                 currentApp.Set(appHost);
                 // Update browser URL for page navigation
-                if (navigateArgs.Purpose is NavigationPurpose.NewDestination && previousApp != navigateArgs.AppId)
+                if (navigateArgs.HistoryOp is HistoryOp.Push && previousApp != navigateArgs.AppId)
                 {
                     client.Redirect(navigateArgs.GetUrl(), replaceHistory);
                 }
@@ -106,14 +106,14 @@ public class DefaultSidebarChrome(ChromeSettings settings) : ViewBase
 
                         // Update browser URL when switching to existing tab
                         var tab = tabs.Value[tabIndex];
-                        if (navigateArgs.Purpose is NavigationPurpose.NewDestination)
+                        if (navigateArgs.HistoryOp is HistoryOp.Push)
                         {
                             client.Redirect(navigateArgs.GetUrl(), replaceHistory, tabId: tab.Id);
                         }
                         return;
                     }
 
-                    if (navigateArgs.Purpose is NavigationPurpose.HistoryTraversal)
+                    if (navigateArgs.HistoryOp is HistoryOp.Pop)
                     {
                         client.Error(new InvalidOperationException("Tab no longer exists."));
                         return;
@@ -148,7 +148,7 @@ public class DefaultSidebarChrome(ChromeSettings settings) : ViewBase
                         selectedIndex.Set(existingTabIndex);
                         tabId = tabs.Value[existingTabIndex].Id;
                         // Update browser URL when switching to existing tab
-                        if (navigateArgs.Purpose is NavigationPurpose.NewDestination && previousSelectedIndex != existingTabIndex)
+                        if (navigateArgs.HistoryOp is HistoryOp.Push && previousSelectedIndex != existingTabIndex)
                         {
                             client.Redirect(navigateArgs.GetUrl(), replaceHistory, tabId: tabId);
                         }
@@ -156,7 +156,7 @@ public class DefaultSidebarChrome(ChromeSettings settings) : ViewBase
                     }
                 }
 
-                if (navigateArgs.Purpose is NavigationPurpose.NewDestination)
+                if (navigateArgs.HistoryOp is HistoryOp.Push)
                 {
                     var app = appRepository!.GetAppOrDefault(navigateArgs.AppId);
                     var newTabs = tabs.Value.Add(new TabState(tabId, app.Id, app.Title, appHost, app.Icon, Guid.NewGuid().ToString()));

--- a/Ivy/Chrome/Shared.cs
+++ b/Ivy/Chrome/Shared.cs
@@ -61,13 +61,13 @@ public static class ChromeSettingsExtensions
 [Signal(BroadcastType.Chrome)]
 public class NavigateSignal : AbstractSignal<NavigateArgs, Unit> { }
 
-public enum NavigationPurpose
+public enum HistoryOp
 {
-    NewDestination,
-    HistoryTraversal,
+    Push,
+    Pop,
 }
 
-public record NavigateArgs(string? AppId, object? AppArgs = null, string? TabId = null, NavigationPurpose Purpose = NavigationPurpose.NewDestination, bool Chrome = true)
+public record NavigateArgs(string? AppId, object? AppArgs = null, string? TabId = null, HistoryOp HistoryOp = HistoryOp.Push, bool Chrome = true)
 {
     public AppHost ToAppHost(string? parentId = null)
     {


### PR DESCRIPTION
Fixes #1511

Old:
```csharp
public enum NavigationPurpose
{
    NewDestination,
    HistoryTraversal,
}
```

New:
```csharp
public enum HistoryOp
{
    Push,
    Pop,
}
```

The semantics are unchanged, but the naming is hopefully clearer now.