### PR TITLE
fix(themes): change default theme to system for auto dark/light mode

### DIFF
--- a/src/frontend/src/components/App.tsx
+++ b/src/frontend/src/components/App.tsx
@@ -53,7 +53,7 @@ export function App() {
   }, [connection]);
 
   return (
-    <ThemeProvider defaultTheme="light" storageKey="ivy-ui-theme">
+    <ThemeProvider defaultTheme="system" storageKey="ivy-ui-theme">
       <ErrorBoundary>
         <EventHandlerProvider eventHandler={eventHandler}>
           <>

--- a/src/frontend/src/components/theme-provider/ThemeProvider.tsx
+++ b/src/frontend/src/components/theme-provider/ThemeProvider.tsx
@@ -6,7 +6,7 @@ import { ThemeProviderContext } from './context';
 
 export function ThemeProvider({
   children,
-  defaultTheme = 'light',
+  defaultTheme = 'system',
   storageKey = 'ivy-ui-theme',
   ...props
 }: ThemeProviderProps) {


### PR DESCRIPTION
Changes the default theme from `light` to `system` so that the website respects the user's system-wide dark/light mode preference by default.

Closes #2281

Generated with [Claude Code](https://claude.ai/code)