### PR TITLE
feat: avoid overlaying of kanban cards

### DIFF
--- a/src/frontend/src/components/ui/shadcn-io/kanban.tsx
+++ b/src/frontend/src/components/ui/shadcn-io/kanban.tsx
@@ -156,7 +156,10 @@ interface KanbanBoardProps {
 export function KanbanBoard({ children, className }: KanbanBoardProps) {
   return (
     <div
-      className={cn('flex h-full bg-background flex-row', className)}
+      className={cn(
+        'inline-flex min-w-full h-full bg-background flex-row',
+        className
+      )}
       style={{ minWidth: 'fit-content', maxWidth: '100%' }}
     >
       {children}
@@ -252,12 +255,15 @@ export function KanbanColumn({
   return (
     <div
       className={cn(
-        hasExplicitWidth ? 'bg-background' : 'flex-1 bg-background',
-        'rounded-lg px-0 pt-2 min-h-0 flex flex-col transition-colors min-w-70',
+        'bg-background rounded-lg px-0 pt-2 min-h-0 flex flex-col transition-colors',
+        hasExplicitWidth ? 'flex-none shrink-0' : 'flex-none shrink-0 min-w-70',
         showDragOver && 'bg-accent rounded-lg',
         className
       )}
-      style={widthStyles}
+      style={{
+        ...widthStyles,
+        ...(hasExplicitWidth ? {} : { width: 'max-content' }),
+      }}
       onDragOver={handleDragOver}
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}


### PR DESCRIPTION
We had an issue with the Kanban widget: when it didn’t fit within the page width, the last Kanban cards were being cropped.

https://github.com/user-attachments/assets/b3b5c953-5051-41bb-9dfd-cfc7fbd3987d

This was fixed by improving how the width is assigned to the Kanban widget on the frontend. Now, the area where the Kanban board is placed becomes scrollable when necessary, and the cards are no longer cropped.
**KanbanBoard**
flex is now inline-flex min-w-full so the board can grow with content and still fill the viewport when narrow.
Keeps style={{ minWidth: 'fit-content', maxWidth: '100%' }} so the board is at least as wide as its content.
**KanbanColumn**
No explicit width: flex-1 + min-w-70 is now flex-none shrink-0 min-w-70 and style: { width: 'max-content' }.
With explicit width: flex-none shrink-0 (same idea, no width: max-content).
Columns no longer shrink (no overlay when zoomed) and grow to fit content (no cropping of long text).
https://github.com/user-attachments/assets/71c4d69e-af16-4ebb-aa72-b71f1e66e77c



