### PR TITLE
fix(ui): use gap instead of space-x in dialog, alert-dialog and sheet footers

### DIFF
--- a/src/frontend/src/components/ui/alert-dialog.tsx
+++ b/src/frontend/src/components/ui/alert-dialog.tsx
@@ -60,7 +60,7 @@ const AlertDialogFooter = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2',
+      'flex flex-col-reverse sm:flex-row sm:justify-end gap-2',
       className
     )}
     {...props}

--- a/src/frontend/src/components/ui/dialog.tsx
+++ b/src/frontend/src/components/ui/dialog.tsx
@@ -76,7 +76,7 @@ const DialogFooter = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2 flex-shrink-0 p-6 pt-4',
+      'flex flex-col-reverse sm:flex-row sm:justify-end gap-2 flex-shrink-0 p-6 pt-4',
       className
     )}
     {...props}

--- a/src/frontend/src/components/ui/sheet.tsx
+++ b/src/frontend/src/components/ui/sheet.tsx
@@ -89,7 +89,7 @@ const SheetFooter = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2',
+      'flex flex-col-reverse sm:flex-row sm:justify-end gap-2',
       className
     )}
     {...props}


### PR DESCRIPTION
Fixed missing spacing between form actions (Cancel/Save) by switching from \space-x-2\ to \gap-2\ in DialogFooter, AlertDialogFooter, and SheetFooter. This provides more reliable spacing when some siblings (like validation messages) are empty or growing.