### PR TITLE
(floating panel): refactor docs

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/02_Layouts/09_FloatingPanel.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/02_Layouts/09_FloatingPanel.md
@@ -25,26 +25,15 @@ public class BasicFloatingPanelView : ViewBase
 {
     public override object? Build()
     {
-        var showPanel = UseState(false);
-        return Layout.Vertical().Gap(4)
-            | new Card(
-                Layout.Horizontal().Gap(2).Align(Align.Center)
-                    | new Button("Show Panel", onClick: _ => showPanel.Set(true))
-                    | new Button("Hide Panel", onClick: _ => showPanel.Set(false))
-            ).Width(Size.Full())
-            | (showPanel.Value ? new FloatingPanel(
-                new Button("Floating Action")
-                    .Icon(Icons.Plus)
-                    .Large()
-                    .BorderRadius(BorderRadius.Full)
-            ) : null);
+        var (panelView, showPanel) = UseTrigger((IState<bool> isOpen) =>
+            isOpen.Value ? new FloatingPanel(new Button("Close", onClick: _ => isOpen.Set(false))) : null);
+
+        return Layout.Vertical()
+            | new Button("Show Panel", onClick: _ => showPanel())
+            | panelView;
     }
 }
 ```
-
-<Callout Type="tip">
-Floating panels automatically use a high z-index (50) to ensure they appear above other content. Be mindful of layering when using multiple floating elements.
-</Callout>
 
 ## Alignment Options
 
@@ -59,24 +48,23 @@ public class CornerAlignmentView : ViewBase
 {
     public override object? Build()
     {
-        var showPanels = UseState(false);
-        var floatingButton = new Button("Action")
-            .Icon(Icons.Star)
-            .Large()
-            .BorderRadius(BorderRadius.Full);
-
-        return Layout.Vertical().Gap(4)
-            | new Card(
-                Layout.Horizontal().Gap(2).Align(Align.Center)
-                    | new Button("Show Panels", onClick: _ => showPanels.Set(true))
-                    | new Button("Hide Panels", onClick: _ => showPanels.Set(false))
-            ).Width(Size.Full())
-            | (showPanels.Value ? new Fragment()
+        var (panelView, showPanels) = UseTrigger((IState<bool> isOpen) =>
+        {
+            var floatingButton = new Button("Action")
+                .Icon(Icons.Star)
+                .Large()
+                .BorderRadius(BorderRadius.Full);
+            return Layout.Vertical()
                 | new FloatingPanel(floatingButton, Align.TopLeft)
                 | new FloatingPanel(floatingButton, Align.TopRight)
                 | new FloatingPanel(floatingButton, Align.BottomLeft)
                 | new FloatingPanel(floatingButton, Align.BottomRight)
-            : null);
+                | new FloatingPanel(new Button("Close", onClick: _ => isOpen.Set(false)).Secondary(), Align.Center);
+        });
+
+        return Layout.Vertical()
+            | new Button("Show Panels", onClick: _ => showPanels())
+            | panelView;
     }
 }
 ```
