### PR TITLE
(docs): fix broken GitHub source URLs in API section

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/08_Forms.md
+++ b/src/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/08_Forms.md
@@ -888,7 +888,7 @@ public class UseFormHookExample : ViewBase
 }
 ```
 
-<WidgetDocs Type="Ivy.Form" ExtensionTypes="Ivy.Views.Forms.FormsExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Forms/Form.cs"/>
+<WidgetDocs Type="Ivy.Form" ExtensionTypes="Ivy.Views.Forms.FormsExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Forms/Form.cs"/>
 
 ## Examples
 

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/02_Icon.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/02_Icon.md
@@ -81,4 +81,4 @@ Layout.Horizontal()
     | new Icon(Icons.Cloud).Large()
 ```
 
-<WidgetDocs Type="Ivy.Icon" ExtensionTypes="Ivy.IconExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Primitives/Icon.cs"/>
+<WidgetDocs Type="Ivy.Icon" ExtensionTypes="Ivy.IconExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Primitives/Icon.cs"/>

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/03_Image.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/03_Image.md
@@ -36,4 +36,4 @@ new Image("https://example.com/image.jpg");  // External URL
 new Image("/ivy/images/logo.png");           // Local file
 ```
 
-<WidgetDocs Type="Ivy.Image" ExtensionTypes="Ivy.ImageExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Primitives/Image.cs"/>
+<WidgetDocs Type="Ivy.Image" ExtensionTypes="Ivy.ImageExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Primitives/Image.cs"/>

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/04_Box.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/04_Box.md
@@ -166,7 +166,7 @@ public class ColorExamplesView : ViewBase
 
 For more colors, see the [Colors](../../04_ApiReference/IvyShared/Colors.md) reference.
 
-<WidgetDocs Type="Ivy.Box" ExtensionTypes="Ivy.BoxExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Primitives/Box.cs"/>
+<WidgetDocs Type="Ivy.Box" ExtensionTypes="Ivy.BoxExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Primitives/Box.cs"/>
 
 ## Examples
 

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/05_Fragment.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/05_Fragment.md
@@ -123,7 +123,7 @@ public class MultipleElementsView : ViewBase
 }
 ```
 
-<WidgetDocs Type="Ivy.Fragment" ExtensionTypes="Ivy.FragmentExtensions"  SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Primitives/Fragment.cs"/>
+<WidgetDocs Type="Ivy.Fragment" ExtensionTypes="Ivy.FragmentExtensions"  SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Primitives/Fragment.cs"/>
 
 ## Examples
 

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/06_Spacer.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/06_Spacer.md
@@ -147,7 +147,7 @@ public class FormSpacerView : ViewBase
 }
 ```
 
-<WidgetDocs Type="Ivy.Spacer" ExtensionTypes="Ivy.SpacerExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Primitives/Spacer.cs"/>
+<WidgetDocs Type="Ivy.Spacer" ExtensionTypes="Ivy.SpacerExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Primitives/Spacer.cs"/>
 
 ## Examples
 

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/07_Separator.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/07_Separator.md
@@ -82,4 +82,4 @@ public class ProfileDetailView : ViewBase
 }
 ```
 
-<WidgetDocs Type="Ivy.Separator" ExtensionTypes="Ivy.SeparatorExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Primitives/Separator.cs"/>
+<WidgetDocs Type="Ivy.Separator" ExtensionTypes="Ivy.SeparatorExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Primitives/Separator.cs"/>

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/08_Avatar.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/08_Avatar.md
@@ -100,4 +100,4 @@ public class AvatarAsFoodIcon : ViewBase
 
 ```
 
-<WidgetDocs Type="Ivy.Avatar" ExtensionTypes="Ivy.AvatarExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Primitives/Avatar.cs"/>
+<WidgetDocs Type="Ivy.Avatar" ExtensionTypes="Ivy.AvatarExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Primitives/Avatar.cs"/>

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/09_Skeleton.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/09_Skeleton.md
@@ -95,4 +95,4 @@ public class ProductCardView : ViewBase
 }
 ```
 
