### PR TITLE
[Navigation]: restore appArgs on reconnect and suppress intentional disconnect modal

### DIFF
--- a/src/Ivy/Chrome/DefaultSidebarChrome.cs
+++ b/src/Ivy/Chrome/DefaultSidebarChrome.cs
@@ -208,7 +208,8 @@ public class DefaultSidebarChrome(ChromeSettings settings) : ViewBase
             var initialAppId = args.NavigationAppId ?? settings.DefaultAppId;
             if (!string.IsNullOrWhiteSpace(initialAppId))
             {
-                OpenApp(new NavigateArgs(initialAppId), replaceHistory: true);
+                var appArgs = args.GetArgs<object>();
+                OpenApp(new NavigateArgs(initialAppId, appArgs), replaceHistory: true);
             }
             else
             {

--- a/src/frontend/src/hooks/use-backend.tsx
+++ b/src/frontend/src/hooks/use-backend.tsx
@@ -313,6 +313,7 @@ export const useBackend = (
 
   // Use a ref that gets updated with the latest connection so we always have it in the callback
   const latestConnectionRef = useRef(connection);
+  const isStoppingRef = useRef(false);
   useEffect(() => {
     latestConnectionRef.current = connection;
   }, [connection]);
@@ -697,6 +698,7 @@ export const useBackend = (
       connection &&
       connection.state === signalR.HubConnectionState.Disconnected
     ) {
+      isStoppingRef.current = false;
       connection
         .start()
         .then(() => {
@@ -807,6 +809,7 @@ export const useBackend = (
           });
 
           connection.onreconnecting(() => {
+            if (isStoppingRef.current) return;
             logger.warn(`[${connection.connectionId}] Reconnecting`);
             setDisconnected(true);
           });
@@ -817,6 +820,7 @@ export const useBackend = (
           });
 
           connection.onclose(() => {
+            if (isStoppingRef.current) return;
             logger.warn(`[${connection.connectionId}] Closed`);
             setDisconnected(true);
           });
@@ -826,6 +830,8 @@ export const useBackend = (
         });
 
       return () => {
+        isStoppingRef.current = true;
+
         connection.off('Refresh');
         connection.off('Update');
         connection.off('Toast');


### PR DESCRIPTION
## 1. Problem
When navigating to a "Hidden App" with arguments using the `Navigator.Navigate("app://...", args)` mechanism, two main issues occurred:
1.  **Loss of Arguments:** The application loaded "empty" and displayed the error: "This hidden app should only be accessed with arguments."
2.  **Connection Loss Message:** A "Connection lost. Trying to reconnect..." message flickered on the screen during the transition.

## 2. Root Cause Analysis

### A. Backend (C#)
The problem was rooted in the SignalR connection lifecycle. When navigation via `Redirect` happens, the browser updates the URL, causing the frontend to establish a **new WebSocket connection**.
*   The server receives the new request with `appArgs` in the query string and correctly populates the `AppContext`.
*   However, in `DefaultSidebarChrome.cs`, during the initial app load (`OpenApp` method), these arguments from the context were **not being passed** to the newly created application host.
*   Consequently, the app started without its required data, even though the data was present in the URL.

### B. Frontend (React/TypeScript)
The "Connection lost" message appeared because the `useBackend` hook reacted to the `appId` change in the URL:
*   When the application changed, the old connection was explicitly stopped (`connection.stop()`).
*   The SignalR library triggered the standard `onclose` event.
*   The handler set the state to `disconnected = true`, which immediately triggered the connection modal, even though the disconnect was planned and intentional.

## 3. Implemented Solution

### Persistent Arguments (Backend)
I updated the initialization logic in `DefaultSidebarChrome.cs`. Now, during the first app load after a redirect, we explicitly extract the arguments from `AppContext` and pass them into `NavigateArgs`.

```csharp
var appArgs = args.GetArgs<object>(); 
OpenApp(new NavigateArgs(initialAppId, appArgs), replaceHistory: true);
```

### UX Enhancement (Frontend)
A mechanism to track "intentional stops" using `useRef` was added to the `useBackend.tsx` hook:
*   Before calling `connection.stop()`, we set `isStoppingRef.current = true`.
*   A check was added to the `onclose` handler: if this flag is set, we bypass setting `disconnected = true`, thus preventing the error modal from appearing.

## 4. Why This Solution?

1.  **Low Impact:** The fix works within the existing Ivy architecture without changing the communication protocol or database schema.
2.  **Reliability:** Arguments are restored directly from the connection context (populated from the URL), ensuring data persistence even on hard refreshes (F5).
3.  **Safety:** The `isStoppingRef` flag is local to the hook and does not interfere with the detection of real network failures (where the flag remains `false` and the error is shown correctly).
4.  **Polish:** Removing the flickering modal provides a seamless, professional "Single Page Application" feel during transitions.

<img width="384" height="269" alt="image" src="https://github.com/user-attachments/assets/c8510bfc-d739-4fb0-bd0e-14d51427843b" />
<img width="489" height="316" alt="image" src="https://github.com/user-attachments/assets/9a3c0166-c402-46e6-b7a9-96065d93f84b" />
