### PR TITLE
[Docs]: document all ways to configure the port

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/19_FileBasedApps.md
+++ b/src/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/19_FileBasedApps.md
@@ -110,4 +110,17 @@ From the directory that contains your `.cs` file:
 > dotnet run HelloApp.cs
 ```
 
-If you need a specific port or other server settings, configure the `Server` in code (for example via `ServerArgs` as in [Program](./01_Program.md)) or use environment variables (e.g. `PORT`) if your setup supports them.
+If you need a specific port, set it via `ServerArgs`:
+
+```csharp
+var server = new Server(new ServerArgs { Port = 5011 });
+```
+
+Or use the `PORT` environment variable before running:
+
+```terminal
+>set PORT=5011
+>dotnet run HelloApp.cs
+```
+
+See [Program](./01_Program.md) for all available `ServerArgs` properties and [Ivy Run](../03_CLI/03_Run.md) for the full list of CLI options.

--- a/src/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/03_Run.md
+++ b/src/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/03_Run.md
@@ -37,6 +37,41 @@ You can also run the command with various options to customize its behavior:
 | `--verbose` | Enable detailed logging for debugging. | `ivy run --verbose` |
 | `--silent` | Start without the welcome banner. | `ivy run --silent` |
 
+## Configuring the Port
+
+By default, Ivy starts on port **5010**. There are several ways to change it:
+
+### CLI Flag
+
+The simplest approach—pass the `--port` flag:
+
+```terminal
+>ivy run --port 5011
+```
+
+### Server Configuration in Code
+
+Set the port directly in `Program.cs` (or in a [file-based app](../02_Concepts/19_FileBasedApps.md)):
+
+```csharp
+var server = new Server(new ServerArgs { Port = 5011 });
+```
+
+This is the recommended approach when running with `dotnet run` or `dotnet watch` directly, since those commands do not support the `--port` flag.
+
+### Environment Variable
+
+Set the `PORT` environment variable before starting the app:
+
+```terminal
+>set PORT=5011
+>dotnet run
+```
+
+This works with any launch method (`ivy run`, `dotnet run`, file-based apps).
+
+See [Program](../02_Concepts/01_Program.md) for more details on server configuration.
+
 ## Conflict Resolution & Debugging
 
 | Flag | Description |


### PR DESCRIPTION
## Issue

The documentation did not clearly explain how to run an Ivy app on a specific port. While `03_Run.md` mentioned the `--port` flag in a table, there was no dedicated section covering all available methods. The `19_FileBasedApps.md` page only had a vague reference to configuring the port "in code or via environment variables" without concrete examples.

## What was done

### `03_Run.md` — added "Configuring the Port" section

A new section that consolidates all three ways to set a custom port:

- **CLI Flag** — `ivy run --port 5011`
- **Server Configuration in Code** — `ServerArgs { Port = 5011 }` in `Program.cs`
- **Environment Variable** — `PORT=5011` before launching

<img width="1223" height="937" alt="image" src="https://github.com/user-attachments/assets/62ecabc3-d578-4adb-a6e5-86dd72183edb" />


### `19_FileBasedApps.md` — added concrete port examples for file-based apps

Replaced the generic one-liner with specific code snippets showing how to set the port via `ServerArgs` and the `PORT` environment variable when using `dotnet run`.

<img width="952" height="599" alt="image" src="https://github.com/user-attachments/assets/99f95eae-b0d5-44aa-9cb0-4889ec5f10c1" />
