### PR TITLE
[GridLayout]: handle text overflow with ellipsis and hover popout

### DIFF
--- a/src/frontend/src/lib/styles.ts
+++ b/src/frontend/src/lib/styles.ts
@@ -382,6 +382,11 @@ export const getOverflow = (overflow?: Overflow): React.CSSProperties => {
   };
 };
 
+export const gridCellOverflow = {
+  ellipsis:
+    '[&>*]:min-w-0 [&>*]:truncate hover:[&>*]:overflow-visible hover:[&>*]:whitespace-normal hover:[&>*]:absolute hover:[&>*]:z-10',
+};
+
 export type Orientation = 'Horizontal' | 'Vertical';
 
 export type Align =

--- a/src/frontend/src/widgets/layouts/GridLayoutWidget.tsx
+++ b/src/frontend/src/widgets/layouts/GridLayoutWidget.tsx
@@ -5,6 +5,7 @@ import {
   getWidth,
   getHeight,
   convertSizeToGridValue,
+  gridCellOverflow,
 } from '../../lib/styles';
 
 interface GridLayoutWidgetProps {
@@ -54,7 +55,7 @@ const GridLayoutCell: React.FC<GridLayoutCellProps> = ({
   return (
     <div
       style={styles}
-      className={`flex items-center h-full w-full ${className}`}
+      className={`relative flex items-center h-full w-full min-w-0 ${gridCellOverflow.ellipsis} ${className}`}
     >
       {children}
     </div>


### PR DESCRIPTION
## Problem
Labels and text content within `Layout.Grid` cells were overflowing their containers. This was particularly noticeable on the `BoolInput` documentation page, where `BoolInputs.Checkbox` text was spilling over into adjacent cells, causing visual clutter and unreadable interfaces.
By default, Flexbox items (which our grid cells are) have a `min-width` of `auto`. This prevents them from shrinking below the size of their content. Furthermore, there was no overflow handling (`overflow: hidden` or `text-overflow: ellipsis`) applied to the cell content, so the text simply rendered outside the cell boundaries when the column was too narrow.

## Solution
I implemented a robust CSS-based solution that ensures text is properly truncated while remaining accessible via user interaction.

### Key Changes:
1.  **Truncation**: Applied `min-w-0` to the cell container (to allow shrinking) and `truncate` (ellipsis) to the content.
2.  **Hover Popout**: Added a "popout" effect on hover. When a user hovers over a truncated cell, the content expands (using `position: absolute`, `z-index: 10`, and `overflow: visible`) to show the full text without shifting the layout.
3.  **Refactoring**: Extracted this styling logic into a reusable constant `gridCellOverflow.ellipsis` in `src/frontend/src/lib/styles.ts` to maintain clean code architecture.

### Why this approach?
*   **Performance**: Pure CSS solution avoids the overhead of JavaScript event listeners or React state for tooltips.
*   **UX**: Users get a clean grid by default (ellipsis) but can easily read long content just by hovering, mimicking a natural tooltip behavior but with better visual continuity (the text stays in place and expands).
*   **Maintainability**: Centralizing the styles in `styles.ts` ensures we can easily reuse or update this behavior across the application.

## Demo Vid
https://github.com/user-attachments/assets/6dc34869-3cdd-4540-9180-61ec340711e3