### PR TITLE
fix(tiptap): remove default export to eliminate MIXED_EXPORTS warning

### DIFF
--- a/src/widgets/Ivy.Widgets.Tiptap/frontend/src/index.ts
+++ b/src/widgets/Ivy.Widgets.Tiptap/frontend/src/index.ts
@@ -10,9 +10,7 @@ import { TiptapInput } from "./TiptapInput";
 if (typeof window !== "undefined") {
   (window as unknown as Record<string, unknown>).TiptapInput = {
     TiptapInput,
-    default: TiptapInput,
   };
 }
 
 export { TiptapInput };
-export { TiptapInput as default };


### PR DESCRIPTION
## Summary

Removes the default export from the Tiptap widget's frontend entry point to eliminate the `MIXED_EXPORTS` bundler warning. The module was exporting `TiptapInput` as both a named and default export, which triggers warnings in bundlers like esbuild/Rollup about mixing export styles. The named export alone is sufficient since consumers already use it by name.