### PR TITLE
[multiselect]: responsive badge count using ResizeObserver

### DIFF
--- a/src/frontend/src/components/ui/multiselect.tsx
+++ b/src/frontend/src/components/ui/multiselect.tsx
@@ -112,16 +112,14 @@ const MultipleSelector = React.forwardRef<
       const input = container.querySelector('input');
       const inputReserve = input
         ? (parseFloat(getComputedStyle(input).minWidth) || 0) +
-        (parseFloat(getComputedStyle(input).marginLeft) || 0)
+          (parseFloat(getComputedStyle(input).marginLeft) || 0)
         : 0;
 
       const calculate = () => {
         const containerWidth = container.clientWidth;
         if (containerWidth === 0) return;
 
-        const badges = Array.from(
-          measureContainer.children
-        ) as HTMLElement[];
+        const badges = Array.from(measureContainer.children) as HTMLElement[];
         const availableWidth = containerWidth - inputReserve;
 
         if (availableWidth <= 0 || badges.length === 0) {
@@ -279,7 +277,7 @@ const MultipleSelector = React.forwardRef<
                     badgeVariants({ scale }),
                     'shrink-0',
                     invalid &&
-                    'bg-destructive/10 border-destructive text-destructive'
+                      'bg-destructive/10 border-destructive text-destructive'
                   )}
                 >
                   {option.label}


### PR DESCRIPTION
## Problem

The `MultipleSelector` component had the number of visible badges hardcoded via the `maxVisibleBadges` prop with a default value of `2`. Regardless of the container width, exactly 2 badges were always shown, and the rest were collapsed into `+N`. On wide screens this left unused space, while on narrow screens the behavior remained inflexible.

## Goal

Make the visible badge count **responsive**: display as many badges as fit within the container width and automatically collapse the rest into `+N`. Maintain backward compatibility — if `maxVisibleBadges` is explicitly set, it should work as before.

## Implementation

### Approach: ResizeObserver + Hidden Measurement Container

The chosen approach uses `ResizeObserver` combined with a hidden DOM container for measuring badge widths.

### Why This Approach

- **Accuracy** — real DOM elements with real styles are measured, not approximate calculations
- **Reactivity** — `ResizeObserver` responds to any width change (window resize, layout shifts, sidebar toggles, etc.)
- **Simplicity** — all logic is contained in a single `useEffect`, no external dependencies required

### Changes Made to `multiselect.tsx`

1. **Removed default `maxVisibleBadges = 2`** — now defaults to `undefined`, enabling responsive mode

2. **Added `useEffect` with `ResizeObserver`:**
   - Caches CSS values (`gap`, `minWidth`, `marginLeft`) once on effect creation to avoid forced reflows
   - On each resize, calculates available width (container minus input field)
   - Iterates over badges from the measurement container, summing widths + gap
   - Accounts for the `+N` badge width when determining if the next badge fits
   - Sets `visibleCount` via `setState`

3. **Hidden measurement container** — renders all badges + overflow badge with `visibility: hidden; position: absolute`. Allows measuring each badge's width without affecting the visible layout.

4. **`shrink-0` on badges** — prevents `flex-shrink` so badges don't compress and remain readable.

5. **Safe initial `visibleCount = 1`** — before the first measurement, only one badge is shown, minimizing unnecessary DOM nodes.

### Backward Compatibility

If `maxVisibleBadges` is explicitly provided (e.g. `.MaxVisibleBadges(3)`), the component works as before with a fixed badge count. The measurement container is not rendered in this case.

<img width="895" height="643" alt="image" src="https://github.com/user-attachments/assets/31738b08-42de-4f88-ae42-cdca2c5f2720" />
<img width="929" height="598" alt="image" src="https://github.com/user-attachments/assets/4fede427-9ffe-482c-a490-116ad28d72d5" />
