### PR TITLE
feat(Option): Add per-item Disabled support to SelectInput options

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/04_Inputs/05_SelectInput.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/04_Inputs/05_SelectInput.md
@@ -143,26 +143,71 @@ public class SelectStylingDemo : ViewBase
         var normalSelect = UseState("");
         var invalidSelect = UseState("");
         var disabledSelect = UseState("");
-        
+
         var options = new[] { "Option 1", "Option 2", "Option 3" };
-        
+
         return Layout.Vertical()
             | normalSelect.ToSelectInput(options)
                 .Placeholder("Choose an option...")
                 .WithField()
                 .Label("Normal SelectInput:")
-            
+
             | invalidSelect.ToSelectInput(options)
                 .Placeholder("This has an error...")
                 .Invalid("This field is required")
                 .WithField()
                 .Label("Invalid SelectInput:")
-            
+
             | disabledSelect.ToSelectInput(options)
                 .Placeholder("This is disabled...")
                 .Disabled(true)
                 .WithField()
                 .Label("Disabled SelectInput:");
+    }
+}
+```
+
+## Disabled Options
+
+Individual options can be disabled using the fluent `.Disabled()` method on `Option<T>`. Disabled options appear greyed out and cannot be selected, but remain visible in the list:
+
+```csharp demo-tabs
+public class DisabledOptionsDemo : ViewBase
+{
+    public override object? Build()
+    {
+        var fruit = UseState("apple");
+        var colors = UseState<string[]>([]);
+
+        var fruitOptions = new IAnyOption[]
+        {
+            new Option<string>("Apple", "apple"),
+            new Option<string>("Orange", "orange"),
+            new Option<string>("Grape (Out of Stock)", "grape").Disabled(),
+            new Option<string>("Banana", "banana"),
+            new Option<string>("Mango (Coming Soon)", "mango").Disabled(),
+        };
+
+        var colorOptions = new IAnyOption[]
+        {
+            new Option<string>("Red", "red"),
+            new Option<string>("Green", "green"),
+            new Option<string>("Blue (Premium)", "blue").Disabled(),
+            new Option<string>("Yellow", "yellow"),
+        };
+
+        return Layout.Vertical()
+            | Text.InlineCode("Select Variant")
+            | fruit.ToSelectInput(fruitOptions)
+                .Placeholder("Select a fruit...")
+
+            | Text.InlineCode("Toggle Variant")
+            | colors.ToSelectInput(colorOptions)
+                .Variant(SelectInputVariants.Toggle)
+
+            | Text.InlineCode("List Variant")
+            | colors.ToSelectInput(colorOptions)
+                .Variant(SelectInputVariants.List);
     }
 }
 ```

--- a/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/SelectInputApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/SelectInputApp.cs
@@ -2,6 +2,7 @@
 
 using System.ComponentModel;
 using Ivy.Shared;
+using Ivy.Widgets.Inputs;
 
 namespace Ivy.Samples.Shared.Apps.Widgets.Inputs;
 
@@ -14,6 +15,7 @@ public class SelectInputApp : SampleBase
             new Tab("Basic", new SelectInputBasicExample()),
             new Tab("Sizes", new SelectInputSizesExample()),
             new Tab("Variants", new SelectInputVariantsExample()),
+            new Tab("Disabled Options", new SelectInputDisabledOptionsExample()),
             new Tab("Nullable & Edge Cases", new SelectInputAdvancedExample()),
             new Tab("Advanced Props", new SelectInputAdvancedPropsExample()),
             new Tab("Ghost", new SelectInputGhostExample())
@@ -180,6 +182,50 @@ public class SelectInputVariantsExample : ViewBase
                 | colorStateToggle.ToSelectInput(colorOptions).Variant(SelectInputVariants.Toggle).Invalid("Invalid")
                 | colorStateToggle.ToSelectInput(colorOptions).Variant(SelectInputVariants.Toggle).Placeholder("Select colors")
                 | Text.InlineCode($"[{string.Join(", ", colorStateToggle.Value)}]"));
+    }
+}
+
+public class SelectInputDisabledOptionsExample : ViewBase
+{
+    public override object? Build()
+    {
+        var fruitState = UseState("apple");
+        var colorState = UseState<string[]>([]);
+
+        var fruitOptions = new IAnyOption[]
+        {
+            new Option<string>("Apple", "apple"),
+            new Option<string>("Orange", "orange"),
+            new Option<string>("Grape (Out of Stock)", "grape").Disabled(),
+            new Option<string>("Banana", "banana"),
+            new Option<string>("Mango (Coming Soon)", "mango").Disabled(),
+        };
+
+        var colorOptions = new IAnyOption[]
+        {
+            new Option<string>("Red", "red"),
+            new Option<string>("Green", "green"),
+            new Option<string>("Blue (Premium)", "blue").Disabled(),
+            new Option<string>("Yellow", "yellow"),
+            new Option<string>("Purple (Unavailable)", "purple").Disabled(),
+        };
+
+        return Layout.Vertical()
+            | Text.H3("Disabled Options")
+            | Text.P("Individual options can be disabled using the fluent .Disabled() method. Disabled options appear greyed out and cannot be selected.")
+            | Layout.Grid().Columns(3).Gap(6)
+                | (Layout.Vertical().Gap(2)
+                    | Text.InlineCode("Select Variant")
+                    | fruitState.ToSelectInput(fruitOptions)
+                        .Placeholder("Select a fruit..."))
+                | (Layout.Vertical().Gap(2)
+                    | Text.InlineCode("List Variant")
+                    | colorState.ToSelectInput(colorOptions)
+                        .Variant(SelectInputVariants.List))
+                | (Layout.Vertical().Gap(2)
+                    | Text.InlineCode("Toggle Variant")
+                    | colorState.ToSelectInput(colorOptions)
+                        .Variant(SelectInputVariants.Toggle));
     }
 }
 

--- a/src/Ivy/Widgets/Inputs/Option.cs
+++ b/src/Ivy/Widgets/Inputs/Option.cs
@@ -16,6 +16,8 @@ public interface IAnyOption
     public object Value { get; set; }
 
     public Icons? Icon { get; set; }
+
+    public bool Disabled { get; set; }
 }
 
 public class Option<TValue> : IAnyOption
@@ -29,13 +31,14 @@ public class Option<TValue> : IAnyOption
         Value = null!;
     }
 
-    public Option(string? label, TValue value, string? group = null, string? description = null, Icons? icon = null)
+    public Option(string? label, TValue value, string? group = null, string? description = null, Icons? icon = null, bool disabled = false)
     {
         Label = label;
         Description = description;
         Value = value!;
         Group = group;
         Icon = icon;
+        Disabled = disabled;
     }
 
     public Type GetOptionType()
@@ -54,6 +57,8 @@ public class Option<TValue> : IAnyOption
     public string? Group { get; set; }
 
     public Icons? Icon { get; set; }
+
+    public bool Disabled { get; set; }
 }
 
 public static class OptionExtensions
@@ -79,8 +84,8 @@ public static class OptionExtensions
 
             var value = Convert.ChangeType(e, enumType);
 
-            // Pass all 5 parameters including optional ones (label, value, group, description, icon)
-            return (IAnyOption)Activator.CreateInstance(optionType, label, value, null, null, null)!;
+            // Pass all 6 parameters including optional ones (label, value, group, description, icon, disabled)
+            return (IAnyOption)Activator.CreateInstance(optionType, label, value, null, null, null, false)!;
         }
 
         return Enum.GetValues(enumType).Cast<object>().Select(MakeOption).ToArray();
@@ -89,5 +94,11 @@ public static class OptionExtensions
     public static MenuItem[] ToMenuItems(this IEnumerable<IAnyOption> options)
     {
         return options.Select(e => MenuItem.Default(e.Label ?? "", e.Value)).ToArray();
+    }
+
+    public static Option<TValue> Disabled<TValue>(this Option<TValue> option, bool disabled = true)
+    {
+        option.Disabled = disabled;
+        return option;
     }
 }

--- a/src/frontend/src/widgets/inputs/SelectInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/SelectInputWidget.tsx
@@ -75,6 +75,7 @@ interface Option {
   value: string | number;
   label: string;
   group?: string;
+  disabled?: boolean;
 }
 
 interface SelectInputWidgetProps {
@@ -417,6 +418,7 @@ const ToggleVariant: React.FC<SelectInputWidgetProps> = ({
                 const isDisabled =
                   disabled ||
                   loading ||
+                  option.disabled ||
                   (!isSelected && isAtMax) ||
                   (isSelected &&
                     minSelections != null &&
@@ -448,6 +450,7 @@ const ToggleVariant: React.FC<SelectInputWidgetProps> = ({
                 const isDisabled =
                   disabled ||
                   loading ||
+                  option.disabled ||
                   (!isSelected && isAtMax) ||
                   (isSelected &&
                     minSelections != null &&
@@ -558,11 +561,13 @@ const RadioVariant: React.FC<SelectInputWidgetProps> = ({
             data-testid={dataTestId}
           >
             {validOptions.map(option => {
+              const isOptionDisabled = disabled || option.disabled;
               return (
                 <div key={option.value} className="flex items-center space-x-2">
                   <RadioGroupItem
                     value={option.value.toString()}
                     id={`${id}-${option.value}`}
+                    disabled={isOptionDisabled}
                     className={cn(
                       'border-input text-input',
                       circleSizeVariants[scale],
@@ -571,7 +576,8 @@ const RadioVariant: React.FC<SelectInputWidgetProps> = ({
                         : undefined,
                       stringValue === option.value.toString() && invalid
                         ? inputStyles.invalidInput
-                        : undefined
+                        : undefined,
+                      isOptionDisabled && 'opacity-50 cursor-not-allowed'
                     )}
                   />
                   <Label
@@ -581,7 +587,8 @@ const RadioVariant: React.FC<SelectInputWidgetProps> = ({
                       selectTextVariants[scale],
                       stringValue === option.value.toString() && invalid
                         ? inputStyles.invalidInput
-                        : undefined
+                        : undefined,
+                      isOptionDisabled && 'opacity-50 cursor-not-allowed'
                     )}
                   >
                     {option.label}
@@ -791,6 +798,7 @@ const CheckboxVariant: React.FC<SelectInputWidgetProps> = ({
                 const isDisabled =
                   disabled ||
                   loading ||
+                  option.disabled ||
                   (!isSelected && isAtMax) ||
                   (isSelected &&
                     minSelections != null &&
@@ -955,6 +963,7 @@ const SelectVariant: React.FC<SelectInputWidgetProps> = ({
       disable:
         disabled ||
         loading ||
+        option.disabled ||
         (isAtMax && !selectedValues.includes(option.value.toString())),
     }));
   }, [validOptions, selectedValues, maxSelections, disabled, loading]);
@@ -1265,7 +1274,7 @@ const SelectVariant: React.FC<SelectInputWidgetProps> = ({
                       key={option.value}
                       value={option.value.toString()}
                       scale={scale}
-                      disabled={disabled || loading}
+                      disabled={disabled || loading || option.disabled}
                     >
                       {option.label}
                     </SelectItem>


### PR DESCRIPTION
Add per-item `Disabled` support to `Option<T>` using fluent API.

- Add `Disabled` property to `IAnyOption` interface and `Option<T>` class
- Add fluent `.Disabled()` extension method
- Update frontend to support disabled options in all SelectInput variants
- Update documentation and example app

Closes #2361

Generated with [Claude Code](https://claude.ai/code)