### PR TITLE
(terminal): fix api link in docs

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/14_Terminal.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/14_Terminal.md
@@ -51,7 +51,7 @@ Layout.Vertical().Gap(4)
         .AddOutput("nothing to commit, working tree clean")
 ```
 
-<WidgetDocs Type="Ivy.Terminal" ExtensionType="Ivy.TerminalExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Primitives/Terminal.cs"/>
+<WidgetDocs Type="Ivy.Terminal" ExtensionTypes="Ivy.TerminalExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Primitives/Terminal.cs"/>
 
 ## Examples
 


### PR DESCRIPTION
Had a problem:
<img width="1787" height="1006" alt="image" src="https://github.com/user-attachments/assets/a817c778-3ffb-4680-9a29-01661828549c" />

Since the Terminal widget is not an internal widget but a primitive, we should update the API link accordingly.
This is a minor change and should be safe to merge.
<img width="2283" height="1009" alt="Screenshot 2026-01-29 at 00 09 30" src="https://github.com/user-attachments/assets/2f6c30bf-5962-4173-94c1-21814c968877" />
