### PR TITLE
(bool): improve visibility to respect theme customiser and ivy desighn system

### DIFF
--- a/src/Ivy/Themes/ThemeConfig.cs
+++ b/src/Ivy/Themes/ThemeConfig.cs
@@ -21,8 +21,6 @@ public class Theme
 
     public string? BorderRadiusSelectors { get; set; }
 
-    public string? BorderRadiusCheckbox { get; set; }
-
     public static Theme Default => new()
     {
         Name = "Default",

--- a/src/frontend/src/components/ui/checkbox.tsx
+++ b/src/frontend/src/components/ui/checkbox.tsx
@@ -69,7 +69,7 @@ const Checkbox = React.forwardRef<
       }
     };
 
-    const baseClass = `peer ${getSizeClasses(scale)} shrink-0 rounded-selector border border-border shadow focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring cursor-pointer disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground data-[state=checked]:border-primary dark:border-white/10`;
+    const baseClass = `peer ${getSizeClasses(scale)} shrink-0 rounded-checkbox border border-border shadow focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring cursor-pointer disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground data-[state=checked]:border-primary dark:border-white/10`;
     const finalClass = className?.includes('bg-red-50')
       ? baseClass.replace('data-[state=checked]:bg-primary', '')
       : baseClass;

--- a/src/frontend/src/index.css
+++ b/src/frontend/src/index.css
@@ -405,14 +405,14 @@
     border-radius: var(--radius-fields);
   }
 
-  /* For small selector components: Badge, Checkbox, Toggle, Radio */
+  /* For small selector components: Toggle, Badge, Radio */
   .rounded-selector {
     border-radius: var(--radius-selectors);
   }
 
-  /* For checkboxes: dedicated scale (0–6px) avoids circle at 8px */
+  /* For checkboxes: half of selector radius (avoids circle when selectors use 1rem) */
   .rounded-checkbox {
-    border-radius: var(--radius-checkbox, 0.25rem);
+    border-radius: calc(var(--radius-selectors) / 2);
   }
 }
 


### PR DESCRIPTION
Now:
<img width="506" height="175" alt="image" src="https://github.com/user-attachments/assets/944f90c9-e0f2-4db1-9d14-844570b3d8e3" />

Before (broken):
<img width="381" height="133" alt="image" src="https://github.com/user-attachments/assets/fe3b065f-7a84-4977-917f-680dbda18d8f" />
The issue was that the bool input in the checkbox variant used the same border-radius scaling as larger elements (such as buttons and badges), which caused it to appear almost circular.