### PR TITLE
(describe): don't depend on port 5010 being available

### DIFF
--- a/src/Ivy/Server.cs
+++ b/src/Ivy/Server.cs
@@ -359,7 +359,7 @@ public class Server
                     return;
                 }
 
-                if (_args.Port != originalPort)
+                if (_args.Port != originalPort && !_args.Silent)
                 {
                     Console.WriteLine($"\x1b[33mPort {originalPort} is in use. Using port {_args.Port} instead.\x1b[0m");
                 }

--- a/src/Ivy/ServerUtils.cs
+++ b/src/Ivy/ServerUtils.cs
@@ -38,6 +38,10 @@ public static class ServerUtils
             Describe = parser.GetValue(parsedArgs, "describe", false)
         };
         serverArgs = serverArgs with { FindAvailablePort = parser.GetValue(parsedArgs, "find-available-port", false) };
+        if (serverArgs.Describe)
+        {
+            serverArgs = serverArgs with { FindAvailablePort = true, Silent = true };
+        }
         return serverArgs;
     }
 }


### PR DESCRIPTION
This PR enables `--describe` to be used even if the default port of 5010 is unavailable. I discovered this issue while trying to deploy an Ivy app that was also running locally in the background:

<img width="638" height="58" alt="image" src="https://github.com/user-attachments/assets/3708c365-a9a3-4fb7-b18e-9c7dd43b720f" />
