### PR TITLE
fix(docs): remove duplicate API section from Box documentation

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/04_Box.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/04_Box.md
@@ -204,8 +204,6 @@ public class ColorExamplesView : ViewBase
 
 For more colors, see the [Colors](../../04_ApiReference/Ivy/Colors.md) reference.
 
-<WidgetDocs Type="Ivy.Box" ExtensionTypes="Ivy.BoxExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Primitives/Box.cs"/>
-
 ## Examples
 
 <Details>


### PR DESCRIPTION
Fixes #2537

The Box docs page contained two `<WidgetDocs>` components, causing the API section to render twice. Removed the first occurrence to keep only the API section at the end of the file.

Generated with [Claude Code](https://claude.ai/code)