### PR TITLE
docs: remove unnecessary `this.` prefix from hooks in documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,7 +208,7 @@ new TextInput().Default()
 ### UseState
 
 var nameState = UseState("World");
-var iconsState = this.UseState<Icons[]>();
+var iconsState = UseState<Icons[]>();
 
 If you don't specify a value, default(T) is used.
 

--- a/src/.releases/Refactors/1.2.17/TextArea-To-Textarea.md
+++ b/src/.releases/Refactors/1.2.17/TextArea-To-Textarea.md
@@ -18,14 +18,14 @@ The `ToTextAreaInput()` extension method has been renamed to `ToTextareaInput()`
 ### Before (v1.2.16 and earlier)
 
 ```csharp
-var state = this.UseState("");
+var state = UseState("");
 return state.ToTextAreaInput(placeholder: "Enter description...");
 ```
 
 ### After (v1.2.17+)
 
 ```csharp
-var state = this.UseState("");
+var state = UseState("");
 return state.ToTextareaInput(placeholder: "Enter description...");
 ```
 
@@ -48,8 +48,8 @@ Replace all instances of `ToTextAreaInput` with `ToTextareaInput`.
 ```csharp
 public override object? Build()
 {
-    var description = this.UseState("");
-    var notes = this.UseState<string?>(null);
+    var description = UseState("");
+    var notes = UseState<string?>(null);
 
     return new VStack(
         description.ToTextAreaInput(placeholder: "Description").Rows(4),
@@ -63,8 +63,8 @@ public override object? Build()
 ```csharp
 public override object? Build()
 {
-    var description = this.UseState("");
-    var notes = this.UseState<string?>(null);
+    var description = UseState("");
+    var notes = UseState<string?>(null);
 
     return new VStack(
         description.ToTextareaInput(placeholder: "Description").Rows(4),

--- a/src/.releases/weekly-notes-archive/weekly-notes-2025-10-13.md
+++ b/src/.releases/weekly-notes-archive/weekly-notes-2025-10-13.md
@@ -50,7 +50,7 @@ var tabsLayout = new TabsLayout(OnTabSelect, OnTabClose, null, null, selectedInd
 ).Variant(TabsVariant.Content).Width(0.8); // 80% width
 
 // For responsive behavior, you can bind to a state
-var width = this.UseState(1.0);
+var width = UseState(1.0);
 var responsiveTabsLayout = new TabsLayout(OnTabSelect, OnTabClose, null, null, selectedIndex.Value,
     tabs.Value.ToArray()
 ).Variant(TabsVariant.Tabs).Width(width.Value);

--- a/src/.releases/weekly-notes-archive/weekly-notes-2025-11-21.md
+++ b/src/.releases/weekly-notes-archive/weekly-notes-2025-11-21.md
@@ -14,7 +14,7 @@ This release introduces comprehensive URL validation and security improvements, 
 Buttons now support binding loading state directly to reactive state objects:
 
 ```csharp
-var loading = this.UseState(false);
+var loading = UseState(false);
 
 async ValueTask OnClick()
 {
@@ -46,7 +46,7 @@ Row actions support tooltips through the `Tooltip` property. The `RowAction` cla
 New simple overload for cases where you don't need to pass data:
 
 ```csharp
-var (dialogView, showDialog) = this.UseTrigger((open) =>
+var (dialogView, showDialog) = UseTrigger((open) =>
     new Dialog("Confirm", "Are you sure?")
         .OnClose(() => open.Set(false))
 );

--- a/src/.releases/weekly-notes-archive/weekly-notes-2025-12-17.md
+++ b/src/.releases/weekly-notes-archive/weekly-notes-2025-12-17.md
@@ -197,7 +197,7 @@ The `SelectInput` widget now properly handles nullable values when cleared. Both
 Ivy now includes a `UseRef` hook for storing values that persist across renders without triggering re-renders, similar to React's useRef.
 
 ```csharp
-var counterRef = this.UseRef(0);
+var counterRef = UseRef(0);
 counterRef.Set(counterRef.Value + 1); // No re-render
 ```
 

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/02_Icon.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/02_Icon.md
@@ -25,9 +25,9 @@ public class LucideIconsView : ViewBase
 {
     public override object? Build()
     {
-        var client = this.UseService<IClientProvider>();
-        var searchState = this.UseState("code");
-        var iconsState = this.UseState<Icons[]>(Array.Empty<Icons>());
+        var client = UseService<IClientProvider>();
+        var searchState = UseState("code");
+        var iconsState = UseState<Icons[]>(Array.Empty<Icons>());
         
         UseEffect(() =>
         {

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/04_Inputs/08_DateRangeInput.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/04_Inputs/08_DateRangeInput.md
@@ -25,7 +25,7 @@ public class BasicDateRangeDemo : ViewBase
 {
     public override object? Build()
     {    
-        var dateRangeState = this.UseState(() => (from: DateTime.Today.AddDays(-7), to: DateTime.Today));
+        var dateRangeState = UseState(() => (from: DateTime.Today.AddDays(-7), to: DateTime.Today));
         var start = dateRangeState.Value.Item1;
         var end = dateRangeState.Value.Item2;
         var span = $"That's {(end-start).Days} days";
@@ -55,10 +55,10 @@ public class DateRangeVariantsDemo : ViewBase
 {
     public override object? Build()
     {
-        var dateRange = this.UseState(() => 
+        var dateRange = UseState(() => 
             (from: DateTime.Today.AddDays(-7), to: DateTime.Today));
         
-        var nullableRange = this.UseState<(DateOnly?, DateOnly?)>(() => 
+        var nullableRange = UseState<(DateOnly?, DateOnly?)>(() => 
             (DateOnly.FromDateTime(DateTime.Today.AddDays(-7)), 
              DateOnly.FromDateTime(DateTime.Today)));
 
@@ -82,7 +82,7 @@ public class FormatDateRangeDemo : ViewBase
 {
     public override object? Build()
     {   
-         var dateRangeState = this.UseState(() => 
+         var dateRangeState = UseState(() => 
             (from: DateTime.Today.AddDays(-7), to: DateTime.Today));
          return Layout.Vertical()
                  | dateRangeState.ToDateRangeInput()
@@ -110,7 +110,7 @@ public class HotelBookingDemo : ViewBase
     
     public override object? Build()
     {
-        var bookingRange = this.UseState<(DateOnly?, DateOnly?)>(() => (null, null));
+        var bookingRange = UseState<(DateOnly?, DateOnly?)>(() => (null, null));
         
         var from = bookingRange.Value.Item1;
         var to = bookingRange.Value.Item2;

--- a/src/Ivy.Docs.Shared/Docs/03_Hooks/01_HookIntroduction.md
+++ b/src/Ivy.Docs.Shared/Docs/03_Hooks/01_HookIntroduction.md
@@ -158,7 +158,7 @@ public class BasicReducerDemo : ViewBase
 
     public override object? Build()
     {
-        var (count, dispatch) = this.UseReducer(CounterReducer, 0);
+        var (count, dispatch) = UseReducer(CounterReducer, 0);
 
         return Layout.Vertical(
             Text.P($"Count: {count}").Large(),

--- a/src/Ivy.Docs.Shared/Docs/03_Hooks/02_Core/07_UseReducer.md
+++ b/src/Ivy.Docs.Shared/Docs/03_Hooks/02_Core/07_UseReducer.md
@@ -45,7 +45,7 @@ public class BasicReducerDemo : ViewBase
     
     public override object? Build()
     {
-        var (count, dispatch) = this.UseReducer(CounterReducer, 0);
+        var (count, dispatch) = UseReducer(CounterReducer, 0);
         
         return Layout.Vertical(
             Text.H3($"Count: {count}"),
@@ -215,7 +215,7 @@ public class ShoppingCartDemo : ViewBase
     
     public override object? Build()
     {
-        var (cart, dispatch) = this.UseReducer(CartReducer, new CartState(new List<CartItem>(), 0m, 0m, 0m, 0m));
+        var (cart, dispatch) = UseReducer(CartReducer, new CartState(new List<CartItem>(), 0m, 0m, 0m, 0m));
         var newItemName = UseState("");
         
         return Layout.Vertical(
@@ -294,7 +294,7 @@ public class GameStateDemo : ViewBase
     
     public override object? Build()
     {
-        var (game, dispatch) = this.UseReducer(GameReducer, new GameState(0, 1, 3, 1, false));
+        var (game, dispatch) = UseReducer(GameReducer, new GameState(0, 1, 3, 1, false));
         
         return Layout.Vertical(
             Text.H3("Game State"),

--- a/src/Ivy.Docs.Shared/Docs/03_Hooks/02_Core/08_UseRef.md
+++ b/src/Ivy.Docs.Shared/Docs/03_Hooks/02_Core/08_UseRef.md
@@ -41,7 +41,7 @@ public class BasicRefDemo : ViewBase
     
     public override object? Build()
     {
-        var renderCount = this.UseRef(() => new Counter());
+        var renderCount = UseRef(() => new Counter());
         var forceUpdate = UseState(0);
         
         // Increment without triggering re-render
@@ -143,8 +143,8 @@ public class PreviousValueDemo : ViewBase
     public override object? Build()
     {
         var count = UseState(0);
-        var previousValue = this.UseRef(() => new PreviousValue());
-        var renderCount = this.UseRef(() => new Counter());
+        var previousValue = UseRef(() => new PreviousValue());
+        var renderCount = UseRef(() => new Counter());
         
         renderCount.Value.Value++;
         
@@ -192,7 +192,7 @@ public class MutableReferenceDemo : ViewBase
     public override object? Build()
     {
         var count = UseState(0);
-        var tracker = this.UseRef(() => new RenderTracker());
+        var tracker = UseRef(() => new RenderTracker());
         
         // Mutate ref value without triggering re-render
         tracker.Value.Count++;

--- a/src/widgets/Ivy.Widgets.Tiptap/README.md
+++ b/src/widgets/Ivy.Widgets.Tiptap/README.md
@@ -15,7 +15,7 @@ dotnet add package Ivy.Widgets.Tiptap
 ```csharp
 using Ivy.Widgets.Tiptap;
 
-var content = this.UseState("<p>Hello, world!</p>");
+var content = UseState("<p>Hello, world!</p>");
 
 new TiptapInput(content);
 ```


### PR DESCRIPTION
The `this.` prefix is no longer needed for hooks. Updated all documentation examples to use the cleaner syntax.

Closes #2410

Generated with [Claude Code](https://claude.ai/code)