### PR TITLE
[Docs}: add Page Title section to Apps documentation

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/10_Apps.md
+++ b/src/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/10_Apps.md
@@ -7,6 +7,7 @@ searchHints:
   - search
   - deeplink
   - metadata
+  - title
 ---
 
 # Apps & The `[App]` Attribute


### PR DESCRIPTION
## Summary
Added a new **Page Title** section to the `Apps documentation`
<img width="960" height="298" alt="image" src="https://github.com/user-attachments/assets/f50b660c-4a4b-4837-bb53-d15d6c04ed8e" />
