### PR TITLE
feat(field): add LabelPosition property for horizontal label layout

### DIFF
--- a/src/Ivy/Widgets/Inputs/Field.cs
+++ b/src/Ivy/Widgets/Inputs/Field.cs
@@ -3,6 +3,12 @@ using Ivy.Core;
 // ReSharper disable once CheckNamespace
 namespace Ivy;
 
+public enum LabelPosition
+{
+    Top,
+    Left
+}
+
 public record Field : WidgetBase<Field>
 {
     public Field(IAnyInput input, string? label = null, string? description = null, bool required = false, string? help = null, Scale scale = Ivy.Scale.Medium) : base([input])
@@ -40,6 +46,8 @@ public record Field : WidgetBase<Field>
 
     [Prop] public string? Help { get; set; }
 
+    [Prop] public LabelPosition LabelPosition { get; set; } = LabelPosition.Top;
+
     public static Field operator |(Field widget, object child)
     {
         throw new NotSupportedException("Field does not support children.");
@@ -55,6 +63,8 @@ public static class FieldExtensions
     public static Field Help(this Field field, string help) => field with { Help = help };
 
     public static Field Required(this Field field) => field with { Required = true };
+
+    public static Field LabelPosition(this Field field, LabelPosition position) => field with { LabelPosition = position };
 
     public static Field WithField(this IAnyInput input) => new Field(input);
 }


### PR DESCRIPTION
Add LabelPosition enum (Top, Left) and corresponding property to Field widget. This enables horizontal form layouts where labels appear beside inputs instead of above them.

Closes #2343

Generated with [Claude Code](https://claude.ai/code)