### PR TITLE
[ValidationHelper]: block backslash and percent in app ID validation

### DIFF
--- a/src/Ivy/Helpers/ValidationHelper.cs
+++ b/src/Ivy/Helpers/ValidationHelper.cs
@@ -228,7 +228,7 @@ public static class ValidationHelper
         }
 
         // AppId should not contain protocol separators, query parameters, or other URL components
-        if (appId.Contains(':') || appId.Contains('?') || appId.Contains('#') || appId.Contains('&'))
+        if (appId.Contains(':') || appId.Contains('?') || appId.Contains('#') || appId.Contains('&') || appId.Contains('%') || appId.Contains('\\'))
         {
             return false;
         }


### PR DESCRIPTION
## Issue

CI tests `AppRoutingHelpersTests.ValidateAppId_UnsafeCharacters_ReturnsUnsafeCharacters` were failing for two input values:

| App ID | Expected | Actual |
|---|---|---|
| `app\backslash` | `UnsafeCharacters` | `Valid` |
| `app%encoded` | `UnsafeCharacters` | `Valid` |

The `ValidationHelper.IsSafeAppId` method only checked for `:`, `?`, `#`, `&`, `/` and control characters, but did not include `\` (backslash) and `%` (percent) in the list of unsafe characters.

Both characters are potentially dangerous in the context of an App ID:
- **`\`** — Windows path separator, not a valid URL character and can cause routing issues
- **`%`** — used for URL encoding (`%20`, `%3A`, etc.), can lead to double-encoding and confusion during route resolution

## Changes

Added `%` and `\` to the unsafe character check in `ValidationHelper.IsSafeAppId` (`src/Ivy/Helpers/ValidationHelper.cs`):

```diff
- if (appId.Contains(':') || appId.Contains('?') || appId.Contains('#') || appId.Contains('&'))
+ if (appId.Contains(':') || appId.Contains('?') || appId.Contains('#') || appId.Contains('&') || appId.Contains('%') || appId.Contains('\\'))
```

## Testing

All 6 test cases of `ValidateAppId_UnsafeCharacters_ReturnsUnsafeCharacters` now pass:

```
dotnet test src/Ivy.Test --filter "FullyQualifiedName~ValidateAppId_UnsafeCharacters" --verbosity normal
```

