### PR TITLE
[Card]: fix content body rendering invisible despite being in the DOM

### DIFF
--- a/src/frontend/src/widgets/card/styles.ts
+++ b/src/frontend/src/widgets/card/styles.ts
@@ -29,7 +29,7 @@ export const cardStyles = {
   },
 
   content: {
-    base: 'flex-1',
+    base: 'flex-auto',
   },
 
   footer: {


### PR DESCRIPTION
## The Problem
When using the `Card` component with `.Title()` and `.Content()` (or similar constructs), the `CardContent` area rendered completely invisible despite being present in the DOM. This issue occurred when the Card did not have an explicit height constraint from its parent layout. 

The root cause was a CSS flex-basis collapse. The content area used the Tailwind class `flex-1`, which expands to `flex: 1 1 0%`. Because the flex-basis is exactly `0%` and the parent `<Card>` container does not enforce a rigid height by default, the content block contributed `0px` to the intrinsic height calculation, causing it to collapse and become invisible. 

*Note: This specific flexbox behavior varies across browser engines. In strict engines (like Safari), it causes complete collapse, while Chromium sometimes masks the issue by attempting to read inner text bounds.*

## What was done
- Modified `src/frontend/src/widgets/card/styles.ts`.
- Changed the base class of the `content` block from `flex-1` to `flex-auto` (which expands to `flex: 1 1 auto`).

## Why this solves the issue
By switching to `flex-auto`, the browser natively uses the intrinsic natural height of the card's internal content as the `flex-basis` metric before distributing any extra space. This allows the `CardContent` to correctly expand to fit inner elements, ensuring the content is visible across all browsers without breaking the existing layout when a card is placed inside a fixed-height container.
