### PR TITLE
(form): avoid infinite recursive after validation data presented with array

### DIFF
--- a/src/Ivy/Views/Forms/FormHelpers.cs
+++ b/src/Ivy/Views/Forms/FormHelpers.cs
@@ -116,9 +116,14 @@ public static class FormHelpers
         return nullabilityInfo.ReadState != NullabilityState.Nullable;
     }
 
-    public static bool CheckForLoadingUploads(object? obj)
+    public static bool CheckForLoadingUploads(object? obj) => CheckForLoadingUploads(obj, new HashSet<object>(ReferenceEqualityComparer.Instance));
+
+    private static bool CheckForLoadingUploads(object? obj, HashSet<object> visited)
     {
         if (obj == null) return false;
+
+        // Prevent infinite recursion by tracking visited objects
+        if (!visited.Add(obj)) return false;
 
         // Check single file upload
         if (obj is IFileUpload file)
@@ -135,6 +140,14 @@ public static class FormHelpers
         if (type.IsPrimitive || type == typeof(string) || type == typeof(decimal) || type == typeof(DateTime) || type == typeof(DateTimeOffset))
             return false;
 
+        // Skip arrays and collections of non-file types - they don't contain file uploads
+        if (type.IsArray)
+        {
+            var elementType = type.GetElementType();
+            if (elementType != null && !typeof(IFileUpload).IsAssignableFrom(elementType) && !elementType.IsClass)
+                return false;
+        }
+
         foreach (var prop in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
         {
             // Skip indexed properties
@@ -144,7 +157,7 @@ public static class FormHelpers
             try
             {
                 var value = prop.GetValue(obj);
-                if (CheckForLoadingUploads(value))
+                if (CheckForLoadingUploads(value, visited))
                     return true;
             }
             catch
@@ -159,7 +172,7 @@ public static class FormHelpers
             try
             {
                 var value = field.GetValue(obj);
-                if (CheckForLoadingUploads(value))
+                if (CheckForLoadingUploads(value, visited))
                     return true;
             }
             catch


### PR DESCRIPTION
Had a problem in docs, forms, 
<img width="805" height="654" alt="Screenshot 2026-01-15 at 13 57 39" src="https://github.com/user-attachments/assets/2457eef3-6072-4483-bad7-4557c8421d80" />
<img width="822" height="263" alt="Screenshot 2026-01-15 at 13 58 06" src="https://github.com/user-attachments/assets/44404055-eb2a-4ac4-b906-a2f28cd348bb" />

Fixed:
<img width="1200" height="559" alt="Screenshot 2026-01-15 at 13 52 43" src="https://github.com/user-attachments/assets/4c7a40a8-f489-40f8-b388-465e8f91a72b" />

When checking properties of a string[], the reflection loop would access the SyncRoot property which returns the same array instance, leading to infinite recursive calls.