### PR TITLE
[Security]: fix cookie attributes and markdown-it ReDoS vulnerability

### DIFF
--- a/src/Ivy/Auth/CookieJar.cs
+++ b/src/Ivy/Auth/CookieJar.cs
@@ -31,13 +31,10 @@ public class CookieJar
         return false;
     }
 
-    public void Delete(string name)
+    public void Delete(string name, CookieOptions options)
     {
-        _assignments.Add(new CookieAssignment(name, string.Empty, new CookieOptions
-        {
-            Expires = DateTimeOffset.UnixEpoch,
-            Path = "/"
-        }));
+        options.Expires = DateTimeOffset.UnixEpoch;
+        _assignments.Add(new CookieAssignment(name, string.Empty, options));
     }
 
     public void WriteToResponse(HttpResponse response)

--- a/src/Ivy/Auth/CookieRegistryExtensions.cs
+++ b/src/Ivy/Auth/CookieRegistryExtensions.cs
@@ -46,8 +46,8 @@ public static class CookieRegistryExtensions
     {
         if (string.IsNullOrEmpty(authToken?.AccessToken))
         {
-            cookies.Delete("auth_token");
-            cookies.Delete("auth_ext_refresh_token");
+            cookies.Delete("auth_token", CreateAuthCookieOptions());
+            cookies.Delete("auth_ext_refresh_token", CreateAuthCookieOptions());
         }
         else
         {
@@ -74,7 +74,7 @@ public static class CookieRegistryExtensions
             }
             else
             {
-                cookies.Delete("auth_ext_refresh_token");
+                cookies.Delete("auth_ext_refresh_token", CreateAuthCookieOptions());
             }
             cookies.Append("auth_token", tokenJson, cookieOptions);
         }
@@ -84,7 +84,7 @@ public static class CookieRegistryExtensions
     {
         if (authSessionData == null)
         {
-            cookies.Delete("auth_session_data");
+            cookies.Delete("auth_session_data", CreateAuthCookieOptions());
         }
         else
         {

--- a/src/widgets/Ivy.Widgets.Tiptap/frontend/package-lock.json
+++ b/src/widgets/Ivy.Widgets.Tiptap/frontend/package-lock.json
@@ -2394,9 +2394,9 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
-      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",

--- a/src/widgets/Ivy.Widgets.Tiptap/frontend/package.json
+++ b/src/widgets/Ivy.Widgets.Tiptap/frontend/package.json
@@ -28,5 +28,8 @@
     "tailwindcss": "^3.4.17",
     "typescript": "^5.7.2",
     "vite": "^6.0.5"
+  },
+  "overrides": {
+    "markdown-it": ">=14.1.1"
   }
 }


### PR DESCRIPTION
This PR resolves 3 security warnings reported by GitHub Code Scanning (CodeQL) and Dependabot.

## Changes

### 1. Cookie `HttpOnly` attribute is not set to true ([Alert #73](https://github.com/Ivy-Interactive/Ivy-Framework/security/code-scanning/73))

**Severity:** Medium | **Tool:** CodeQL (`cs/web/cookie-httponly-not-set`)

**Problem:** The `CookieJar.Delete()` method was creating a `CookieOptions` without setting `HttpOnly = true`. Cookies without this flag are accessible to client-side JavaScript via `document.cookie`. In case of an XSS vulnerability, a malicious script could steal sensitive cookie data.

**Root cause:** The `Delete()` method hardcoded its own `CookieOptions` with only `Expires` and `Path`, while the `CreateAuthCookieOptions()` helper (used for setting cookies) already had proper security flags.

---

### 2. Cookie `Secure` attribute is not set to true ([Alert #72](https://github.com/Ivy-Interactive/Ivy-Framework/security/code-scanning/72))

**Severity:** Medium (CWE-319, CWE-614) | **Tool:** CodeQL (`cs/web/cookie-secure-not-set`)

**Problem:** Same `CookieOptions` in `Delete()` was missing `Secure = true`. Without this flag, cookies may be transmitted over HTTP instead of HTTPS, making them vulnerable to interception by a third party.

**Root cause:** Same as above — the `Delete()` method had its own inline `CookieOptions` that didn't mirror the security policy from `CreateAuthCookieOptions()`.

---

### Solution for Alerts #72 and #73

Instead of duplicating security flags inside `CookieJar.Delete()`, the method signature was changed to accept `CookieOptions` as a parameter — matching the pattern already used by `CookieJar.Append()`. This keeps `CookieJar` as a generic container without knowledge of security policies.

All call sites in `CookieRegistryExtensions` now pass `CreateAuthCookieOptions()` to `Delete()`, ensuring a **single source of truth** for cookie security configuration (`HttpOnly`, `Secure`, `SameSite`).

**Modified files:**
- `src/Ivy/Auth/CookieJar.cs` — `Delete()` now accepts `CookieOptions`
- `src/Ivy/Auth/CookieRegistryExtensions.cs` — all 4 `Delete()` calls pass `CreateAuthCookieOptions()`

---

### 3. markdown-it ReDoS vulnerability ([Dependabot Alert #47](https://github.com/Ivy-Interactive/Ivy-Framework/security/dependabot/47))

**Severity:** Moderate (CVSS 5.5/10)

**Problem:** `markdown-it` versions `>= 13.0.0, < 14.1.1` are vulnerable to Regular Expression Denial of Service (ReDoS) due to the regex `/*+$/` in the `linkify` function. An attacker can supply a long sequence of `*` characters followed by a non-matching character, which triggers excessive backtracking and may lead to a denial-of-service condition.

**Root cause:** `markdown-it` is a **transitive dependency** introduced via:
- `@tiptap/pm` → ... → `markdown-it 14.1.0`
- `@tiptap/starter-kit` → ... → `markdown-it 14.1.0`

**Solution:** Added an `overrides` entry in `package.json` to force `markdown-it >= 14.1.1` (the patched version). After `npm install`, the vulnerability is resolved (`found 0 vulnerabilities`).

**Modified files:**
- `src/widgets/Ivy.Widgets.Tiptap/frontend/package.json` — added `overrides` section
- `src/widgets/Ivy.Widgets.Tiptap/frontend/package-lock.json` — updated automatically
