### PR TITLE
(docs): Fix GitHub auth docs title

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/04_Authentication/02_GitHub.md
+++ b/src/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/04_Authentication/02_GitHub.md
@@ -1,4 +1,5 @@
 ---
+title: GitHub
 searchHints:
   - github
   - authentication


### PR DESCRIPTION
Rendered title: "Git Hub Auth"
Correct title: "GitHub"

Issues:
- Space between "Git" and "Hub". All docs pages must have explicit titles if CamelCasing is intended instead of Separate Words.
- Inclusion of the word "Auth", when the other providers don't (besides Basic Auth, which I think is justified)