### PR TITLE
Add form-level LabelPosition API to FormBuilder

### DIFF
--- a/src/Ivy/Views/Forms/FormBuilder.cs
+++ b/src/Ivy/Views/Forms/FormBuilder.cs
@@ -17,6 +17,7 @@ public class FormBuilder<TModel> : ViewBase
 
     internal bool _formDisabled = false;
     internal Density _density = Ivy.Density.Medium;
+    internal LabelPosition? _labelPosition;
     internal Func<bool, Button> _submitBuilder = DefaultSubmitBuilder("Save");
     internal FormValidationStrategy _validationStrategy;
     internal FormSubmitStrategy _submitStrategy;
@@ -324,6 +325,19 @@ public class FormBuilder<TModel> : ViewBase
     public FormBuilder<TModel> Medium() => Density(Ivy.Density.Medium);
     public FormBuilder<TModel> Large() => Density(Ivy.Density.Large);
 
+    public FormBuilder<TModel> LabelPosition(LabelPosition position)
+    {
+        _labelPosition = position;
+        return this;
+    }
+
+    public FormBuilder<TModel> LabelPosition(Expression<Func<TModel, object>> field, LabelPosition position)
+    {
+        var hint = GetField(field);
+        hint.LabelPosition = position;
+        return this;
+    }
+
     private FormBuilderField<TModel> GetField<TU>(Expression<Func<TModel, TU>> field)
     {
         var name = TypeHelper.GetNameFromMemberExpression(field.Body);
@@ -352,6 +366,7 @@ public class FormBuilder<TModel> : ViewBase
             .Where(e => e is { Removed: false, InputFactory: not null })
             .Select(e =>
             {
+                var effectiveLabelPosition = e.LabelPosition ?? _labelPosition;
                 IFormFieldBinding<TModel> binding = new FormFieldBinding<TModel>(
                     CreateSelector(e.Name),
                     e.InputFactory!,
@@ -369,7 +384,8 @@ public class FormBuilder<TModel> : ViewBase
                     e.Help,
                     e.Placeholder,
                     _submitStrategy,
-                    e.Disabled || _formDisabled
+                    e.Disabled || _formDisabled,
+                    effectiveLabelPosition
                 );
                 return binding;
             })

--- a/src/Ivy/Views/Forms/FormBuilderField.cs
+++ b/src/Ivy/Views/Forms/FormBuilderField.cs
@@ -47,5 +47,7 @@ public class FormBuilderField<TModel>(
 
     public bool Required { get; set; } = required;
 
+    public LabelPosition? LabelPosition { get; set; }
+
     public List<Func<object?, (bool, string)>> Validators { get; set; } = new();
 }

--- a/src/Ivy/Views/Forms/FormView.cs
+++ b/src/Ivy/Views/Forms/FormView.cs
@@ -56,7 +56,8 @@ public class FormFieldView(
     FormValidationStrategy validationStrategy = FormValidationStrategy.OnBlur,
     Density density = Density.Medium,
     FormSubmitStrategy submitStrategy = FormSubmitStrategy.OnSubmit,
-    bool disabled = false)
+    bool disabled = false,
+    LabelPosition? labelPosition = null)
     : ViewBase, IFormFieldView
 {
     public FormFieldLayoutOptions Layout { get; } = layoutOptions ?? new FormFieldLayoutOptions(Guid.NewGuid());
@@ -167,7 +168,12 @@ public class FormFieldView(
             WidgetBaseExtensions.SetDensityViaReflection(input, density);
         }
 
-        return visibleState.Value ? new Field(input, label, description, required, help, density) : null;
+        var field = new Field(input, label, description, required, help, density);
+        if (labelPosition.HasValue)
+        {
+            field = field with { LabelPosition = labelPosition.Value };
+        }
+        return visibleState.Value ? field : null;
     }
 }
 
@@ -190,13 +196,14 @@ public class FormFieldBinding<TModel>(
     string? help = null,
     string? placeholder = null,
     FormSubmitStrategy submitStrategy = FormSubmitStrategy.OnSubmit,
-    bool disabled = false
+    bool disabled = false,
+    LabelPosition? labelPosition = null
     ) : IFormFieldBinding<TModel>
 {
     public (IFormFieldView, IDisposable) Bind(IState<TModel> model)
     {
         var (fieldState, disposable) = StateHelpers.MemberState(model, selector);
-        var fieldView = new FormFieldView(fieldState, factory, visible, updateSignal, formValidationSignal, formSubmitSignal, label, description, help, placeholder, required, layoutOptions, validators, validationStrategy, density, submitStrategy, disabled);
+        var fieldView = new FormFieldView(fieldState, factory, visible, updateSignal, formValidationSignal, formSubmitSignal, label, description, help, placeholder, required, layoutOptions, validators, validationStrategy, density, submitStrategy, disabled, labelPosition);
         return (fieldView, disposable);
     }
 }


### PR DESCRIPTION
## Summary
- Add form-level LabelPosition API to FormBuilder, allowing default label position for all fields with per-field overrides

Closes #2635