### PR TITLE
[Docs]: fix broken image links in db integration and auth docs

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/04_Authentication/02_Auth0.md
+++ b/src/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/04_Authentication/02_Auth0.md
@@ -25,15 +25,15 @@ Before using Auth0 with Ivy, you'll need to create an Auth0 application and obta
 ### Step 1: Create an Auth0 Account and Application
 
 1. **Sign up** at [Auth0](https://auth0.com) if you don't have an account
-2. **Go to** the [Auth0 Dashboard](https://manage.auth0.com/dashboard) and navigate to **Applications**: ![Auth0 Applications Option in Sidebar]../../../../Assets/auth0_applications.webp "Auth0 Applications Option in Sidebar")
+2. **Go to** the [Auth0 Dashboard](https://manage.auth0.com/dashboard) and navigate to **Applications**: ![Auth0 Applications Option in Sidebar](/ivy/assets/auth0_applications.webp "Auth0 Applications Option in Sidebar")
 3. **Click "Create Application"**
 4. **Choose "Regular Web Applications"** as the application type
-5. **Click "Create"**: ![Auth0 Create Application Panel]../../../../Assets/auth0_create_application.webp "Auth0 Create Application Panel")
+5. **Click "Create"**: ![Auth0 Create Application Panel](/ivy/assets/auth0_create_application.webp "Auth0 Create Application Panel")
 
 ### Step 2: Configure Your Application
 
-1. Navigate to your application's **Settings** tab: ![Auth0 Settings Tab]../../../../Assets/auth0_application_settings_tab.webp "Auth0 Settings Tab")
-2. **Set Allowed Callback URLs** to `http://localhost:5010/ivy/webhook`, replacing the base URL (`http://localhost:5010`) with your application's URL: ![Auth0 Allowed Callback URLs]../../../../Assets/auth0_callback.webp "Auth0 Allowed Callback URLs")
+1. Navigate to your application's **Settings** tab: ![Auth0 Settings Tab](/ivy/assets/auth0_application_settings_tab.webp "Auth0 Settings Tab")
+2. **Set Allowed Callback URLs** to `http://localhost:5010/ivy/webhook`, replacing the base URL (`http://localhost:5010`) with your application's URL: ![Auth0 Allowed Callback URLs](/ivy/assets/auth0_callback.webp "Auth0 Allowed Callback URLs")
 3. **Click "Save"**
 
 ### Step 3: Get Your Configuration Values
@@ -44,7 +44,7 @@ In your application settings, copy these values from the Basic Information secti
 - **Client ID**
 - **Client Secret**
 
-![Auth0 Basic Information]../../../../Assets/auth0_basic_information.webp "Auth0 Basic Information")
+![Auth0 Basic Information](/ivy/assets/auth0_basic_information.webp "Auth0 Basic Information")
 
 ### Step 4: Create an API
 
@@ -56,7 +56,7 @@ In your application settings, copy these values from the Basic Information secti
 6. **Click "Create"**
 7. **Copy the Identifier** - this is your **Audience** value
 
-![Auth0 Create API]../../../../Assets/auth0_create_api.webp "Auth0 Create API")
+![Auth0 Create API](/ivy/assets/auth0_create_api.webp "Auth0 Create API")
 
 ### Step 5: Enable Authentication Options
 
@@ -64,12 +64,12 @@ You'll need to enable the specific authentication options you want to use in you
 
 #### Email and Password
 
-1. **Go to Authentication > Database** in the Auth0 Dashboard: ![Auth0 Database]../../../../Assets/auth0_database.webp "Auth0 Database")
-2. **Click on the "Username-Password-Authentication" connection**: ![Auth0 Database Connections]../../../../Assets/auth0_database_connections.webp "Auth0 Database Connections")
-3. **Go to the "Applications" tab and ensure that the connection is enabled on your application**: ![Auth0 Connection Enabled]../../../../Assets/auth0_connection_enabled.webp "Auth0 Connection Enabled")
+1. **Go to Authentication > Database** in the Auth0 Dashboard: ![Auth0 Database](/ivy/assets/auth0_database.webp "Auth0 Database")
+2. **Click on the "Username-Password-Authentication" connection**: ![Auth0 Database Connections](/ivy/assets/auth0_database_connections.webp "Auth0 Database Connections")
+3. **Go to the "Applications" tab and ensure that the connection is enabled on your application**: ![Auth0 Connection Enabled](/ivy/assets/auth0_connection_enabled.webp "Auth0 Connection Enabled")
 4. **Go to the "Settings" tab and enable "Disable Sign Ups"** if you want to control user registration manually
 5. **Go to the "Authentication Methods" tab and configure your password policy** as needed for your security requirements
