### PR TITLE
(docs)getting-started-mcp

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/01_Onboarding/01_GettingStarted/07_IvyMCPServer/02_Claude.md
+++ b/src/Ivy.Docs.Shared/Docs/01_Onboarding/01_GettingStarted/07_IvyMCPServer/02_Claude.md
@@ -4,6 +4,11 @@
 The Ivy MCP Server enables AI assistants to directly interact with the Ivy Framework, providing them with the capability to read documentation, query widget properties, and build complex Ivy applications. By connecting your AI tools to the Ivy MCP Server, you can unlock powerful agentic coding workflows tailored for the Ivy ecosystem.
 </Ingress>
 
+
+For more information on configuring MCP servers in Claude, please refer to their [official documentation](https://code.claude.com/docs/en/mcp).
+
+To use the Ivy MCP Server, you first need to install Ivy. Refer to the [installation guide](../02_Installation.md) to learn how.
+
 ## Setup
 
 The fastest way to get started is scaffolding the sample `--hello` project, which configures the IDE-specific MCP settings in one command.
@@ -11,4 +16,3 @@ The fastest way to get started is scaffolding the sample `--hello` project, whic
 ```terminal
 ivy init --hello --claude
 ```
-

--- a/src/Ivy.Docs.Shared/Docs/01_Onboarding/01_GettingStarted/07_IvyMCPServer/03_Cursor.md
+++ b/src/Ivy.Docs.Shared/Docs/01_Onboarding/01_GettingStarted/07_IvyMCPServer/03_Cursor.md
@@ -4,6 +4,11 @@
 The Ivy MCP Server enables AI assistants to directly interact with the Ivy Framework, providing them with the capability to read documentation, query widget properties, and build complex Ivy applications. By connecting your AI tools to the Ivy MCP Server, you can unlock powerful agentic coding workflows tailored for the Ivy ecosystem.
 </Ingress>
 
+For more information on configuring MCP servers in Cursor, please refer to their [official documentation](https://cursor.com/docs/context/mcp).
+
+To use the Ivy MCP Server, you first need to install Ivy. Refer to the [installation guide](../02_Installation.md) to learn how.
+
+
 ## Setup
 
 The fastest way to get started is scaffolding the sample `--hello` project, which configures the IDE-specific MCP settings in one command.

--- a/src/Ivy.Docs.Shared/Docs/01_Onboarding/01_GettingStarted/07_IvyMCPServer/04_VSCode.md
+++ b/src/Ivy.Docs.Shared/Docs/01_Onboarding/01_GettingStarted/07_IvyMCPServer/04_VSCode.md
@@ -4,18 +4,45 @@
 The Ivy MCP Server enables AI assistants to directly interact with the Ivy Framework, providing them with the capability to read documentation, query widget properties, and build complex Ivy applications. By connecting your AI tools to the Ivy MCP Server, you can unlock powerful agentic coding workflows tailored for the Ivy ecosystem.
 </Ingress>
 
+For more information on configuring MCP servers in VS Code, please refer to their [official documentation](https://code.visualstudio.com/docs/copilot/customization/mcp-servers).
+
+To use the Ivy MCP Server, you first need to install Ivy. Refer to the [installation guide](../02_Installation.md) to learn how.
+
+
 
 ## Setup
 
 1. Open your project directory in VS Code.
 2. Initialise the Ivy project: 
-```terminal
-ivy init 
-```
+   ```terminal
+   ivy init 
+   ```
 3. Generate the MCP configuration: 
 
-```terminal
-ivy mcp config
-```
+   ```terminal
+   ivy mcp config
+   ```
 
 4. In the chat, prompt `@AGENTS.md` to sync the project context and agent instructions.
+
+### Manual Configuration
+
+If you prefer to configure the MCP server manually, use the following configuration:
+
+```json
+{
+  "mcpServers": {
+    "ivy-release": {
+      "command": "<path-to-dotnet-tools>/ivy",
+      "args": [
+        "mcp",
+        "--path",
+        "<path-to-your-project>"
+      ],
+      "env": {
+        "Ivy__Mcp__ApiUrl": "https://staging.mcp.ivy.app"
+      }
+    }
+  }
+}
+```

--- a/src/Ivy.Docs.Shared/Docs/01_Onboarding/01_GettingStarted/07_IvyMCPServer/05_Antigravity.md
+++ b/src/Ivy.Docs.Shared/Docs/01_Onboarding/01_GettingStarted/07_IvyMCPServer/05_Antigravity.md
@@ -5,17 +5,43 @@ The Ivy MCP Server enables AI assistants to directly interact with the Ivy Frame
 </Ingress>
 
 
+For more information on configuring MCP servers in Antigravity, please refer to their [official documentation](https://antigravity.google/docs/mcp).
+
+To use the Ivy MCP Server, you first need to install Ivy. Refer to the [installation guide](../02_Installation.md) to learn how.
+
 ## Setup
 
 1. Open your project directory in Antigravity
 2. Initialise the Ivy project: 
-```terminal
-ivy init 
-```
+   ```terminal
+   ivy init 
+   ```
 3. Generate the MCP configuration: 
 
-```terminal
-ivy mcp config
-```
+   ```terminal
+   ivy mcp config
+   ```
 
 4. In the chat, prompt `@AGENTS.md` to sync the project context and agent instructions.
+
+### Manual Configuration
+
+If you prefer to configure the MCP server manually, use the following configuration:
+
+```json
+{
+  "mcpServers": {
+    "ivy-release": {
+      "command": "<path-to-dotnet-tools>/ivy",
+      "args": [
+        "mcp",
+        "--path",
+        "<path-to-your-project>"
+      ],
+      "env": {
+        "Ivy__Mcp__ApiUrl": "https://staging.mcp.ivy.app"
+      }
+    }
+  }
+}
+```

--- a/src/Ivy.Docs.Shared/Docs/01_Onboarding/01_GettingStarted/07_IvyMCPServer/06_Windsurf.md
+++ b/src/Ivy.Docs.Shared/Docs/01_Onboarding/01_GettingStarted/07_IvyMCPServer/06_Windsurf.md
@@ -1,20 +1,48 @@
-# Getting Started: Windsurf (Cascade)
+# Getting Started: Windsurf 
 
 <Ingress>
 The Ivy MCP Server enables AI assistants to directly interact with the Ivy Framework, providing them with the capability to read documentation, query widget properties, and build complex Ivy applications. By connecting your AI tools to the Ivy MCP Server, you can unlock powerful agentic coding workflows tailored for the Ivy ecosystem.
 </Ingress>
 
+For more information on configuring MCP servers in Windsurf, please refer to their [official documentation](https://windsurf.com/university/tutorials/configuring-first-mcp-server).
+
+To use the Ivy MCP Server, you first need to install Ivy. Refer to the [installation guide](../02_Installation.md) to learn how.
+
+
+
 ## Setup
 
 1. Open your project directory in Windsurf.
 2. Initialise the Ivy project: 
-```terminal
-ivy init 
-```
+   ```terminal
+   ivy init 
+   ```
 3. Generate the MCP configuration: 
 
-```terminal
-ivy mcp config
-```
+   ```terminal
+   ivy mcp config
+   ```
 
 4. In the chat, prompt `#AGENTS.md` to sync the project context and agent instructions.
+
+### Manual Configuration
+
+If you prefer to configure the MCP server manually, use the following configuration:
+
+```json
+{
+  "mcpServers": {
+    "ivy-release": {
+      "command": "<path-to-dotnet-tools>/ivy",
+      "args": [
+        "mcp",
+        "--path",
+        "<path-to-your-project>"
+      ],
+      "env": {
+        "Ivy__Mcp__ApiUrl": "https://staging.mcp.ivy.app"
+      }
+    }
+  }
+}
+```

--- a/src/Ivy.Docs.Shared/Docs/01_Onboarding/01_GettingStarted/07_IvyMCPServer/_Index.md
+++ b/src/Ivy.Docs.Shared/Docs/01_Onboarding/01_GettingStarted/07_IvyMCPServer/_Index.md
@@ -9,5 +9,4 @@ searchHints:
   - antigravity
   - vscode
   - windsurf
-  - rider
 ---


### PR DESCRIPTION


https://github.com/user-attachments/assets/d85dd18a-ce50-4887-b865-b370c8924b7a

-MCP instructions for setting up with different IDEs
-Implemented folder with separate page for each IDE
-Added links to external MCP pages (for each IDE), and installation link with Ivy
-Code blocks implemented with Terminal 
-JSON code block added to bottom of IDE pages to allow users to Ctrl+c .mcp.json



