### PR TITLE
Fix Screenshot overlay text capitalization

### DIFF
--- a/src/widgets/Ivy.Widgets.ScreenshotFeedback/frontend/src/ScreenshotFeedback.tsx
+++ b/src/widgets/Ivy.Widgets.ScreenshotFeedback/frontend/src/ScreenshotFeedback.tsx
@@ -214,7 +214,7 @@ export const ScreenshotFeedback: React.FC<ScreenshotFeedbackProps> = ({
             fontFamily: "var(--font-sans, sans-serif)",
           }}
         >
-          Capturing screenshot...
+          Capturing Screenshot...
         </div>
       </div>
     );


### PR DESCRIPTION
## Summary
- Capitalize Screenshot in capture overlay text