### PR TITLE
[DataTable]: add RowActions usage example to documentation

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/07_Advanced/01_DataTable.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/07_Advanced/01_DataTable.md
@@ -151,6 +151,44 @@ Use `HandleRowAction()` to respond to row action menu selections. The handler re
 
 The handler can access both properties: `args.Id` to identify the row and `args.Tag` to determine which action was selected. This is particularly useful when handling nested menu items, as each child menu item can have its own tag.
 
+```csharp demo-tabs
+public class RowActionsDemo : ViewBase
+{
+    public record Employee(int Id, string Name, string Email, int Salary);
+
+    public override object? Build()
+    {
+        var client = UseService<IClientProvider>();
+        var employees = Enumerable.Range(1, 50)
+            .Select(i => new Employee(i, $"Employee {i}", $"emp{i}@company.com", 40000 + i * 1000))
+            .AsQueryable();
+
+        return employees.ToDataTable(idSelector: e => e.Id)
+            .Header(e => e.Name, "Name")
+            .Header(e => e.Email, "Email")
+            .Header(e => e.Salary, "Salary")
+            .RowActions(
+                MenuItem.Default(Icons.Pencil, "edit"),
+                MenuItem.Default(Icons.Trash2, "delete"),
+                MenuItem.Default(Icons.EllipsisVertical, "more")
+                    .Children([
+                        MenuItem.Default(Icons.Archive, "archive").Label("Archive"),
+                        MenuItem.Default(Icons.Download, "export").Label("Export"),
+                        MenuItem.Default(Icons.Share2, "share").Label("Share")
+                    ])
+            )
+            .HandleRowAction(async e =>
+            {
+                var args = e.Value;
+                client.Toast($"Action: {args.Tag} on row ID: {args.Id}");
+                await ValueTask.CompletedTask;
+            })
+            .Height(Size.Units(100));
+    }
+}
+```
+
+
 <Callout Type="tip">
 Use <code>Renderer(expr, new LinkDisplayRenderer { Type = LinkDisplayType.Url })</code> to mark a URL string column as a clickable hyperlink. Click on a link to open it. External links (http/https) open in a new focused tab, while relative URLs navigate in the same tab.
 </Callout>


### PR DESCRIPTION
## Problem

The **Row Actions** section in the DataTable documentation contained only a textual description without any code examples. Developers did not have clear guidance on:

- How to configure `RowActions()`
- How to define action handlers via `HandleRowAction()`
- How to pass row-specific data to actions using `idSelector`

This was inconsistent with other sections of the same page (AI-Powered Filtering, DateTime Filtering, Performance), which all include interactive `demo-tabs` code examples.

## Solution

Added an interactive `demo-tabs` code example to the **Row Actions** section in `01_DataTable.md`. The example is a self-contained `ViewBase` class (`RowActionsDemo`) with its own `record Employee` model, which avoids modifying the shared `prepare` frontmatter used by other demos.

### The example demonstrates:

1. **Configuring rowActions** — simple action buttons (`edit`, `delete`) and a nested dropdown menu via `.Children()` (`archive`, `export`, `share`)
2. **Defining an action handler** — `HandleRowAction()` with access to `e.Value.Tag` (which action) and `e.Value.Id` (which row)
3. **Passing row-specific data** — `idSelector: e => e.Id` in `.ToDataTable()` to bind row identity

## Changes

- `src/Ivy.Docs.Shared/Docs/02_Widgets/07_Advanced/01_DataTable.md` — added `demo-tabs` example in the Row Actions section

<img width="2008" height="1215" alt="image" src="https://github.com/user-attachments/assets/2b315894-9d48-450b-b775-24033875f5db" />
<img width="991" height="533" alt="image" src="https://github.com/user-attachments/assets/95e1dfa2-79e2-4247-9251-37aa39ac4bd0" />
<img width="1745" height="795" alt="image" src="https://github.com/user-attachments/assets/affd790c-4531-4170-8963-9b645f204d91" />
<img width="1148" height="1138" alt="image" src="https://github.com/user-attachments/assets/2c42e9af-440b-4cb8-80c8-265763c3a465" />