-<WidgetDocs Type="Ivy.Skeleton" ExtensionTypes="Ivy.SkeletonExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Primitives/Skeleton.cs"/>
+<WidgetDocs Type="Ivy.Skeleton" ExtensionTypes="Ivy.SkeletonExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Primitives/Skeleton.cs"/>

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/10_Code.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/10_Code.md
@@ -36,5 +36,5 @@ for (let i = 0; i < 10; i++) {
 ```
 
 
-<WidgetDocs Type="Ivy.Code" ExtensionTypes="Ivy.CodeExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Primitives/Code.cs"/>
+<WidgetDocs Type="Ivy.Code" ExtensionTypes="Ivy.CodeExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Primitives/Code.cs"/>
 

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/11_Kbd.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/11_Kbd.md
@@ -22,4 +22,4 @@ Layout.Horizontal() |
     new Kbd("Shift + Ctrl + C")
 ```
 
-<WidgetDocs Type="Ivy.Kbd" ExtensionTypes="Ivy.KbdExtensions"  SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Primitives/Kbd.cs"/>
+<WidgetDocs Type="Ivy.Kbd" ExtensionTypes="Ivy.KbdExtensions"  SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Primitives/Kbd.cs"/>

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/12_Callout.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/12_Callout.md
@@ -212,7 +212,7 @@ public class FormCalloutView : ViewBase
 }
 ```
 
-<WidgetDocs Type="Ivy.Callout" ExtensionTypes="Ivy.CalloutExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Primitives/Callout.cs"/>
+<WidgetDocs Type="Ivy.Callout" ExtensionTypes="Ivy.CalloutExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Primitives/Callout.cs"/>
 
 ## Examples
 

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/13_Error.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/13_Error.md
@@ -276,7 +276,7 @@ public class EffectErrorView : ViewBase
 }
 ```
 
-<WidgetDocs Type="Ivy.Error" ExtensionTypes="Ivy.ErrorExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Primitives/Error.cs"/>
+<WidgetDocs Type="Ivy.Error" ExtensionTypes="Ivy.ErrorExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Primitives/Error.cs"/>
 
 ## Examples
 

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/14_Markdown.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/14_Markdown.md
@@ -253,4 +253,4 @@ public class ComprehensiveMarkdownView : ViewBase
 }
 ```
 
-<WidgetDocs Type="Ivy.Markdown" ExtensionTypes="Ivy.MarkdownExtensions"  SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Primitives/Markdown.cs"/>
+<WidgetDocs Type="Ivy.Markdown" ExtensionTypes="Ivy.MarkdownExtensions"  SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Primitives/Markdown.cs"/>

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/15_Html.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/15_Html.md
@@ -381,4 +381,4 @@ public class UserContentView : ViewBase
 - You need JavaScript functionality
 - Simple text formatting would suffice (use [Text widget](01_TextBlock.md))
 
-<WidgetDocs Type="Ivy.Html" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Primitives/Html.cs"/>
+<WidgetDocs Type="Ivy.Html" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Primitives/Html.cs"/>

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/16_Xml.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/16_Xml.md
@@ -91,7 +91,7 @@ public class XObjectXmlExample : ViewBase
 }
 ```
 
-<WidgetDocs Type="Ivy.Xml" ExtensionTypes="Ivy.XmlExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Primitives/Xml.cs"/>
+<WidgetDocs Type="Ivy.Xml" ExtensionTypes="Ivy.XmlExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Primitives/Xml.cs"/>
 
 ## Examples
 

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/17_Json.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/17_Json.md
@@ -35,4 +35,4 @@ public class BasicJsonExample : ViewBase
 }
 ```
 
-<WidgetDocs Type="Ivy.Json" ExtensionTypes="Ivy.JsonExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Primitives/Json.cs"/>
+<WidgetDocs Type="Ivy.Json" ExtensionTypes="Ivy.JsonExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Primitives/Json.cs"/>

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/18_Svg.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/18_Svg.md
@@ -65,4 +65,4 @@ public class SimpleSvgView : ViewBase
 }
 ```
 
-<WidgetDocs Type="Ivy.Svg" ExtensionTypes="Ivy.SvgExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Primitives/Svg.cs"/>
+<WidgetDocs Type="Ivy.Svg" ExtensionTypes="Ivy.SvgExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Primitives/Svg.cs"/>

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/19_Embed.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/19_Embed.md
@@ -60,4 +60,4 @@ Layout.Vertical().Gap(4)
     | new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fqrcoder%2Fdevcontainer.json&location=EuropeWest")
 ```
 
-<WidgetDocs Type="Ivy.Embed" ExtensionTypes="Ivy.EmbedExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Primitives/Embed.cs"/>
+<WidgetDocs Type="Ivy.Embed" ExtensionTypes="Ivy.EmbedExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Primitives/Embed.cs"/>

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/20_Iframe.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/20_Iframe.md
@@ -172,4 +172,4 @@ sequenceDiagram
     S-->>I: Fresh content
 ```
 
