### PR TITLE
Fix Radix accessibility warnings on dialogs

### DIFF
--- a/src/frontend/src/widgets/dialogs/DialogWidget.tsx
+++ b/src/frontend/src/widgets/dialogs/DialogWidget.tsx
@@ -20,7 +20,11 @@ export const DialogWidget: React.FC<DialogWidgetProps> = ({ id, children, width 
 
   return (
     <Dialog open={true} onOpenChange={() => eventHandler("OnClose", id, [])}>
-      <DialogContent style={styles} className={cn(isVisible && "alert-animate-enter")}>
+      <DialogContent
+        style={styles}
+        className={cn(isVisible && "alert-animate-enter")}
+        aria-describedby={undefined}
+      >
         {children}
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
## Summary
- Pass aria-describedby={undefined} to DialogContent to suppress Radix UI console warning about missing Description on WithConfirm dialogs

Closes #2755