### PR TITLE
[Iframe]: block javascript execution by default

### DIFF
--- a/src/Ivy/Widgets/Primitives/Iframe.cs
+++ b/src/Ivy/Widgets/Primitives/Iframe.cs
@@ -24,4 +24,6 @@ public record Iframe : WidgetBase<Iframe>
     [Prop] public string Src { get; set; } = null!;
 
     [Prop] public long? RefreshToken { get; }
+
+    [Prop] public bool AllowJavaScript { get; set; }
 }

--- a/src/frontend/src/widgets/primitives/IframeWidget.tsx
+++ b/src/frontend/src/widgets/primitives/IframeWidget.tsx
@@ -7,6 +7,7 @@ interface IframeWidgetProps {
   width?: string;
   height?: string;
   refreshToken?: number;
+  allowJavaScript?: boolean;
 }
 
 export const IframeWidget: React.FC<IframeWidgetProps> = ({
@@ -15,6 +16,7 @@ export const IframeWidget: React.FC<IframeWidgetProps> = ({
   width = 'Full',
   height = 'Full',
   refreshToken,
+  allowJavaScript = false,
 }) => {
   const [iframeKey, setIframeKey] = useState(id);
 
@@ -28,5 +30,15 @@ export const IframeWidget: React.FC<IframeWidgetProps> = ({
     setIframeKey(`${id}-${refreshToken}`);
   }, [refreshToken, id]);
 
-  return <iframe src={src} key={iframeKey} style={styles} />;
+  const sandbox = [
+    'allow-forms',
+    'allow-modals',
+    'allow-popups',
+    'allow-same-origin',
+    allowJavaScript ? 'allow-scripts' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return <iframe src={src} key={iframeKey} style={styles} sandbox={sandbox} />;
 };


### PR DESCRIPTION
### Issue
Previously, the `Iframe` widget allowed arbitrary JavaScript execution within embedded content. This posed a potential security risk (XSS), as there were no restrictions on what scripts could run inside the frame.

### Root Cause
The underlying `<iframe>` HTML element was rendered without a `sandbox` attribute. In modern browsers, iframes typically have full script execution privileges unless explicitly restricted by the `sandbox` attribute or Content Security Policy (CSP).

### Solution
I implemented a "secure by default" strategy:

1.  **Frontend (`IframeWidget.tsx`)**:
    *   Added the `sandbox` attribute to the rendered `<iframe>`.
    *   Configured the default sandbox policy to allow forms, modals, popups, and same-origin requests, but **block scripts** (`allow-scripts` is omitted by default).

2.  **Backend (`Iframe.cs`)**:
    *   Added a new property `AllowJavaScript` (boolean, default: `false`).
    *   This allows developers to explicitly opt-in to script execution if their use case requires it.

### Reasoning
This changes the behavior from "permissive by default" to "restrictive by default". It ensures that embedding external content does not automatically introduce script execution vulnerabilities. The addition of the `AllowJavaScript` flag satisfies the requirement to allow scripts only when explicitly requested by the developer.
