### PR TITLE
[Datatable]: add tooltip support for row action buttons

### DIFF
--- a/src/frontend/src/types/widgets.ts
+++ b/src/frontend/src/types/widgets.ts
@@ -18,6 +18,7 @@ export interface MenuItem {
   label: string;
   icon?: string;
   tag?: string;
+  tooltip?: string;
   children?: MenuItem[];
   variant: 'Default' | 'Separator' | 'Checkbox' | 'Radio' | 'Group';
   checked: boolean;

--- a/src/frontend/src/widgets/dataTables/dataTableRowAction/actionButton.tsx
+++ b/src/frontend/src/widgets/dataTables/dataTableRowAction/actionButton.tsx
@@ -36,6 +36,7 @@ export const ActionButton: React.FC<ActionButtonProps> = ({
       onClick={handleClick}
       onMouseDown={handleMouseDown}
       aria-label={action.label || actionId}
+      title={action.tooltip}
       type="button"
     >
       {action.icon && (

--- a/src/frontend/src/widgets/dataTables/dataTableRowAction/actionDropdown.tsx
+++ b/src/frontend/src/widgets/dataTables/dataTableRowAction/actionDropdown.tsx
@@ -39,6 +39,7 @@ const TriggerButton = React.forwardRef<HTMLButtonElement, TriggerButtonProps>(
         {...props}
         onMouseDown={handleMouseDown}
         aria-label={action.label || actionId}
+        title={action.tooltip}
         type="button"
       >
         {action.icon && (


### PR DESCRIPTION
## Issue Description

When using `.Tooltip("...")` on `MenuItem` items in DataTable's `RowActions`, the tooltips were not displayed on hover.

### Root Cause

The backend correctly serializes the `Tooltip` property of `MenuItem` (defined in `MenuItem.cs`), but the frontend components responsible for rendering row action buttons did not utilize this data:

1. **`actionButton.tsx`** - rendered the button without reading `action.tooltip`
2. **`actionDropdown.tsx`** - same issue for dropdown trigger buttons
3. **`widgets.ts`** - TypeScript `MenuItem` interface was missing the `tooltip` field

## Solution

Added native HTML `title` attribute support to display browser tooltips:

### Changes Made

| File | Change |
|------|--------|
| `actionButton.tsx` | Added `title={action.tooltip}` attribute |
| `actionDropdown.tsx` | Added `title={action.tooltip}` attribute |
| `widgets.ts` | Added `tooltip?: string` field to `MenuItem` interface |

### Why Native `title` Attribute?

1. **Simplicity** - Works out of the box without additional dependencies
2. **Reliability** - Native browser behavior, no conflicts with grid event handling
3. **Consistency** - Same approach used elsewhere in the codebase
4. **Performance** - No extra React components or state management needed

## Testing

1. Create a DataTable with RowActions using `.Tooltip()`:
```csharp
.RowActions(
    MenuItem.Default(Icons.Pencil, "edit").Tooltip("Edit item"),
    MenuItem.Default(Icons.Trash2, "delete").Tooltip("Delete item")
)
```

2. Hover over the action buttons - tooltips should appear after a brief delay.


<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/1240f738-fc91-4c88-a269-2645ff831ecb" />
