### PR TITLE
[chore]: Isolate Dockerfiles for PR-based docs and samples deployments

### DIFF
--- a/.github/docker/Dockerfile.docs
+++ b/.github/docker/Dockerfile.docs
@@ -1,0 +1,29 @@
+# Dockerfile.docs — used in ivy-examples to deploy docs preview from PRs.
+
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
+USER $APP_UID
+WORKDIR /app
+EXPOSE 5010
+
+# Build frontend (Ivy embeds frontend/dist)
+FROM node:20-alpine AS frontend
+WORKDIR /src
+COPY ["src/frontend/package.json", "src/frontend/package-lock.json", "src/frontend/"]
+RUN cd src/frontend && npm ci
+COPY ["src/frontend/", "src/frontend/"]
+RUN cd src/frontend && npm run build
+
+# Build .NET from source (no IVY_PACKAGE_VERSION = use ProjectReference, your changes apply)
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+ARG BUILD_CONFIGURATION=Release
+WORKDIR /src
+COPY . .
+COPY --from=frontend /src/src/frontend/dist /src/src/frontend/dist
+RUN dotnet restore "src/Ivy.Docs/Ivy.Docs.csproj"
+RUN dotnet publish "src/Ivy.Docs/Ivy.Docs.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
+
+FROM base AS final
+WORKDIR /app
+ENV PORT=5010
+COPY --from=build /app/publish .
+ENTRYPOINT ["dotnet", "Ivy.Docs.dll"]

--- a/.github/docker/Dockerfile.samples
+++ b/.github/docker/Dockerfile.samples
@@ -1,0 +1,29 @@
+# Dockerfile.samples — used in ivy-examples to deploy samples preview from PRs.
+
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
+USER $APP_UID
+WORKDIR /app
+EXPOSE 5010
+
+# Build frontend (Ivy embeds frontend/dist)
+FROM node:20-alpine AS frontend
+WORKDIR /src
+COPY ["src/frontend/package.json", "src/frontend/package-lock.json", "src/frontend/"]
+RUN cd src/frontend && npm ci
+COPY ["src/frontend/", "src/frontend/"]
+RUN cd src/frontend && npm run build
+
+# Build .NET from source (no IVY_PACKAGE_VERSION = use ProjectReference, your changes apply)
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+ARG BUILD_CONFIGURATION=Release
+WORKDIR /src
+COPY . .
+COPY --from=frontend /src/src/frontend/dist /src/src/frontend/dist
+RUN dotnet restore "src/Ivy.Samples/Ivy.Samples.csproj"
+RUN dotnet publish "src/Ivy.Samples/Ivy.Samples.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
+
+FROM base AS final
+WORKDIR /app
+ENV PORT=5010
+COPY --from=build /app/publish .
+ENTRYPOINT ["dotnet", "Ivy.Samples.dll"]


### PR DESCRIPTION
## Summary
- Added and separated dedicated Dockerfiles for documentation and samples deployments.
- Updated the `ivy-examples` PR-driven deployment flow to use these isolated Dockerfiles for each new PR.
- Ensured Docker build artifacts/configs do not conflict with other services or repositories.

## Context
`ivy-examples` monitors for new pull requests and triggers deployments per PR.  
To make this deployment reliable, Dockerfiles were moved out and split so docs and samples can be built/deployed independently without interfering with anyone else's setup.

## Why
- Prevent cross-project/build interference.
- Make per-PR deployments deterministic and easier to maintain.
- Keep docs and samples deployment paths clearly separated.