### PR TITLE
[Empty]: Create public parameterless constructor

### DIFF
--- a/Ivy/Widgets/Primitives/Empty.cs
+++ b/Ivy/Widgets/Primitives/Empty.cs
@@ -5,5 +5,5 @@ namespace Ivy;
 
 public record Empty : WidgetBase<Empty>
 {
-    internal Empty() { }
+    public Empty() { }
 }


### PR DESCRIPTION
### Issue
The `Empty` widget is declared as `public`, but its parameterless constructor was marked as `internal`. When `Empty` is used from a different assembly, attempting to create an instance with `new Empty()` results in compiler error CS1729 because there is no accessible constructor. This makes `Empty` impossible to instantiate from consuming projects.

### Solution
Changed the constructor access modifier from `internal` to `public` to match the class visibility.

### Related
- Fixes compiler error CS1729 when using `Empty` from external assemblies