### PR TITLE
(details):  handle gaps for multiline fields

### DIFF
--- a/frontend/src/components/ui/detail/detail-variants.ts
+++ b/frontend/src/components/ui/detail/detail-variants.ts
@@ -35,9 +35,9 @@ export const detailValueSizeVariants = cva('align-middle min-w-0', {
 export const detailValueMultiLinePaddingVariants = cva('', {
   variants: {
     scale: {
-      Small: 'pb-2',
-      Medium: 'pb-3',
-      Large: 'pb-4',
+      Small: 'pb-2 pt-0',
+      Medium: 'pb-3 pt-1',
+      Large: 'pb-4 pt-2',
     },
   },
   defaultVariants: {


### PR DESCRIPTION
### Had a problem:
<img width="311" height="422" alt="image" src="https://github.com/user-attachments/assets/f5a37f5b-1246-43ea-8fbc-f8fdc66b12b5" />

### Fixed by overriding padding scaling for the multiline variant in Details.
<img width="2289" height="612" alt="Screenshot 2026-01-08 at 11 48 07" src="https://github.com/user-attachments/assets/07c52d53-516e-464d-af97-085878b6cc9b" />
<img width="741" height="343" alt="Screenshot 2026-01-08 at 11 48 15" src="https://github.com/user-attachments/assets/6dfc388a-78e5-46c8-a8c2-b602811351db" />
<img width="738" height="343" alt="Screenshot 2026-01-08 at 11 48 19" src="https://github.com/user-attachments/assets/6d6abaa7-8e3c-44de-912b-91c915220a63" />
<img width="740" height="344" alt="Screenshot 2026-01-08 at 11 48 23" src="https://github.com/user-attachments/assets/b7826eba-f9c1-42ab-b1d4-6ef68cfcd28f" />
