### PR TITLE
Fix: restored borders for ghost variant in Select components

### DIFF
--- a/src/frontend/src/widgets/inputs/AsyncSelectInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/AsyncSelectInputWidget.tsx
@@ -155,7 +155,8 @@ export const AsyncSelectInputWidget: React.FC<AsyncSelectInputWidgetProps> = ({
         className={cn(
           asyncSelectContainerVariant({ density }),
           invalid && inputStyles.invalidInput,
-          ghost && 'border-transparent shadow-none'
+          ghost &&
+            'border-transparent shadow-none bg-transparent dark:border-transparent dark:bg-transparent'
         )}
       >
         {wrappedDisplayValue}

--- a/src/frontend/src/widgets/inputs/SelectSingleVariant.tsx
+++ b/src/frontend/src/widgets/inputs/SelectSingleVariant.tsx
@@ -131,7 +131,7 @@ export const SelectSingleVariant: React.FC<SelectInputWidgetProps> = ({
         invalid && inputStyles.invalidInput,
         !hasValue && 'text-muted-foreground',
         ghost &&
-          'border-transparent shadow-none bg-transparent hover:bg-accent hover:text-accent-foreground'
+          'border-transparent shadow-none bg-transparent hover:bg-accent hover:text-accent-foreground dark:border-transparent dark:bg-transparent dark:hover:bg-accent dark:hover:text-accent-foreground'
       )}
       density={density}
     >


### PR DESCRIPTION
This PR fixes a bug where the ghost variant for the Select inputs accidentally stripped the default borders due to a recently applied border-transparent class. By removing border-transparent, the Select ghost variant properly inherits its expected visual borders while remaining transparent in background.