### PR TITLE
[VideoPlayer]: add example of large video file in docs page

### DIFF
--- a/Ivy.Docs.Shared/Docs/02_Widgets/03_Primitives/VideoPlayer.md
+++ b/Ivy.Docs.Shared/Docs/02_Widgets/03_Primitives/VideoPlayer.md
@@ -76,6 +76,15 @@ new VideoPlayer("https://www.w3schools.com/html/mov_bbb.mp4")
     .Poster("https://www.w3schools.com/html/pic_trulli.jpg")
 ```
 
+### Large Video Files
+
+The VideoPlayer also supports streaming of large video files.
+
+```csharp demo-tabs
+new VideoPlayer("https://archive.org/download/BigBuckBunny_124/Content/big_buck_bunny_720p_surround.mp4")
+    .Height(Size.Units(100))
+```
+
 ### YouTube Video Embed
 
 Embed a YouTube video directly by providing its URL:


### PR DESCRIPTION
I noticed that video player alredy support video files >10MB, so I added an example in documentation
<img width="717" height="541" alt="image" src="https://github.com/user-attachments/assets/bb243353-2828-4d88-a329-0d4ee88bbff6" />