-<WidgetDocs Type="Ivy.Iframe" ExtensionTypes="Ivy.IframeExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Primitives/Iframe.cs"/>
+<WidgetDocs Type="Ivy.Iframe" ExtensionTypes="Ivy.IframeExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Primitives/Iframe.cs"/>

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/21_AudioPlayer.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/21_AudioPlayer.md
@@ -58,4 +58,4 @@ Layout.Vertical().Gap(4)
     .Preload(AudioPreload.Auto)
 ```
 
-<WidgetDocs Type="Ivy.AudioPlayer" ExtensionTypes="Ivy.AudioPlayerExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Primitives/AudioPlayer.cs"/>
+<WidgetDocs Type="Ivy.AudioPlayer" ExtensionTypes="Ivy.AudioPlayerExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Primitives/AudioPlayer.cs"/>

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/22_VideoPlayer.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/22_VideoPlayer.md
@@ -95,4 +95,4 @@ new VideoPlayer("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
     .Controls(false)
 ```
 
-<WidgetDocs Type="Ivy.VideoPlayer" ExtensionTypes="Ivy.VideoPlayerExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Primitives/VideoPlayer.cs"/>
+<WidgetDocs Type="Ivy.VideoPlayer" ExtensionTypes="Ivy.VideoPlayerExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Primitives/VideoPlayer.cs"/>

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/23_Stepper.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/23_Stepper.md
@@ -115,4 +115,4 @@ public class StepperDynamicStatesDemo : ViewBase
 }
 ```
 
-<WidgetDocs Type="Ivy.Stepper" ExtensionTypes="Ivy.StepperExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Primitives/Stepper.cs"/>
+<WidgetDocs Type="Ivy.Stepper" ExtensionTypes="Ivy.StepperExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Primitives/Stepper.cs"/>

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/02_Layouts/01_StackLayout.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/02_Layouts/01_StackLayout.md
@@ -82,7 +82,7 @@ public class AdvancedStackLayoutExample : ViewBase
 StackLayout is the foundation for most other layout widgets. Understanding its properties will help you master more complex layout systems.
 </Callout>
 
-<WidgetDocs Type="Ivy.StackLayout" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Layouts/StackLayout.cs"/>
+<WidgetDocs Type="Ivy.StackLayout" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Layouts/StackLayout.cs"/>
 
 ## Examples
 

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/02_Layouts/02_WrapLayout.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/02_Layouts/02_WrapLayout.md
@@ -110,7 +110,7 @@ Layout.Vertical()
 ], gap: 6, padding: new Thickness(4), margin: new Thickness(4))
 ```
 
-<WidgetDocs Type="Ivy.WrapLayout" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Layouts/WrapLayout.cs"/>
+<WidgetDocs Type="Ivy.WrapLayout" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Layouts/WrapLayout.cs"/>
 
 ## Examples
 

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/02_Layouts/03_GridLayout.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/02_Layouts/03_GridLayout.md
@@ -269,4 +269,4 @@ Layout.Vertical()
 | GridColumnSpan(int) | Span child across multiple columns |
 | GridRowSpan(int) | Span child across multiple rows |
 
-<WidgetDocs Type="Ivy.GridLayout" ExtensionTypes="Ivy.GridExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Layouts/GridLayout.cs"/>
+<WidgetDocs Type="Ivy.GridLayout" ExtensionTypes="Ivy.GridExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Layouts/GridLayout.cs"/>

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/02_Layouts/04_HeaderLayout.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/02_Layouts/04_HeaderLayout.md
@@ -257,4 +257,4 @@ public class FormHeaderExample : ViewBase
 }
 ```
 
-<WidgetDocs Type="Ivy.HeaderLayout" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Layouts/HeaderLayout.cs"/>
+<WidgetDocs Type="Ivy.HeaderLayout" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Layouts/HeaderLayout.cs"/>

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/02_Layouts/05_FooterLayout.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/02_Layouts/05_FooterLayout.md
@@ -114,7 +114,7 @@ public class SheetWithFooterExample : ViewBase
 Use FooterLayout for multi-step forms, long questionnaires, and data entry interfaces.
 </Callout>
 
-<WidgetDocs Type="Ivy.FooterLayout" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Layouts/FooterLayout.cs"/>
+<WidgetDocs Type="Ivy.FooterLayout" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Layouts/FooterLayout.cs"/>
 
 ## Examples
 

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/02_Layouts/06_SidebarLayout.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/02_Layouts/06_SidebarLayout.md
@@ -255,4 +255,4 @@ public class SidebarMenuAdvancedExample : ViewBase
 }
 ```
 