@@ -90,24 +78,23 @@ public class EdgeCenterAlignmentView : ViewBase
 {
     public override object? Build()
     {
-        var showPanels = UseState(false);
-        var floatingButton = new Button("Center")
-            .Icon(Icons.Move)
-            .Large()
-            .BorderRadius(BorderRadius.Full);
-
-        return Layout.Vertical().Gap(4)
-            | new Card(
-                Layout.Horizontal().Gap(2).Align(Align.Center)
-                    | new Button("Show Panels", onClick: _ => showPanels.Set(true))
-                    | new Button("Hide Panels", onClick: _ => showPanels.Set(false))
-            ).Width(Size.Full())
-            | (showPanels.Value ? new Fragment()
+        var (panelView, showPanels) = UseTrigger((IState<bool> isOpen) =>
+        {
+            var floatingButton = new Button("Center")
+                .Icon(Icons.Move)
+                .Large()
+                .BorderRadius(BorderRadius.Full);
+            return Layout.Vertical()
                 | new FloatingPanel(floatingButton, Align.TopCenter)
                 | new FloatingPanel(floatingButton, Align.BottomCenter)
                 | new FloatingPanel(floatingButton, Align.Left)
                 | new FloatingPanel(floatingButton, Align.Right)
-            : null);
+                | new FloatingPanel(new Button("Close", onClick: _ => isOpen.Set(false)).Secondary(), Align.Center);
+        });
+
+        return Layout.Vertical()
+            | new Button("Show Panels", onClick: _ => showPanels())
+            | panelView;
     }
 }
 ```
@@ -121,23 +108,20 @@ public class CenterAlignmentView : ViewBase
 {
     public override object? Build()
     {
-        var showPanel = UseState(false);
-        
-        return Layout.Vertical().Gap(4)
-            | new Card(
-                Layout.Horizontal().Gap(2).Align(Align.Center)
-                    | new Button("Show Panel", onClick: _ => showPanel.Set(true))
-                    | new Button("Hide Panel", onClick: _ => showPanel.Set(false))
-            ).Width(Size.Full())
-            | (showPanel.Value ? new FloatingPanel(
+        var (panelView, showPanel) = UseTrigger((IState<bool> isOpen) =>
+            isOpen.Value ? new FloatingPanel(
                 new Card(
                     Layout.Vertical()
                         | Text.H3("Centered Panel")
                         | Text.Block("This panel is positioned")
                         | Text.Block("in the center of the screen")
-                        | new Button("Close", onClick: _ => showPanel.Set(false)).Secondary()
-                ).Width(Size.Auto())
-            , Align.Center) : null);
+                        | new Button("Close", onClick: _ => isOpen.Set(false)).Secondary()
+                ),
+                Align.Center) : null);
+
+        return Layout.Vertical()
+            | new Button("Show Panel", onClick: _ => showPanel())
+            | panelView;
     }
 }
 ```
