### PR TITLE
[Docs]: add Layout page

### DIFF
--- a/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/Layout.md
+++ b/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/Layout.md
@@ -14,10 +14,10 @@ searchHints:
 # Layout
 
 <Ingress>
-The Layout static class provides a fluent API for creating common layout compositions with minimal code, serving as the primary entry point for building [UI structures](../../../01_Onboarding/02_Concepts/Views.md) in Ivy.
+The Layout static class provides a fluent API for creating common layout compositions with minimal code, serving as the primary entry point for building [UI structures](./Views.md) in Ivy.
 </Ingress>
 
-The Layout class offers convenient factory methods that return pre-configured layout [views](../../../01_Onboarding/02_Concepts/Views.md). Instead of manually instantiating layout widgets, you can use Layout.Vertical(), Layout.Horizontal(), and other methods to quickly compose your UI with a clean, fluent syntax.
+The Layout class offers convenient factory methods that return pre-configured layout views. Instead of manually instantiating layout widgets, you can use Layout.Vertical(), Layout.Horizontal(), and other methods to quickly compose your UI with a clean, fluent syntax.
 
 ## Basic Usage
 
@@ -43,7 +43,7 @@ Layout.Horizontal()
 
 ## Pipe Operator Syntax
 
-The Layout class supports the pipe operator (|) for adding children, enabling a clean and readable composition syntax:
+The Layout class supports the pipe operator `|` for adding children, enabling a clean and readable composition syntax:
 
 ```csharp demo-tabs
 Layout.Vertical().Gap(4)
@@ -51,7 +51,7 @@ Layout.Vertical().Gap(4)
     | (Layout.Horizontal().Gap(2)
         | new Badge("Active").Primary()
         | new Badge("Premium").Secondary())
-    | Text.Small("Welcome to your dashboard")
+    | Text.Small("Choose your plan")
 ```
 
 ## Configuration Methods
@@ -67,7 +67,7 @@ Layout.Vertical()
     | Text.Label("No Gap:")
     | (Layout.Horizontal().Gap(0)
         | new Badge("A") | new Badge("B") | new Badge("C"))
-    | Text.Label("Large Gap (8):")
+    | Text.Label("With Gap:")
     | (Layout.Horizontal().Gap(8)
         | new Badge("A") | new Badge("B") | new Badge("C"))
 ```
@@ -130,6 +130,7 @@ The LayoutExtensions class provides additional helper methods:
 |-----------|-------------|
 | .WithMargin(int) | Wraps any object in a layout with margin |
 | .WithMargin(int, int) | Wraps with horizontal and vertical margin |
+| .WithMargin(int, int, int, int) | Wraps with left, top, right, bottom margin |
 | .WithLayout() | Wraps any object in a vertical layout |
 
 ## Available Methods
@@ -150,14 +151,13 @@ The Layout class provides the following factory methods:
 
 | Layout | Description |
 |--------|-------------|
-| [StackLayout](./StackLayout.md) | Arranges elements vertically or horizontally in a linear sequence |
-| [GridLayout](./GridLayout.md) | Two-dimensional grid system with precise control over positioning and spanning |
-| [WrapLayout](./WrapLayout.md) | Automatically wraps items to new lines when space is limited |
-| [TabsLayout](./TabsLayout.md) | Organizes content into tabbed sections for easy navigation |
-| [SidebarLayout](./SidebarLayout.md) | Main content area with a collapsible sidebar for navigation |
-| [HeaderLayout](./HeaderLayout.md) | Page layout with a fixed header section |
-| [FooterLayout](./FooterLayout.md) | Page layout with a fixed footer section |
-| [FloatingPanel](./FloatingPanel.md) | Overlay panels that float above the main content |
-| [ResizeablePanelGroup](./ResizeablePanelGroup.md) | Split panels that users can resize by dragging |
+| [StackLayout](../../02_Widgets/04_Layouts/StackLayout.md) | Arranges elements vertically or horizontally in a linear sequence |
+| [GridLayout](../../02_Widgets/04_Layouts/GridLayout.md) | Two-dimensional grid system with precise control over positioning and spanning |
+| [WrapLayout](../../02_Widgets/04_Layouts/WrapLayout.md) | Automatically wraps items to new lines when space is limited |
+| [TabsLayout](../../02_Widgets/04_Layouts/TabsLayout.md) | Organizes content into tabbed sections for easy navigation |
+| [SidebarLayout](../../02_Widgets/04_Layouts/SidebarLayout.md) | Main content area with a collapsible sidebar for navigation |
+| [HeaderLayout](../../02_Widgets/04_Layouts/HeaderLayout.md) | Page layout with a fixed header section |
+| [FooterLayout](../../02_Widgets/04_Layouts/FooterLayout.md) | Page layout with a fixed footer section |
+| [FloatingPanel](../../02_Widgets/04_Layouts/FloatingPanel.md) | Overlay panels that float above the main content |
+| [ResizeablePanelGroup](../../02_Widgets/04_Layouts/ResizeablePanelGroup.md) | Split panels that users can resize by dragging |
 
-<WidgetDocs Type="Ivy.StackLayout" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Views/Layout.cs"/>


### PR DESCRIPTION
<img width="1107" height="563" alt="image" src="https://github.com/user-attachments/assets/9a6f6c28-8d6c-43d5-a737-ff24f6d04ada" />
<img width="1101" height="587" alt="image" src="https://github.com/user-attachments/assets/31a6ce42-cc0c-4c1b-b496-7ea7887c83c1" />
<img width="1014" height="569" alt="image" src="https://github.com/user-attachments/assets/74db2481-f4d6-4d73-972f-0abf0220339a" />
<img width="1142" height="552" alt="image" src="https://github.com/user-attachments/assets/2b66f3e6-4a28-4181-934d-c3f8b3b9a48c" />
<img width="1087" height="588" alt="image" src="https://github.com/user-attachments/assets/6461ad54-ba24-48b7-bd8e-fc257c740934" />
<img width="1145" height="573" alt="image" src="https://github.com/user-attachments/assets/0a25691c-34d3-45ca-8fd3-000de9ed8134" />
<img width="1072" height="578" alt="image" src="https://github.com/user-attachments/assets/ab03cc57-6f48-4645-a6d8-13d3f64025f0" />
<img width="1050" height="563" alt="image" src="https://github.com/user-attachments/assets/3c4f9b71-1a12-4497-8da6-385ade35a63a" />
<img width="1080" height="544" alt="image" src="https://github.com/user-attachments/assets/12036d27-006e-4a90-aeff-fad2314171bc" />
<img width="1172" height="546" alt="image" src="https://github.com/user-attachments/assets/d8bc1ff4-f89d-4bec-895a-0515dca00eb1" />

## Why no API section?

The `Layout` class is a **static factory class** with no instantiable properties or configurable state — it only provides factory methods (`Vertical()`, `Horizontal()`, `Center()`, etc.) that return `LayoutView` instances. Since the `<WidgetDocs>` component is designed to document widget properties, constructors, and setters, it doesn't provide meaningful documentation for a static class. Adding a `WidgetDocs` tag for `LayoutView` would be misleading, as the page documents the `Layout` entry point, not the `LayoutView` implementation details. The comprehensive method tables in the "Available Methods" and "Extension Methods" sections serve as the API reference for this page.

## Location

Placed in `01_Onboarding/02_Concepts/` rather than `02_Widgets/04_Layouts/` because `Layout` is a **concept/pattern** for building UIs, not a specific widget. This aligns with other conceptual pages like `Views.md` and `Widgets.md`.
