### PR TITLE
[Auth]: Make authentication cookie options configurable

### DIFF
--- a/src/Ivy/Auth/CookieRegistryExtensions.cs
+++ b/src/Ivy/Auth/CookieRegistryExtensions.cs
@@ -8,12 +8,6 @@ namespace Ivy.Auth;
 
 public static class CookieRegistryExtensions
 {
-    /// <summary>
-    /// Configure cookie options for authentication cookies.
-    /// Set this in Program.cs before calling RunAsync() to customize cookie behavior.
-    /// Example: CookieRegistryExtensions.ConfigureCookieOptions = options => options.Expires = DateTimeOffset.UtcNow.AddDays(30);
-    /// </summary>
-    public static Action<CookieOptions>? ConfigureCookieOptions { get; set; }
 
     public static IActionResult? WriteCookiesToResponse(this Controller controller, AppSessionStore sessionStore, CookieJarId cookieJarId, string intent, out CookieJar cookies)
     {
@@ -113,7 +107,7 @@ public static class CookieRegistryExtensions
         };
 
         // Apply custom configuration if provided
-        ConfigureCookieOptions?.Invoke(cookieOptions);
+        Server.ConfigureAuthCookieOptions?.Invoke(cookieOptions);
 
         return cookieOptions;
     }

--- a/src/Ivy/Server.cs
+++ b/src/Ivy/Server.cs
@@ -53,7 +53,7 @@ public class Server
     public IConfiguration Configuration { get; private set; } = ServerUtils.GetConfiguration();
     public Type? AuthProviderType { get; private set; } = null;
     public ServerArgs Args => _args;
-
+    public static Action<CookieOptions>? ConfigureAuthCookieOptions { get; set; }
     private IContentBuilder? _contentBuilder;
     private bool _useHotReload;
     private bool _useHttpRedirection;


### PR DESCRIPTION
## Summary
This PR introduces a static delegate `ConfigureAuthCookieOptions` in the `Server` class, allowing consumers of the library to customize authentication cookie settings (such as `Expires`, `SameSite`, `Secure`, etc.) globally from `Program.cs`. It also refactors the internal cookie creation logic to eliminate code duplication.

## Changes
- Added `public static Action<CookieOptions>? ConfigureAuthCookieOptions` property to the `Server` class.
- Extracted cookie creation logic into a reusable private helper method `CreateAuthCookieOptions` in `CookieRegistryExtensions`.
- Updated `AddCookiesForAuthToken` and `AddCookiesForAuthSessionData` to utilize the new helper method and apply any user-defined configurations via `Server.ConfigureAuthCookieOptions`.

## Motivation
Previously, authentication cookies had hardcoded settings (e.g., 1-year expiration, `SameSiteMode.Lax`). This implementation empowers developers to override these defaults based on their application's specific security requirements or preferences. The configuration is exposed through the `Server` class, which aligns with Ivy's pattern of configuring the framework through the main `Server` API rather than internal extension classes.

## Usage Example
In your application startup (e.g., `Program.cs`):
```csharp
Server.ConfigureAuthCookieOptions = options => 
{
    options.Expires = DateTimeOffset.UtcNow.AddDays(30);
};
```

https://github.com/user-attachments/assets/9eaccfff-ca93-404e-bc4e-db3673fa1632


## Authentication Token Behavior

**Previously:**
The `auth_token` cookie expiration was **hardcoded** to persist for 1 year after login.

**Now:**
The expiration time is fully **configurable**. You can now set it to a shorter duration, such as 30 seconds, or any other time that fits your security policy.

**Why this matters:**
This control is particularly important when using providers like **GitHub OAuth**, where the underlying access token often has an indefinite lifespan. By customizing the cookie expiration, you can effectiveley enforce your own session timeout policies on the client side, regardless of the provider's token lifetime.
