### PR TITLE
feat(separator): add TextAlign property with fluent API

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/07_Separator.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/07_Separator.md
@@ -82,4 +82,21 @@ public class ProfileDetailView : ViewBase
 }
 ```
 
+## Text Alignment
+
+When using a label with the separator, you can control its alignment using the `TextAlign` method:
+
+```csharp demo-tabs
+public class SeparatorTextAlignView : ViewBase
+{
+    public override object? Build()
+    {
+        return Layout.Vertical().Gap(4)
+            | new Separator("Left Aligned").TextAlign(TextAlignment.Left)
+            | new Separator("Center Aligned").TextAlign(TextAlignment.Center)
+            | new Separator("Right Aligned").TextAlign(TextAlignment.Right);
+    }
+}
+```
+
 <WidgetDocs Type="Ivy.Separator" ExtensionTypes="Ivy.SeparatorExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Primitives/Separator.cs"/>

--- a/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/SeparatorApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/SeparatorApp.cs
@@ -16,7 +16,10 @@ public class SeparatorApp : SampleBase
                     new Button(icon: Icons.Save, variant: ButtonVariant.Outline),
                     new Button(icon: Icons.Trash, variant: ButtonVariant.Outline)
                 ),
-                new Separator()
+                new Separator(),
+                new Separator("Left Aligned").TextAlign(TextAlignment.Left),
+                new Separator("Center Aligned").TextAlign(TextAlignment.Center),
+                new Separator("Right Aligned").TextAlign(TextAlignment.Right)
             );
     }
 }

--- a/src/Ivy/Widgets/Primitives/Separator.cs
+++ b/src/Ivy/Widgets/Primitives/Separator.cs
@@ -22,6 +22,8 @@ public record Separator : WidgetBase<Separator>
     [Prop] public Orientation Orientation { get; set; } = Orientation.Horizontal;
 
     [Prop] public string? Text { get; set; }
+
+    [Prop] public TextAlignment TextAlign { get; set; } = TextAlignment.Center;
 }
 
 public static class SeparatorExtensions
@@ -29,4 +31,6 @@ public static class SeparatorExtensions
     public static Separator Orientation(this Separator separator, Orientation orientation) => separator with { Orientation = orientation };
 
     public static Separator Text(this Separator separator, string? text) => separator with { Text = text };
+
+    public static Separator TextAlign(this Separator separator, TextAlignment textAlign) => separator with { TextAlign = textAlign };
 }

--- a/src/frontend/src/widgets/primitives/SeparatorWidget.tsx
+++ b/src/frontend/src/widgets/primitives/SeparatorWidget.tsx
@@ -7,6 +7,7 @@ interface SeparatorWidgetProps {
   id: string;
   orientation: 'Vertical' | 'Horizontal';
   text?: string;
+  textAlign?: 'Left' | 'Center' | 'Right' | 'Justify';
   height?: string;
   width?: string;
 }
@@ -14,6 +15,7 @@ interface SeparatorWidgetProps {
 export const SeparatorWidget: React.FC<SeparatorWidgetProps> = ({
   orientation = 'Horizontal',
   text,
+  textAlign = 'Center',
   width,
   height,
 }) => {
@@ -28,10 +30,22 @@ export const SeparatorWidget: React.FC<SeparatorWidgetProps> = ({
   );
 
   if (text) {
+    const textAlignClass = {
+      Left: 'left-4',
+      Center: 'left-1/2 -translate-x-1/2',
+      Right: 'right-4',
+      Justify: 'left-1/2 -translate-x-1/2',
+    }[textAlign];
+
     return (
-      <div className={cn('relative flex items-center justify-center')}>
+      <div className={cn('relative flex items-center')}>
         {separator}
-        <span className="absolute px-2 text-small-label text-muted-foreground bg-background">
+        <span
+          className={cn(
+            'absolute px-2 text-small-label text-muted-foreground bg-background',
+            textAlignClass
+          )}
+        >
           {text}
         </span>
       </div>


### PR DESCRIPTION
Closes #2369

Add TextAlign property to Separator widget allowing label text to be positioned at Left, Center, or Right along the separator line.

Generated with [Claude Code](https://claude.ai/code)