### PR TITLE
fix(markdown): add missing border to code blocks

### DIFF
--- a/src/frontend/src/components/MarkdownRenderer.tsx
+++ b/src/frontend/src/components/MarkdownRenderer.tsx
@@ -195,7 +195,7 @@ const CodeBlock = memo(
             <div className="absolute top-2 right-2 z-10">
               <CopyToClipboardButton textToCopy={content} />
             </div>
-            <ScrollArea className="w-full">
+            <ScrollArea className="w-full border border-border rounded-md">
               <SyntaxHighlighter
                 language={match[1]}
                 style={dynamicTheme}


### PR DESCRIPTION
Fixes #2280

The ScrollArea wrapping SyntaxHighlighter was missing the border classes that were present in the fallback block, causing code blocks to render without borders.

Generated with [Claude Code](https://claude.ai/code)