### PR TITLE
[CopyToClipboard]: add forceDarkMode prop for terminal theme awareness

### DIFF
--- a/frontend/src/components/CopyToClipboardButton.tsx
+++ b/frontend/src/components/CopyToClipboardButton.tsx
@@ -39,6 +39,7 @@ interface CopyToClipboardButtonProps {
   'aria-label'?: string;
   scale?: Scales;
   className?: string;
+  forceDarkMode?: boolean;
 }
 
 const CopyToClipboardButton: React.FC<CopyToClipboardButtonProps> = ({
@@ -47,6 +48,7 @@ const CopyToClipboardButton: React.FC<CopyToClipboardButtonProps> = ({
   'aria-label': ariaLabel,
   scale = Scales.Medium,
   className,
+  forceDarkMode = false,
 }) => {
   const [copied, setCopied] = useState(false);
 
@@ -62,6 +64,12 @@ const CopyToClipboardButton: React.FC<CopyToClipboardButtonProps> = ({
 
   const isIconOnly = !label;
 
+  const darkModeStyles = forceDarkMode
+    ? copied
+      ? 'bg-emerald-600 text-white hover:bg-emerald-500'
+      : 'bg-zinc-800 text-zinc-100 hover:bg-zinc-700'
+    : '';
+
   return (
     <button
       onClick={handleCopy}
@@ -70,17 +78,23 @@ const CopyToClipboardButton: React.FC<CopyToClipboardButtonProps> = ({
         isIconOnly
           ? cn(
               copyButtonSizeVariants({ scale }),
-              copied && 'bg-primary text-primary-foreground'
+              !forceDarkMode && copied && 'bg-primary text-primary-foreground'
             )
           : 'flex items-center gap-1 px-3 py-2 rounded-lg transition-all duration-200 ease-in-out cursor-pointer hover:bg-accent hover:shadow-sm border-0',
-        !isIconOnly &&
+        !forceDarkMode &&
+          !isIconOnly &&
           (copied
             ? 'bg-primary text-primary-foreground'
             : 'bg-transparent text-muted-foreground hover:text-foreground'),
-        isIconOnly && !copied && 'bg-background hover:bg-accent',
-        copied &&
+        !forceDarkMode &&
+          isIconOnly &&
+          !copied &&
+          'bg-background hover:bg-accent',
+        !forceDarkMode &&
+          copied &&
           isIconOnly &&
           'hover:bg-primary hover:text-primary-foreground focus-visible:ring-primary',
+        darkModeStyles,
         className
       )}
     >

--- a/frontend/src/widgets/internal/TerminalWidget.tsx
+++ b/frontend/src/widgets/internal/TerminalWidget.tsx
@@ -53,7 +53,7 @@ const TerminalWidget = ({
           <div className="absolute top-2 right-2 z-50">
             <CopyToClipboardButton
               textToCopy={commandsText}
-              className="bg-zinc-800 text-white hover:bg-zinc-700"
+              forceDarkMode={true}
             />
           </div>
         )}


### PR DESCRIPTION
## Problem

The "Copy to Clipboard" button in `TerminalWidget` was not displaying correctly when the application theme changed. The terminal component has a fixed dark background (`bg-zinc-900`), but the `CopyToClipboardButton` component uses theme-aware CSS variables like `bg-background` and `hover:bg-accent`.

When using a light theme:
- The button background became light (white/gray)
- The copy icon became invisible against the dark terminal background
- The button looked broken and out of place

## Solution

Added a `forceDarkMode` prop to `CopyToClipboardButton` component that disables theme adaptation and uses hardcoded dark colors instead.

### Changes

**`CopyToClipboardButton.tsx`**
- Added `forceDarkMode?: boolean` prop to the component interface
- When enabled, applies fixed dark color scheme:
  - Default: `bg-zinc-800 text-zinc-100 hover:bg-zinc-700`
  - Copied state: `bg-emerald-600 text-white hover:bg-emerald-500`

**`TerminalWidget.tsx`**
- Updated to use `forceDarkMode={true}` instead of inline className overrides

## Testing

- ✅ Button displays correctly on dark terminal background
- ✅ Works properly in both light and dark application themes
- ✅ Copy functionality works as expected
- ✅ Visual feedback on copy (icon change) works correctly

## Screenshots
<img width="776" height="457" alt="image" src="https://github.com/user-attachments/assets/9de4b9e0-bded-489f-bcb8-42788bafd826" />
<img width="738" height="440" alt="image" src="https://github.com/user-attachments/assets/920bc779-28ba-4223-9c90-734e120aa7bf" />

