### PR TITLE
(doc tools): improve md path recognizing algorithm to be case insensitive

### DIFF
--- a/src/Ivy.Docs.Shared/Middleware/MarkdownMiddleware.cs
+++ b/src/Ivy.Docs.Shared/Middleware/MarkdownMiddleware.cs
@@ -19,6 +19,7 @@ public class MarkdownMiddleware
     private readonly RequestDelegate _next;
     private static readonly Assembly Assembly = typeof(MarkdownMiddleware).Assembly;
     private static readonly string ResourcePrefix = "Ivy.Docs.Shared.Generated.";
+    private static readonly string[] ManifestResourceNames = Assembly.GetManifestResourceNames();
     private static readonly ConcurrentDictionary<string, byte[]?> ContentCache = new();
 
     public MarkdownMiddleware(RequestDelegate next)
@@ -66,7 +67,9 @@ public class MarkdownMiddleware
     {
         return ContentCache.GetOrAdd(resourceName, name =>
         {
-            using var stream = Assembly.GetManifestResourceStream(name);
+            var resolvedName =
+                ManifestResourceNames.FirstOrDefault(r => r.Equals(name, StringComparison.OrdinalIgnoreCase)) ?? name;
+            using var stream = Assembly.GetManifestResourceStream(resolvedName);
             if (stream == null)
                 return null;
 
@@ -88,9 +91,6 @@ public class MarkdownMiddleware
     {
         if (string.IsNullOrEmpty(input))
             return input;
-
-        if (input.Equals("cli", StringComparison.OrdinalIgnoreCase))
-            return "CLI";
 
         var parts = input.Split(['-', '_'], StringSplitOptions.RemoveEmptyEntries);
         var result = new StringBuilder();

--- a/src/Ivy.Docs.Shared/Middleware/SsrMarkdownMiddleware.cs
+++ b/src/Ivy.Docs.Shared/Middleware/SsrMarkdownMiddleware.cs
@@ -19,6 +19,7 @@ public class SsrMarkdownMiddleware
     private readonly RequestDelegate _next;
     private static readonly Assembly Assembly = typeof(SsrMarkdownMiddleware).Assembly;
     private static readonly string ResourcePrefix = "Ivy.Docs.Shared.Generated.";
+    private static readonly string[] ManifestResourceNames = Assembly.GetManifestResourceNames();
     private static readonly ConcurrentDictionary<string, string> ContentCache = new();
 
     public SsrMarkdownMiddleware(RequestDelegate next)
@@ -163,7 +164,10 @@ public class SsrMarkdownMiddleware
         return ContentCache.GetOrAdd(appId, id =>
         {
             var resourceName = ConvertAppIdToResourceName(id);
-            using var stream = Assembly.GetManifestResourceStream(resourceName);
+            var resolvedName =
+                ManifestResourceNames.FirstOrDefault(r => r.Equals(resourceName, StringComparison.OrdinalIgnoreCase)) ??
+                resourceName;
+            using var stream = Assembly.GetManifestResourceStream(resolvedName);
             if (stream == null)
                 return null!;
 
@@ -183,9 +187,6 @@ public class SsrMarkdownMiddleware
     {
         if (string.IsNullOrEmpty(input))
             return input;
-
-        if (input.Equals("cli", StringComparison.OrdinalIgnoreCase))
-            return "CLI";
 
         var parts = input.Split(['-', '_'], StringSplitOptions.RemoveEmptyEntries);
         var result = new StringBuilder();


### PR DESCRIPTION
The "Copy Page" button in documentation pages allows users to copy page content to clipboard. However, it was failing for all docs in the CLI folder with 404 errors:
<img width="963" height="700" alt="Screenshot 2026-01-29 at 00 59 16" src="https://github.com/user-attachments/assets/06521aca-6d73-465f-894c-4ed72eadd0bb" />

The issue was that `MarkdownMiddleware` and `SsrMarkdownMiddleware` were performing case-sensitive lookups when resolving embedded markdown resources. Since the generated resources use `CLI` (uppercase) but the URL paths use `cli` (lowercase), the lookup failed.

Updated both middlewares to perform case-insensitive resource name resolution by:
- Caching the assembly's manifest resource names at startup
- Using case-insensitive matching when looking up resources before opening the stream

This makes the system resilient to any case mismatches between URL paths and embedded resource names, not just CLI.

P.S. Already tested out the copying from diferent folders - works fine.