### PR TITLE
fix(PTY): exclude app from CommandLine

### DIFF
--- a/src/Ivy.Hooks.Pty/UsePty.cs
+++ b/src/Ivy.Hooks.Pty/UsePty.cs
@@ -154,7 +154,7 @@ public static class UsePtyExtensions
             Rows = options.Rows,
             Cwd = cwd,
             App = app,
-            CommandLine = commandLine,
+            CommandLine = commandLine[1..],
             Environment = env
         };
 


### PR DESCRIPTION
Including the app name in CommandLine leads to a command like `dotnet watch` being turned into `dotnet dotnet watch` (which coincidentally works, but others do not).