### PR TITLE
[ButtonWidget]: fix AI variant gradient clipping for Full rounded shape

### DIFF
--- a/src/frontend/src/widgets/button/ButtonWidget.tsx
+++ b/src/frontend/src/widgets/button/ButtonWidget.tsx
@@ -219,7 +219,11 @@ export const ButtonWidget: React.FC<ButtonWidgetProps> = ({
     // Determine border radius classes based on borderRadius prop
     const getBorderRadiusClass = () => {
       if (borderRadius === 'Full') {
-        return { container: 'rounded-full', button: 'rounded-full' };
+        return {
+          container: 'rounded-full',
+          button: 'rounded-full',
+          buttonStyle: { borderRadius: '9999px' } as React.CSSProperties,
+        };
       }
       if (borderRadius === 'Rounded') {
         return { container: 'rounded-lg', button: 'rounded-md' };
@@ -275,6 +279,7 @@ export const ButtonWidget: React.FC<ButtonWidgetProps> = ({
             hasChildren &&
               'p-2 h-auto items-start justify-start text-left inline-block'
           )}
+          style={borderRadiusClasses.buttonStyle}
           tooltipText={tooltip || undefined}
           data-testid={dataTestId}
         >


### PR DESCRIPTION
## Issue Description
When using the `Ai` variant of the `Button` (which adds an animated RGB border), the gradient was visually clipped:
1. The border was cropped at the top and bottom at various sizes (especially `Small` and `Large`).
2. When using `borderRadius="Full"`, the gradient broke completely: instead of a "pill" shape, the button looked like a narrow oval with the gradient completely missing on the sides (it was clipped off).
3. Unequal border radii (the border radius of the outer container didn't match the inner button).

## Root Cause
1. **Spacing Algorithm Conflict (Inline-flex and Height):** The outer container `div` had `padding: 2px` and `overflow-hidden` (to hide the giant square gradient background). The inner button was `inline-flex`. Without explicitly defining heights, `inline-flex` creates extra strut space (line-height bias in block formatting contexts), which caused the container to stretch and clip the top/bottom edges of the inner button's border.
2. **CSS Utility Override (Border-radius conflict):** The inner button always receives the `rounded-field` utility class by default (using a CSS variable for consistent input rounding across the project). When trying to set `borderRadius={"Full"}`, the Tailwind `rounded-full` class was appended to the `className` string, but `twMerge` doesn't recognize our custom class so they weren't merged as the same property type. In the final CSS, `rounded-field` is defined later, causing it to override `rounded-full`. As a result, the outer container became a pill, while the inner button remained a rectangle with slight rounded corners, creating giant empty spaces on the sides.

## Solution
1. **Strict Dimension Control:** Restored and stabilized the `getContainerHeight()` function.
   Instead of relying on automatic floating/flex sizing, we now explicitly set the height for both the outer container and the inner button (e.g., `h-9` and `h-[35px]`). This guarantees that the container is exactly 2-4px larger than the button on each side to accommodate the RGB border padding, completely eliminating vertical clipping caused by flex rendering quirks.
2. **Inline-style Overrides for `border-radius`:**
   For the `borderRadius="Full"` variant, an inline style `style={{ borderRadius: '9999px' }}` was added to the inner button.
   Since inline styles have the highest CSS specificity, this reliably overrides the `rounded-field` class from the base variants. Now both the container and the button have a smooth pill shape, and the RGB gradient wraps around the button seamlessly with perfect thickness on all edges.

## Result
The AI Button (Button Widget with `Ai` variant) now renders correctly at all sizes (`Small`, `Large`, `Default`, `Icon`) and with all border radius variants (especially `Full`). The animated RGB gradient is smooth and unclipped.

<img width="712" height="306" alt="image" src="https://github.com/user-attachments/assets/e895201d-41fe-454e-9ca8-9b45089255dd" />