### PR TITLE
[Card]: remove border styling options

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/04_Card.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/04_Card.md
@@ -42,22 +42,6 @@ new Card(
  .Width(Size.Units(100))
 ```
 
-## Border Customization
-
-Cards support the same border functionality as [Box widgets](../01_Primitives/04_Box.md), allowing you to customize the appearance with [Colors](../../04_ApiReference/IvyShared/Colors.md) and border options while maintaining the default card styling when no border properties are specified.
-
-```csharp demo-below
-new Card(
-    "This card has a custom border with dashed style and primary color.",
-    new Button("Action", _ => client.Toast("Button clicked!"))
-).Title("Custom Border Card")
- .Description("Demonstrating border customization")
- .BorderThickness(3)
- .BorderStyle(BorderStyle.Dashed)
- .BorderColor(Colors.Primary)
- .BorderRadius(BorderRadius.Rounded)
- .Width(Size.Units(100))
-```
 
 ## Dashboard Metrics
 

--- a/src/Ivy.Samples.Shared/Apps/Widgets/CardApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/CardApp.cs
@@ -16,25 +16,6 @@ public class CardApp : SampleBase
                     | Text.H4("Card App").WithLayout().Grow()
         ).TestId("card-app");
 
-        var card2 = new Card(
-            content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam nec purus nec nunc",
-            header: Layout.Horizontal().Align(Align.Center)
-                    | Text.H4("Card with Border").WithLayout().Grow()
-        ).BorderThickness(3)
-         .BorderStyle(BorderStyle.Dashed)
-         .BorderColor(Colors.Primary)
-         .BorderRadius(BorderRadius.Rounded)
-         .TestId("card-border");
-
-        var card3 = new Card(
-            content: "This card demonstrates the border color fix with a thick red border.",
-            header: Layout.Horizontal().Align(Align.Center)
-                    | Text.H4("Border Color Test").WithLayout().Grow()
-        ).BorderThickness(4)
-         .BorderStyle(BorderStyle.Solid)
-         .BorderColor(Colors.Red)
-         .BorderRadius(BorderRadius.Rounded)
-         .TestId("card-border-color");
 
         var card4 = new Card(
             content: "This card demonstrates OnClick handlers.",
@@ -72,10 +53,8 @@ public class CardApp : SampleBase
         return Layout.Vertical()
          | Text.H1("Card")
          | Text.H2("Basic Examples")
-         | (Layout.Grid().Columns(4)
+         | (Layout.Grid().Columns(2)
             | card1
-            | card2
-            | card3
             | card4
             )
          | (Layout.Grid().Columns(4)

--- a/src/Ivy/Widgets/Card.cs
+++ b/src/Ivy/Widgets/Card.cs
@@ -34,13 +34,7 @@ public record Card : WidgetBase<Card>
     internal object? Description { get; set; }
     internal object? Icon { get; set; }
 
-    [Prop] public Thickness? BorderThickness { get; set; }
 
-    [Prop] public BorderRadius? BorderRadius { get; set; }
-
-    [Prop] public BorderStyle? BorderStyle { get; set; }
-
-    [Prop] public Colors? BorderColor { get; set; }
 
     [Prop] public CardHoverVariant HoverVariant { get; set; } = CardHoverVariant.None;
 
@@ -105,15 +99,6 @@ public static class CardExtensions
         return card.Header(card.Title, card.Description, icon);
     }
 
-    public static Card BorderThickness(this Card card, int thickness) => card with { BorderThickness = new(thickness) };
-
-    public static Card BorderThickness(this Card card, Thickness thickness) => card with { BorderThickness = thickness };
-
-    public static Card BorderRadius(this Card card, BorderRadius radius) => card with { BorderRadius = radius };
-
-    public static Card BorderStyle(this Card card, BorderStyle style) => card with { BorderStyle = style };
-
-    public static Card BorderColor(this Card card, Colors color) => card with { BorderColor = color };
 
     public static Card Hover(this Card card, CardHoverVariant variant) => card with { HoverVariant = variant };
 

--- a/src/frontend/src/widgets/card/CardWidget.tsx
+++ b/src/frontend/src/widgets/card/CardWidget.tsx
@@ -4,16 +4,7 @@ import {
   CardFooter,
   CardHeader,
 } from '@/components/ui/card';
-import {
-  getHeight,
-  getWidth,
-  getBorderRadius,
-  getBorderStyle,
-  getBorderThickness,
-  getColor,
-  BorderRadius,
-  BorderStyle,
-} from '@/lib/styles';
+import { getHeight, getWidth } from '@/lib/styles';
 import { cn } from '@/lib/utils';
 import { useEventHandler } from '@/components/event-handler';
 import React, { useCallback } from 'react';
@@ -25,10 +16,6 @@ interface CardWidgetProps {
   events: string[];
   width?: string;
   height?: string;
-  borderThickness?: string;
-  borderRadius?: BorderRadius;
-  borderStyle?: BorderStyle;
-  borderColor?: string;
   hoverVariant?: 'None' | 'Pointer' | 'PointerAndTranslate';
   scale?: Scales;
   'data-testid'?: string;
@@ -44,10 +31,6 @@ export const CardWidget: React.FC<CardWidgetProps> = ({
   events = [],
   width = 'Full',
   height,
-  borderThickness,
-  borderRadius,
-  borderStyle,
-  borderColor,
   hoverVariant = 'None',
   scale = Scales.Medium,
   slots,
@@ -59,10 +42,6 @@ export const CardWidget: React.FC<CardWidgetProps> = ({
   const styles = {
     ...getWidth(width),
     ...getHeight(height),
-    ...(borderStyle && getBorderStyle(borderStyle)),
-    ...(borderThickness && getBorderThickness(borderThickness)),
-    ...(borderRadius && getBorderRadius(borderRadius)),
-    ...(borderColor && getColor(borderColor, 'borderColor', 'background')),
   };
 
   const footerIsEmpty = !slots?.Footer || slots.Footer.length === 0;


### PR DESCRIPTION
## Problem

The `Card` component had border styling properties (`BorderThickness`, `BorderRadius`, `BorderStyle`, `BorderColor`) that duplicated functionality already available in the `Box` primitive.

This violated the Single Responsibility Principle:
- **Card** should be a semantic container (header, content, footer)
- **Box** should handle visual styling (borders, colors, padding)

## Solution

Removed all border styling properties from `Card`. Users who need custom borders should wrap their Card in a Box:

```csharp
// Before
new Card("Content").BorderColor(Colors.Red)

// After
new Box(new Card("Content")).Color(Colors.Red)
```

## Changes

| File | Changes |
|------|---------|
| `Card.cs` | Removed `BorderThickness`, `BorderRadius`, `BorderStyle`, `BorderColor` properties and extension methods |
| `CardWidget.tsx` | Removed border-related props and styles |
| `CardApp.cs` | Removed examples using border styling |
| `04_Card.md` | Removed "Border Customization" section |