- <WidgetDocs Type="Ivy.SidebarLayout" ExtensionTypes="Ivy.SidebarLayoutExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Layouts/SidebarLayout.cs"/>
+ <WidgetDocs Type="Ivy.SidebarLayout" ExtensionTypes="Ivy.SidebarLayoutExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Layouts/SidebarLayout.cs"/>

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/02_Layouts/07_TabsLayout.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/02_Layouts/07_TabsLayout.md
@@ -142,4 +142,4 @@ Layout.Tabs(
 )
 ```
 
-<WidgetDocs Type="Ivy.TabsLayout" ExtensionTypes="Ivy.Views.Tabs.TabsLayoutExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/TabsLayout/TabsLayout.cs"/>
+<WidgetDocs Type="Ivy.TabsLayout" ExtensionTypes="Ivy.Views.Tabs.TabsLayoutExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/TabsLayout/TabsLayout.cs"/>

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/02_Layouts/08_ResizeablePanelGroup.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/02_Layouts/08_ResizeablePanelGroup.md
@@ -281,7 +281,7 @@ public class NestedLayoutView : ViewBase
 }
 ```
 
-<WidgetDocs Type="Ivy.ResizeablePanelGroup" ExtensionTypes="Ivy.ResizeablePanelsExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Layouts/ResizeablePanelGroup.cs"/>
+<WidgetDocs Type="Ivy.ResizeablePanelGroup" ExtensionTypes="Ivy.ResizeablePanelsExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Layouts/ResizeablePanelGroup.cs"/>
 
 ## Examples
 

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/02_Layouts/09_FloatingPanel.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/02_Layouts/09_FloatingPanel.md
@@ -326,7 +326,7 @@ public class ActionPanelView : ViewBase
 Ensure floating panels don't interfere with content readability and provide clear visual hierarchy. Use appropriate contrast and sizing for interactive elements.
 </Callout>
 
-<WidgetDocs Type="Ivy.FloatingPanel" ExtensionTypes="Ivy.FloatingLayerExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Layouts/FloatingPanel.cs"/>
+<WidgetDocs Type="Ivy.FloatingPanel" ExtensionTypes="Ivy.FloatingLayerExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Layouts/FloatingPanel.cs"/>
 
 ## Examples
 

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/01_Button.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/01_Button.md
@@ -92,4 +92,4 @@ Buttons with URLs support [right-click actions](../../01_Onboarding/02_Concepts/
             .Url("https://github.com/Ivy-Interactive/Ivy-Framework")
 ```
 
-<WidgetDocs Type="Ivy.Button" ExtensionTypes="Ivy.ButtonExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Button.cs"/>
+<WidgetDocs Type="Ivy.Button" ExtensionTypes="Ivy.ButtonExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Button.cs"/>

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/02_Badge.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/02_Badge.md
@@ -74,7 +74,7 @@ Layout.Vertical().Gap(4)
         | new Badge(null, icon:Icons.X, variant:BadgeVariant.Destructive))
 ```
 
-<WidgetDocs Type="Ivy.Badge" ExtensionTypes="Ivy.BadgeExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Badge.cs"/>
+<WidgetDocs Type="Ivy.Badge" ExtensionTypes="Ivy.BadgeExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Badge.cs"/>
 
 ## Examples
 

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/03_Tooltip.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/03_Tooltip.md
@@ -176,4 +176,4 @@ Layout.Vertical()
     | new Badge("Status").WithTooltip("Current status is clearly indicated for all users")
 ```
 
-<WidgetDocs Type="Ivy.Tooltip" ExtensionTypes="Ivy.TooltipExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Tooltip.cs"/>
+<WidgetDocs Type="Ivy.Tooltip" ExtensionTypes="Ivy.TooltipExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Tooltip.cs"/>

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/04_Card.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/04_Card.md
@@ -81,4 +81,4 @@ new MetricView(
 
 The `MetricView` uses UseQuery hooks for data loading, which automatically handles loading states, error handling, and caching. It also displays trend arrows with color-coded indicators for performance tracking. See the [MetricView documentation](13_MetricView.md) for more details.
 
-<WidgetDocs Type="Ivy.Card" ExtensionTypes="Ivy.CardExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Card.cs"/>
+<WidgetDocs Type="Ivy.Card" ExtensionTypes="Ivy.CardExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Card.cs"/>

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/05_Details.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/05_Details.md
@@ -105,4 +105,4 @@ UseState(() => new { Name = "John Doe", Age = 30 })
     .ToDetails()
 ```
 
-<WidgetDocs Type="Ivy.Details" ExtensionTypes="Ivy.Views.Builders.DetailsBuilderExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Views/Builders/DetailsBuilder.cs"/>
+<WidgetDocs Type="Ivy.Details" ExtensionTypes="Ivy.Views.Builders.DetailsBuilderExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Views/Builders/DetailsBuilder.cs"/>

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/06_Expandable.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/06_Expandable.md
@@ -53,7 +53,7 @@ Layout.Vertical().Gap(2)
     | new Expandable("Open", "This expandable is open").Open()
 ```
 
-<WidgetDocs Type="Ivy.Expandable" ExtensionTypes="Ivy.ExpandableExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Expandable.cs"/>
+<WidgetDocs Type="Ivy.Expandable" ExtensionTypes="Ivy.ExpandableExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Expandable.cs"/>
 
 ## Examples
 

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/07_List.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/07_List.md
@@ -165,7 +165,7 @@ public class SearchableListDemo : ViewBase
 }
 ```
 
-<WidgetDocs Type="Ivy.List" ExtensionTypes="Ivy.WidgetBaseExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Lists/List.cs"/>
+<WidgetDocs Type="Ivy.List" ExtensionTypes="Ivy.WidgetBaseExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Lists/List.cs"/>
 
 ## Examples
 

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/08_Table.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/08_Table.md
@@ -414,4 +414,4 @@ public class TableIntegrationExample : ViewBase
 }
 ```
 
-<WidgetDocs Type="Ivy.Table" ExtensionTypes="Ivy.Views.Tables.TableExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Tables/Table.cs"/>
+<WidgetDocs Type="Ivy.Table" ExtensionTypes="Ivy.Views.Tables.TableExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Tables/Table.cs"/>

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/09_Pagination.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/09_Pagination.md
@@ -56,4 +56,4 @@ public class PaginationConfigurationApp : ViewBase
 }
 ```
 
