### PR TITLE
(docs): use small scale for tables in api section

### DIFF
--- a/src/Ivy.Docs.Shared/Helpers/WidgetDocsView.cs
+++ b/src/Ivy.Docs.Shared/Helpers/WidgetDocsView.cs
@@ -34,7 +34,7 @@ public class WidgetDocsView(string typeName, string? extensionsTypeName, string?
         {
             constructorSection = Layout.Vertical().Gap(2)
                                  | Text.H3("Constructors")
-                                 | constructors.ToTable().Width(Size.Full());
+                                 | constructors.ToTable().Small().Width(Size.Full());
         }
 
         object? supportedTypesSection = null;
@@ -84,7 +84,7 @@ public class WidgetDocsView(string typeName, string? extensionsTypeName, string?
                     | Text.H3("Supported Types")
                     | new Table(
                         new[] { headerRow }.Concat(dataRows).ToArray()
-                    ).Width(Size.Full());
+                    ).Small().Width(Size.Full());
             }
         }
 
@@ -97,7 +97,7 @@ public class WidgetDocsView(string typeName, string? extensionsTypeName, string?
 
         var propertySection = Layout.Vertical().Gap(2)
                               | Text.H3("Properties")
-                              | properties.ToTable().Width(Size.Full())
+                              | properties.ToTable().Small().Width(Size.Full())
                                   .ColumnWidth(p => p.Setters, Size.Fraction(0.4f))
             ;
 
@@ -113,7 +113,7 @@ public class WidgetDocsView(string typeName, string? extensionsTypeName, string?
         {
             eventSection = Layout.Vertical().Gap(2)
                            | Text.H3("Events")
-                           | events.ToTable().Width(Size.Full())
+                           | events.ToTable().Small().Width(Size.Full())
                 ;
         }
 


### PR DESCRIPTION
As an example of this change, here is the updated API section of the Grid Layout documentation page:
How it was:
<img width="2314" height="1354" alt="image" src="https://github.com/user-attachments/assets/5af6c6e2-1e8d-4ceb-8cc8-2b3e2140d4b2" />

How it's now:
<img width="2312" height="1356" alt="image" src="https://github.com/user-attachments/assets/77cb8804-892e-42e9-91aa-62b007444b19" />
