### PR TITLE
[Tree]: expand nodes on label click

### DIFF
--- a/src/frontend/src/widgets/tree/TreeItem.tsx
+++ b/src/frontend/src/widgets/tree/TreeItem.tsx
@@ -34,6 +34,9 @@ export const TreeItem: React.FC<TreeItemWidgetProps> = ({
   const handleClick = (e: React.MouseEvent) => {
     if (item.disabled) return;
     e.stopPropagation();
+    if (hasChildren) {
+      setIsOpen(prev => !prev);
+    }
     onItemClick(item);
   };
 


### PR DESCRIPTION
## Description
In the `Tree Widget` component, users encountered an inconvenience: nodes containing child elements could only be expanded or collapsed by clicking the chevron (arrow) icon. Clicking on the node's text (label) only highlighted the node (triggering a select event), but the list itself did not open.

The expected behavior, as described in issue [#2402](https://github.com/Ivy-Interactive/Ivy-Framework/issues/2402), was that clicking on any area of the parent node's text would trigger its expansion or collapse.

## What was done
Changes were made to the frontend implementation of the `TreeItem` component (file `src/frontend/src/widgets/tree/TreeItem.tsx`).

### Code Changes:
- A check for the presence of child elements (`hasChildren`) was added to the `handleClick` event handler of the `TreeItem` component.
- If a node with children is clicked, the node's expanded state (`isOpen`) now toggles (`setIsOpen(prev => !prev)`).
- The node selection event (`onItemClick`) continues to trigger correctly, sending the corresponding `tag`, ensuring backward compatibility with implemented business logic.

## Results
- **UX Improvement:** Users no longer need to aim for the small chevron icon. Clicking on the node text now expands the tree more intuitively.
- **API Preservation:** All node selection events (`OnSelect`) work as before, both on parent nodes (triggering OnSelect + Expand/Collapse) and on leaf nodes (only OnSelect).