-<WidgetDocs Type="Ivy.Pagination" ExtensionTypes="Ivy.PaginationExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Pagination.cs"/>
+<WidgetDocs Type="Ivy.Pagination" ExtensionTypes="Ivy.PaginationExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Pagination.cs"/>

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/10_Progress.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/10_Progress.md
@@ -41,4 +41,4 @@ public class ProgressDemo : ViewBase
 }
 ```
 
-<WidgetDocs Type="Ivy.Progress" ExtensionTypes="Ivy.ProgressExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Progress.cs"/>
+<WidgetDocs Type="Ivy.Progress" ExtensionTypes="Ivy.ProgressExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Progress.cs"/>

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/11_DropDownMenu.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/11_DropDownMenu.md
@@ -196,7 +196,7 @@ new DropDownMenu(@evt => {
     | MenuItem.Default("Share").Tag("share")
 ```
 
-<WidgetDocs Type="Ivy.DropDownMenu" ExtensionTypes="Ivy.DropDownMenuExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/DropDownMenu.cs"/>
+<WidgetDocs Type="Ivy.DropDownMenu" ExtensionTypes="Ivy.DropDownMenuExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/DropDownMenu.cs"/>
 
 ## Examples
 

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/12_Blades.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/12_Blades.md
@@ -227,4 +227,4 @@ In most cases, you'll use `UseBlades()` directly in your views. The hook manages
 </Callout>
 
 
-<WidgetDocs Type="Ivy.Blade" ExtensionTypes="Ivy.Views.Blades.UseBladesExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Views/Blades/UseBlades.cs"/>
+<WidgetDocs Type="Ivy.Blade" ExtensionTypes="Ivy.Views.Blades.UseBladesExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Views/Blades/UseBlades.cs"/>

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/13_MetricView.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/13_MetricView.md
@@ -118,7 +118,7 @@ new MetricView(
 )
 ```
 
-<WidgetDocs Type="Ivy.Views.Dashboards.MetricView" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Views/Dashboards/MetricView.cs"/>
+<WidgetDocs Type="Ivy.Views.Dashboards.MetricView" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Views/Dashboards/MetricView.cs"/>
 
 ## Examples
 

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/14_Terminal.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/14_Terminal.md
@@ -51,7 +51,7 @@ Layout.Vertical().Gap(4)
         .AddOutput("nothing to commit, working tree clean")
 ```
 
-<WidgetDocs Type="Ivy.Widgets.Internal.Terminal" ExtensionTypes="Ivy.Widgets.Internal.TerminalExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Internal/Terminal.cs"/>
+<WidgetDocs Type="Ivy.Widgets.Internal.Terminal" ExtensionTypes="Ivy.Widgets.Internal.TerminalExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Internal/Terminal.cs"/>
 
 ## Examples
 

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/04_Inputs/01_Field.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/04_Inputs/01_Field.md
@@ -105,4 +105,4 @@ public class MixedInputsDemo : ViewBase
 Use `Field` whenever you want **consistent form layout** across your application with labels, description and required asterisk.
 </Callout>
 
