### PR TITLE
(docs tocs):  display proper names for GitHub contributors

### DIFF
--- a/frontend/src/widgets/article/GitHubContributors.tsx
+++ b/frontend/src/widgets/article/GitHubContributors.tsx
@@ -32,14 +32,14 @@ interface GitHubContributorsProps {
   show?: boolean;
 }
 
-// Ivy team members with their roles
-const IVY_TEAM_MEMBERS: Record<string, string> = {
-  ArtemKhvorostianyi: 'Engineer',
-  rorychatt: 'Founding Engineer',
-  nielsbosma: 'Founder',
-  zachwolfe: 'Software Developer',
-  // Add more team members as needed
-};
+// Ivy team members with their roles and display names
+const IVY_TEAM_MEMBERS: Record<string, { role: string; displayName?: string }> =
+  {
+    ArtemKhvorostianyi: { role: 'Engineer' },
+    rorychatt: { role: 'Founding Engineer' },
+    nielsbosma: { role: 'Founder', displayName: 'Niels Bosma' },
+    zachwolfe: { role: 'Software Developer' },
+  };
 
 // Helper function to generate correct commits URL for main branch
 const getCommitsUrl = (githubUrl: string): string => {
@@ -126,36 +126,41 @@ export const GitHubContributors: React.FC<GitHubContributorsProps> = ({
         return response.json();
       })
       .then((commits: GitHubCommit[]) => {
-        // Extract unique contributors from commits
         const contributorMap = new Map<string, Contributor>();
 
         commits.forEach(commit => {
           if (commit.author) {
             const login = commit.author.login;
-            if (contributorMap.has(login)) {
-              contributorMap.get(login)!.contributions += 1;
+            const existing = contributorMap.get(login);
+            if (existing) {
+              existing.contributions += 1;
             } else {
-              const isIvyMember = login in IVY_TEAM_MEMBERS;
+              const teamMember = IVY_TEAM_MEMBERS[login];
               contributorMap.set(login, {
-                login: commit.author.login,
-                name: commit.commit.author.name,
+                login,
+                name:
+                  teamMember?.displayName ||
+                  (commit.commit.author.name !== login
+                    ? commit.commit.author.name
+                    : undefined),
                 avatar_url: commit.author.avatar_url,
                 html_url: commit.author.html_url,
                 contributions: 1,
-                role: isIvyMember
-                  ? IVY_TEAM_MEMBERS[login]
-                  : 'Open Source Contributor',
-                isIvyMember,
+                role:
+                  login in IVY_TEAM_MEMBERS
+                    ? IVY_TEAM_MEMBERS[login].role
+                    : 'Open Source Contributor',
+                isIvyMember: login in IVY_TEAM_MEMBERS,
               });
             }
           }
         });
 
-        const sortedContributors = Array.from(contributorMap.values()).sort(
-          (a, b) => b.contributions - a.contributions
+        setContributors(
+          Array.from(contributorMap.values()).sort(
+            (a, b) => b.contributions - a.contributions
+          )
         );
-
-        setContributors(sortedContributors);
       })
       .catch(err => {
         console.error('Failed to fetch contributors:', err);


### PR DESCRIPTION
The issue:

- The code used commit.commit.author.name from the commit data
- That field can be the login if the user's git config isn't set to a full name
- So "nielsbosma" appeared instead of "Niels Bosma"

The fix:

- Added a displayName mapping in IVY_TEAM_MEMBERS for known team members
- For nielsbosma, it now shows "Niels Bosma" from the mapping
- For others, it falls back to the commit author name if it differs from the login, otherwise shows the login

<img width="261" height="180" alt="image" src="https://github.com/user-attachments/assets/49a5ae67-762c-4eb0-8a03-5f0ad89a3997" />
<img width="239" height="188" alt="image" src="https://github.com/user-attachments/assets/e7dbb5f2-17b3-4989-9b44-48b34c97db6f" />
<img width="297" height="236" alt="image" src="https://github.com/user-attachments/assets/7b90a2e8-e4cb-4ae3-a4f0-722f6b1c3391" />
