### PR TITLE
(tree):  add a doc section about handling raw actions

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/16_Tree.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/16_Tree.md
@@ -63,6 +63,47 @@ public class TreeClickDemo : ViewBase
 }
 ```
 
+## Row Actions
+
+**Row actions** can be defined as a set of actions (buttons or menu items) displayed for each tree row. Configure them via `.RowActions()` with one or more `MenuItem`s, and subscribe to clicks with `.HandleRowAction()`.
+
+```csharp demo-tabs
+public class TreeRowActionsDemo : ViewBase
+{
+    public override object? Build()
+    {
+        var lastAction = UseState("None");
+
+        return Layout.Vertical()
+            | Text.Block($"  Last Action: {lastAction.Value}")
+            | new Tree(
+                new MenuItem("src")
+                    .Icon(Icons.Folder)
+                    .Expanded()
+                    .Children(
+                        new MenuItem("components")
+                            .Icon(Icons.Folder)
+                            .Expanded()
+                            .Children(
+                                new MenuItem("Button.tsx").Icon(Icons.Code).Tag("Button.tsx"),
+                                new MenuItem("Card.tsx").Icon(Icons.Code).Tag("Card.tsx")
+                            ),
+                        new MenuItem("App.tsx").Icon(Icons.Code).Tag("App.tsx")
+                    ),
+                new MenuItem("package.json").Icon(Icons.Braces).Tag("package.json")
+            )
+            .RowActions(
+                new MenuItem("Edit").Icon(Icons.Pencil).Tag("edit"),
+                new MenuItem("More").Icon(Icons.Ellipsis).Children(
+                    new MenuItem("Duplicate").Icon(Icons.Copy).Tag("duplicate"),
+                    new MenuItem("Delete").Icon(Icons.Trash).Tag("delete")
+                )
+            )
+            .HandleRowAction(e => lastAction.Set($"{e.Value.ActionTag} on {e.Value.ItemValue}"));
+    }
+}
+```
+
 ## Disabled Items
 
 Individual menu items can be disabled to prevent interaction.


### PR DESCRIPTION
Added a new section about handling raw actions in the tree doc page. New section fits well under click events section. In code examples was explained creating simple raw actions and raw actions with children. 
<img width="2288" height="1182" alt="Screenshot 2026-03-04 at 01 21 53" src="https://github.com/user-attachments/assets/a6c99e01-14a5-428f-8a6a-b9d644ad514b" />