-6. **Enable the Password Grant**: In your Auth0 application, go to the **Settings** tab, scroll down to **Advanced Settings**, click **Grant Types**, and ensure the **Password** grant type is checked: ![Auth0 Password Grant]../../../../Assets/auth0_password_grant.webp "Auth0 Password Grant")
+6. **Enable the Password Grant**: In your Auth0 application, go to the **Settings** tab, scroll down to **Advanced Settings**, click **Grant Types**, and ensure the **Password** grant type is checked: ![Auth0 Password Grant](/ivy/assets/auth0_password_grant.webp "Auth0 Password Grant")
 
 ##### Adding Users for Email and Password Authentication
 

--- a/src/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/04_Authentication/02_Clerk.md
+++ b/src/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/04_Authentication/02_Clerk.md
@@ -40,7 +40,7 @@ To find your API keys, go to **Configure → API keys** in your Clerk Dashboard.
 - **Publishable key**: Starts with `pk_test_` (development) or `pk_live_` (production)
 - **Secret key**: Starts with `sk_test_` (development) or `sk_live_` (production)
 
-![Clerk API Keys]../../../../Assets/clerk_api_keys.webp "Clerk API Keys")
+![Clerk API Keys](/ivy/assets/clerk_api_keys.webp "Clerk API Keys")
 
 > **Important**: Keep your secret key secure. Never commit it to version control or expose it in client-side code.
 

--- a/src/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/04_Authentication/02_MicrosoftEntra.md
+++ b/src/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/04_Authentication/02_MicrosoftEntra.md
@@ -44,7 +44,7 @@ From your app registration **Overview** page, copy these values:
 - **Application (client) ID**: This is your **Client ID**
 - **Directory (tenant) ID**: This is your **Tenant ID**
 
-![Entra client and tenant IDs]../../../../Assets/entra_client_and_tenant_ids.webp "Entra client and tenant IDs")
+![Entra client and tenant IDs](/ivy/assets/entra_client_and_tenant_ids.webp "Entra client and tenant IDs")
 
 ### Step 3: Create a Client Secret
 
@@ -55,7 +55,7 @@ From your app registration **Overview** page, copy these values:
 5. **Click "Add"**
 6. **Copy the secret Value** (this is your **Client Secret**). Note that only **Value** is needed, not **Secret ID**.
 
-![Newly-created Entra client secret]../../../../Assets/entra_client_secret.webp "Newly-created Entra client secret")
+![Newly-created Entra client secret](/ivy/assets/entra_client_secret.webp "Newly-created Entra client secret")
 
 > ⚠️ **Warning:** This secret value will only be shown once, so copy it before leaving the page.
 
@@ -66,7 +66,7 @@ From your app registration **Overview** page, copy these values:
 3. **Under "Implicit grant and hybrid flows"**, check **"ID tokens"**
 4. **Click "Save"**
 
-![ID tokens enabled]../../../../Assets/entra_id_tokens_enabled.webp "ID tokens enabled")
+![ID tokens enabled](/ivy/assets/entra_id_tokens_enabled.webp "ID tokens enabled")
 
 ### Step 5: Set API Permissions
 

--- a/src/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/05_DatabaseIntegration/01_DatabaseOverview.md
+++ b/src/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/05_DatabaseIntegration/01_DatabaseOverview.md
@@ -74,23 +74,23 @@ This command opens a GUI to guide you through the process of designing a databas
 
 First, you will be prompted for a choice of database provider, a format for table and field names, and a description of your database schema. Currently, database schema generation supports the providers SQLite, SQL Server, PostgreSQL, and MySQL, and the casing schemes `PascalCase`, `camelCase` and `snake_case`. The defaults are SQLite and `snake_case`.
 
-![Ivy Database Generator UI, start page]../../../../Assets/db_generator_1.webp "Ivy Database Generator UI")
+![Ivy Database Generator UI, start page](/ivy/assets/db_generator_1.webp "Ivy Database Generator UI")
 
 If you're having trouble coming up with a schema description, Ivy includes a variety of examples to serve as a starting point:
 
-![Ivy Database Generator UI, samples dropdown]../../../../Assets/db_generator_2.webp "Ivy Database Generator UI")
+![Ivy Database Generator UI, samples dropdown](/ivy/assets/db_generator_2.webp "Ivy Database Generator UI")
 
 On the next page, you can preview Ivy's generated schema on the left, with a graph of relationships on the right:
 
-![Ivy Database Generator UI, preview page]../../../../Assets/db_generator_3.webp "Ivy Database Generator UI")
+![Ivy Database Generator UI, preview page](/ivy/assets/db_generator_3.webp "Ivy Database Generator UI")
 
 Finally, you can choose which apps to generate, make a final selection of database provider, tweak the connection string, and choose whether or not to generate seed data:
 
