### PR TITLE
[Sidebar]: use pathKey for data-menu-item to prevent collisions

### DIFF
--- a/src/frontend/src/widgets/layouts/sidebar/SidebarLayoutWidget.tsx
+++ b/src/frontend/src/widgets/layouts/sidebar/SidebarLayoutWidget.tsx
@@ -386,7 +386,7 @@ const CollapsibleMenuItem: React.FC<{
   if (item.children && item.children.length > 0) {
     return (
       <Collapsible open={isOpen} onOpenChange={handleOpenChange}>
-        <li className="relative" ref={itemRef} data-menu-item={item.tag || item.label}>
+        <li className="relative" ref={itemRef} data-menu-item={item.tag || pathKey}>
           <CollapsibleTrigger asChild>
             <button
               className={cn(
@@ -427,7 +427,7 @@ const CollapsibleMenuItem: React.FC<{
     );
   } else {
     return (
-      <li key={item.label} ref={itemRef} data-menu-item={item.tag || item.label}>
+      <li key={item.label} ref={itemRef} data-menu-item={item.tag || pathKey}>
         <button
           className={cn(
             "flex w-full items-center gap-2 rounded-selector p-2 text-large-label hover:bg-accent hover:text-accent-foreground cursor-pointer h-8 text-left",


### PR DESCRIPTION
## Description
This PR addresses Issue #2636, where clicking the second of two identically named sidebar groups would incorrectly expand or select the first one. For example, having an "Ivy" folder under "Api Reference" and another "Ivy" folder under "Other" would result in an interaction conflict.

## Root Cause
In `SidebarLayoutWidget.tsx`, the `CollapsibleMenuItem` utilizes the `data-menu-item` HTML attribute to uniquely identify and find elements in the DOM (e.g., for auto-scrolling to the active item). 

The value for this attribute was assigned as `item.tag || item.label`.
While "leaf" menu items possess unique `item.tag` identifiers (derived from their App IDs), structural group/folder items do not have tags. As a result, groups fell back to using `item.label`. 

If two groups shared the exact same label (e.g., "Ivy"), they both received the identical `data-menu-item="Ivy"` attribute in the DOM. Consequently, any `querySelector` call looking for this attribute would invariably return the first matching element it found in the DOM tree, causing clicks or scrolls intended for the second group to affect the first.

## Solution
Modified `SidebarLayoutWidget.tsx` to use `pathKey` instead of `item.label` as the fallback for the `data-menu-item` attribute. 
The `pathKey` is already calculated during menu generation and represents the full path of the item within the menu hierarchy (e.g., `"Api Reference/Ivy"` vs `"Other/Ivy"`).

```tsx
// Before (Lines 389, 430)
<li className="relative" ref={itemRef} data-menu-item={item.tag || item.label}>

// After
<li className="relative" ref={itemRef} data-menu-item={item.tag || pathKey}>
```

This small adjustment ensures that every group in the sidebar, even those with identical display labels, receives a unique `data-menu-item` attribute in the HTML, entirely preventing DOM selection collisions.

https://github.com/user-attachments/assets/686dfaf0-45ae-41d9-ad55-8d0aec84eb22


