### PR TITLE
[Clerk]: gracefully handle existing session on sign-in

### DIFF
--- a/src/auth/Ivy.Auth.Clerk/ClerkAuthProvider.cs
+++ b/src/auth/Ivy.Auth.Clerk/ClerkAuthProvider.cs
@@ -10,6 +10,7 @@ using System.Text;
 using System.Security.Claims;
 using Microsoft.AspNetCore.WebUtilities;
 using Ivy.Auth.Clerk.ApiClient.Models;
+using Ivy.Auth.Clerk.ApiClient.Responses;
 
 namespace Ivy.Auth.Clerk;
 
@@ -86,6 +87,36 @@ public class ClerkAuthProvider : IAuthProvider
         return activeSessions.FirstOrDefault(session => session.Id == client.LastActiveSessionId)
             ?? activeSessions.FirstOrDefault();
     }
+
+    private async Task<AuthToken?> TryRestoreExistingSessionAsync(IAuthSession authSession, ClerkCredentials credentials, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var frontendClient = MakeFrontendApiClient(authSession);
+            var activeSession = await GetActiveSession(frontendClient, credentials, cancellationToken);
+            if (activeSession == null)
+            {
+                return null;
+            }
+
+            await frontendClient.TouchSessionAsync(activeSession.Id, credentials, cancellationToken);
+            var newToken = await frontendClient.CreateSessionTokenAsync(activeSession.Id, credentials, cancellationToken);
+
+            if (await ValidateToken(newToken.Jwt, lenientLifetimeValidation: true, cancellationToken) == null)
+            {
+                return null;
+            }
+
+            return new AuthToken(newToken.Jwt!);
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+
+    private static bool IsSessionExistsError(ClerkException ex)
+        => ex.Errors?.Any(e => e.Code == "session_exists") == true;
 
     private async Task<ClerkSession?> GetActiveSession(FrontendApiClient frontendClient, ClerkCredentials credentials, CancellationToken cancellationToken)
     {
@@ -192,7 +223,22 @@ public class ClerkAuthProvider : IAuthProvider
             var credentials = await GetClerkCredentialsAsync(authSession, cancellationToken: cancellationToken);
             var frontendClient = MakeFrontendApiClient(authSession);
 
-            var signInResponse = await frontendClient.CreatePasswordSignInAsync(credentials, email, password, cancellationToken);
+            ClerkSignInResponse signInResponse;
+            try
+            {
+                signInResponse = await frontendClient.CreatePasswordSignInAsync(credentials, email, password, cancellationToken);
+            }
+            catch (ClerkException ex) when (IsSessionExistsError(ex))
+            {
+                var restoredToken = await TryRestoreExistingSessionAsync(authSession, credentials, cancellationToken);
+                if (restoredToken != null)
+                {
+                    return restoredToken;
+                }
+
+                await frontendClient.RemoveAllSessionsAsync(credentials, cancellationToken);
+                signInResponse = await frontendClient.CreatePasswordSignInAsync(credentials, email, password, cancellationToken);
+            }
 
             if (signInResponse.Response?.CreatedSessionId is not { } sessionId)
             {
@@ -235,7 +281,17 @@ public class ClerkAuthProvider : IAuthProvider
 
         var redirectUrl = callback.GetUri(includeIdInPath: true).ToString();
         var frontendClient = MakeFrontendApiClient(authSession);
-        var signInResponse = await frontendClient.CreateSignInAsync(credentials, _origin, strategy, redirectUrl, null, cancellationToken);
+
+        ClerkSignInResponse signInResponse;
+        try
+        {
+            signInResponse = await frontendClient.CreateSignInAsync(credentials, _origin, strategy, redirectUrl, null, cancellationToken);
+        }
+        catch (ClerkException ex) when (IsSessionExistsError(ex))
+        {
+            await frontendClient.RemoveAllSessionsAsync(credentials, cancellationToken);
+            signInResponse = await frontendClient.CreateSignInAsync(credentials, _origin, strategy, redirectUrl, null, cancellationToken);
+        }
 
         var firstFactorVerificationResponse = await frontendClient.PrepareFirstFactorVerificationAsync(credentials, _origin, signInResponse.Response!.Id, strategy, redirectUrl, null, cancellationToken);
 


### PR DESCRIPTION
## Issue

When a user's `auth_token` cookie expires or is deleted while the `auth_session_data` cookie remains intact, the application treats the user as unauthenticated and shows the login screen. However, the Clerk backend still has an active session for this client.

When the user attempts to log in again (via email/password or OAuth), `CreateSignInAsync` / `CreatePasswordSignInAsync` fails with:

```
session_exists: Session already exists
You're already signed in.
```

This results in a confusing "Authentication error" or "Login failed" message with no way to recover without manually clearing cookies.

## Root Cause

The Clerk Frontend API rejects new sign-in attempts when the client (identified by `auth_session_data` / DevBrowserToken) already has an active session. The framework did not handle this specific error, causing it to bubble up as a generic failure.

## Solution

Added `session_exists` error handling to `ClerkAuthProvider` in two flows:

### Email/Password Login (`LoginAsync`)
1. Catch `session_exists` from `CreatePasswordSignInAsync`
2. Attempt to restore the existing session (get active session → touch → create new JWT)
3. If restoration succeeds → return the restored token (user is logged in instantly)
4. If restoration fails → remove all sessions and retry the sign-in from scratch

### OAuth Login (`GetOAuthUriAsync`)
1. Catch `session_exists` from `CreateSignInAsync`
2. Remove all existing sessions
3. Retry the sign-in (user proceeds through OAuth flow normally)

## Changes

- **`ClerkAuthProvider.cs`** — Added `TryRestoreExistingSessionAsync()`, `IsSessionExistsError()`, and `session_exists` handling in both `LoginAsync` and `GetOAuthUriAsync`

## Testing

1. Start `ClerkExample`, log in with email/password
2. Delete `auth_token` cookie (keep `auth_session_data`)
3. Reload page → login screen appears
4. Log in again → `session_exists` is caught, session restored, user logged in successfully