### PR TITLE
(tooltip): resolve tooltip button-in-button hydration error

### DIFF
--- a/src/frontend/src/widgets/tooltip/TooltipWidget.tsx
+++ b/src/frontend/src/widgets/tooltip/TooltipWidget.tsx
@@ -22,10 +22,15 @@ export const TooltipWidget: React.FC<TooltipWidgetProps> = ({ slots }) => {
       </div>
     );
   }
+
+  // asChild + span: we need a single DOM node that receives ref/handlers (slot widgets like ButtonWidget don't forward ref).
+  // A span wrapper avoids TooltipTrigger's default <button> so we don't get invalid button-in-button.
   return (
     <TooltipProvider>
       <Tooltip>
-        <TooltipTrigger>{slots.Trigger}</TooltipTrigger>
+        <TooltipTrigger asChild>
+          <span style={{ display: 'inline-block' }}>{slots.Trigger}</span>
+        </TooltipTrigger>
         <TooltipContent className="bg-popover text-popover-foreground shadow-md">
           {slots.Content}
         </TooltipContent>


### PR DESCRIPTION
Loading the Icons (and Icon) docs page caused a React hydration error: **"In HTML, \<button> cannot be a descendant of \<button>"**.
 TooltipWidget now uses `TooltipTrigger asChild` and wraps the trigger slot content in a single `<span>`.

<img width="2153" height="914" alt="Screenshot 2026-01-30 at 03 42 42" src="https://github.com/user-attachments/assets/593848a5-2dad-4fc4-934e-ec85f0231289" />

Tested out. Non of tooltip functionality was broken by this change. 