-![Ivy Database Generator UI, app selection page]../../../../Assets/db_generator_4.webp "Ivy Database Generator UI")
+![Ivy Database Generator UI, app selection page](/ivy/assets/db_generator_4.webp "Ivy Database Generator UI")
 
 Ivy will then generate your database schema and associated apps:
 
-![Ivy Database Generator UI, generation page]../../../../Assets/db_generator_5.webp "Ivy Database Generator UI")
+![Ivy Database Generator UI, generation page](/ivy/assets/db_generator_5.webp "Ivy Database Generator UI")
 
 ## Supported Database Providers
 

--- a/src/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/05_DatabaseIntegration/02_Airtable.md
+++ b/src/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/05_DatabaseIntegration/02_Airtable.md
@@ -43,7 +43,7 @@ See [Database Overview](01_DatabaseOverview.md) for more information on adding d
 
 Airtable uses personal access tokens (PATs) for authentication. You can generate a token from the [Personal access tokens](https://airtable.com/create/tokens) page in your Airtable Builder Hub. Be sure to enable the scopes `data.records:read` and `schema.bases:read`, and if writing to Airtable is needed for your project, `data.records:write` as well. No other scopes are currently used by Ivy. Then, give it access to the Airtable base(s) you wish to use or select "Add all resources."
 
-![Airtable create personal access token page]../../../../Assets/airtable_create_pat.webp "Airtable create personal access token page")
+![Airtable create personal access token page](/ivy/assets/airtable_create_pat.webp "Airtable create personal access token page")
 
 For detailed instructions, see the [Airtable personal access tokens documentation](https://airtable.com/developers/web/guides/personal-access-tokens).
 
@@ -51,11 +51,11 @@ For detailed instructions, see the [Airtable personal access tokens documentatio
 
 To find your base ID, login to Airtable in your browser and visit the [Airtable API Reference](https://airtable.com/api). At the bottom of that page, you should see a list of bases your account has access to:
 
-![Airtable API Reference]../../../../Assets/airtable_api_reference.webp "Airtable API Reference")
+![Airtable API Reference](/ivy/assets/airtable_api_reference.webp "Airtable API Reference")
 
 Select the one you want your Ivy project to connect to. This will lead you to base-specific API documentation. You can find the base ID on the Introduction page. Look for "The ID of this base is..."
 
-![Airtable Base-Specific API Reference, showing the chosen base's ID]../../../../Assets/airtable_base_id.webp "Airtable Base-Specific API Reference")
+![Airtable Base-Specific API Reference, showing the chosen base's ID](/ivy/assets/airtable_base_id.webp "Airtable Base-Specific API Reference")
 
 ## Configuration
 

--- a/src/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/05_DatabaseIntegration/02_Supabase.md
+++ b/src/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/05_DatabaseIntegration/02_Supabase.md
@@ -37,7 +37,7 @@ You will be asked to name your connection, then prompted for a connection string
 
 For more detailed information, see the [official Supabase documentation on connecting to Postgres](https://supabase.com/docs/guides/database/connecting-to-postgres).
 
-![Supabase connect screen, showing all three types of connection string]../../../../Assets/supabase_connect_screen.webp "Supabase connect screen")
+![Supabase connect screen, showing all three types of connection string](/ivy/assets/supabase_connect_screen.webp "Supabase connect screen")
 
 Your connection string will look something like this:
 


### PR DESCRIPTION
## Problem

Images in the CLI documentation (Database Integration and Authentication sections) were not displaying. The issue had two root causes:

### 1. Incorrect Markdown Syntax
The image links were missing the opening parenthesis `(` after `]`:

```markdown
<!-- Before (broken) -->
![Alt text]../../../../Assets/image.webp "Title")

<!-- After (fixed) -->
![Alt text](../../../../Assets/image.webp "Title")
```

### 2. Wrong Path Format
Relative paths like `../../../../Assets/` don't work in Ivy's documentation system. The server serves assets via the `/ivy/assets/` endpoint (configured in `Server.cs`):

```csharp
app.UseAssets(_args, logger, "Assets", "ivy/assets");
```

The correct path format is:
```markdown
![Alt text](/ivy/assets/image.webp "Title")
```

## Solution

Changed all 23 image references across 6 files from relative paths to absolute `/ivy/assets/` paths.

## Changed Files

| File | Images Fixed |
|------|--------------|
| `01_DatabaseOverview.md` | 5 |
| `02_Airtable.md` | 3 |
| `02_Supabase.md` | 1 |
| `02_Auth0.md` | 10 |
| `02_Clerk.md` | 1 |
| `02_MicrosoftEntra.md` | 3 |
| **Total** | **23** |

## Testing

- [x] All images display correctly in local documentation
- [x] No other broken image links found in documentation

<img width="1314" height="692" alt="image" src="https://github.com/user-attachments/assets/81a1bb7d-4a8a-48a1-bd89-9db776edd61d" />
