### PR TITLE
(widgets): remove bad symbol from ingress text

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/03_Widgets.md
+++ b/src/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/03_Widgets.md
@@ -11,7 +11,7 @@ searchHints:
 # Widgets
 
 <Ingress>
-Discover the fundamental [building blocks](./02_Views.md) of Ivy [applications](./15_Apps.md) - Widgets provide declarative UI components inspired by React's component mode;.
+Discover the fundamental [building blocks](./02_Views.md) of Ivy [applications](./15_Apps.md) - Widgets provide declarative UI components inspired by React's component mode.
 </Ingress>
 
 Widgets are the fundamental building blocks of the Ivy framework. They represent the smallest unit of UI and are used to construct [Views](./02_Views.md).


### PR DESCRIPTION
Had a typo:
<img width="1048" height="537" alt="image" src="https://github.com/user-attachments/assets/7e432eea-fc48-49d0-99c8-8357d908ecba" />

Fixed:

<img width="804" height="143" alt="image" src="https://github.com/user-attachments/assets/b25081fa-4f2b-40ba-80c7-f70689e451b3" />
