### PR TITLE
Fix frontend build errors on main

### DIFF
--- a/src/frontend/src/services/grpcTableService.test.ts
+++ b/src/frontend/src/services/grpcTableService.test.ts
@@ -46,7 +46,7 @@ describe('GrpcTableService', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    service = new GrpcTableService('http://localhost:8080');
+    service = new GrpcTableService();
   });
 
   afterEach(() => {
@@ -54,8 +54,8 @@ describe('GrpcTableService', () => {
   });
 
   describe('constructor', () => {
-    it('should create service with server URL', () => {
-      const testService = new GrpcTableService('http://test.com:9000');
+    it('should create service', () => {
+      const testService = new GrpcTableService();
       expect(testService).toBeInstanceOf(GrpcTableService);
     });
   });

--- a/src/frontend/src/services/grpcTableService.ts
+++ b/src/frontend/src/services/grpcTableService.ts
@@ -110,8 +110,7 @@ export interface GrpcTableStreamOptions {
 export class GrpcTableService extends EventEmitter {
   private isConnected = false;
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  constructor(_serverUrl?: string) {
+  constructor() {
     super();
   }
 
@@ -865,7 +864,7 @@ let _grpcTableServiceInstance: GrpcTableService | null = null;
 
 export function getGrpcTableService(): GrpcTableService {
   if (!_grpcTableServiceInstance) {
-    _grpcTableServiceInstance = new GrpcTableService('');
+    _grpcTableServiceInstance = new GrpcTableService();
   }
   return _grpcTableServiceInstance;
 }


### PR DESCRIPTION
Fix TS build errors in frontend by installing use-debounce and removing an unused parameter in grpcTableService.