@@ -155,36 +139,35 @@ public class BasicOffsetView : ViewBase
 {
     public override object? Build()
     {
-        var showPanels = UseState(false);
-        
-        return Layout.Vertical().Gap(4)
-            | new Card(
-                Layout.Horizontal().Gap(2).Align(Align.Center)
-                    | new Button("Show Panels", onClick: _ => showPanels.Set(true))
-                    | new Button("Hide Panels", onClick: _ => showPanels.Set(false))
-            ).Width(Size.Full())
-            | (showPanels.Value ? new Fragment()
+        var (panelView, showPanels) = UseTrigger((IState<bool> isOpen) =>
+        {
+            return Layout.Vertical()
                 | new FloatingPanel(
                     new Button("Default Position")
                         .Icon(Icons.Circle)
                         .Large()
-                        .BorderRadius(BorderRadius.Full)
-                , Align.TopRight)
+                        .BorderRadius(BorderRadius.Full),
+                    Align.TopRight)
                 | new FloatingPanel(
                     new Button("Offset Down & Left")
                         .Icon(Icons.ArrowDownLeft)
                         .Large()
-                        .BorderRadius(BorderRadius.Full)
-                , Align.BottomLeft)
+                        .BorderRadius(BorderRadius.Full),
+                    Align.BottomLeft)
                     .Offset(new Thickness(0, 20, 0, 0))  // 20 units up from bottom edge
                 | new FloatingPanel(
                     new Button("Custom Offset")
                         .Icon(Icons.Move)
                         .Large()
-                        .BorderRadius(BorderRadius.Full)
-                , Align.BottomRight)
+                        .BorderRadius(BorderRadius.Full),
+                    Align.BottomRight)
                     .Offset(new Thickness(10, 0, 0, 10)) // Thickness(left, top, right, bottom): 10 from left edge, 10 from bottom edge
-            : null);
+                | new FloatingPanel(new Button("Close", onClick: _ => isOpen.Set(false)).Secondary(), Align.Center);
+        });
+
+        return Layout.Vertical()
+            | new Button("Show Panels", onClick: _ => showPanels())
+            | panelView;
     }
 }
 ```
@@ -198,44 +181,43 @@ public class ConvenienceOffsetView : ViewBase
 {
     public override object? Build()
     {
-        var showPanels = UseState(false);
-        
-        return Layout.Vertical().Gap(4)
-            | new Card(
-                Layout.Horizontal().Gap(2).Align(Align.Center)
-                    | new Button("Show Panels", onClick: _ => showPanels.Set(true))
-                    | new Button("Hide Panels", onClick: _ => showPanels.Set(false))
-            ).Width(Size.Full())
-            | (showPanels.Value ? new Fragment()
+        var (panelView, showPanels) = UseTrigger((IState<bool> isOpen) =>
+        {
+            return Layout.Vertical()
                 | new FloatingPanel(
                     new Button("Top Offset")
                         .Icon(Icons.ArrowUp)
                         .Large()
-                        .BorderRadius(BorderRadius.Full)
-                , Align.TopRight)
-                    .OffsetTop(30) 
+                        .BorderRadius(BorderRadius.Full),
+                    Align.TopRight)
+                    .OffsetTop(30)
                 | new FloatingPanel(
                     new Button("Left Offset")
                         .Icon(Icons.ArrowLeft)
                         .Large()
-                        .BorderRadius(BorderRadius.Full)
-                , Align.TopRight)
-                    .OffsetLeft(30) 
+                        .BorderRadius(BorderRadius.Full),
+                    Align.TopRight)
+                    .OffsetLeft(30)
                 | new FloatingPanel(
                     new Button("Right Offset")
                         .Icon(Icons.ArrowRight)
                         .Large()
-                        .BorderRadius(BorderRadius.Full)
-                , Align.TopLeft)
-                    .OffsetRight(30) 
+                        .BorderRadius(BorderRadius.Full),
+                    Align.TopLeft)
+                    .OffsetRight(30)
                 | new FloatingPanel(
                     new Button("Bottom Offset")
                         .Icon(Icons.ArrowDown)
                         .Large()
-                        .BorderRadius(BorderRadius.Full)
-                , Align.BottomLeft)
-                    .OffsetBottom(30) 
-            : null);
+                        .BorderRadius(BorderRadius.Full),
+                    Align.BottomLeft)
+                    .OffsetBottom(30)
+                | new FloatingPanel(new Button("Close", onClick: _ => isOpen.Set(false)).Secondary(), Align.Center);
+        });
+
+        return Layout.Vertical()
+            | new Button("Show Panels", onClick: _ => showPanels())
+            | panelView;
     }
 }
 ```
