### PR TITLE
(async select): fix paddings for list items only in async select

### DIFF
--- a/src/Ivy/Widgets/Inputs/AsyncSelectInput.cs
+++ b/src/Ivy/Widgets/Inputs/AsyncSelectInput.cs
@@ -164,7 +164,7 @@ public class AsyncSelectListSheet<T>(RefreshToken refreshToken, AsyncSelectSearc
         var header = Layout.Vertical().Gap(2)
             | searchInput;
 
-        var content = Layout.Vertical().Gap(2)
+        var content = Layout.Vertical().Gap(2).RemoveParentPadding()
             | (loading ? Text.Block("Loading...") : new List(items));
 
         return new HeaderLayout(header, content)


### PR DESCRIPTION
We previously had an issue where the solution for list items in AsyncSelect involved removing the parent padding from the List widget. That change resulted in a “plain” view for the List widget and was addressed in PR https://github.com/Ivy-Interactive/Ivy-Framework/pull/2422/changes

However, those changes also brought back the original issue in the AsyncSelect widget.

<img width="363" height="433" alt="Screenshot 2026-03-03 at 13 59 33" src="https://github.com/user-attachments/assets/8ac3abd1-6764-4c0f-887f-4661890906e3" />

My current solution removes the parent padding only for the AsyncSelect content part, which essentially renders list items. This way, it no longer affects the List widget itself, while still resolving the layout issue in AsyncSelect. The handling is now done on the backend side.

<img width="353" height="403" alt="Screenshot 2026-03-03 at 14 02 22" src="https://github.com/user-attachments/assets/f9426462-acc2-4b3e-819e-e6e04de32299" />
