### PR TITLE
[SmartSearch]: fix result list scroll overflow and pin search input

### DIFF
--- a/src/Ivy.Docs.Shared/Internal/SmartSearch.cs
+++ b/src/Ivy.Docs.Shared/Internal/SmartSearch.cs
@@ -185,7 +185,6 @@ public class SmartSearchView : ViewBase
             : Text.Muted("Type to search or pick a suggestion above.");
 
         var overlayContent = Layout.Vertical().Gap(4)
-            | searchInput
             | overlayListOrPlaceholder;
 
         var footer = new DialogFooter(askButton);
@@ -209,6 +208,7 @@ public class SmartSearchView : ViewBase
             baseSlots.Add(new Slot(
                 "OverlayPanel",
                 new DialogHeader("Search"),
+                (Layout.Vertical().Padding(4) | searchInput),
                 new DialogBody(overlayContent),
                 footer));
             return new SmartSearch(baseSlots.ToArray());

--- a/src/frontend/src/docs-internal/SmartSearch.tsx
+++ b/src/frontend/src/docs-internal/SmartSearch.tsx
@@ -303,7 +303,9 @@ export const SmartSearch: React.FC<SmartSearchProps> = ({
             }}
             className={cn("alert-animate-enter", "!top-4 sm:!top-8 !translate-y-0")}
           >
-            <div data-smart-search-list>{overlayPanel}</div>
+            <div data-smart-search-list className="flex flex-col flex-1 min-h-0">
+              {overlayPanel}
+            </div>
           </DialogContent>
         </Dialog>
       )}


### PR DESCRIPTION
## Issue

When opening the Command Palette (Search) from the docs sidebar, the result list was not scrollable. If a search query returned many results, the list would overflow beyond the dialog boundaries, making the "Get an answer from Ivy Agent" button invisible and inaccessible. Additionally, users could not scroll back up to view the search bar after navigating down through results.

**Steps to reproduce:**
1. Open Command Palette (search in sidebar)
2. Enter a search query
3. List of items shown — items overflow beyond the dialog
4. Cannot scroll back up to view the search bar
5. AI search button ("Get an answer from Ivy Agent") is not visible

## Root Cause

The `data-smart-search-list` wrapper inside `DialogContent` was a plain `div` without flex layout properties. Since `DialogContent` uses `flex flex-col` with `max-h-[85vh]` and `overflow-hidden`, its child div needed to participate in flex layout to properly constrain height. Without this, `DialogBody`'s `flex-1` and `overflow-auto` had no effect — the content simply overflowed and was clipped.

Additionally, the search input was placed inside `DialogBody` alongside the result list, meaning it would scroll away with the results.

## Solution

### Frontend (`SmartSearch.tsx`)
Added `flex flex-col flex-1 min-h-0` to the `data-smart-search-list` container. This establishes a proper flex chain from `DialogContent` → `data-smart-search-list` → `DialogBody`, allowing `DialogBody` to correctly calculate its available height and enable `overflow-auto` scrolling.

### Backend (`SmartSearch.cs`)
Moved `searchInput` out of `DialogBody` and placed it as a separate element between `DialogHeader` and `DialogBody` in the overlay slot. This pins the search input at the top of the dialog while the result list scrolls independently inside `DialogBody`.

## What this fixes [IMPORTANT!]

- **Primary issue (#2730):** Users can now scroll back up to see the search bar after scrolling through results
- **Result list scrollability:** The result list is now properly scrollable within the dialog boundaries, respecting `max-h-[85vh]`
- **AI search button visibility:** The "Get an answer from Ivy Agent" footer button is now always visible at the bottom of the dialog, regardless of the number of results

https://github.com/user-attachments/assets/e30fd253-2226-4493-bdd6-c31cd763b602
