### PR TITLE
[DataTable]: remove footer overlay to fix last row cropping

### DIFF
--- a/src/frontend/src/widgets/dataTables/DataTableWidget.tsx
+++ b/src/frontend/src/widgets/dataTables/DataTableWidget.tsx
@@ -7,7 +7,6 @@ import { ErrorDisplay } from '@/components/ErrorDisplay';
 import { Loading } from '@/components/Loading';
 import { DataTableEditor } from './dataTableEditor';
 import { DataTableHeader } from './DataTableHeader';
-import { DataTableFooter } from './DataTableFooter';
 import { DataTableOption } from './DataTableOption';
 import { DataTableFilterOption } from './options/DataTableFilterOption';
 import { Filter as FilterIcon } from 'lucide-react';
@@ -94,7 +93,6 @@ export const DataTable: React.FC<TableProps> = ({
             widgetId={id}
             hasOptions={finalConfig.allowFiltering}
             rowActions={rowActions}
-            footer={<DataTableFooter />}
           />
         </TableLayout>
       </TableProvider>


### PR DESCRIPTION
## Problem Description

The last row of the DataTable was being cropped/hidden when the table content required vertical scrolling. Users could not see the complete last row of data.

## Root Cause Analysis

The issue was caused by the `DataTableFooter` component which used `position: absolute; bottom: 0` to overlay the bottom of the table. This footer was designed to provide space for the horizontal scrollbar, but it created several architectural problems:

### Problems with the Footer Approach

1. **Row Cropping**: The footer overlay covered the last row of the table content, making it partially or fully invisible.

2. **No DPI Scaling Support**: The footer positioning used fixed pixel values that didn't adapt to different display scaling settings. What worked at 100% scaling broke at 125% or 150% scaling.

3. **Unnecessary Space**: The footer reserved space for the horizontal scrollbar even when content didn't overflow horizontally, wasting vertical space and creating visual inconsistency.

4. **Architectural Inconsistency**: The design provided dedicated space for the horizontal scrollbar via the footer, but the vertical scrollbar had no equivalent dedicated space. This asymmetry in the scrollbar handling broke the UI architecture consistency.

## Solution

**Removed the `DataTableFooter` component from `DataTableWidget.tsx`.**

Without the footer overlay:
- All table rows are fully visible
- No content is hidden or cropped
- The scrollbars render in their native positions within the glide-data-grid component
- The UI remains clean and consistent across different scaling settings

## Changes Made

- **`DataTableWidget.tsx`**: Removed `DataTableFooter` import and its usage in the `DataTableEditor` component

## Testing

- Verified that all rows are visible in tables with many rows
- Confirmed horizontal and vertical scrolling works correctly
- Tested at different browser zoom levels to ensure consistent behavior

## Before:
<img width="1102" height="589" alt="image" src="https://github.com/user-attachments/assets/f67f58ed-fc7a-4848-910b-4192e9dedaea" />

## After:
<img width="1101" height="594" alt="image" src="https://github.com/user-attachments/assets/efe0e64a-3811-4bb3-817d-37f134a4ab26" />