### PR TITLE
[GridLayout]: fix cell overflow behavior on hover

### DIFF
--- a/src/frontend/src/lib/styles.ts
+++ b/src/frontend/src/lib/styles.ts
@@ -382,11 +382,6 @@ export const getOverflow = (overflow?: Overflow): React.CSSProperties => {
   };
 };
 
-export const gridCellOverflow = {
-  ellipsis:
-    '[&>*]:min-w-0 [&>*]:truncate hover:[&>*]:overflow-visible hover:[&>*]:whitespace-normal hover:[&>*]:absolute hover:[&>*]:z-10',
-};
-
 export type Orientation = 'Horizontal' | 'Vertical';
 
 export type Align =

--- a/src/frontend/src/widgets/layouts/GridLayoutWidget.tsx
+++ b/src/frontend/src/widgets/layouts/GridLayoutWidget.tsx
@@ -5,7 +5,6 @@ import {
   getWidth,
   getHeight,
   convertSizeToGridValue,
-
 } from '../../lib/styles';
 
 interface GridLayoutWidgetProps {


### PR DESCRIPTION
**Description:**
This PR fixes a critical UX issue where interactive widgets (like `ColorInput`) inside a `Layout.Grid` would unexpectedly "pop out" (switching to absolute positioning with high z-index) when hovered, causing layout shifting and preventing proper interaction.

**Context:**
This behavior was introduced in #2095 to handle text overflow in grid cells. However, enforcing this style (`gridCellOverflow.ellipsis`) globally on `GridLayoutWidget` is too aggressive for a generic layout container. It indiscriminately treats all cell content—including complex forms and interactive components—as truncatable text.

**Changes:**
- Reverts the forced `gridCellOverflow.ellipsis` usage in `GridLayoutWidget`.
- Restores stable layout behavior for components inside Grids.