### PR TITLE
fix(xaml-builder): use RowGap/ColumnGap instead of non-existent Gap property

### DIFF
--- a/src/Ivy.Samples.Shared/Apps/Advanced/XamlBuilderApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Advanced/XamlBuilderApp.cs
@@ -6,9 +6,9 @@ public class XamlBuilderApp : ViewBase
     private static readonly Dictionary<string, string> Examples = new()
     {
         ["Simple Layout"] = """<StackLayout Orientation="Vertical"><Badge Title="Hello" /><Badge Title="World" Variant="Success" /></StackLayout>""",
-        ["Buttons"] = """<StackLayout Orientation="Horizontal" Gap="2"><Button Title="Primary" Variant="Primary" /><Button Title="Secondary" Variant="Secondary" /><Button Title="Destructive" Variant="Destructive" /></StackLayout>""",
+        ["Buttons"] = """<StackLayout Orientation="Horizontal" RowGap="2" ColumnGap="2"><Button Title="Primary" Variant="Primary" /><Button Title="Secondary" Variant="Secondary" /><Button Title="Destructive" Variant="Destructive" /></StackLayout>""",
         ["Card"] = """<Card><Badge Title="Content inside a card" /></Card>""",
-        ["Nested Layout"] = """<StackLayout Orientation="Vertical" Gap="4"><StackLayout Orientation="Horizontal" Gap="2"><Badge Title="A" /><Badge Title="B" /></StackLayout><StackLayout Orientation="Horizontal" Gap="2"><Badge Title="C" Variant="Destructive" /><Badge Title="D" Variant="Success" /></StackLayout></StackLayout>""",
+        ["Nested Layout"] = """<StackLayout Orientation="Vertical" RowGap="4" ColumnGap="4"><StackLayout Orientation="Horizontal" RowGap="2" ColumnGap="2"><Badge Title="A" /><Badge Title="B" /></StackLayout><StackLayout Orientation="Horizontal" RowGap="2" ColumnGap="2"><Badge Title="C" Variant="Destructive" /><Badge Title="D" Variant="Success" /></StackLayout></StackLayout>""",
         ["Line Chart"] = """
             <LineChart>
               <Data><![CDATA[


### PR DESCRIPTION
Fixes #2541

The `StackLayout` widget has `RowGap` and `ColumnGap` properties, not a single `Gap` property. Fixed the Buttons and Nested Layout examples to use the correct property names.

Generated with [Claude Code](https://claude.ai/code)