### PR TITLE
feat: treat analyzer warnings as errors

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Enforces zero-warning builds by treating analyzer warnings as errors in Ivy and Ivy-Framework.