### PR TITLE
(sidebar): set padding by default for main content

### DIFF
--- a/src/frontend/src/widgets/layouts/sidebar/SidebarLayoutWidget.tsx
+++ b/src/frontend/src/widgets/layouts/sidebar/SidebarLayoutWidget.tsx
@@ -155,7 +155,7 @@ export const SidebarLayoutWidget: React.FC<SidebarLayoutWidgetProps> = ({
       <div
         className={cn(
           `relative h-full overflow-auto`,
-          !mainAppSidebar ? `p-${mainContentPadding}` : ''
+          !mainAppSidebar ? `p-${mainContentPadding ?? 2}` : ''
         )}
       >
         {/* Toggle Button - Only show for main app sidebar */}


### PR DESCRIPTION
Had a problem

<img width="699" height="375" alt="Screenshot 2026-01-20 at 00 10 42" src="https://github.com/user-attachments/assets/76a72a9c-a584-4c8d-a115-14445b091060" />

Set p-2 by default for main content in sidebar layouts:

<img width="914" height="480" alt="Screenshot 2026-01-20 at 00 10 09" src="https://github.com/user-attachments/assets/ee66fd2c-82f8-4093-b0d9-ef9b282e4726" />

Problem:
<img width="678" height="289" alt="Screenshot 2026-01-20 at 00 12 24" src="https://github.com/user-attachments/assets/6e8825ca-d5c5-418f-9dec-eb2b40a4756a" />

Fixed:
<img width="564" height="278" alt="Screenshot 2026-01-20 at 00 13 11" src="https://github.com/user-attachments/assets/5745fedd-31cd-45d1-82e0-9a8e103586bc" />
