### PR TITLE
(doc tools): copy/download page without raw markdown links

### DIFF
--- a/src/frontend/src/widgets/article/DocumentTools.tsx
+++ b/src/frontend/src/widgets/article/DocumentTools.tsx
@@ -122,9 +122,9 @@ export const DocumentTools: React.FC<DocumentToolsProps> = ({
         description: 'Fetching markdown from server...',
       });
 
-      const content = await fetchMarkdown();
+      const rawContent = await fetchMarkdown();
 
-      if (!content.trim()) {
+      if (!rawContent.trim()) {
         toast({
           title: 'Download Failed',
           description: 'No content found to download',
@@ -133,6 +133,7 @@ export const DocumentTools: React.FC<DocumentToolsProps> = ({
         return;
       }
 
+      const content = stripMarkdownLinks(rawContent);
       // Create and download the file
       const blob = new Blob([content], { type: 'text/markdown' });
       const url = URL.createObjectURL(blob);


### PR DESCRIPTION
When using "Copy Page" or "Download as Markdown" in document tools, markdown links like `[widget](../../01_Onboarding/02_Concepts/03_Widgets.md)` were kept as-is. They are now replaced with the link text only (e.g. `widget`).
Source for example:
<img width="802" height="211" alt="image" src="https://github.com/user-attachments/assets/4df09bd3-baf5-402a-94a0-0154b81307bd" />
How it was:
<img width="1560" height="171" alt="image" src="https://github.com/user-attachments/assets/4607e694-5d07-4637-98f6-b33ee54c7f8f" />
Copied page after fix:
<img width="1321" height="130" alt="image" src="https://github.com/user-attachments/assets/d408600e-1d96-4afe-9764-0aa89c4d1794" />
Downloaded page after fix:
<img width="1520" height="136" alt="image" src="https://github.com/user-attachments/assets/3c63cfbc-7aee-4da2-8ebc-11005e31bf6a" />