-<WidgetDocs Type="Ivy.Field" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Inputs/Field.cs"/>
+<WidgetDocs Type="Ivy.Field" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Inputs/Field.cs"/>

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/04_Inputs/02_TextInput.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/04_Inputs/02_TextInput.md
@@ -351,7 +351,7 @@ public class BasicFilter : ViewBase
 }
 ```
 
-<WidgetDocs Type="Ivy.TextInput" ExtensionTypes="Ivy.TextInputExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Inputs/TextInput.cs"/>
+<WidgetDocs Type="Ivy.TextInput" ExtensionTypes="Ivy.TextInputExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Inputs/TextInput.cs"/>
 
 ## Examples
 

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/04_Inputs/03_NumberInput.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/04_Inputs/03_NumberInput.md
@@ -215,7 +215,7 @@ new NumberInput<int>(onChangedState.Value, e =>
 });
 ```
 
-<WidgetDocs Type="Ivy.NumberInput" ExtensionTypes="Ivy.NumberInputExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Inputs/NumberInput.cs"/>
+<WidgetDocs Type="Ivy.NumberInput" ExtensionTypes="Ivy.NumberInputExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Inputs/NumberInput.cs"/>
 
 ## Examples
 

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/04_Inputs/04_BoolInput.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/04_Inputs/04_BoolInput.md
@@ -185,7 +185,7 @@ public class SingleToggleDemo : ViewBase
 BoolInput also supports integer-based boolean values (0 = false, 1 = true) for compatibility with legacy systems. Simply use `UseState(0)` or `UseState(1)` with standard extension methods like `ToBoolInput()`, `ToSwitchInput()`, or `ToToggleInput()`.
 </Callout>
 
-<WidgetDocs Type="Ivy.BoolInput" ExtensionTypes="Ivy.BoolInputExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Inputs/BoolInput.cs"/>
+<WidgetDocs Type="Ivy.BoolInput" ExtensionTypes="Ivy.BoolInputExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Inputs/BoolInput.cs"/>
 
 ## Examples
 

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/04_Inputs/05_SelectInput.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/04_Inputs/05_SelectInput.md
@@ -173,7 +173,7 @@ public class SelectStylingDemo : ViewBase
 Use Select for single choice dropdowns, List for multiple selection with checkboxes, and Toggle for visual button-based selection. The List variant is particularly useful for [forms](../../01_Onboarding/02_Concepts/13_Forms.md) where users need to select multiple options.
 </Callout>
 
-<WidgetDocs Type="Ivy.SelectInput" ExtensionTypes="Ivy.SelectInputExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Inputs/SelectInput.cs"/>
+<WidgetDocs Type="Ivy.SelectInput" ExtensionTypes="Ivy.SelectInputExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Inputs/SelectInput.cs"/>
 
 ## Examples
 

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/04_Inputs/06_AsyncSelectInput.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/04_Inputs/06_AsyncSelectInput.md
@@ -362,4 +362,4 @@ public class StylingDemo : ViewBase
 AsyncSelectInput automatically handles loading states and provides a smooth user [experience](../../01_Onboarding/02_Concepts/02_Views.md). The query function is called as the user types, and the lookup function is called when displaying the selected value.
 </Callout>
 
-<WidgetDocs Type="Ivy.AsyncSelectInput" ExtensionTypes="Ivy.AsyncSelectInputExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Inputs/AsyncSelectInput.cs"/>
+<WidgetDocs Type="Ivy.AsyncSelectInput" ExtensionTypes="Ivy.AsyncSelectInputExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Inputs/AsyncSelectInput.cs"/>

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/04_Inputs/07_DateTimeInput.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/04_Inputs/07_DateTimeInput.md
@@ -121,4 +121,4 @@ public class FormatDemo : ViewBase
 }    
 ```
 
-<WidgetDocs Type="Ivy.DateTimeInput" ExtensionTypes="Ivy.DateTimeInputExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Inputs/DateTimeInput.cs"/>
+<WidgetDocs Type="Ivy.DateTimeInput" ExtensionTypes="Ivy.DateTimeInputExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Inputs/DateTimeInput.cs"/>

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/04_Inputs/08_DateRangeInput.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/04_Inputs/08_DateRangeInput.md
@@ -91,7 +91,7 @@ public class FormatDateRangeDemo : ViewBase
 }        
 ```
 
