### PR TITLE
EventDispatchQueue race condition fix

### DIFF
--- a/src/Ivy/Core/EventDispatchQueue.cs
+++ b/src/Ivy/Core/EventDispatchQueue.cs
@@ -68,6 +68,8 @@ public sealed class EventDispatchQueue : IDisposable
     public void Dispose()
     {
         _disposed = true;
+
+        // Signal cancellation
         try
         {
             _cts.Cancel();
@@ -77,6 +79,7 @@ public sealed class EventDispatchQueue : IDisposable
             // ignored
         }
 
+        // Complete the channel so the worker knows to stop
         try
         {
             _channel.Writer.TryComplete();
@@ -86,15 +89,25 @@ public sealed class EventDispatchQueue : IDisposable
             // ignored
         }
 
+        // Wait for the worker to actually complete before disposing CTS
+        var workerCompleted = false;
         try
         {
-            _worker.Wait(TimeSpan.FromSeconds(2));
+            // Wait returns true if task completed, false if timeout
+            workerCompleted = _worker.Wait(TimeSpan.FromSeconds(5));
         }
-        catch
+        catch (AggregateException)
         {
-            // ignored
+            // Task completed with exception (expected for cancelled tasks)
+            workerCompleted = true;
         }
 
-        _cts.Dispose();
+        // Only dispose CTS if worker has actually stopped to prevent race condition
+        if (workerCompleted)
+        {
+            _cts.Dispose();
+        }
+        // If timeout occurred, don't dispose - prevents accessing disposed CTS
+        // The CTS will be finalized by GC, avoiding unobserved task exceptions
     }
 }


### PR DESCRIPTION
## Summary

Fixes EventDispatchQueue disposal race condition during server shutdown.

This critical fix prevents race conditions that could occur when the server is shutting down and the event dispatch queue is being disposed.