### PR TITLE
[Calendar]: make date clickable and fix view

### DIFF
--- a/frontend/src/components/ui/calendar/calendar.tsx
+++ b/frontend/src/components/ui/calendar/calendar.tsx
@@ -126,7 +126,7 @@ export function Calendar({
           'text-muted-foreground opacity-50',
           defaultClassNames.disabled
         ),
-        hidden: cn('invisible', defaultClassNames.hidden),
+        hidden: cn('hidden', defaultClassNames.hidden),
         ...classNames,
       }}
       components={{

--- a/frontend/src/components/ui/popover.tsx
+++ b/frontend/src/components/ui/popover.tsx
@@ -22,6 +22,7 @@ const PopoverContent = React.forwardRef<
         'z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
         className
       )}
+      data-slot="popover-content"
       {...props}
     />
   </PopoverPrimitive.Portal>

--- a/frontend/src/widgets/inputs/DateRangeInputWidget.tsx
+++ b/frontend/src/widgets/inputs/DateRangeInputWidget.tsx
@@ -334,6 +334,9 @@ export const DateRangeInputWidget: React.FC<DateRangeInputWidgetProps> = ({
                   className="p-2 bg-background"
                   disabled={[{ after: today }]}
                   scale={scale}
+                  captionLayout="dropdown"
+                  fromYear={1900}
+                  toYear={2100}
                 />
               </div>
             </div>

--- a/frontend/src/widgets/inputs/DateTimeInputWidget/DateTimeVariant.tsx
+++ b/frontend/src/widgets/inputs/DateTimeInputWidget/DateTimeVariant.tsx
@@ -200,6 +200,9 @@ export const DateTimeVariant: React.FC<DateTimeVariantProps> = ({
               onSelect={handleDateSelect}
               initialFocus
               scale={scale}
+              captionLayout="dropdown"
+              fromYear={1900}
+              toYear={2100}
             />
             <div className="flex items-center gap-2">
               <Clock

--- a/frontend/src/widgets/inputs/DateTimeInputWidget/DateVariant.tsx
+++ b/frontend/src/widgets/inputs/DateTimeInputWidget/DateVariant.tsx
@@ -95,6 +95,9 @@ export const DateVariant: React.FC<DateVariantProps> = ({
             onSelect={handleSelect}
             initialFocus
             scale={scale}
+            captionLayout="dropdown"
+            fromYear={1900}
+            toYear={2100}
           />
         </PopoverContent>
       </Popover>


### PR DESCRIPTION
## Summary
This PR addresses two key issues with the `Calendar` and `DateTimeInput` components: difficult navigation to distant dates and a visual regression where the popover borders appeared "eaten" or clipped.

## Changes

### 1. Visual Bug Fix: "Eaten" Corners
**The Issue:** The `Calendar` component had an opaque background that was rendering over the rounded corners of the parent `Popover` container, creating a square visual artifact that clipped the expected rounded borders.

**The Fix:**
- Added `data-slot="popover-content"` to the `PopoverContent` component in `popover.tsx`.
- This allows the `Calendar` component to detect when it's rendered inside a popover and apply `bg-transparent`. This ensures the `Calendar` respects the container's rounded corners and borders.
- Additionally, changed a class from `invisible` to `hidden` in `calendar.tsx` to prevent hidden elements from occupying layout space.

### 2. Month/Year Navigation
**The Issue:** Users could not easily navigate to dates far in the past or future (e.g., January 2000) because the month text was static.

**The Fix:**
- Updated `DateVariant`, `DateTimeVariant`, and `DateRangeInputWidget`.
- Enabled `captionLayout="dropdown"` on the underlying `DayPicker` component.
- Configured the year dropdown range from **1900 to 2100**.
- This enables interactive dropdowns for both Month and Year in the calendar header.

## Screenshots
<img width="351" height="403" alt="image" src="https://github.com/user-attachments/assets/aec157a5-1bd8-4914-a489-c447acc9e50a" />
<img width="396" height="465" alt="image" src="https://github.com/user-attachments/assets/1862950a-85c3-4ecb-a47e-a874822bd1d1" />
<img width="384" height="577" alt="image" src="https://github.com/user-attachments/assets/14a130a9-6108-4eae-8235-591737ba18b0" />
<img width="335" height="429" alt="image" src="https://github.com/user-attachments/assets/142bb320-7af9-4dd3-bd95-4ce917f12a37" />
<img width="827" height="392" alt="image" src="https://github.com/user-attachments/assets/930f4174-a45e-4112-b78f-81aaa813564f" />