-<WidgetDocs Type="Ivy.DateRangeInput" ExtensionTypes="Ivy.DateRangeInputExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Inputs/DateRangeInput.cs"/>
+<WidgetDocs Type="Ivy.DateRangeInput" ExtensionTypes="Ivy.DateRangeInputExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Inputs/DateRangeInput.cs"/>
 
 ## Examples
 

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/04_Inputs/09_ColorInput.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/04_Inputs/09_ColorInput.md
@@ -146,7 +146,7 @@ public class ColorStylingDemo : ViewBase
 }
 ```
 
-<WidgetDocs Type="Ivy.ColorInput" ExtensionTypes="Ivy.ColorInputExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Inputs/ColorInput.cs"/>
+<WidgetDocs Type="Ivy.ColorInput" ExtensionTypes="Ivy.ColorInputExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Inputs/ColorInput.cs"/>
 
 ## Examples
 

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/04_Inputs/10_FileInput.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/04_Inputs/10_FileInput.md
@@ -593,4 +593,4 @@ public class ConfiguredUploadExample : ViewBase
 | `MaxFileSize`| `long?`        | Maximum file size in bytes                                       |
 | `MaxFiles`   | `int?`         | Maximum number of files (for multiple file uploads)              |
 
-<WidgetDocs Type="Ivy.FileInput" ExtensionTypes="Ivy.FileInputExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Inputs/FileInput.cs"/>
+<WidgetDocs Type="Ivy.FileInput" ExtensionTypes="Ivy.FileInputExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Inputs/FileInput.cs"/>

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/04_Inputs/11_CodeInput.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/04_Inputs/11_CodeInput.md
@@ -187,4 +187,4 @@ public class CodeInputWithValidation : ViewBase
 }
 ```
 
-<WidgetDocs Type="Ivy.CodeInput" ExtensionTypes="Ivy.CodeInputExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Inputs/CodeInput.cs"/>
+<WidgetDocs Type="Ivy.CodeInput" ExtensionTypes="Ivy.CodeInputExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Inputs/CodeInput.cs"/>

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/04_Inputs/12_AudioRecorder.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/04_Inputs/12_AudioRecorder.md
@@ -154,4 +154,4 @@ public class AudioRecorderDisabledDemo : ViewBase
 }
 ```
 
-<WidgetDocs Type="Ivy.AudioRecorder" ExtensionTypes="Ivy.AudioRecorderExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/AudioRecorder.cs"/>
+<WidgetDocs Type="Ivy.AudioRecorder" ExtensionTypes="Ivy.AudioRecorderExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/AudioRecorder.cs"/>

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/04_Inputs/13_FeedbackInput.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/04_Inputs/13_FeedbackInput.md
@@ -117,4 +117,4 @@ public class StyledFeedbackDemo : ViewBase
 }        
 ```
 
-<WidgetDocs Type="Ivy.FeedbackInput" ExtensionTypes="Ivy.FeedbackInputExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Inputs/FeedbackInput.cs"/>
+<WidgetDocs Type="Ivy.FeedbackInput" ExtensionTypes="Ivy.FeedbackInputExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Inputs/FeedbackInput.cs"/>

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/04_Inputs/14_ReadOnlyInput.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/04_Inputs/14_ReadOnlyInput.md
@@ -32,7 +32,7 @@ public class ReadOnlyDemo : ViewBase
 }    
 ```
 
-<WidgetDocs Type="Ivy.ReadOnlyInput" ExtensionTypes="Ivy.ReadOnlyInputExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Inputs/ReadOnlyInput.cs"/>
+<WidgetDocs Type="Ivy.ReadOnlyInput" ExtensionTypes="Ivy.ReadOnlyInputExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Inputs/ReadOnlyInput.cs"/>
 
 ## Examples
 

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/05_Effects/Animation.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/05_Effects/Animation.md
@@ -344,7 +344,7 @@ Layout.Wrap().Gap(4).Align(Align.Center)
         .Duration(0.6)
 ```
 
-<WidgetDocs Type="Ivy.Animation" ExtensionTypes="Ivy.AnimationExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Effects/Animation.cs"/>
+<WidgetDocs Type="Ivy.Animation" ExtensionTypes="Ivy.AnimationExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Effects/Animation.cs"/>
 
 ## Examples
 

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/05_Effects/Confetti.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/05_Effects/Confetti.md
@@ -54,7 +54,7 @@ Layout.Vertical().Gap(10)
             .WithConfetti(AnimationTrigger.Click)))
 ```
 
-<WidgetDocs Type="Ivy.Confetti" ExtensionTypes="Ivy.ConfettiExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Effects/Confetti.cs"/>
+<WidgetDocs Type="Ivy.Confetti" ExtensionTypes="Ivy.ConfettiExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Effects/Confetti.cs"/>
 
 ## Examples
 

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/06_Charts/01_LineChart.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/06_Charts/01_LineChart.md
@@ -112,7 +112,7 @@ public class LineWidthDemo : ViewBase
 }
 ```
 
