### PR TITLE
[GridLayout]: resolve labels overflow

### DIFF
--- a/src/frontend/src/lib/styles.ts
+++ b/src/frontend/src/lib/styles.ts
@@ -384,7 +384,7 @@ export const getOverflow = (overflow?: Overflow): React.CSSProperties => {
 
 export const gridCellOverflow = {
   ellipsis:
-    '[&>*]:min-w-0 [&>*]:truncate hover:[&>*]:overflow-visible hover:[&>*]:whitespace-normal hover:[&>*]:absolute hover:[&>*]:z-10',
+    '[&>*:not(:has(*))]:min-w-0 [&>*:not(:has(*))]:overflow-hidden [&>*:not(:has(*))]:text-ellipsis [&>*:not(:has(*))]:whitespace-nowrap hover:[&>*:not(:has(*))]:overflow-visible hover:[&>*:not(:has(*))]:whitespace-normal hover:[&>*:not(:has(*))]:relative hover:[&>*:not(:has(*))]:z-10',
 };
 export type Orientation = 'Horizontal' | 'Vertical';
 

--- a/src/frontend/src/widgets/layouts/GridLayoutWidget.tsx
+++ b/src/frontend/src/widgets/layouts/GridLayoutWidget.tsx
@@ -5,6 +5,7 @@ import {
   getWidth,
   getHeight,
   convertSizeToGridValue,
+  gridCellOverflow,
 } from '../../lib/styles';
 
 interface GridLayoutWidgetProps {
@@ -54,7 +55,7 @@ const GridLayoutCell: React.FC<GridLayoutCellProps> = ({
   return (
     <div
       style={styles}
-      className={`relative flex items-center h-full w-full min-w-0 ${className}`}
+      className={`relative flex items-center h-full w-full min-w-0 ${gridCellOverflow.ellipsis} ${className}`}
     >
       {children}
     </div>


### PR DESCRIPTION
## Problem

Labels and text content within `Layout.Grid` cells were overflowing their containers, spilling over into adjacent cells and causing visual clutter. This was particularly noticeable on the BoolInput documentation page, where `BoolInputs.Checkbox` text was overlapping neighboring elements.

<img width="1049" height="597" alt="image" src="https://github.com/user-attachments/assets/78e5f55d-c45f-4780-adc4-65626d3e5686" />

### Root Cause

By default, Flexbox items (which our grid cells are) have `min-width: auto`. This prevents them from shrinking below the size of their content. Additionally, there was no overflow handling (`overflow: hidden` or `text-overflow: ellipsis`) applied to cell content, so text simply rendered outside cell boundaries when the column was too narrow.

## Previous Attempts

### PR #2095 — Hover Popout Approach

Added `gridCellOverflow.ellipsis` style that:
- Truncated text with ellipsis
- On hover, made elements `absolute` with `z-index: 10` to show full text

```typescript
// Previous implementation
'[&>*]:min-w-0 [&>*]:truncate hover:[&>*]:absolute hover:[&>*]:z-10'
```

**Issue:** The `hover:[&>*]:absolute` broke layout for interactive components like ColorInput, causing them to "pop out" and shift when hovered.

### PR #2149 — Revert

Reverted the changes from #2095 due to the layout-breaking side effects, which reopened issue #2059.

## Solution

Implemented a refined CSS-based approach that:

1. **Truncates only leaf elements** — Uses `:not(:has(*))` selector to apply truncation only to elements without children (text nodes), avoiding complex components like Swatch or ColorPicker.

2. **Uses `relative` instead of `absolute`** — On hover, elements expand to show full text while staying in document flow, preventing layout shifts.

https://github.com/user-attachments/assets/cfb971dc-862f-480f-a900-da3f7dcb53f5

### Key Changes

**`src/frontend/src/lib/styles.ts`**
```typescript
export const gridCellOverflow = {
  ellipsis:
    '[&>*:not(:has(*))]:min-w-0 [&>*:not(:has(*))]:overflow-hidden [&>*:not(:has(*))]:text-ellipsis [&>*:not(:has(*))]:whitespace-nowrap hover:[&>*:not(:has(*))]:overflow-visible hover:[&>*:not(:has(*))]:whitespace-normal hover:[&>*:not(:has(*))]:relative hover:[&>*:not(:has(*))]:z-10',
};
```

**`src/frontend/src/widgets/layouts/GridLayoutWidget.tsx`**
- Added import for `gridCellOverflow`
- Applied `gridCellOverflow.ellipsis` to `GridLayoutCell`

### Why This Approach?

| Aspect | Benefit |
|--------|---------|
| **No layout shifts** | `relative` positioning keeps elements in document flow |
| **Selective truncation** | `:not(:has(*))` targets only text elements, preserving complex components |
| **Hover reveal** | Full text visible on hover without tooltips |
| **Performance** | Pure CSS solution, no JavaScript overhead |

## Testing

Verified on:
- ✅ BoolInput page — labels truncate correctly, full text shown on hover
- ✅ ColorInput page — Swatch component displays fully, no clipping
- ✅ No layout shifts when hovering over any grid content