### PR TITLE
[OAuth]: fix callback redirect in Sliplane Auth Provider

### DIFF
--- a/src/auth/Ivy.Auth.Sliplane/SliplaneAuthProvider.cs
+++ b/src/auth/Ivy.Auth.Sliplane/SliplaneAuthProvider.cs
@@ -220,7 +220,11 @@ public class SliplaneAuthProvider : IAuthProvider
 
         try
         {
-            var redirectUri = $"{request.Scheme}://{request.Host}{request.Path}";
+            var scheme = request.Headers.TryGetValue("X-Forwarded-Proto", out var forwardedProto)
+                ? forwardedProto.ToString()
+                : request.Scheme;
+
+            var redirectUri = $"{scheme}://{request.Host}{request.Path}";
 
             using var content = new FormUrlEncodedContent(new[]
             {


### PR DESCRIPTION
## Summary

Fix Sliplane OAuth integration behind a reverse proxy

## Problem

- Sliplane OAuth login consistently failed with `401` and `error: "invalid_grant"` after the user granted access.
- The `/oauth/authorize` request used a `redirect_uri` with `https`, but the token exchange used a `redirect_uri` built from `request.Scheme`, which was seen as `http` behind the proxy.
- The Sliplane provider used a raw `new HttpClient()`, bypassing Ivy’s tunneled `HttpMessageHandler`, which can cause the token request to go out via the wrong HTTP client/path in hosted environments.

## Changes

- **Redirect URI handling**
  - In `SliplaneAuthProvider.HandleOAuthCallbackAsync`, respect `X-Forwarded-Proto` when present and fall back to `request.Scheme` otherwise.

## Testing

- Deploy an Ivy app behind Sliplane/Caddy with `X-Forwarded-Proto` set to `https`.
- Configure Sliplane OAuth with `redirect_uri=https://<host>/ivy/auth/callback`.
- Start the OAuth flow using the Sliplane provider:
  - Verify that the authorize URL contains the correct `redirect_uri` (https).
  - Complete the consent screen and confirm that the token exchange succeeds (no more `invalid_grant` / 401).
- Confirm that login completes and auth cookies are set as expected.