### PR TITLE
refactor: clean up CodeBlockWidget formatting

### DIFF
--- a/src/frontend/src/widgets/primitives/CodeBlockWidget.tsx
+++ b/src/frontend/src/widgets/primitives/CodeBlockWidget.tsx
@@ -145,14 +145,7 @@ const CodeWidget: React.FC<CodeWidgetProps> = memo(
     const highlighterKey = useMemo(
       () =>
         `${id}-${mapLanguageToPrism(language)}-${showLineNumbers}-${showBorder}-${startingLineNumber}-${wrapLines}`,
-      [
-        id,
-        language,
-        showLineNumbers,
-        showBorder,
-        startingLineNumber,
-        wrapLines,
-      ],
+      [id, language, showLineNumbers, showBorder, startingLineNumber, wrapLines],
     );
 
     const dynamicTheme = useMemo(() => createPrismTheme(), []);
@@ -169,9 +162,7 @@ const CodeWidget: React.FC<CodeWidgetProps> = memo(
 
     return (
       <div className="relative" style={containerStyles}>
-        {showCopyButton && (
-          <MemoizedCopyButton textToCopy={content} density={density} />
-        )}
+        {showCopyButton && <MemoizedCopyButton textToCopy={content} density={density} />}
         <ScrollArea
           className={cn(
             "w-full",
@@ -199,11 +190,7 @@ const CodeWidget: React.FC<CodeWidgetProps> = memo(
               wrapLongLines={wrapLines}
               key={highlighterKey}
               codeTagProps={{ style: codeTagStyle }}
-              lineProps={
-                showLineNumbers
-                  ? { style: { display: "table-row" } }
-                  : undefined
-              }
+              lineProps={showLineNumbers ? { style: { display: "table-row" } } : undefined}
               lineNumberStyle={
                 showLineNumbers
                   ? {


### PR DESCRIPTION
## Summary

Cleans up formatting in CodeBlockWidget component - consolidates multi-line JSX expressions to single lines for better readability.