### PR TITLE
Fix textarea resize marker size and value/placeholder font consistency

### DIFF
--- a/src/frontend/src/components/ui/textarea/textarea.css
+++ b/src/frontend/src/components/ui/textarea/textarea.css
@@ -23,8 +23,8 @@
     z-index: 10;
   }
   .ivy-textarea-wrapper::after {
-    width: 8px;
-    bottom: 8px;
+    width: 6px;
+    bottom: 7px;
     right: 2px;
   }
   .ivy-textarea-wrapper:has(.resize-none)::before,

--- a/src/frontend/src/components/ui/textarea/textarea.tsx
+++ b/src/frontend/src/components/ui/textarea/textarea.tsx
@@ -10,7 +10,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, React.ComponentProps<"tex
       <div className="ivy-textarea-wrapper relative w-full h-full">
         <textarea
           className={cn(
-            "ivy-textarea flex min-h-[60px] w-full rounded-field border border-input px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 dark:border-white/10",
+            "ivy-textarea flex min-h-[60px] w-full rounded-field border border-input px-3 py-2 shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 dark:border-white/10",
             className,
           )}
           ref={ref}


### PR DESCRIPTION
## Summary
- Reduced textarea resize grip marker length from 8px to 6px and adjusted bottom offset from 8px to 7px for better proportions
- Removed hardcoded `text-sm` class so value text font size matches placeholder text (both now inherit from the size variant/density prop)

## Review result
`npm run build` clean (7463 modules, no errors). No bugs, logic errors, or edge cases found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)