### PR TITLE
[OAuth]: Fix redirect to use same tab instead of new tab

### DIFF
--- a/Ivy/Auth/DefaultAuthApp.cs
+++ b/Ivy/Auth/DefaultAuthApp.cs
@@ -143,6 +143,7 @@ public class OAuthFlowView(AuthOption option) : ViewBase
     {
         var args = this.UseService<AppArgs>();
         var auth = this.UseService<IAuthService>();
+        var client = this.UseService<IClientProvider>();
 
         var callback = this.UseWebhook(async (request) =>
         {
@@ -152,10 +153,19 @@ public class OAuthFlowView(AuthOption option) : ViewBase
 
         // Redirect to our OAuth login endpoint, which will in turn redirect to the provider's OAuth URL.
         // This is done to evade Safari's pop-up blocking feature.
+        // Use client.Redirect() instead of navigator.Navigate() to open in the same tab.
+        // navigator.Navigate() for HTTP URLs calls client.OpenUrl() which opens in a new tab.
         var oauthUriBuilder = new UriBuilder($"{args.Scheme}://{args.Host}/ivy/auth/oauth-login")
         {
             Query = $"optionId={Uri.EscapeDataString(option.Id ?? "")}&callbackId={Uri.EscapeDataString(callback.Id)}&connectionId={Uri.EscapeDataString(args.ConnectionId)}"
         };
-        return new Button(option.Name).Secondary().Icon(option.Icon).Width(Size.Full()).Url(oauthUriBuilder.ToString());
+        // Extract relative path (path + query) for Redirect - it only accepts relative paths
+        // Uri.PathAndQuery already includes the query string with proper formatting
+        var oauthPath = oauthUriBuilder.Uri.PathAndQuery;
+        return new Button(option.Name)
+            .Secondary()
+            .Icon(option.Icon)
+            .Width(Size.Full())
+            .HandleClick(() => client.Redirect(oauthPath));
     }
 }


### PR DESCRIPTION
## Changes
- Changed OAuth authentication flow to open in the same window instead of a new tab
- Replaced `client.OpenUrl()` with `client.Redirect()` for OAuth URL navigation
- Extract relative path from OAuth URL for redirect validation

## Problem
Previously, clicking OAuth login buttons opened the authentication flow in a new tab/window, which could be blocked by pop-up blockers and provides a less seamless user experience.

## Solution
- Use `client.Redirect()` instead of `client.OpenUrl()` to navigate in the same window
- Extract relative path (`PathAndQuery`) from the OAuth URL to comply with redirect validation (which only accepts relative paths or same-origin URLs)