### PR TITLE
[Docs]: Add authentication cookie configuration documentation

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/04_Authentication/01_AuthenticationOverview.md
+++ b/src/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/04_Authentication/01_AuthenticationOverview.md
@@ -188,6 +188,32 @@ For complete control over the login experience, you can replace the entire login
 server.UseAuth<BasicAuthProvider>(viewFactory: () => new MyCustomLoginApp());
 ```
 
+## Customizing Authentication Cookies
+
+Ivy allows you to customize authentication cookie settings globally from your [Program.cs](../../02_Concepts/01_Program.md) using the `Server.ConfigureAuthCookieOptions` static property. This enables you to override default cookie settings (such as expiration time, SameSite policy, Secure flag, etc.) based on your application's specific security requirements.
+
+### Default Cookie Settings
+
+By default, Ivy authentication cookies are configured with:
+- **HttpOnly**: `true` (prevents JavaScript access)
+- **Secure**: `true` in production, `false` in development (requires HTTPS)
+- **SameSite**: `Lax` (provides CSRF protection while allowing cross-site navigation)
+- **Expires**: 1 year from creation
+- **Path**: `/` (available site-wide)
+
+### Customizing Cookie Options
+
+To override these defaults, set `Server.ConfigureAuthCookieOptions` in your `Program.cs` before calling `server.RunAsync()`:
+
+```csharp
+Server.ConfigureAuthCookieOptions = options => 
+{
+    options.Expires = DateTimeOffset.UtcNow.AddDays(30);
+};
+```
+
+> **Note**: Custom configuration is applied after Ivy sets the default values, allowing you to override any setting. It's recommended to keep `HttpOnly = true` for security.
+
 ## Best Practices
 
 **Security** - Always use HTTPS in production, store sensitive configuration in user secrets or environment variables, regularly rotate client secrets, use strong passwords for Basic Auth, and implement proper session management.


### PR DESCRIPTION
## Summary
Adds documentation for customizing authentication cookie settings using `Server.ConfigureAuthCookieOptions` in the Authentication Overview guide.

## Changes
- Added new "Customizing Authentication Cookies" section to `01_AuthenticationOverview.md`
- Documents default cookie settings (HttpOnly, Secure, SameSite, Expires, Path)
- Provides example usage of `Server.ConfigureAuthCookieOptions` to override defaults
- Includes security recommendations for cookie configuration

## Motivation
The `Server.ConfigureAuthCookieOptions` feature allows developers to customize authentication cookie settings globally, but this capability was not previously documented. This PR makes the feature discoverable and provides guidance on how to use it effectively.
<img width="1648" height="918" alt="image" src="https://github.com/user-attachments/assets/02cea22f-5efd-4411-b27d-89434db46e78" />
