### PR TITLE
[Skeleton]: Create public parameterless constructor

### DIFF
--- a/Ivy/Widgets/Primitives/Skeleton.cs
+++ b/Ivy/Widgets/Primitives/Skeleton.cs
@@ -6,7 +6,7 @@ namespace Ivy;
 
 public record Skeleton : WidgetBase<Skeleton>
 {
-    internal Skeleton()
+    public Skeleton()
     {
         Width = Size.Full();
         Height = Size.Full();


### PR DESCRIPTION
### Issue
The `Skeleton` widget is declared as `public`, but its parameterless constructor is marked as `internal`. When `Skeleton` is used from a different assembly, attempting to create an instance with `new Skeleton()` results in compiler error CS1729 because there is no accessible constructor. This makes `Skeleton` impossible to instantiate from consuming projects.

### Solution
Changed the constructor access modifier to `public` to match the class visibility.

### Related
- Fixes compiler error CS1729 when using `Skeleton` from external assemblies