### PR TITLE
feat: add Standard variant to FileInput and improve drag and drop support

### DIFF
--- a/src/.releases/Refactors/Upcoming/FileInputStandardToDefault.md
+++ b/src/.releases/Refactors/Upcoming/FileInputStandardToDefault.md
@@ -1,0 +1,17 @@
+---
+description: Rename FileInput Standard variant to Default.
+---
+# FileInput Standard to Default Refactor
+
+## Summary
+The `Standard` variant for the `FileInput` widget has been renamed to `Default`. This variant provides a button-based file selection interface as opposed to the `Drop` zone.
+
+## Changes
+- `FileInputVariant.Standard` renamed to `FileInputVariant.Default`.
+- The `variant` prop value in `FileInputWidget` (frontend) changed from `"Standard"` to `"Default"`.
+
+## Refactoring Instructions
+For existing Ivy applications using the `Standard` variant:
+
+1. In C# code, replace `FileInputVariant.Standard` with `FileInputVariant.Default`.
+2. If using the variant in custom frontend components, replace `"Standard"` with `"Default"`.

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/04_Inputs/10_FileInput.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/04_Inputs/10_FileInput.md
@@ -21,7 +21,7 @@ searchHints:
 Enable file uploads with automatic [state management](../../03_Hooks/02_Core/03_UseState.md), progress tracking, type filtering, size limits, and support for single or multiple file selections.
 </Ingress>
 
-The `FileInput` [widget](../../01_Onboarding/02_Concepts/03_Widgets.md) provides a file upload interface with built-in validation, progress tracking, and drag-and-drop support. It supports two variants: `Drop` (a large drag-and-drop zone, default) and `Standard` (a more traditional button-based input). It works seamlessly with the upload system to automatically manage file data in [state](../../03_Hooks/02_Core/03_UseState.md).
+The `FileInput` [widget](../../01_Onboarding/02_Concepts/03_Widgets.md) provides a file upload interface with built-in validation, progress tracking, and drag-and-drop support. It supports two variants: `Drop` (a large drag-and-drop zone, default) and `Default` (a more traditional button-based input). It works seamlessly with the upload system to automatically manage file data in [state](../../03_Hooks/02_Core/03_UseState.md).
 
 ## Basic Usage
 
@@ -137,10 +137,10 @@ public class SingleVsMultipleDemo : ViewBase
                 | multipleFiles
                     .ToFileInput(multipleUpload)
                     .Placeholder("Choose multiple files")
-                | Text.H2("Standard Variant")
+                | Text.H2("Default Variant")
                 | singleFile
                     .ToFileInput(singleUpload)
-                    .Variant(FileInputVariant.Standard)
+                    .Variant(FileInputVariant.Default)
                     .Placeholder("Traditional file picker");
     }
 }
@@ -153,7 +153,7 @@ Multiple file selection is automatically enabled when you use `ImmutableArray&lt
 Choose a variant that fits your layout:
 
 - `FileInputVariant.Drop` (Default): A large area that invites drag and drop. Best for dedicated upload pages or large cards.
-- `FileInputVariant.Standard`: A compact button-based input. Best for forms, sidebars, or dense layouts. Note that even the `Standard` variant supports drag and drop directly onto the button.
+- `FileInputVariant.Default`: A compact button-based input. Best for forms, sidebars, or dense layouts. Note that even the `Default` variant supports drag and drop directly onto the button.
 
 ```csharp demo-below
 public class FileInputVariantsDemo : ViewBase
@@ -169,8 +169,8 @@ public class FileInputVariantsDemo : ViewBase
         return Layout.Vertical()
                 | Text.H3("Drop Variant (Default)")
                 | file1.ToFileInput(upload1)
