### PR TITLE
[Init]: add missing ivy init options including --script to docs page

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/02_Init.md
+++ b/src/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/02_Init.md
@@ -54,10 +54,58 @@ This command will:
 >ivy init --verbose
 ```
 
-`--helloworld` or `--hello` - Include a simple demo app in the new project to help you get started.
+`--hello` - Include a simple demo app in the new project to help you get started.
 
 ```terminal
->ivy init --helloworld
+>ivy init --hello
+```
+
+`--script` - Create a simple Ivy script file instead of a full project. Perfect for quick prototyping or single-file applications.
+
+```terminal
+>ivy init --script
+```
+
+`--template <TEMPLATE>` or `-t <TEMPLATE>` - Use a specific template for the new project.
+
+```terminal
+>ivy init --template my-template
+```
+
+`--select-template` - Interactively select a template from available options.
+
+```terminal
+>ivy init --select-template
+```
+
+`--cursor` - Install Cursor MCP integration after project creation.
+
+```terminal
+>ivy init --cursor
+```
+
+`--claude` - Install Claude Code MCP integration after project creation.
+
+```terminal
+>ivy init --claude
+```
+
+`--ignore-git` - Skip Git checks and commit during initialization.
+
+```terminal
+>ivy init --ignore-git
+```
+
+`--prerelease` - Include prerelease versions when fetching the latest Ivy version.
+
+```terminal
+>ivy init --prerelease
+```
+
+`--yes-to-all` - Skip all prompts and use default values. Useful for automated scripts.
+
+```terminal
+>ivy init --yes-to-all
 ```
 
 ### Interactive Mode


### PR DESCRIPTION
Added --script and some other missing options
<img width="1366" height="612" alt="image" src="https://github.com/user-attachments/assets/f72f64b6-50a7-4270-911a-b3a761b98fe5" />
<img width="1366" height="606" alt="image" src="https://github.com/user-attachments/assets/967f1bdb-7c6e-4356-a0a0-69a9a878765f" />
<img width="1366" height="600" alt="image" src="https://github.com/user-attachments/assets/e2b0c26c-bf34-4b2e-afac-459d177afbac" />
<img width="1366" height="344" alt="image" src="https://github.com/user-attachments/assets/432e91d4-0175-4f32-838a-79d40aee5b08" />
