### PR TITLE
[ExternalWidgets]: clarify multiple widgets sharing same frontend

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/07_Advanced/05_ExternalWidgets.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/07_Advanced/05_ExternalWidgets.md
@@ -6,6 +6,9 @@ searchHints:
   - Vite
   - IIFE
   - embedded resource
+  - multiple widgets
+  - shared frontend
+  - same bundle
 ---
 
 # External Widgets
@@ -243,9 +246,15 @@ When the widget lives inside the host app (e.g. `HostApp/Widgets/MyWidget/`), ad
 </ItemGroup>
 ```
 
-### Multiple widgets in one bundle
+### Multiple widgets in one bundle (same frontend)
 
-You can ship several widgets from one frontend project. Use a single entry (e.g. `src/index.ts`) that exports and assigns all of them to one global object whose name matches the Vite `name` and C# `GlobalName`:
+You can ship **several widgets from one frontend project**: one Vite build produces a single JS bundle, and multiple C# widget records point to that same script. Each widget type is resolved by `ExportName` from the same global object. The backend serves the same embedded file for all of them; the browser may cache it per URL.
+
+- **One frontend** — one `frontend/` project, one `npm run build`, one output file (e.g. `ExternalWidgets.js`).
+- **Same script path and GlobalName** — every C# widget uses the same `[ExternalWidget("frontend/dist/ExternalWidgets.js", ..., GlobalName = "MyProject_Widgets")]` so they all use the same global object.
+- **Different ExportName** — each C# record must specify the React component name explicitly: `ExportName = "MyWidget"`, `ExportName = "AnotherWidget"`, etc. Do not rely on `"default"` for multi-widget bundles.
+
+**Vite and entry point:** Use one library name for the whole bundle and assign all components to that global:
 
 ```typescript
 // vite.config.ts — one name for the whole bundle
@@ -259,7 +268,15 @@ fileName: () => 'ExternalWidgets.js',
 };
 ```
 
-Then in C# use the same `GlobalName` for each widget and different `ExportName` values.
+**C#:** Use the same `Script path` and `GlobalName` for each widget, and different `ExportName` values so the loader picks the right component from the same global:
+
+```csharp
+[ExternalWidget("frontend/dist/ExternalWidgets.js", ExportName = "MyWidget", GlobalName = "MyProject_Widgets")]
+public record MyWidget : WidgetBase<MyWidget> { ... }
+
+[ExternalWidget("frontend/dist/ExternalWidgets.js", ExportName = "AnotherWidget", GlobalName = "MyProject_Widgets")]
+public record AnotherWidget : WidgetBase<AnotherWidget> { ... }
+```
 
 ## Host requirements
 


### PR DESCRIPTION
## Summary

Updates External Widgets docs to clarify how multiple widgets can share one frontend bundle.

## Changes

- **Search hints** — Added `multiple widgets`, `shared frontend`, `same bundle` for discoverability
- **Multiple widgets in one bundle** — Clarified:
  - How `GlobalName` and `ExportName` work together
  - That the backend serves the same embedded file for all widgets; the browser may cache it per URL
  - That `ExportName` must be set explicitly for each widget (do not rely on `"default"`)
- **Bullet list** — Added checklist: one frontend, same script path and `GlobalName`, different `ExportName`

<img width="1539" height="915" alt="image" src="https://github.com/user-attachments/assets/d870e33f-ed5d-48ea-bd17-17a2698b178b" />