@@ -253,15 +235,8 @@ public class NavigationPanelView : ViewBase
 {
     public override object? Build()
     {
-        var showPanel = UseState(false);
-        
-        return Layout.Vertical().Gap(4)
-            | new Card(
-                Layout.Horizontal().Gap(2).Align(Align.Center)
-                    | new Button("Show Panel", onClick: _ => showPanel.Set(true))
-                    | new Button("Hide Panel", onClick: _ => showPanel.Set(false))
-            ).Width(Size.Full())
-            | (showPanel.Value ? new FloatingPanel(
+        var (panelView, showPanel) = UseTrigger((IState<bool> isOpen) =>
+            isOpen.Value ? new FloatingPanel(
                 Layout.Vertical().Gap(2)
                     | new Button("Home")
                         .Icon(Icons.House)
@@ -279,8 +254,13 @@ public class NavigationPanelView : ViewBase
                         .Icon(Icons.Info)
                         .Secondary()
                         .Width(Size.Units(12))
-            , Align.Right)
+                    | new Button("Close", onClick: _ => isOpen.Set(false)).Secondary(),
+                Align.Right)
                 .Offset(new Thickness(0, 0, 10, 0)) : null);
+
+        return Layout.Vertical()
+            | new Button("Show Panel", onClick: _ => showPanel())
+            | panelView;
     }
 }
 ```
@@ -294,15 +274,8 @@ public class ActionPanelView : ViewBase
 {
     public override object? Build()
     {
-        var showPanel = UseState(false);
-        
-        return Layout.Vertical().Gap(4)
-            | new Card(
-                Layout.Horizontal().Gap(2).Align(Align.Center)
-                    | new Button("Show Panel", onClick: _ => showPanel.Set(true))
-                    | new Button("Hide Panel", onClick: _ => showPanel.Set(false))
-            ).Width(Size.Full())
-            | (showPanel.Value ? new FloatingPanel(
+        var (panelView, showPanel) = UseTrigger((IState<bool> isOpen) =>
+            isOpen.Value ? new FloatingPanel(
                 Layout.Horizontal().Gap(2)
                     | new Button("New")
                         .Icon(Icons.Plus)
@@ -316,8 +289,13 @@ public class ActionPanelView : ViewBase
                         .Icon(Icons.Trash)
                         .Destructive()
                         .BorderRadius(BorderRadius.Full)
-            , Align.BottomCenter)
+                    | new Button("Close", onClick: _ => isOpen.Set(false)).Secondary(),
+                Align.BottomCenter)
                 .Offset(new Thickness(0, 0, 0, 20)) : null);
+
+        return Layout.Vertical()
+            | new Button("Show Panel", onClick: _ => showPanel())
+            | panelView;
     }
 }
 ```
@@ -335,29 +313,28 @@ Ensure floating panels don't interfere with content readability and provide clea
 Back to Top Button
 </Summary>
 <Body>
-A common use case for floating panels - a "back to top" button:
+A common use case for floating panels—a "back to top" button:
 
 ```csharp demo-tabs
 public class BackToTopView : ViewBase
 {
     public override object? Build()
     {
-        var showButton = UseState(false);
-        
-        return Layout.Vertical().Gap(4)
-            | new Card(
+        var (panelView, showButton) = UseTrigger((IState<bool> isOpen) =>
+            isOpen.Value ? new FloatingPanel(
                 Layout.Horizontal().Gap(2).Align(Align.Center)
-                    | new Button("Show Button", onClick: _ => showButton.Set(true))
-                    | new Button("Hide Button", onClick: _ => showButton.Set(false))
-            ).Width(Size.Full())
-            | (showButton.Value ? new FloatingPanel(
-                new Button("Top")
-                    .Icon(Icons.ArrowUp)
-                    .Large()
-                    .BorderRadius(BorderRadius.Full)
-                    .Secondary()
-            , Align.BottomRight)
+                    | new Button("Top")
+                        .Icon(Icons.ArrowUp)
+                        .Large()
+                        .BorderRadius(BorderRadius.Full)
+                        .Secondary()
+                    | new Button("Close", onClick: _ => isOpen.Set(false)).Secondary(),
+                Align.BottomRight)
                 .Offset(new Thickness(0, 0, 20, 20)) : null);
+
+        return Layout.Vertical()
+            | new Button("Show Button", onClick: _ => showButton())
+            | panelView;
     }
 }
 ```
@@ -377,24 +354,20 @@ public class FloatingSearchView : ViewBase
 {
     public override object? Build()
     {
-        var showSearchBar = UseState(false);
-        
-        return Layout.Vertical().Gap(4)
-            | new Card(
-                Layout.Horizontal().Gap(2).Align(Align.Center)
-                    | new Button("Show Search Bar", onClick: _ => showSearchBar.Set(true))
-                    | new Button("Hide Search Bar", onClick: _ => showSearchBar.Set(false))
-            ).Width(Size.Full())
-            | (showSearchBar.Value ? new FloatingPanel(
+        var (panelView, showSearchBar) = UseTrigger((IState<bool> isOpen) =>
+            isOpen.Value ? new FloatingPanel(
                 new Card(
                     Layout.Horizontal().Gap(2)
                         | new TextInput(placeholder: "Search...")
-                        | new Button("Search")
-                            .Icon(Icons.Search)
-                            .Primary()
-                )
-            , Align.TopCenter)
+                        | new Button("Search").Icon(Icons.Search).Primary()
+                        | new Button("Close", onClick: _ => isOpen.Set(false)).Secondary()
+                ),
+                Align.TopCenter)
                 .Offset(new Thickness(0, 10, 0, 0)) : null);
+
+        return Layout.Vertical()
+            | new Button("Show Search Bar", onClick: _ => showSearchBar())
+            | panelView;
     }
 }
 ```
@@ -414,38 +387,32 @@ public class MultiPanelView : ViewBase
 {
     public override object? Build()
     {
-        var showPanels = UseState(false);
-        
-        return Layout.Vertical().Gap(4)
-            | new Card(
-                Layout.Horizontal().Gap(2).Align(Align.Center)
-                    | new Button("Show Panels", onClick: _ => showPanels.Set(true))
-                    | new Button("Hide Panels", onClick: _ => showPanels.Set(false))
-            ).Width(Size.Full())
-            | (showPanels.Value ? new Fragment()
+        var (panelView, showPanels) = UseTrigger((IState<bool> isOpen) =>
+        {
+            return Layout.Vertical()
                 | new FloatingPanel(
                     new Button("Menu")
                         .Icon(Icons.Menu)
                         .Large()
                         .BorderRadius(BorderRadius.Full)
-                        .Secondary()
-                , Align.TopLeft)
+                        .Secondary(),
+                    Align.TopLeft)
                     .Offset(new Thickness(10, 10, 0, 0))
                 | new FloatingPanel(
                     new Button("Notifications")
                         .Icon(Icons.Bell)
                         .Large()
                         .BorderRadius(BorderRadius.Full)
-                        .Secondary()
-                , Align.TopRight)
+                        .Secondary(),
+                    Align.TopRight)
                     .Offset(new Thickness(0, 10, 10, 0))
                 | new FloatingPanel(
                     new Button("Chat")
                         .Icon(Icons.MessageCircle)
                         .Large()
                         .BorderRadius(BorderRadius.Full)
-                        .Primary()
-                , Align.BottomRight)
+                        .Primary(),
+                    Align.BottomRight)
                     .Offset(new Thickness(0, 0, 20, 20))
                 | new FloatingPanel(
                     new Card(
@@ -453,10 +420,15 @@ public class MultiPanelView : ViewBase
                             | Text.Block("Quick Actions")
                             | new Button("Save").Small().Primary()
                             | new Button("Share").Small().Secondary()
-                    ).Width(Size.Units(40))
-                , Align.Left)
-                    .Offset(new Thickness(10, 0, 0, 0))
-            : null);
+                            | new Button("Close", onClick: _ => isOpen.Set(false)).Small().Secondary()
+                    ).Width(Size.Units(40)),
+                    Align.Left)
+                    .Offset(new Thickness(10, 0, 0, 0));
+        });
+
+        return Layout.Vertical()
+            | new Button("Show Panels", onClick: _ => showPanels())
+            | panelView;
     }
 }
 ```


### PR DESCRIPTION
- **Before:** `UseState(false)` with separate "Show" and "Hide" buttons that call `isOpen.Set(true)` / `isOpen.Set(false)`; panel rendered with a ternary `isOpen.Value ? new FloatingPanel(...) : null`.

<img width="812" height="307" alt="Screenshot 2026-02-24 at 04 14 23" src="https://github.com/user-attachments/assets/98c86a55-8f1e-47f5-8ab1-67ee9ed2565c" />

- **After:** `UseTrigger` returning `(panelView, showPanel)`. A single **Show** button calls `showPanel()`; closing is done with a **Close** button inside the panel content that calls `isOpen.Set(false)`. No boolean state in the view.
<img width="801" height="236" alt="Screenshot 2026-02-24 at 04 14 46" src="https://github.com/user-attachments/assets/46ddf672-44bd-42b5-862d-70833f20af57" />


Works the same. 