### PR TITLE
[CodeInputWidget]: use basic Lucide CopyToClipboard button to avoid visual bugs 

### DIFF
--- a/src/Ivy.Samples.Shared/Apps/Tests/NullableInputsApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Tests/NullableInputsApp.cs
@@ -2,7 +2,7 @@ using Ivy.Shared;
 
 namespace Ivy.Samples.Shared.Apps.Widgets.Inputs;
 
-[App(icon: Icons.CircleOff, path: ["Widgets", "Inputs"], isVisible: true, searchHints: ["nullable", "null", "clear", "optional"])]
+[App(icon: Icons.CircleOff, path: ["Widgets", "Inputs"], isVisible: false, searchHints: ["nullable", "null", "clear", "optional"])]
 public class NullableInputsApp : SampleBase
 {
     protected override object? BuildSample()

--- a/src/frontend/src/widgets/inputs/code/CodeInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/code/CodeInputWidget.tsx
@@ -17,12 +17,11 @@ import { useEventHandler } from '@/components/event-handler';
 import { cn } from '@/lib/utils';
 import { getHeight, getWidth, inputStyles } from '@/lib/styles';
 import { InvalidIcon } from '@/components/InvalidIcon';
-import CopyToClipboardButton from '@/components/CopyToClipboardButton';
 import { cpp } from '@codemirror/lang-cpp';
 import { dbml } from './dbml-language';
 import { createIvyCodeTheme } from './theme';
 import { Scales } from '@/types/scale';
-import { X } from 'lucide-react';
+import { X, Copy } from 'lucide-react';
 import { xIconVariants } from '@/components/ui/input/text-input-variants';
 import {
   keymap,
@@ -164,12 +163,14 @@ export const CodeInputWidget: React.FC<CodeInputWidgetProps> = ({
       {(showCopy || showClear || invalid) && (
         <div className="absolute top-2 right-2 z-50 flex items-center">
           {showCopy && (
-            <CopyToClipboardButton
-              textToCopy={localValue}
+            <button
+              type="button"
+              onClick={() => navigator.clipboard.writeText(localValue)}
               aria-label="Copy to clipboard"
-              scale={scale}
-              className="!h-auto !p-1"
-            />
+              className="p-1 rounded hover:bg-accent focus:outline-none cursor-pointer"
+            >
+              <Copy className={xIconVariants({ scale })} />
+            </button>
           )}
           {showClear && (
             <button


### PR DESCRIPTION
<img width="1167" height="65" alt="Screenshot 2026-01-15 at 16 27 46" src="https://github.com/user-attachments/assets/1aa38796-4bb7-40cb-8a3f-eb77c32308b4" />
<img width="152" height="52" alt="Screenshot 2026-01-15 at 16 27 52" src="https://github.com/user-attachments/assets/6ec0d761-f4ba-4e13-99ca-7cdb0e89a476" />
<img width="568" height="281" alt="Screenshot 2026-01-15 at 16 28 21" src="https://github.com/user-attachments/assets/a734f6f4-c5ee-4a45-baa8-f64b950bd1bb" />
<img width="1238" height="675" alt="Screenshot 2026-01-15 at 16 30 24" src="https://github.com/user-attachments/assets/97c8c48b-c369-4f8e-afdc-3d635b5c4d49" />

