### PR TITLE
(expandable): disable cursor for disabled variant

### DIFF
--- a/src/frontend/src/widgets/expandable/ExpandableWidget.tsx
+++ b/src/frontend/src/widgets/expandable/ExpandableWidget.tsx
@@ -89,8 +89,12 @@ export const ExpandableWidget: React.FC<ExpandableWidgetProps> = ({
       role="details"
     >
       <CollapsibleTrigger
-        disabled={false}
-        className={cn(expandableTriggerVariants({ scale }), 'relative')}
+        disabled={disabled}
+        className={cn(
+          expandableTriggerVariants({ scale }),
+          'relative',
+          disabled && 'cursor-not-allowed'
+        )}
         onClick={handleTriggerClick}
         data-collapsible-trigger
       >


### PR DESCRIPTION

Had a problem:
<img width="631" height="240" alt="Screenshot 2026-01-16 at 11 54 32" src="https://github.com/user-attachments/assets/2fa2ea0f-f090-4c96-8c88-b533a18fbe65" />
On disabled state cursor still was active.
Fixed:
https://github.com/user-attachments/assets/2d10d528-819a-4d11-a843-8aad212b7c66

