### PR TITLE
[Docs]: serve /agents.md and /llms.txt routes

### DIFF
--- a/src/Ivy.Docs.Shared/Ivy.Docs.Shared.csproj
+++ b/src/Ivy.Docs.Shared/Ivy.Docs.Shared.csproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <EmbeddedResource Include="Assets/**/*" />
     <EmbeddedResource Include="Generated/**/*.md" />
+    <EmbeddedResource Include="..\..\AGENTS.md" Link="Assets\AGENTS.md" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ivy.Docs.Shared/Middleware/SitemapMiddleware.cs
+++ b/src/Ivy.Docs.Shared/Middleware/SitemapMiddleware.cs
@@ -30,6 +30,12 @@ public class SitemapMiddleware(RequestDelegate next, Server server)
             return;
         }
 
+        if (path is "/agents.md" or "/llms.txt")
+        {
+            await ServeAgentsFile(context);
+            return;
+        }
+
         await next(context);
     }
 
@@ -70,5 +76,19 @@ public class SitemapMiddleware(RequestDelegate next, Server server)
         context.Response.ContentType = "application/xml; charset=utf-8";
         context.Response.StatusCode = 200;
         await context.Response.WriteAsync(sb.ToString());
+    }
+
+    private static async Task ServeAgentsFile(HttpContext context)
+    {
+        await using var stream = typeof(SitemapMiddleware).Assembly.GetManifestResourceStream("Ivy.Docs.Shared.Assets.AGENTS.md");
+        if (stream == null)
+        {
+            context.Response.StatusCode = 404;
+            return;
+        }
+
+        context.Response.ContentType = "text/plain; charset=utf-8";
+        context.Response.StatusCode = 200;
+        await stream.CopyToAsync(context.Response.Body);
     }
 }

--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -71,7 +71,7 @@ export default defineConfig(({ mode }) => ({
   plugins: [react(), tailwindcss(), injectMeta(mode)] as Plugin[],
   server: {
     proxy: {
-      '^/.*\\.md$': {
+      '^/(.*\\.md|llms\\.txt)$': {
         target: process.env.IVY_HOST || 'http://localhost:5010',
         changeOrigin: true,
       },


### PR DESCRIPTION
## Problem

The documentation site (`docs.ivy.app`) did not serve the raw contents of `AGENTS.md` and `llms.txt` at dedicated URLs. AI agents and LLMs that look for these standard files (similar to `robots.txt` for search engines) could not automatically discover context about the Ivy framework from the docs site.

## Solution

Both `/agents.md` and `/llms.txt` now serve the raw content of the root `AGENTS.md` file. A separate `llms.txt` file is not needed because its content is identical to `AGENTS.md` — both are introductory guides for LLMs about the Ivy framework.

### Why reuse `AGENTS.md` for both routes?

The repo already had a comprehensive `llms.txt` (commit `6e904af6`) which was essentially the same content as `AGENTS.md`. Maintaining two separate files with identical content would create unnecessary duplication. Instead, both routes serve the same embedded resource.

### Why `SitemapMiddleware`?

The serving logic was added to the existing `SitemapMiddleware` rather than creating a new middleware. This middleware already handles similar "meta" files for bots and crawlers (`/robots.txt`, `/sitemap.xml`), so `/agents.md` and `/llms.txt` fit naturally alongside them.

## Changes

### Backend

- **`SitemapMiddleware.cs`** — Added handling for `/agents.md` and `/llms.txt` routes, serving the embedded `AGENTS.md` resource as `text/plain`
- **`Ivy.Docs.Shared.csproj`** — Added `AGENTS.md` from the repo root as an embedded resource

### Frontend

- **`vite.config.ts`** — Updated the dev server proxy regex from `^/.*\.md$` to `^/(.*\.md|llms\.txt)$` so that `/llms.txt` is also proxied to the backend during development

<img width="1210" height="1032" alt="image" src="https://github.com/user-attachments/assets/33c08709-0162-4acb-876a-9000b3a9c76c" />
<img width="935" height="669" alt="image" src="https://github.com/user-attachments/assets/bda3b63c-9841-436b-9ff9-b4360c522790" />
