### PR TITLE
[Tabs]: use visibility instead of display to prevent canvas flicker on tab switch

### DIFF
--- a/src/frontend/src/widgets/layouts/tabs/components/Variants.tsx
+++ b/src/frontend/src/widgets/layouts/tabs/components/Variants.tsx
@@ -193,7 +193,7 @@ export const ContentVariant: React.FC<ContentVariantProps> = ({
           {dropdownMenu}
         </div>
       </div>
-      <div className="flex-1 overflow-hidden">
+      <div className="flex-1 overflow-hidden relative">
         {orderedTabWidgets.map(tabWidget => {
           if (!React.isValidElement(tabWidget)) return null;
           const props = getTabProps(tabWidget);
@@ -201,15 +201,17 @@ export const ContentVariant: React.FC<ContentVariantProps> = ({
           const { id } = props;
           if (!loadedTabs.has(id)) return null;
           const paddingStyle = getPadding(padding);
+          const isActive = activeTabId === id;
           return (
             <div
               key={id}
               role="tabpanel"
-              aria-hidden={activeTabId !== id}
+              aria-hidden={!isActive}
               className={cn(
-                'h-full overflow-auto',
-                activeTabId === id ? 'block' : 'hidden',
-                'border-none'
+                'overflow-auto border-none',
+                isActive
+                  ? 'relative h-full visible z-[1]'
+                  : 'absolute inset-0 invisible opacity-0 z-0'
               )}
               style={paddingStyle}
             >
@@ -345,7 +347,7 @@ export const TabsVariant: React.FC<TabsVariantProps> = ({
         </div>
       </div>
 
-      <div className="flex-1 overflow-hidden">
+      <div className="flex-1 overflow-hidden relative">
         {React.useMemo(() => {
           return tabWidgets.map(tabWidget => {
             if (!React.isValidElement(tabWidget)) return null;
@@ -377,8 +379,10 @@ export const TabsVariant: React.FC<TabsVariantProps> = ({
               <div
                 key={id}
                 className={cn(
-                  'h-full overflow-auto',
-                  activeTabId === id ? 'block' : 'hidden'
+                  'overflow-auto',
+                  activeTabId === id
+                    ? 'relative h-full visible z-[1]'
+                    : 'absolute inset-0 invisible opacity-0 z-0'
                 )}
                 style={paddingStyle}
               >


### PR DESCRIPTION
## Issue

Canvas-based widgets (DataTable, Charts) inside `TabsLayout` visually flicker and rebuild every time the user switches between tabs. The DataTable loses its scroll position and column widths, and charts re-animate from scratch. This creates a poor user experience, especially with large datasets.

## Root Cause

The tab content panels used Tailwind's `hidden` / `block` classes to show and hide inactive tabs. These classes map to `display: none` and `display: block` respectively.

When a tab panel has `display: none`, its entire subtree is removed from the layout. Canvas elements (used by glide-data-grid for DataTable and by chart libraries) lose their dimensions (collapse to 0×0). When the tab becomes active again (`display: block`), the canvas must recalculate its dimensions and redraw all content from scratch — producing the visible flicker.

This affects **all** canvas-based widgets inside tabs, not just DataTable.

## Solution

Replace the `display: none` / `display: block` visibility strategy with `visibility: hidden` + `opacity: 0` combined with absolute positioning:

```diff
- activeTabId === id ? 'block' : 'hidden'
+ isActive
+   ? 'relative h-full visible z-[1]'
+   : 'absolute inset-0 invisible opacity-0 z-0'
```

**Active tab:** `relative` positioning with `visible` and `z-[1]` to stay on top.

**Inactive tab:** `absolute inset-0` fills the same container space, `invisible` + `opacity-0` hides it visually (double layer prevents canvas bleed-through), `z-0` places it behind the active tab.

The key difference: `visibility: hidden` keeps the element in the layout with its full dimensions. The canvas maintains its rendered state and doesn't need to redraw when the tab becomes active — the switch is instant with no flicker.

The container div also gets `relative` added to serve as the positioning context for the absolutely-positioned inactive panels.

## Why this approach

| Approach | Pros | Cons |
|----------|------|------|
| `display: none` (original) | Simple, no memory for hidden content | Canvas redraws on every show, causes flicker |
| `visibility: hidden` + absolute ✅ | Canvas keeps dimensions, instant switch, no flicker | Hidden tabs stay in memory (negligible overhead) |
| Structural sharing in `use-backend.tsx` | Prevents unnecessary React re-renders | Doesn't fix the CSS-level canvas issue, higher risk |
| Deep comparison in `MemoizedWidget` | Prevents unnecessary React re-renders | Same — doesn't fix the CSS-level issue |

The chosen approach is minimal (single file, ~6 lines changed), fixes the root cause at the CSS level, and benefits all canvas-based widgets universally.

## Files Changed

- `src/frontend/src/widgets/layouts/tabs/components/Variants.tsx` — Updated `ContentVariant` and `TabsVariant` tab panel visibility strategy

## Testing

- ✅ DataTable: no flicker on tab switch, scroll position and column widths preserved
- ✅ Charts: no re-animation on tab switch
- ✅ Regular content tabs: work as before
- ✅ Tab features (drag-and-drop reorder, close, refresh, dropdown overflow) unaffected