-<WidgetDocs Type="Ivy.LineChart" ExtensionTypes="Ivy.LineChartExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Charts/LineChart.cs"/>
+<WidgetDocs Type="Ivy.LineChart" ExtensionTypes="Ivy.LineChartExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Charts/LineChart.cs"/>
 
 ## Example
 

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/06_Charts/02_BarChart.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/06_Charts/02_BarChart.md
@@ -87,7 +87,7 @@ with a specific [Colors](../../04_ApiReference/IvyShared/Colors.md) value. The `
 to use squares. Using the `Name` function, the name of a bar can be renamed. Like
 here is done for the `Blueberry` column.
 
-<WidgetDocs Type="Ivy.BarChart" ExtensionTypes="Ivy.BarChartExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Charts/BarChart.cs"/>
+<WidgetDocs Type="Ivy.BarChart" ExtensionTypes="Ivy.BarChartExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Charts/BarChart.cs"/>
 
 ## Examples
 

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/06_Charts/03_AreaChart.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/06_Charts/03_AreaChart.md
@@ -44,7 +44,7 @@ public class BasicAreaChart : ViewBase
 }
 ```
 
-<WidgetDocs Type="Ivy.AreaChart" ExtensionTypes="Ivy.AreaChartExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Charts/AreaChart.cs"/>
+<WidgetDocs Type="Ivy.AreaChart" ExtensionTypes="Ivy.AreaChartExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Charts/AreaChart.cs"/>
 
 ## Examples
 

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/06_Charts/04_PieChart.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/06_Charts/04_PieChart.md
@@ -253,4 +253,4 @@ public class DrillDownDemo : ViewBase
 }
 ```
 
-<WidgetDocs Type="Ivy.PieChart" ExtensionTypes="Ivy.PieChartExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Charts/PieChart.cs"/>
+<WidgetDocs Type="Ivy.PieChart" ExtensionTypes="Ivy.PieChartExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Charts/PieChart.cs"/>

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/07_Advanced/01_DataTable.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/07_Advanced/01_DataTable.md
@@ -311,4 +311,4 @@ sampleUsers.ToDataTable()
 </Body>
 </Details>
 
-<WidgetDocs Type="Ivy.DataTable" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/DataTables/DataTable.cs"/>
+<WidgetDocs Type="Ivy.DataTable" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/DataTables/DataTable.cs"/>

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/07_Advanced/02_Sheet.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/07_Advanced/02_Sheet.md
@@ -338,7 +338,7 @@ public class TaskFormSheet : ViewBase
 }
 ```
 
-<WidgetDocs Type="Ivy.Sheet" ExtensionTypes="Ivy.SheetExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Sheet.cs"/>
+<WidgetDocs Type="Ivy.Sheet" ExtensionTypes="Ivy.SheetExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Sheet.cs"/>
 
 ## Examples
 

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/07_Advanced/03_Kanban.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/07_Advanced/03_Kanban.md
@@ -405,4 +405,4 @@ public class SimpleStatusBoard : ViewBase
 </Body>
 </Details>
 
-<WidgetDocs Type="Ivy.Kanban" ExtensionTypes="Ivy.KanbanColumnExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Kanban/Kanban.cs"/>
+<WidgetDocs Type="Ivy.Kanban" ExtensionTypes="Ivy.KanbanColumnExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Kanban/Kanban.cs"/>

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/07_Advanced/04_Chat.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/07_Advanced/04_Chat.md
@@ -396,4 +396,4 @@ public class AdvancedChatDemo : ViewBase
 }
 ```
 
-<WidgetDocs Type="Ivy.Chat" ExtensionTypes="Ivy.ChatExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/Ivy/Widgets/Chat.cs"/>
+<WidgetDocs Type="Ivy.Chat" ExtensionTypes="Ivy.ChatExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Chat.cs"/>

--- a/src/Ivy.Docs.Shared/Helpers/WidgetDocsView.cs
+++ b/src/Ivy.Docs.Shared/Helpers/WidgetDocsView.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 
 namespace Ivy.Docs.Shared.Helpers;
 


### PR DESCRIPTION
API documentation links in doc pages were returning 404 errors. The GitHub URLs were missing the `src/` directory prefix after the project was moved to the `src` folder.

<img width="717" height="98" alt="image" src="https://github.com/user-attachments/assets/27d88ef2-6432-4bb6-8f42-b89269de3e8b" />

On clicking all the links to source code we had:

<img width="2551" height="457" alt="image" src="https://github.com/user-attachments/assets/90e72009-09a5-4754-84ee-0ad47f88bad5" />

Fixed and tested.

<img width="2559" height="1215" alt="image" src="https://github.com/user-attachments/assets/63421060-8090-4b28-aaea-03549b3b6f14" />
