### PR TITLE
[Chart]: improve Y-axis auto-scaling

### DIFF
--- a/src/frontend/src/widgets/charts/sharedUtils.ts
+++ b/src/frontend/src/widgets/charts/sharedUtils.ts
@@ -317,7 +317,7 @@ export const generateYAxis = (
       ),
     },
     splitNumber: largeSpread ? 3 : 5,
-    min: largeSpread ? safeTransform(minValue) : Math.min(minValue, 0),
+    ...(largeSpread && { min: safeTransform(minValue) }),
     ...(largeSpread && { max: safeTransform(maxValue) }),
     position: yAxis?.[0]?.orientation === 'Right' ? 'right' : 'left',
     axisLine: {


### PR DESCRIPTION
## Summary

Simplify `generateYAxis` configuration so that, for normal ranges, we let ECharts auto-calculate both the minimum and maximum Y-axis bounds.  
This produces nicer, rounded axis limits for datasets with negative values and keeps the behavior for large-spread (log-scaled) data unchanged.

## Technical details

Previously, `generateYAxis` always set a fixed minimum value on the Y-axis (either a transformed minimum for large-spread data or an exact/zero value for normal data).

Now we only set `min` and `max` when the data has a very large spread.

For regular charts, we no longer fix the Y-axis minimum and maximum, and instead let ECharts automatically choose “nice” rounded bounds based on the data.

## Behavior before vs after

**Example dataset (Rounding Behavior Test – high precision values):**

- Min value: `-567.891234`
- Max value: `650.456789`

**Before:**
<img width="582" height="274" alt="image" src="https://github.com/user-attachments/assets/37723e5d-1dfb-40d8-a21e-6c02e013ae7e" />

- Config sent to ECharts:
  - `min = Math.min(-567.891234, 0) = -567.891234`
  - `max` not set (auto)
- Result:
  - Lower bound was pinned to the exact value `-567.891234`
  - Upper bound auto-scaled to a rounded value (e.g. `800`)
  - Axis looked asymmetric and had an “ugly” lower tick

**After:**
<img width="574" height="264" alt="image" src="https://github.com/user-attachments/assets/bb527f33-1e9f-46ae-834b-f00b0b061f67" />

- Config sent to ECharts for normal ranges:
  - `min` not set
  - `max` not set
- Result:
  - ECharts auto-rounds **both** bounds (e.g. lower bound `-600`, upper bound `800`)
  - Y-axis ticks are nicer and more symmetric around the data range

For `largeSpread === true` (log-like scaling), behavior remains the same: we still explicitly set both `min` and `max` using `safeTransform(minValue/maxValue)`.