### PR TITLE
(forms): avoid infinite recursion in validation

### DIFF
--- a/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/13_Forms.md
+++ b/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/13_Forms.md
@@ -499,13 +499,10 @@ public class CollectionValidationExample : ViewBase
     public class SurveyModel
     {
         [Display(Name = "Interests", Description = "Select at least one interest")]
-        [Required(ErrorMessage = "Please select at least one interest")]
-        [MinLength(1, ErrorMessage = "You must select at least one interest")]
         [AllowedValues("Technology", "Sports", "Music", "Art", "Travel")]
         public string[] Interests { get; set; } = Array.Empty<string>();
         
         [Display(Name = "Tags")]
-        [Length(1, 5, ErrorMessage = "Select between 1 and 5 tags")]
         public List<string> Tags { get; set; } = new();
     }
 
@@ -517,7 +514,12 @@ public class CollectionValidationExample : ViewBase
         
         return survey.ToForm()
             .Builder(m => m.Interests, s => s.ToSelectInput(interestOptions).List())
-            .Builder(m => m.Tags, s => s.ToSelectInput(tagOptions).List());
+            .Builder(m => m.Tags, s => s.ToSelectInput(tagOptions).List())
+            // Validate collection counts using programmatic validation
+            .Validate<string[]>(m => m.Interests, interests =>
+                (interests.Length >= 1, "You must select at least one interest"))
+            .Validate<List<string>>(m => m.Tags, tags =>
+                (tags.Count >= 1 && tags.Count <= 5, "Select between 1 and 5 tags"));
     }
 }
 ```

--- a/Ivy/Views/Forms/FormHelpers.cs
+++ b/Ivy/Views/Forms/FormHelpers.cs
@@ -1,6 +1,8 @@
 using System.Collections;
 using System.ComponentModel.DataAnnotations;
+using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Ivy.Services;
 
 namespace Ivy.Views.Forms;
@@ -118,7 +120,19 @@ public static class FormHelpers
 
     public static bool CheckForLoadingUploads(object? obj)
     {
+        var visited = new HashSet<object>(ReferenceEqualityComparer.Instance);
+        return CheckForLoadingUploads(obj, visited);
+    }
+
+    private static bool CheckForLoadingUploads(object? obj, HashSet<object> visited)
+    {
         if (obj == null) return false;
+
+        // Prevent infinite recursion by tracking visited objects
+        if (visited.Contains(obj))
+            return false;
+
+        visited.Add(obj);
 
         // Check single file upload
         if (obj is IFileUpload file)
@@ -144,7 +158,7 @@ public static class FormHelpers
             try
             {
                 var value = prop.GetValue(obj);
-                if (CheckForLoadingUploads(value))
+                if (CheckForLoadingUploads(value, visited))
                     return true;
             }
             catch
@@ -159,7 +173,7 @@ public static class FormHelpers
             try
             {
                 var value = field.GetValue(obj);
-                if (CheckForLoadingUploads(value))
+                if (CheckForLoadingUploads(value, visited))
                     return true;
             }
             catch
@@ -169,6 +183,21 @@ public static class FormHelpers
         }
 
         return false;
+    }
+
+    private class ReferenceEqualityComparer : IEqualityComparer<object>
+    {
+        public static readonly ReferenceEqualityComparer Instance = new();
+
+        bool IEqualityComparer<object>.Equals(object? x, object? y)
+        {
+            return ReferenceEquals(x, y);
+        }
+
+        int IEqualityComparer<object>.GetHashCode(object obj)
+        {
+            return RuntimeHelpers.GetHashCode(obj);
+        }
     }
 
     public record DisplayInfo(


### PR DESCRIPTION
Got a problem with examples with validations:

<img width="625" height="642" alt="Screenshot 2026-01-13 at 14 30 43" src="https://github.com/user-attachments/assets/caf44129-7149-4e3c-966a-1642ae40a07d" />

Fixed.
Tested out other forms, nothing seems to be broken