### PR TITLE
refactor(size): remove FractionGap API

### DIFF
--- a/src/.releases/Refactors/Upcoming/RemoveFractionGapAPI.md
+++ b/src/.releases/Refactors/Upcoming/RemoveFractionGapAPI.md
@@ -1,0 +1,28 @@
+---
+title: Removing FractionGap Size API
+---
+
+# Removing FractionGap Size API
+
+## Description
+The `FractionGap` size API has been removed as it was unused and provided redundant functionality with standard `Fraction` plus layout gaps.
+
+## Impact
+This is a breaking change if you were using `Size.FractionGap()`.
+
+## Migration
+Replace any usage of `Size.FractionGap(x)` with `Size.Fraction(x)`. If gaps were an issue, ensure your `Layout` has a `Gap` configured.
+
+### Before
+```csharp
+new Box().Width(Size.FractionGap(0.5f))
+```
+
+### After
+```csharp
+new Box().Width(Size.Fraction(0.5f))
+```
+
+## Verification
+- Run `dotnet build` to ensure no C# compiler errors.
+- Run `npm run build` in frontend to ensure no TypeScript errors.

--- a/src/Ivy/Shared/Size.cs
+++ b/src/Ivy/Shared/Size.cs
@@ -11,7 +11,6 @@ public enum SizeType
     Px,
     Rem,
     Fraction,
-    FractionGap,
     Full,
     Fit,
     Screen,
@@ -140,10 +139,6 @@ public record Size
         return Fraction(int.Parse(cleaned) / 100f);
     }
 
-    public static Size FractionGap(float value)
-    {
-        return new Size(SizeType.FractionGap, value);
-    }
 
     public static implicit operator string(Size size)
     {

--- a/src/frontend/src/lib/styles.ts
+++ b/src/frontend/src/lib/styles.ts
@@ -32,13 +32,6 @@ const _getWantedWidth = (width?: string): React.CSSProperties => {
       return {
         width: `${parseFloat(value) * 100}%`,
       };
-    case 'fraction-gap':
-      return {
-        flexBasis: `${parseFloat(value) * 100}%`,
-        flexShrink: 1,
-        flexGrow: 0,
-        minWidth: 0, // Allow shrinking below flex-basis to accommodate gaps
-      };
     case 'full':
       return { width: '100%' };
     case 'fit':
@@ -75,10 +68,6 @@ const _getMinWidth = (width?: string): React.CSSProperties => {
       return {
         minWidth: `${parseFloat(value) * 100}%`,
       };
-    case 'fraction-gap':
-      return {
-        minWidth: 0, // Allow shrinking to accommodate gaps
-      };
     case 'full':
       return { minWidth: '100%' };
     case 'fit':
@@ -108,10 +97,6 @@ const _getMaxWidth = (width?: string): React.CSSProperties => {
     case 'rem':
       return { maxWidth: `${value}rem` };
     case 'fraction':
-      return {
-        maxWidth: `${parseFloat(value) * 100}%`,
-      };
-    case 'fraction-gap':
       return {
         maxWidth: `${parseFloat(value) * 100}%`,
       };


### PR DESCRIPTION
## Summary
This PR removes the FractionGap API from both the C# backend and the frontend codebase. This was a deprecated API with no active usages in the documentation or samples.

## Changes Made
- **Backend**: Removed SizeType.FractionGap and Size.FractionGap() from Ivy.Shared/Size.cs.
- **Frontend**: Removed raction-gap logic from rontend/src/lib/styles.ts.
- **Documentation**: Cleaned generated documentation to resolve build errors and created a release note in .releases/Refactors/Upcoming/RemoveFractionGapAPI.md.

## Verification
- dotnet build in Ivy.Docs.Shared succeeded after cleaning.
- 
pm run build in rontend succeeded.