### PR TITLE
[Tabs]: Fix dropdown overflow and improve width calculations

### DIFF
--- a/src/frontend/src/widgets/layouts/tabs/components/DropdownMenu.tsx
+++ b/src/frontend/src/widgets/layouts/tabs/components/DropdownMenu.tsx
@@ -32,7 +32,7 @@ interface TabsDropdownMenuProps {
 /**
  * Dropdown menu component for displaying hidden tabs when they overflow.
  * Supports drag-and-drop reordering within the dropdown.
- * 
+ *
  * Returns an object with trigger button and menu content to allow flexible placement.
  */
 export const TabsDropdownMenu: React.FC<TabsDropdownMenuProps> = ({
@@ -48,45 +48,46 @@ export const TabsDropdownMenu: React.FC<TabsDropdownMenuProps> = ({
   handleTabSelect,
   isUserInitiatedChangeRef,
 }) => {
-  const menuContent = hiddenTabs.length > 0 ? (
-    <DropdownMenuContent align="end">
-      <DndContext
-        collisionDetection={closestCenter}
-        onDragEnd={handleDragEnd}
-        sensors={sensors}
-      >
-        <SortableContext items={tabOrder}>
-          <div className="flex flex-col gap-1 w-48">
-            {orderedTabWidgets.map(tabWidget => {
-              if (!React.isValidElement(tabWidget)) return null;
-              const props = getTabProps(tabWidget);
-              if (!props?.id) return null;
-              const { title, id } = props;
+  const menuContent =
+    hiddenTabs.length > 0 ? (
+      <DropdownMenuContent align="end">
+        <DndContext
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
+          sensors={sensors}
+        >
+          <SortableContext items={tabOrder}>
+            <div className="flex flex-col gap-1 w-48">
+              {orderedTabWidgets.map(tabWidget => {
+                if (!React.isValidElement(tabWidget)) return null;
+                const props = getTabProps(tabWidget);
+                if (!props?.id) return null;
+                const { title, id } = props;
 
-              // Only render tabs that are hidden
-              if (!hiddenTabs.includes(id)) return null;
+                // Only render tabs that are hidden
+                if (!hiddenTabs.includes(id)) return null;
 
-              return (
-                <SortableDropdownMenuItem
-                  key={id}
-                  id={id}
-                  onClick={() => {
-                    // Mark as user-initiated to prevent flicker
-                    isUserInitiatedChangeRef.current = true;
-                    handleTabSelect(id);
-                  }}
-                  isActive={activeTabId === id}
-                  showClose={showClose}
-                >
-                  {title}
-                </SortableDropdownMenuItem>
-              );
-            })}
-          </div>
-        </SortableContext>
-      </DndContext>
-    </DropdownMenuContent>
-  ) : null;
+                return (
+                  <SortableDropdownMenuItem
+                    key={id}
+                    id={id}
+                    onClick={() => {
+                      // Mark as user-initiated to prevent flicker
+                      isUserInitiatedChangeRef.current = true;
+                      handleTabSelect(id);
+                    }}
+                    isActive={activeTabId === id}
+                    showClose={showClose}
+                  >
+                    {title}
+                  </SortableDropdownMenuItem>
+                );
+              })}
+            </div>
+          </SortableContext>
+        </DndContext>
+      </DropdownMenuContent>
+    ) : null;
 
   return (
     <DropdownMenu open={dropdownOpen} onOpenChange={setDropdownOpen}>

--- a/src/frontend/src/widgets/layouts/tabs/components/Variants.tsx
+++ b/src/frontend/src/widgets/layouts/tabs/components/Variants.tsx
@@ -321,7 +321,7 @@ export const TabsVariant: React.FC<TabsVariantProps> = ({
                         // Active tab styling (overrides inactive)
                         'data-[state=active]:bg-background data-[state=active]:hover:bg-card',
                         (variant as string) === 'Content' &&
-                        'border-b-2 border-b-transparent data-[state=active]:border-b-primary'
+                          'border-b-2 border-b-transparent data-[state=active]:border-b-primary'
                       )}
                     >
                       {renderTabContent(tabWidget)}

--- a/src/frontend/src/widgets/layouts/tabs/hooks/useTabCalculation.ts
+++ b/src/frontend/src/widgets/layouts/tabs/hooks/useTabCalculation.ts
@@ -36,11 +36,13 @@ export function useTabCalculation(
     if (dropdownOpen) return;
 
     // Use tabsList width in TabsVariant, container width in ContentVariant
-    const referenceElement = tabsList.classList.contains('w-full') ? tabsList : container;
+    const referenceElement = tabsList.classList.contains('w-full')
+      ? tabsList
+      : container;
     const elementComputedStyle = getComputedStyle(referenceElement);
     const elementPadding =
       parseFloat(elementComputedStyle.paddingLeft) +
-      parseFloat(elementComputedStyle.paddingRight) || 0;
+        parseFloat(elementComputedStyle.paddingRight) || 0;
     const dropdownButtonWidth = 40;
     let availableWidth = referenceElement.clientWidth - elementPadding;
 


### PR DESCRIPTION
## Problem
- Dropdown button was overflowing container boundaries when width decreased
- Add button width wasn't accounted for in tab visibility calculations
- Incorrect width reference used in TabsVariant (container vs tabsList)


https://github.com/user-attachments/assets/a7641d43-cb70-4a67-8844-72e85b3fe409


## Solution
- Moved dropdown button inside flex container (after add button) to prevent overflow
- Removed unnecessary wrapper div around add button for cleaner structure
- Fixed width calculation to use correct reference element (tabsList for TabsVariant, container for ContentVariant)
- Added automatic measurement of non-tab elements (add button, dropdown) to accurately calculate available space

## Changes
- **DropdownMenu.tsx**: Changed dropdown positioning from absolute to inline flex item
- **Variants.tsx**: Simplified add button structure and moved dropdown inside flex container
- **useTabCalculation.ts**: Improved width calculations with proper reference element and automatic non-tab element measurement
