### PR TITLE
Refactor sample apps: rename DefaultContentBuilderApp and remove ConnectionsApp

### DIFF
--- a/src/Ivy.Samples.Shared/Apps/Concepts/DefaultContentBuilderApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Concepts/DefaultContentBuilderApp.cs
@@ -2,7 +2,7 @@
 namespace Ivy.Samples.Shared.Apps.Concepts;
 
 [App(icon: Icons.Paintbrush, searchHints: ["rendering", "display", "types", "conversion", "formatting", "output"])]
-public class DefaultContentApp : SampleBase
+public class DefaultContentBuilderApp : SampleBase
 {
     protected override object? BuildSample()
     {


### PR DESCRIPTION
This PR renames DefaultContentBuilderApp to DefaultContentApp and removes the ConnectionsApp as it was mostly just a code block. Verified with builds and documentation regeneration.