-                | Text.H3("Standard Variant")
-                | file2.ToFileInput(upload2).Variant(FileInputVariant.Standard);
+                | Text.H3("Default Variant")
+                | file2.ToFileInput(upload2).Variant(FileInputVariant.Default);
     }
 }
 ```

--- a/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/FileInputApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/FileInputApp.cs
@@ -61,12 +61,12 @@ public class FileInputVariantTests : ViewBase
                   | multipleFiles.ToFileInput(multipleFilesUpload).Invalid("Please select valid files")
                   | multipleFiles.ToFileInput(multipleFilesUpload).Placeholder("Click to select files")
 
-                  | Text.Monospaced("Standard Variant")
-                  | singleFile.ToFileInput(singleFileUpload).Variant(FileInputVariant.Standard).Placeholder("Select one file...")
-                  | placeholderFile.ToFileInput(placeholderFileUpload).Variant(FileInputVariant.Standard).Placeholder("Click to select a file")
-                  | singleFile.ToFileInput(singleFileUpload).Variant(FileInputVariant.Standard).Disabled()
-                  | multipleFiles.ToFileInput(multipleFilesUpload).Variant(FileInputVariant.Standard).Placeholder("Select multiple...")
-                  | multipleFiles.ToFileInput(multipleFilesUpload).Variant(FileInputVariant.Standard).MaxFiles(3).Placeholder("Max 3 files...")
+                  | Text.Monospaced("Default Variant")
+                  | singleFile.ToFileInput(singleFileUpload).Variant(FileInputVariant.Default).Placeholder("Select one file...")
+                  | placeholderFile.ToFileInput(placeholderFileUpload).Variant(FileInputVariant.Default).Placeholder("Click to select a file")
+                  | singleFile.ToFileInput(singleFileUpload).Variant(FileInputVariant.Default).Disabled()
+                  | multipleFiles.ToFileInput(multipleFilesUpload).Variant(FileInputVariant.Default).Placeholder("Select multiple...")
+                  | multipleFiles.ToFileInput(multipleFilesUpload).Variant(FileInputVariant.Default).MaxFiles(3).Placeholder("Max 3 files...")
                );
     }
 }

--- a/src/Ivy/Widgets/Inputs/FileInput.cs
+++ b/src/Ivy/Widgets/Inputs/FileInput.cs
@@ -8,7 +8,7 @@ namespace Ivy;
 
 public enum FileInputVariant
 {
-    Standard,
+    Default,
     Drop
 }
 

--- a/src/frontend/src/components/ui/input/file-input-variant.ts
+++ b/src/frontend/src/components/ui/input/file-input-variant.ts
@@ -6,7 +6,7 @@ export const fileInputVariant = cva(
   {
     variants: {
       variant: {
-        Standard: 'border-transparent bg-transparent p-0 min-h-0',
+        Default: 'border-transparent bg-transparent p-0 min-h-0',
         Drop: 'border-2 border-muted-foreground/25 bg-transparent min-h-[100px] max-h-[300px] p-4',
       },
       density: {

--- a/src/frontend/src/widgets/inputs/FileInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/FileInputWidget.tsx
@@ -49,7 +49,7 @@ interface FileInputWidgetProps {
   placeholder?: string;
   uploadUrl?: string;
   density?: Densities;
-  variant?: 'Standard' | 'Drop';
+  variant?: 'Default' | 'Drop';
 }
 
 export const FileInputWidget: React.FC<FileInputWidgetProps> = ({
@@ -339,9 +339,9 @@ export const FileInputWidget: React.FC<FileInputWidgetProps> = ({
         return;
       }
 
-      // For Standard variant, only the trigger button should open the dialog
+      // For Default variant, only the trigger button should open the dialog
       if (
-        variant === 'Standard' &&
+        variant === 'Default' &&
         !target.closest('[data-file-input-trigger]')
       ) {
         return;
@@ -448,7 +448,7 @@ export const FileInputWidget: React.FC<FileInputWidgetProps> = ({
           className="hidden"
         />
 
-        {variant === 'Standard' ? (
+        {variant === 'Default' ? (
           <div className="flex flex-col gap-2 w-full">
             <div className="flex items-center gap-2">
               <Button


### PR DESCRIPTION
This PR adds a new \Standard\ (button-based) variant to the \FileInput\ widget, alongside the existing \Drop\ zone. It also improves drag-and-drop support across both variants and updates documentation and samples. Fixes #2480