### PR TITLE
fix: fix incorrect doc links in analyser diagnostic messages

### DIFF
--- a/src/Ivy.Analyser/Analyzers/AppConstructorAnalyzer.cs
+++ b/src/Ivy.Analyser/Analyzers/AppConstructorAnalyzer.cs
@@ -13,7 +13,7 @@ public class AppConstructorAnalyzer : DiagnosticAnalyzer
     private static readonly DiagnosticDescriptor Rule = new(
         DiagnosticId,
         "App class must have a parameterless constructor",
-        "App '{0}' must have a parameterless constructor, use UseService<T>() inside Build() instead of constructor injection. See: https://docs.ivy.app/other/ivy-analyser/ivyapp001.",
+        "App '{0}' must have a parameterless constructor, use UseService<T>() inside Build() instead of constructor injection. See: https://docs.ivy.app/other/ivy/analyser/ivyapp001.",
         "Ivy.Apps",
         DiagnosticSeverity.Error,
         isEnabledByDefault: true,

--- a/src/Ivy.Analyser/Analyzers/HookUsageAnalyzer.cs
+++ b/src/Ivy.Analyser/Analyzers/HookUsageAnalyzer.cs
@@ -13,43 +13,43 @@ namespace Ivy.Analyser.Analyzers
     {
         public const string DiagnosticId = "IVYHOOK001";
         private const string Title = "Invalid Ivy Hook Usage";
-        private const string MessageFormat = "Ivy hook '{0}' must be called at the top level of the Build() method — not inside lambdas, local functions, or helper methods. Hooks must always execute in the same order on every render. See: https://docs.ivy.app/other/ivy-analyser/ivyhook001.";
+        private const string MessageFormat = "Ivy hook '{0}' must be called at the top level of the Build() method — not inside lambdas, local functions, or helper methods. Hooks must always execute in the same order on every render. See: https://docs.ivy.app/other/ivy/analyser/ivyhook001.";
         private const string Description = "Ivy hooks must be called directly inside the Build() method, not inside lambdas, local functions, or other methods.";
 
         public const string DiagnosticIdNestedClosure = "IVYHOOK001B";
         private const string TitleNestedClosure = "Ivy Hook Used in Nested Closure";
-        private const string MessageFormatNestedClosure = "Ivy hook '{0}' is inside a {1} within Build() — move it to the top level of Build(). Hooks must always execute in the same order on every render. See: https://docs.ivy.app/other/ivy-analyser/ivyhook001b.";
+        private const string MessageFormatNestedClosure = "Ivy hook '{0}' is inside a {1} within Build() — move it to the top level of Build(). Hooks must always execute in the same order on every render. See: https://docs.ivy.app/other/ivy/analyser/ivyhook001b.";
         private const string DescriptionNestedClosure = "Ivy hooks cannot be called inside lambdas, local functions, or anonymous methods even when those are defined within Build(). Move the hook call to the top level of Build().";
         private const string Category = "Usage";
 
         public const string DiagnosticIdConditional = "IVYHOOK002";
         private const string TitleConditional = "Ivy Hook Called Conditionally";
-        private const string MessageFormatConditional = "Ivy hook '{0}' cannot be called conditionally. Hooks must be called in the same order on every render. See: https://docs.ivy.app/other/ivy-analyser/ivyhook002.";
+        private const string MessageFormatConditional = "Ivy hook '{0}' cannot be called conditionally. Hooks must be called in the same order on every render. See: https://docs.ivy.app/other/ivy/analyser/ivyhook002.";
         private const string DescriptionConditional = "Ivy hooks must be called unconditionally at the top level of the Build() method. Do not call hooks inside if statements, ternary operators, or other conditional logic.";
 
         public const string DiagnosticIdLoop = "IVYHOOK003";
         private const string TitleLoop = "Ivy Hook Called in Loop";
-        private const string MessageFormatLoop = "Ivy hook '{0}' cannot be called inside a loop. Hooks must be called in the same order on every render. See: https://docs.ivy.app/other/ivy-analyser/ivyhook003.";
+        private const string MessageFormatLoop = "Ivy hook '{0}' cannot be called inside a loop. Hooks must be called in the same order on every render. See: https://docs.ivy.app/other/ivy/analyser/ivyhook003.";
         private const string DescriptionLoop = "Ivy hooks must be called unconditionally at the top level of the Build() method. Do not call hooks inside for, foreach, while, or do-while loops.";
 
         public const string DiagnosticIdSwitch = "IVYHOOK004";
         private const string TitleSwitch = "Ivy Hook Called in Switch Statement";
-        private const string MessageFormatSwitch = "Ivy hook '{0}' cannot be called inside a switch statement. Hooks must be called in the same order on every render. See: https://docs.ivy.app/other/ivy-analyser/ivyhook004.";
+        private const string MessageFormatSwitch = "Ivy hook '{0}' cannot be called inside a switch statement. Hooks must be called in the same order on every render. See: https://docs.ivy.app/other/ivy/analyser/ivyhook004.";
         private const string DescriptionSwitch = "Ivy hooks must be called unconditionally at the top level of the Build() method. Do not call hooks inside switch statements.";
 
         public const string DiagnosticIdNotAtTop = "IVYHOOK005";
         private const string TitleNotAtTop = "Ivy Hook Not at Top of Build Method";
-        private const string MessageFormatNotAtTop = "Ivy hook '{0}' must be called at the top of the Build() method, before any other statements. See: https://docs.ivy.app/other/ivy-analyser/ivyhook005.";
+        private const string MessageFormatNotAtTop = "Ivy hook '{0}' must be called at the top of the Build() method, before any other statements. See: https://docs.ivy.app/other/ivy/analyser/ivyhook005.";
         private const string DescriptionNotAtTop = "All hooks must be called at the very top of the Build() method, before any other non-hook statements. This ensures hooks are called in a consistent order on every render.";
 
         public const string DiagnosticIdFieldStorage = "IVYHOOK006";
         private const string TitleFieldStorage = "Hook Result Stored in Class Member";
-        private const string MessageFormatFieldStorage = "Ivy hook '{0}' result must not be stored in a class field or property. Use a local variable instead. See: https://docs.ivy.app/other/ivy-analyser/ivyhook006.";
+        private const string MessageFormatFieldStorage = "Ivy hook '{0}' result must not be stored in a class field or property. Use a local variable instead. See: https://docs.ivy.app/other/ivy/analyser/ivyhook006.";
         private const string DescriptionFieldStorage = "Storing hook results in class fields or properties breaks the reactive system. The state object is captured once and reused across renders, causing hooks to receive wrong indices.";
 
         public const string DiagnosticIdInlineExpression = "IVYHOOK007";
         private const string TitleInlineExpression = "Hook Called Inline in Expression";
-        private const string MessageFormatInlineExpression = "'{0}' should be assigned to a local variable at the top of the Build method, not called inline in an expression. Extract to: var myVar = {0}; See: https://docs.ivy.app/other/ivy-analyser/ivyhook007.";
+        private const string MessageFormatInlineExpression = "'{0}' should be assigned to a local variable at the top of the Build method, not called inline in an expression. Extract to: var myVar = {0}; See: https://docs.ivy.app/other/ivy/analyser/ivyhook007.";
         private const string DescriptionInlineExpression = "Hooks must be assigned to a top-level local variable or called as a standalone expression statement. Do not call hooks inline within widget construction expressions, pipe chains, constructor arguments, or return statements.";
 
         private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(

--- a/src/Ivy.Analyser/Analyzers/LeafWidgetAnalyzer.cs
+++ b/src/Ivy.Analyser/Analyzers/LeafWidgetAnalyzer.cs
@@ -17,7 +17,7 @@ namespace Ivy.Analyser.Analyzers
         private static readonly DiagnosticDescriptor LeafRule = new DiagnosticDescriptor(
             LeafDiagnosticId,
             "Adding Children to Leaf Widget",
-            "'{0}' does not support children. See: https://docs.ivy.app/other/ivy-analyser/ivychild001.",
+            "'{0}' does not support children. See: https://docs.ivy.app/other/ivy/analyser/ivychild001.",
             "Usage",
             DiagnosticSeverity.Error,
             isEnabledByDefault: true,
@@ -27,7 +27,7 @@ namespace Ivy.Analyser.Analyzers
         private static readonly DiagnosticDescriptor SingleChildRule = new DiagnosticDescriptor(
             SingleChildDiagnosticId,
             "Adding Multiple Children to Single-Child Widget",
-            "'{0}' only supports a single child. See: https://docs.ivy.app/other/ivy-analyser/ivychild002.",
+            "'{0}' only supports a single child. See: https://docs.ivy.app/other/ivy/analyser/ivychild002.",
             "Usage",
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true,
@@ -37,7 +37,7 @@ namespace Ivy.Analyser.Analyzers
         private static readonly DiagnosticDescriptor WrongChildTypeRule = new DiagnosticDescriptor(
             WrongChildTypeDiagnosticId,
             "Wrong Child Type for Widget",
-            "'{0}' only accepts children of type '{1}'. Got '{2}'. See: https://docs.ivy.app/other/ivy-analyser/ivychild003.",
+            "'{0}' only accepts children of type '{1}'. Got '{2}'. See: https://docs.ivy.app/other/ivy/analyser/ivychild003.",
             "Usage",
             DiagnosticSeverity.Error,
             isEnabledByDefault: true,

--- a/src/Ivy.Analyser/Analyzers/UseEffectTaskAnalyzer.cs
+++ b/src/Ivy.Analyser/Analyzers/UseEffectTaskAnalyzer.cs
@@ -14,7 +14,7 @@ public class UseEffectTaskAnalyzer : DiagnosticAnalyzer
     private static readonly DiagnosticDescriptor Rule = new(
         DiagnosticId,
         "Avoid Task.ContinueWith inside UseEffect",
-        "Task.ContinueWith() inside UseEffect can cause NullReferenceException when the component is disposed. Use a CancellationTokenSource with proper cleanup instead. See: https://docs.ivy.app/other/ivy-analyser/ivyeffect001.",
+        "Task.ContinueWith() inside UseEffect can cause NullReferenceException when the component is disposed. Use a CancellationTokenSource with proper cleanup instead. See: https://docs.ivy.app/other/ivy/analyser/ivyeffect001.",
         "Usage",
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,


### PR DESCRIPTION
## Summary\n\nAll analyzer diagnostic messages contained incorrect URL paths:\n\n- **Before:** https://docs.ivy.app/other/ivy-analyser/ivyhookXXX\n- **After:** https://docs.ivy.app/other/ivy/analyser/ivyhookXXX\n\n## Changes\n\nFixed 13 broken URLs across 4 files:\n- HookUsageAnalyzer.cs — 8 links (IVYHOOK001–IVYHOOK007)\n- LeafWidgetAnalyzer.cs — 3 links (IVYCHILD001–IVYCHILD003)\n- UseEffectTaskAnalyzer.cs — 1 link (IVYEFFECT001)\n- AppConstructorAnalyzer.cs — 1 link (IVYAPP001)