### PR TITLE
[InlineCode]: add h-fit to styles

### DIFF
--- a/src/frontend/src/lib/styles.ts
+++ b/src/frontend/src/lib/styles.ts
@@ -611,7 +611,7 @@ export const typography: Record<string, string> = {
   blockquote: 'border-l-2 pl-6 italic',
 
   // Code
-  code: 'relative rounded bg-muted px-[0.25rem] py-[0.05rem] font-mono text-sm font-semibold',
+  code: 'relative rounded bg-muted px-[0.25rem] py-[0.05rem] font-mono text-sm font-semibold h-fit',
 
   // Table
   table: 'w-full border-collapse border border-border',


### PR DESCRIPTION
## Problem Description
Inline code elements (`Text.InlineCode`) were stretching vertically to fill the entire height of their container when placed inside flex or grid layouts alongside taller elements (e.g., input fields). This was visually disruptive because the inline code has a background color, making the stretching obvious and undesirable.

## Root Cause
The robust default behavior of Flexbox (and Grid) is `align-items: stretch`. When an inline element like a `code` block is a flex item, it expands to match the cross-axis size of the container, which is determined by the tallest sibling (in this case, the input components).

## Solution
Added the `h-fit` utility class (equivalent to `height: fit-content`) to the global `typography.code` definition in `src/frontend/src/lib/styles.ts`.

### Why this approach?
1.  **Global Fix**: This prevents any `code` block from ever stretching beyond its content height, regardless of where it is used. It solves the issue universally without requiring manual layout tweaks in every component.
2.  **No Side Effects**: Unlike `self-center` (which was also considered), `h-fit` strictly controls the *height* and does not interfere with alignment. `self-center` caused regressions in vertical stacks (e.g., `CodeApp.cs`) by centering elements horizontally instead of left-aligning them. `h-fit` keeps the correct alignment while fixing the height.

## Changes
- `src/frontend/src/lib/styles.ts`: Added `h-fit` to `code` styles.

## Before:
<img width="776" height="498" alt="image" src="https://github.com/user-attachments/assets/e7f1ee22-0672-4ed2-bcdd-33872c92f824" />

## After:
<img width="799" height="498" alt="image" src="https://github.com/user-attachments/assets/7afb91d2-f785-4531-a834-57d671d768d3" />