### PR TITLE
feat(spacer): default to grow behavior

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/06_Spacer.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/06_Spacer.md
@@ -14,7 +14,7 @@ searchHints:
 Add precise spacing between layout elements for fine-tuned control over alignment and visual balance in your [interfaces](../../01_Onboarding/02_Concepts/02_Views.md).
 </Ingress>
 
-The `Spacer` [widget](../../01_Onboarding/02_Concepts/03_Widgets.md) creates empty space between elements in your layout. It's useful for fine-tuning spacing and alignment.
+The `Spacer` [widget](../../01_Onboarding/02_Concepts/03_Widgets.md) creates empty space between elements in your layout. By default, it grows to fill available space in the parent layout's direction, making it easy to push elements apart. It's useful for fine-tuning spacing and alignment.
 
 ## Basic Usage
 
@@ -36,7 +36,7 @@ public class BasicSpacerView : ViewBase
 
 ### Flexible Spacing
 
-Use `Spacer` with `Size.Grow()` to push elements to opposite sides:
+A bare `Spacer` grows to fill available space by default, automatically pushing elements apart:
 
 ```csharp demo-tabs
 public class FlexibleSpacerView : ViewBase
@@ -45,15 +45,14 @@ public class FlexibleSpacerView : ViewBase
     {
         return Layout.Horizontal().Gap(4)
             | new Button("Left Button").Variant(ButtonVariant.Outline)
-            | new Spacer().Width(Size.Grow())
+            | new Spacer()
             | new Button("Right Button").Variant(ButtonVariant.Primary);
     }
 }
 ```
 
 <Callout Type="tip">
-The `Spacer().Width(Size.Grow())` pattern is essential for creating responsive layouts. It makes the spacer take up all available horizontal space, effectively pushing elements to opposite sides. See [Size](../../04_ApiReference/IvyShared/Size.md) for `Size.Grow()` and other sizing options.
-Without `Size.Grow()`, the spacer would only take up minimal space, and elements wouldn't be pushed to the edges.
+The `Spacer` defaults to grow behavior (`flex-grow: 1`), making it take up all available space in the parent layout's direction. This effectively pushes sibling elements to opposite sides. See [Size](../../04_ApiReference/IvyShared/Size.md) for other sizing options like explicit widths or heights.
 </Callout>
 
 ### Header Layout with Spacing
@@ -171,13 +170,13 @@ public class DashboardSpacerView : ViewBase
                     | Text.P("Total Users").Small()
                     | Text.Label("12.3K").Color(Colors.Primary)
             )
-            | new Spacer().Width(Size.Grow())
+            | new Spacer()
             | new Card(
                 Layout.Vertical().Gap(2)
                     | Text.P("Revenue").Small()
                     | Text.Label("$54K").Color(Colors.Green)
             )
-            | new Spacer().Width(Size.Grow())
+            | new Spacer()
             | new Card(
                 Layout.Vertical().Gap(2)
                     | Text.P("Growth").Small()
@@ -186,7 +185,7 @@ public class DashboardSpacerView : ViewBase
             
         var actionBar = Layout.Horizontal().Gap(3)
             | new Button("Export Data").Icon(Icons.Download).Variant(ButtonVariant.Outline)
-            | new Spacer().Width(Size.Grow())
+            | new Spacer()
             | new Button("Refresh").Icon(Icons.RefreshCw).Variant(ButtonVariant.Ghost)
             | new Button("Settings").Icon(Icons.Settings).Variant(ButtonVariant.Ghost);
             

--- a/src/Ivy/Widgets/Primitives/Spacer.cs
+++ b/src/Ivy/Widgets/Primitives/Spacer.cs
@@ -1,10 +1,16 @@
+using Ivy.Shared;
+
 // ReSharper disable once CheckNamespace
 namespace Ivy;
 
 /// <summary>
 /// Adds empty space between elements.
+/// By default, grows to fill available space in the parent layout's direction.
 /// </summary>
 public record Spacer : WidgetBase<Spacer>
 {
-    public Spacer() { }
+    public Spacer()
+    {
+        Width = Size.Grow();
+    }
 }


### PR DESCRIPTION
A bare `new Spacer()` now defaults to grow behavior (flex-grow: 1), automatically filling available space in the parent layout's direction.

Closes #2372

Generated with [Claude Code](https://claude.ai/code)