### PR TITLE
[CLI]: add Upgrade docs page and update links

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/01_CLIOverview.md
+++ b/src/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/01_CLIOverview.md
@@ -28,6 +28,7 @@ Get started with Ivy CLI in just a few commands:
 
 ```terminal
 >ivy init
+>ivy upgrade
 >ivy db add
 >ivy auth add
 >ivy deploy
@@ -97,13 +98,15 @@ Most Ivy commands require authentication. Use `ivy login` to authenticate with y
 ## Next Steps
 
 1. **Initialize a project**: `ivy init`
-2. **Add a database**: `ivy db add`
-3. **Add authentication**: `ivy auth add`
-4. **Deploy your project**: `ivy deploy`
+2. **Upgrade your project**: `ivy upgrade`
+3. **Add a database**: `ivy db add`
+4. **Add authentication**: `ivy auth add`
+5. **Deploy your project**: `ivy deploy`
 
 For detailed information on each feature, see the specific documentation files:
 
 - [Project Initialization](02_Init.md)
+- [Project Upgrade](08_Upgrade.md)
 - [Database Integration](05_DatabaseIntegration/01_DatabaseOverview.md)
 - [Authentication Setup](04_Authentication/01_AuthenticationOverview.md)
 - [Deployment Guide](06_Deployment/01_DeploymentOverview.md)

--- a/src/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/08_Upgrade.md
+++ b/src/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/08_Upgrade.md
@@ -1,0 +1,88 @@
+---
+searchHints:
+  - upgrade
+  - update
+  - version
+  - migrate
+  - latest
+---
+
+# Ivy Upgrade
+
+<Ingress>
+Upgrade your existing Ivy project to the latest version of the Ivy framework with a single command.
+</Ingress>
+
+The `ivy upgrade` command updates your Ivy project to the latest available version. It modifies your project file (`.csproj`) to reference the newest Ivy packages, ensuring you have access to the latest features, bug fixes, and improvements.
+
+## Basic Usage
+
+```terminal
+>ivy upgrade
+```
+
+This command will:
+
+- Detect the current Ivy version in your project
+- Fetch the latest available Ivy version
+- Update all Ivy package references in your `.csproj` file
+- Optionally commit the changes to Git
+
+## Command Options
+
+`--verbose` or `-v` - Enable verbose logging for detailed output during the upgrade process.
+
+```terminal
+>ivy upgrade --verbose
+```
+
+`--ignore-git` - Skip Git checks and commit. By default, Ivy verifies your Git status and commits the upgrade changes automatically.
+
+```terminal
+>ivy upgrade --ignore-git
+```
+
+## What to Expect
+
+When you run the command, Ivy will update the package references in your project file. A successful upgrade looks like this:
+
+```terminal
+>ivy upgrade
+Upgrading Ivy from 1.2.14 to 1.2.15...
+Updated package references in YourProject.csproj
+Ivy upgrade complete!
+```
+
+<Callout Type="Tip">
+After upgrading, run `ivy run` to verify that your project builds and runs correctly with the new version.
+</Callout>
+
+## Prerequisites
+
+Before running `ivy upgrade`, ensure you have:
+
+1. **Ivy Project** - Must be run in a valid Ivy project directory (created with `ivy init`)
+2. **Git** - A clean Git working tree (unless using `--ignore-git`)
+
+## Troubleshooting
+
+**Build Errors After Upgrade** - If you encounter build errors after upgrading, check the [release notes](https://github.com/Ivy-Interactive/Ivy-Framework/releases) for any breaking changes. You can also use the `ivy fix` command to automatically resolve common issues.
+
+```terminal
+>ivy fix
+```
+
+**Git Errors** - If Git checks fail, ensure you have committed or stashed all changes before upgrading. Alternatively, use `--ignore-git` to skip Git checks.
+
+```terminal
+>ivy upgrade --ignore-git
+```
+
+## Related Commands
+
+| Command | Description |
+| :--- | :--- |
+| `ivy init` | [Create a new Ivy project](02_Init.md) |
+| `ivy run` | [Run your application locally](03_Run.md) |
+| `ivy fix` | Fix build and runtime issues |
+| `ivy deploy` | [Deploy your application](06_Deployment/01_DeploymentOverview.md) |


### PR DESCRIPTION
## Issue

The `ivy upgrade` CLI command had no documentation in the Ivy Docs. Searching for "upgrade" in the documentation site returned **"No results found"**, making it impossible for users to discover or learn about this command through the docs.

## What was done

### New file: `08_Upgrade.md`

Created a new documentation page for the `ivy upgrade` command at `src/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/08_Upgrade.md`.

The page follows the same structure and style as existing CLI docs (`Run.md`, `RemoveBranding.md`) and covers:

- Command description and purpose (upgrading an Ivy project to the latest version)
- Basic usage example
- All available options:
  - `--verbose` / `-v` — enable verbose logging
  - `--ignore-git` — skip Git checks and commit
- Expected output example
- Prerequisites
- Troubleshooting (build errors after upgrade, Git issues)
- Related commands table

<img width="2426" height="1246" alt="image" src="https://github.com/user-attachments/assets/94120b79-dc77-41b0-829b-dc08fe06f72b" />
<img width="2090" height="1280" alt="image" src="https://github.com/user-attachments/assets/4845ea2c-c36a-4426-9f16-39ea370bfd9f" />
<img width="1543" height="1049" alt="image" src="https://github.com/user-attachments/assets/2ffe89ab-928e-4d02-9a97-7cfa7988729c" />

YAML frontmatter includes `searchHints` (`upgrade`, `update`, `version`, `migrate`, `latest`) so the page will appear in documentation search results.

### Modified: `CLIOverview.md`

Updated the CLI Overview page to reference the new `ivy upgrade` command:

- Added `>ivy upgrade` to the **Quick Start** terminal block
- Added step **"Upgrade your project"** to **Next Steps** list
- Added **[Project Upgrade](08_Upgrade.md)** link to the documentation links section

<img width="1268" height="799" alt="image" src="https://github.com/user-attachments/assets/80d97a35-ee6d-42e0-89f3-b7e3119f9c0e" />
<img width="1110" height="656" alt="image" src="https://github.com/user-attachments/assets/89be1365-3374-4944-8c40-02514d027de1" />

## Why

The file was numbered `08_` (after `07_RemoveBranding.md`) to avoid conflicting with existing `04_Authentication/` directory. The content was written based on the actual `ivy upgrade --help` output to ensure accuracy.
