### PR TITLE
fix: remove double eye icon in password input

### DIFF
--- a/src/frontend/src/widgets/inputs/TextInputWidget/variants/PasswordVariant.tsx
+++ b/src/frontend/src/widgets/inputs/TextInputWidget/variants/PasswordVariant.tsx
@@ -111,6 +111,7 @@ export const PasswordVariant: React.FC<PasswordVariantProps> = ({
           className={cn(
             textInputSizeVariant({ density }),
             'border-0 shadow-none dark:bg-transparent',
+            '[&::-ms-reveal]:hidden [&::-ms-clear]:hidden',
             props.invalid && inputStyles.invalidInput,
             props.invalid || showClear ? 'pr-14' : 'pr-8',
             hasLastPass && 'pr-3',
@@ -131,13 +132,24 @@ export const PasswordVariant: React.FC<PasswordVariantProps> = ({
           <div className="pointer-events-auto flex items-center h-6">
             <button
               type="button"
-              className={eyeIconVariant({ density })}
+              className="p-1 rounded hover:bg-accent focus:outline-none cursor-pointer flex items-center"
               onClick={togglePassword}
+              aria-label={showPassword ? 'Hide password' : 'Show password'}
             >
               {showPassword ? (
-                <EyeOffIcon className={eyeIconVariant({ density })} />
+                <EyeOffIcon
+                  className={cn(
+                    'text-muted-foreground',
+                    eyeIconVariant({ density })
+                  )}
+                />
               ) : (
-                <EyeIcon className={eyeIconVariant({ density })} />
+                <EyeIcon
+                  className={cn(
+                    'text-muted-foreground',
+                    eyeIconVariant({ density })
+                  )}
+                />
               )}
             </button>
           </div>


### PR DESCRIPTION
## Problem\n\nThe password input field was showing two eye icons — one from our custom toggle button and one from the browser's native password reveal button.\n\n## Root Cause\n\nIn PasswordVariant.tsx, the <button> element wrapping the eye icon toggle was incorrectly using yeIconVariant({ density }) as its className. This variant only produces icon-sizing classes (h-4 w-4 etc.), not button styling. This caused the button container itself to be styled as a tiny icon-sized box AND contain a real <EyeIcon> component — visually duplicating the eye.\n\nAdditionally, the browser's native password reveal button (::-ms-reveal / ::-webkit-credentials-auto-fill-button) was not suppressed, contributing to the double icon on some browsers.\n\n## Fix\n\n- Gave the <button> proper button classes (p-1 rounded hover:bg-accent focus:outline-none cursor-pointer flex items-center)\n- Moved yeIconVariant exclusively to the <EyeIcon> / <EyeOffIcon> components inside the button\n- Added 	ext-muted-foreground color to the icons\n- Added ria-label for accessibility\n- Added [&::-ms-reveal]:hidden [&::-ms-clear]:hidden to suppress browser native password reveal icons