### PR TITLE
[TextInput]: add .Rows() support for TextAreaInput

### DIFF
--- a/src/Ivy/Widgets/Inputs/TextInput.cs
+++ b/src/Ivy/Widgets/Inputs/TextInput.cs
@@ -56,6 +56,8 @@ public abstract record TextInputBase : WidgetBase<TextInputBase>, IAnyTextInput
 
     [Prop] public int? MaxLength { get; set; }
 
+    [Prop] public int? Rows { get; set; }
+
     [Prop] public bool Nullable { get; set; }
 
     [Event] public Func<Event<IAnyInput>, ValueTask>? OnBlur { get; set; }
@@ -177,6 +179,8 @@ public static class TextInputExtensions
     public static TextInputBase ShortcutKey(this TextInputBase widget, string shortcutKey) => widget with { ShortcutKey = shortcutKey };
 
     public static TextInputBase MaxLength(this TextInputBase widget, int maxLength) => widget with { MaxLength = maxLength };
+
+    public static TextInputBase Rows(this TextInputBase widget, int rows) => widget with { Rows = rows };
 
     public static TextInputBase Prefix(this TextInputBase widget, string prefixText)
         => widget with { Prefix = prefixText.ToAffix() };

--- a/src/frontend/src/widgets/inputs/TextInputWidget/TextInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/TextInputWidget/TextInputWidget.tsx
@@ -26,6 +26,7 @@ export const TextInputWidget: React.FC<TextInputWidgetProps> = ({
   prefix,
   suffix,
   maxLength,
+  rows,
   'data-testid': dataTestId,
 }) => {
   const eventHandler = useEventHandler();
@@ -100,6 +101,7 @@ export const TextInputWidget: React.FC<TextInputWidgetProps> = ({
       prefix,
       suffix,
       maxLength,
+      rows,
       'data-testid': dataTestId,
     }),
     [
@@ -117,6 +119,7 @@ export const TextInputWidget: React.FC<TextInputWidgetProps> = ({
       prefix,
       suffix,
       maxLength,
+      rows,
       dataTestId,
     ]
   );

--- a/src/frontend/src/widgets/inputs/TextInputWidget/types.ts
+++ b/src/frontend/src/widgets/inputs/TextInputWidget/types.ts
@@ -31,5 +31,6 @@ export interface TextInputWidgetProps {
   prefix?: Affix;
   suffix?: Affix;
   maxLength?: number;
+  rows?: number;
   'data-testid'?: string;
 }

--- a/src/frontend/src/widgets/inputs/TextInputWidget/variants/TextareaVariant.tsx
+++ b/src/frontend/src/widgets/inputs/TextInputWidget/variants/TextareaVariant.tsx
@@ -76,6 +76,7 @@ export const TextareaVariant: React.FC<TextareaVariantProps> = ({
           value={props.value}
           disabled={props.disabled}
           maxLength={props.maxLength}
+          rows={props.rows}
           onChange={handleChange}
           onBlur={onBlur}
           onFocus={onFocus}


### PR DESCRIPTION
## Problem

When building apps, developers naturally expect `.Rows(int)` on `ToTextAreaInput()`, mirroring the HTML `<textarea rows="6">` attribute. However, only `.Height(int)` was available, which uses the framework's abstract `Size.Units` system — not rows or pixels. This made textarea sizing unintuitive and inconsistent with standard HTML conventions.

This was also observed in agent sessions, where the coding agent attempted `.ToTextAreaInput().Rows(6)` and received a build failure (`CS1061: 'TextInputBase' does not contain a definition for 'Rows'`).

## Solution

Added native `rows` support by introducing a `Rows` property on `TextInputBase` and passing it through to the frontend as the native HTML `rows` attribute on `<textarea>`.

This approach lets the browser handle row-based sizing natively, adapting automatically to font size, line height, and scale — unlike the alternative of converting rows to a fixed pixel height.

### Changes

**Backend (C#)**
- Added `[Prop] public int? Rows` property to `TextInputBase`
- Added `Rows(int)` extension method in `TextInputExtensions`

**Frontend (TypeScript/React)**
- Added `rows?: number` to `TextInputWidgetProps` in `types.ts`
- Passed `rows` through `TextInputWidget.tsx` via destructuring and `commonProps`
- Forwarded `rows` as a native HTML attribute on `<Textarea>` in `TextareaVariant.tsx`

## Usage

<img width="734" height="946" alt="image" src="https://github.com/user-attachments/assets/eedcb598-fdda-40d6-a7ae-1e7df677dbde" />
<img width="793" height="511" alt="image" src="https://github.com/user-attachments/assets/fdf61c55-2c7e-4fc9-9413-3032676892e8" />

```csharp
// Before: pixel-based height calculation
comment.ToTextAreaInput().Height(Size.Units(100))

// After: intuitive row-based sizing
comment.ToTextAreaInput().Rows(6)
```