### PR TITLE
[List] Safe full‑bleed mode via remove-parent-padding

### DIFF
--- a/src/frontend/src/widgets/lists/ListWidget.tsx
+++ b/src/frontend/src/widgets/lists/ListWidget.tsx
@@ -19,7 +19,12 @@ export const ListWidget = ({ children }: ListWidgetProps) => {
   });
 
   return (
-    <div ref={parentRef} className="relative h-full w-full overflow-y-auto">
+    <div
+      ref={parentRef}
+      className={cn(
+        'relative h-full w-full overflow-y-auto remove-parent-padding'
+      )}
+    >
       <div
         style={{
           height: rowVirtualizer.getTotalSize(),


### PR DESCRIPTION
Please review closed PR  https://github.com/Ivy-Interactive/Ivy-Framework/pull/2422

Yes, the main goal of that PR was to fix an issue in the docs, but it introduced problems with how the List widget behaves inside other elements.

<img width="1538" height="917" alt="image" src="https://github.com/user-attachments/assets/24370198-2793-4c0c-a14c-ebfe550e255a" />

I reintroduced the full-bleed behavior for the List widget without mutating ancestor DOM elements or modifying global padding.

The original issue in the docs occurred because ListWidget was mutating its parent container and stripping padding from the entire demo box. As a result, sibling Text.P elements lost their spacing.

Now, the List widget never touches ancestor elements — it only styles its own root container.

<img width="373" height="756" alt="image" src="https://github.com/user-attachments/assets/e3e97664-045c-4567-8c0c-5fcd83b84028" />

Old version without removing parent padding:

<img width="374" height="520" alt="image" src="https://github.com/user-attachments/assets/e40f8dc3-c305-4101-8983-bf4dbb10d999" />

The List docs page still renders neighboring text with correct padding.

<img width="757" height="829" alt="image" src="https://github.com/user-attachments/assets/e1923aa9-583b-4a3e-990d-ced8b32db792" />

 There was also a related bug, which is now resolved.

<img width="761" height="807" alt="image" src="https://github.com/user-attachments/assets/87c03cdb-63a8-4c6e-a1e9-1fa917e21e65" />

In summary, we still need to remove parent padding visually for list items, but the implementation had to be refactored to ensure the List widget maintains proper visibility when used inside different widgets and does not affect surrounding elements.