### PR TITLE
(auth): Fix Microsoft Entra auth

### DIFF
--- a/src/Ivy/Auth/AuthController.cs
+++ b/src/Ivy/Auth/AuthController.cs
@@ -59,8 +59,7 @@ public class AuthController() : Controller
             scheme = forwardedProto.ToString();
         }
         var host = HttpContext.Request.Host.Value ?? throw new InvalidOperationException("Host not found in request");
-        var callbackBaseUrl = $"{scheme}://{host}/ivy/auth/callback";
-        var callback = new WebhookEndpoint(callbackId, callbackBaseUrl);
+        var callback = WebhookEndpoint.CreateAuthCallback(callbackId, scheme, host);
 
         try
         {
@@ -112,14 +111,18 @@ public class AuthController() : Controller
 
         try
         {
+            HttpMessageHandler httpMessageHandler;
             // Get the session and its HttpMessageHandler using the connectionId from the pending callback
-            if (!sessionStore.Sessions.TryGetValue(pending.ConnectionId, out var appSession))
+            if (sessionStore.Sessions.TryGetValue(pending.ConnectionId, out var appSession))
             {
-                logger.LogWarning("OAuth callback failed: Session not found for connection {ConnectionId}", pending.ConnectionId);
-                return BadRequest("Authentication error: app session expired");
+                httpMessageHandler = appSession.AppServices.GetRequiredService<HttpMessageHandler>();
+            }
+            else
+            {
+                logger.LogWarning("OAuth callback: session not found for connection {ConnectionId}. This will prevent the Clerk auth provider from working correctly. All other providers are unaffected.", pending.ConnectionId);
+                httpMessageHandler = new HttpClientHandler();
             }
 
-            var httpMessageHandler = appSession.AppServices.GetRequiredService<HttpMessageHandler>();
             var tempSession = AuthHelper.GetAuthSession(HttpContext, httpMessageHandler);
 
             var token = await authProvider.HandleOAuthCallbackAsync(tempSession, HttpContext.Request);

--- a/src/Ivy/Core/WebhookEndpoint.cs
+++ b/src/Ivy/Core/WebhookEndpoint.cs
@@ -1,12 +1,29 @@
 namespace Ivy.Core;
 
-public record WebhookEndpoint(string Id, string BaseUrl)
+public record WebhookEndpoint
 {
-    public WebhookEndpoint(string id, string scheme, string host) : this(id, BuildBaseUrl(scheme, host))
+    public string Id { get; init; }
+    public string BaseUrl { get; init; }
+
+    private WebhookEndpoint(string id, string baseUrl)
     {
+        Id = id;
+        BaseUrl = baseUrl;
     }
 
-    public static string BuildBaseUrl(string scheme, string host) => $"{scheme}://{host}/ivy/webhook";
+    public static WebhookEndpoint CreateWebhook(string id, string scheme, string host)
+    {
+        return new(id, BuildWebhookBaseUrl(scheme, host));
+    }
+
+    public static WebhookEndpoint CreateAuthCallback(string id, string scheme, string host)
+    {
+        return new(id, BuildAuthCallbackBaseUrl(scheme, host));
+    }
+
+    public static string BuildWebhookBaseUrl(string scheme, string host) => $"{scheme}://{host}/ivy/webhook";
+
+    public static string BuildAuthCallbackBaseUrl(string scheme, string host) => $"{scheme}://{host}/ivy/auth/callback";
 
     public Uri GetUri(bool includeIdInPath = true) => includeIdInPath
         ? new Uri($"{BaseUrl}/{Id}")

--- a/src/Ivy/Hooks/UseWebhook.cs
+++ b/src/Ivy/Hooks/UseWebhook.cs
@@ -39,7 +39,7 @@ public static class UseWebhookExtensions
 
         context.UseEffect(() => webhookController.Register(webhookId.Value, handler), [EffectTrigger.OnMount()]);
 
-        return new WebhookEndpoint(webhookId.Value, args.Scheme, args.Host);
+        return WebhookEndpoint.CreateWebhook(webhookId.Value, args.Scheme, args.Host);
     }
 }
 

--- a/src/auth/Ivy.Auth.MicrosoftEntra/MicrosoftEntraAuthProvider.cs
+++ b/src/auth/Ivy.Auth.MicrosoftEntra/MicrosoftEntraAuthProvider.cs
@@ -62,7 +62,7 @@ public class MicrosoftEntraAuthProvider : IAuthProvider
 
     public Task InitializeAsync(IAuthSession authSession, string requestScheme, string requestHost, CancellationToken cancellationToken = default)
     {
-        _baseUrl = WebhookEndpoint.BuildBaseUrl(requestScheme, requestHost);
+        _baseUrl = WebhookEndpoint.BuildAuthCallbackBaseUrl(requestScheme, requestHost);
         return Task.CompletedTask;
     }
 


### PR DESCRIPTION
Fixes two issues affecting Microsoft Entra auth:
- Stop passing old `/ivy/webhook` callback URL
- Don't fail if our app session is disconnected by the time we receive an auth callback. After #2068 it is **expected** to be disconnected by that point!
  - In theory all other auth providers besides Clerk should've also been broken by this. I don't know why they weren't.

Also refactors `WebhookEndpoint` API to replace both public constructors with two static methods for creating an instance: `CreateWebhook` and `CreateAuthCallback`.