### PR TITLE
[Nuget]: create dedicated README for Ivy package

### DIFF
--- a/src/Ivy/Ivy.csproj
+++ b/src/Ivy/Ivy.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="../README.md" Pack="true" PackagePath="" />
+    <None Include="README.md" Pack="true" PackagePath="" />
     <None Include="../../llms.txt" Pack="true" PackagePath="" />
     <None Include="../Ivy.Docs.Shared/Generated/**/*.md" Pack="true" PackagePath="docs/generated" />
   </ItemGroup>

--- a/src/Ivy/README.md
+++ b/src/Ivy/README.md
@@ -1,1 +1,46 @@
-# Ivy: Build Internal Applications with AI and Pure C#
+![Ivy Framework](https://raw.githubusercontent.com/Ivy-Interactive/Ivy-Framework/main/src/assets/logo_green_w200.png)
+
+[![NuGet](https://img.shields.io/nuget/v/Ivy?style=flat)](https://www.nuget.org/packages/Ivy)
+[![NuGet Downloads](https://img.shields.io/nuget/dt/Ivy?style=flat)](https://www.nuget.org/packages/Ivy)
+[![License](https://img.shields.io/github/license/Ivy-Interactive/Ivy-Framework?style=flat)](https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/LICENSE)
+[![Website](https://img.shields.io/badge/website-ivy.app-green?style=flat)](https://ivy.app)
+
+# Build Full-Stack Applications in Pure C#
+
+Ivy is a modern C# framework that lets you build reactive full-stack web applications entirely in pure C# — using familiar React-style components, hooks, and declarative patterns.
+
+No frontend/backend split, no HTML/CSS/JS — just write type-safe C# code and ship beautiful, production-ready internal tools at lightning speed.
+
+## Quick Start
+
+```csharp
+public class CounterApp : ViewBase
+{
+    public override object? Build()
+    {
+        var count = UseState(0);
+        
+        return Layout.Vertical(
+            Text.Block($"Count: {count.Value}"),
+            new Button("Increment", onClick: _ => count.Set(count.Value + 1))
+        );
+    }
+}
+```
+
+## Features
+
+- 🧩 **Rich Widget Library** — Extensive set of pre-built widgets
+- 🪝 **Hooks** — React-style hooks for state management
+- 📝 **Forms** — Complex CRUD forms with validation
+- 📊 **Data Tables** — Sort, filter, and paginate data
+- 📈 **Charts/Dashboards** — Interactive visualizations
+- 🔥 **Hot-Reloading** — Full support with maintained state
+- 🤖 **LLM Compatible** — Designed for AI code generation
+
+## Links
+
+- 📖 [Documentation](https://docs.ivy.app)
+- 🎮 [Samples](https://samples.ivy.app)
+- 💻 [GitHub Repository](https://github.com/Ivy-Interactive/Ivy-Framework)
+- 💬 [Discord Community](https://discord.gg/CffzHm66BW)


### PR DESCRIPTION
## Problem

Currently, the release workflows copy the root `README.md` into the NuGet package. This causes issues on nuget.org:

- **Codespaces badge** — doesn't work (GitHub-specific feature)
- **Relative image links** — broken on nuget.org
- **CI badge** — irrelevant for package consumers

Additionally, the path `../README.md` in `Ivy.csproj` pointed to `src/README.md` which doesn't exist in this repository.

## Solution

### 1. Created dedicated NuGet README

**File:** `src/Ivy/README.md`

A NuGet-optimized README that includes:
- Logo with absolute URL
- Relevant badges (NuGet version, downloads, license, website)
- Framework description and code example
- Key features list
- Links to documentation, samples, and community

<img width="797" height="662" alt="image" src="https://github.com/user-attachments/assets/87f0a7b3-9a61-44f6-8292-e98e0592a39b" />
<img width="790" height="680" alt="image" src="https://github.com/user-attachments/assets/4ce6e4a1-d60b-4a94-8d8c-aee813721bcb" />
<img width="809" height="674" alt="image" src="https://github.com/user-attachments/assets/28d7ad3e-29d1-424a-b522-47a7eff4fe1e" />

### 2. Updated package configuration

**File:** `src/Ivy/Ivy.csproj`

```diff
- <None Include="../README.md" Pack="true" PackagePath="" />
+ <None Include="README.md" Pack="true" PackagePath="" />
```

Now the package uses its own local README instead of relying on external paths.

## Changes

| File | Change |
|------|--------|
| `src/Ivy/README.md` | Added NuGet-specific content |
| `src/Ivy/Ivy.csproj` | Updated README path |
