### PR TITLE
(docs): implement external widgets doc page

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/07_Advanced/05_ExternalWidgets.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/07_Advanced/05_ExternalWidgets.md
@@ -14,8 +14,6 @@ searchHints:
 External [widgets](../../01_Onboarding/02_Concepts/03_Widgets.md) let you extend the Ivy Framework with custom React components built and bundled separately from the core framework. Use them for domain-specific UI (e.g. diagrams, charts, or rich editors) without coupling that code to the framework backend.
 </Ingress>
 
-The pattern has three parts: a **C# proxy** (a widget record with `[ExternalWidget]`), a **React component** (your UI), and a **build pipeline** that compiles the frontend and embeds the assets into the widget assembly.
-
 ## Architecture Overview
 
 1. **C# proxy** — A record inheriting from `WidgetBase<T>` with `[ExternalWidget]`, defining [props](../../01_Onboarding/02_Concepts/03_Widgets.md) and [events](../../01_Onboarding/02_Concepts/05_EventHandlers.md).


### PR DESCRIPTION
I built a simple external widget using this documentation, so it has been tested in practice (except for the troubleshooting section, which was copied from the source md file in the issue).

<img width="1275" height="815" alt="Screenshot 2026-02-11 at 05 26 12" src="https://github.com/user-attachments/assets/7d9f64cd-b41d-46f7-8db2-49e06ebf1777" />
<img width="1273" height="813" alt="Screenshot 2026-02-11 at 05 26 26" src="https://github.com/user-attachments/assets/d17cac01-97f2-4430-bfea-13d8433ddfdb" />
<img width="1275" height="815" alt="Screenshot 2026-02-11 at 05 26 38" src="https://github.com/user-attachments/assets/3d837302-ade4-4c3e-8fa4-4625b539b11b" />
<img width="1270" height="811" alt="Screenshot 2026-02-11 at 05 26 50" src="https://github.com/user-attachments/assets/5dce896b-365b-4511-8921-bf334c799d23" />
<img width="1273" height="815" alt="Screenshot 2026-02-11 at 05 27 05" src="https://github.com/user-attachments/assets/8d82a9b0-823f-4bd0-8f29-f9eee60ee8b9" />
<img width="1276" height="813" alt="Screenshot 2026-02-11 at 05 27 17" src="https://github.com/user-attachments/assets/0ff205a2-9662-4938-9042-7e735355cb87" />
<img width="1273" height="813" alt="Screenshot 2026-02-11 at 05 27 27" src="https://github.com/user-attachments/assets/8d54fcc0-180f-4a91-8cf7-5b4ea0084cab" />
