### PR TITLE
(AvatarWidget): Be more tolerant of empty fallback

### DIFF
--- a/src/frontend/src/widgets/primitives/AvatarWidget.tsx
+++ b/src/frontend/src/widgets/primitives/AvatarWidget.tsx
@@ -18,7 +18,7 @@ export const AvatarWidget: React.FC<AvatarWidgetProps> = ({
   fallback,
 }) => {
   const displayFallback =
-    fallback.length === 2 ? fallback : getInitials(fallback);
+    fallback?.length === 2 ? fallback : getInitials(fallback || '');
   return (
     <Avatar>
       <AvatarImage src={image} title={fallback} />


### PR DESCRIPTION
If `UserInfo` doesn't have enough info to generate initials (e.g., because Auth0 or Clerk is configured without required claims), we end up crashing because `UserInfo.Initials` returns an empty string, which I guess translates to `undefined` or `null` in the frontend.

<img width="762" height="1154" alt="Screenshot 2026-02-06 at 5 20 11 PM" src="https://github.com/user-attachments/assets/537aa8e0-beaf-437f-8e94-c7c83254f304" />
