### PR TITLE
[Multiselect]: fix opened dropdown shift when overflow badge is visible

### DIFF
--- a/src/frontend/src/components/ui/multiselect.tsx
+++ b/src/frontend/src/components/ui/multiselect.tsx
@@ -333,7 +333,14 @@ const MultipleSelector = React.forwardRef<
                     containerRef.current.scrollLeft = 0;
                   }
                 }}
-                onFocus={() => setOpen(true)}
+                onFocus={() => {
+                  setOpen(true);
+                  requestAnimationFrame(() => {
+                    if (containerRef.current) {
+                      containerRef.current.scrollLeft = 0;
+                    }
+                  });
+                }}
                 placeholder={
                   hidePlaceholderWhenSelected && value.length > 0 ? undefined : placeholder
                 }


### PR DESCRIPTION
## Problem

When using `MultipleSelector` with multiple selected items and the `+n` overflow badge visible, clicking the ChevronDown icon caused a visual shift of the badges to the left.

The bug **did not reproduce** when all badges fit without the `+n` badge.

## Root Cause

The badge container (`<span ref={containerRef}>`) has `overflow-hidden` and a fixed width. It contains:

- Visible badges for selected items
- The `+n` badge (when not all fit)
- `<input>` with `min-w-[120px]`

When the `+n` badge is present, the total content width **exceeds** the container width. Calling `focus()` on the `<input>` triggers the browser's built-in behavior of **auto-scrolling** the parent container (`scrollLeft`) to make the focused element visible. This auto-scroll is what caused the visual badge shift.

Without the `+n` badge, the total content width didn't exceed the container, so there was nothing to scroll and the bug didn't manifest.

## Fix

Added a `scrollLeft` reset to `0` via `requestAnimationFrame` in the input's `onFocus` handler:

```tsx
onFocus={() => {
  setOpen(true);
  requestAnimationFrame(() => {
    if (containerRef.current) {
      containerRef.current.scrollLeft = 0;
    }
  });
}}
```

`requestAnimationFrame` is necessary because the browser performs the auto-scroll **after** the `focus` event. Resetting `scrollLeft` on the next animation frame ensures we undo the browser's auto-scroll after it has already occurred.

The same pattern was already used in the `onBlur` handler to reset scroll position when closing the dropdown.

## Files Changed

- `src/components/ui/multiselect.tsx` — `onFocus` handler of `CommandPrimitive.Input`
### Before
https://github.com/user-attachments/assets/968e4480-aea5-45ad-a5e0-ac8e95b8c280


### After
https://github.com/user-attachments/assets/9a9d8fd4-a6af-4d15-9de2-fdfc866c0d8e
