### PR TITLE
(hooks): preserve hook names without spaces in docs sidebar

### DIFF
--- a/src/Ivy/Utils.cs
+++ b/src/Ivy/Utils.cs
@@ -210,9 +210,8 @@ public static class Utils
     public static string? SplitPascalCase(string? input)
     {
         if (input == null) return null;
-        //string[] words = Regex.Matches(input, "([A-Z]+(?![a-z])|[A-Z][a-z]+|[0-9]+|[a-z]+)")
-        string[] words = Regex.Matches(input, "([A-Z]+[a-z]+|[0-9]+|[a-z]+|[A-Z]+)")
-            //.OfType<Match>()
+        string[] words = Regex
+            .Matches(input, "([A-Z]+[a-z]+|[0-9]+|[a-z]+|[A-Z]+)")
             .Select(m => m.Value)
             .ToArray();
         return string.Join(" ", words);
@@ -240,7 +239,10 @@ public static class Utils
             .Replace('_', '-')
             .Replace(' ', '-');
 
-        var normalized = Regex.Replace(withWordBoundaries, "-{2,}", "-").Trim('-').ToLowerInvariant();
+        var normalized = Regex
+            .Replace(withWordBoundaries, "-{2,}", "-")
+            .Trim('-')
+            .ToLowerInvariant();
 
         if (hadUnderscore)
         {
@@ -261,8 +263,8 @@ public static class Utils
         }
 
         // Check if this is a hook
-        bool isHook = input.Length >= 4 && 
-                      input.StartsWith("Use", StringComparison.Ordinal) && 
+        bool isHook = input.Length >= 4 &&
+                      input.StartsWith("Use", StringComparison.Ordinal) &&
                       char.IsUpper(input[3]);
 
         StringBuilder sb = new();


### PR DESCRIPTION
We had an issue with the default doc name parsing logic: it automatically inserts spaces before capital letters. This works fine for regular docs, but caused problems for hook docs, where an extra space was incorrectly added.

<img width="252" height="854" alt="image" src="https://github.com/user-attachments/assets/2bf49f5b-1212-4a28-aaf1-1b4868c93206" />

Fixed this by adding a small exception: if the doc is a hook doc, we skip the space-insertion logic.

<img width="236" height="614" alt="image" src="https://github.com/user-attachments/assets/b83ce052-5ca6-4f16-a1b8-fcecdca66f8d" />

I checked other document names as well — nothing is broken by this change.

<img width="149" height="1228" alt="image" src="https://github.com/user-attachments/assets/f86ee574-cad9-4abf-9dff-ef350ab41b60" />
