### PR TITLE
avatar widget api needs to support different colors

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/08_Avatar.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/08_Avatar.md
@@ -101,4 +101,16 @@ public class AvatarAsFoodIcon : ViewBase
 
 ```
 
+## Colors
+
+Avatars support custom colors using the `.Color()` and `.Background()` extension methods.
+
+```csharp demo-tabs
+Layout.Horizontal()
+    | new Avatar("Niels Bosma").Color(Colors.Primary)
+    | new Avatar("Mikael Rinne").Background(Colors.Destructive)
+    | new Avatar("Renco Smeding").Color(Colors.Info)
+    | new Avatar("Jesper").Background(Colors.Warning)
+```
+
 <WidgetDocs Type="Ivy.Avatar" ExtensionTypes="Ivy.AvatarExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Primitives/Avatar.cs"/>

--- a/src/Ivy/Widgets/Primitives/Avatar.cs
+++ b/src/Ivy/Widgets/Primitives/Avatar.cs
@@ -21,6 +21,10 @@ public record Avatar : WidgetBase<Avatar>
     [Prop] public string Fallback { get; set; } = string.Empty;
 
     [Prop] public string? Image { get; set; }
+
+    [Prop] public Colors? Color { get; set; }
+
+    [Prop] public Colors? Background { get; set; }
 }
 
 public static class AvatarExtensions
@@ -28,4 +32,8 @@ public static class AvatarExtensions
     public static Avatar Fallback(this Avatar avatar, string fallback) => avatar with { Fallback = fallback };
 
     public static Avatar Image(this Avatar avatar, string? image) => avatar with { Image = image };
+
+    public static Avatar Color(this Avatar avatar, Colors? color) => avatar with { Color = color };
+
+    public static Avatar Background(this Avatar avatar, Colors? background) => avatar with { Background = background };
 }

--- a/src/frontend/src/widgets/primitives/AvatarWidget.tsx
+++ b/src/frontend/src/widgets/primitives/AvatarWidget.tsx
@@ -1,9 +1,12 @@
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { getColor } from "@/lib/styles";
 import React from "react";
 
 interface AvatarWidgetProps {
   image: string;
   fallback: string;
+  color?: string;
+  background?: string;
 }
 
 // Utility function to extract initials from a full name
@@ -13,12 +16,16 @@ const getInitials = (name: string): string => {
   return initials;
 };
 
-export const AvatarWidget: React.FC<AvatarWidgetProps> = ({ image, fallback }) => {
+export const AvatarWidget: React.FC<AvatarWidgetProps> = ({ image, fallback, color, background }) => {
   const displayFallback = fallback?.length === 2 ? fallback : getInitials(fallback || "");
+  const fallbackStyle = {
+    ...getColor(color, "color", "background"),
+    ...getColor(background, "backgroundColor", "background"),
+  };
   return (
     <Avatar>
       <AvatarImage src={image} title={fallback} />
-      <AvatarFallback title={fallback}>{displayFallback}</AvatarFallback>
+      <AvatarFallback title={fallback} style={fallbackStyle}>{displayFallback}</AvatarFallback>
     </Avatar>
   );
 };


### PR DESCRIPTION
## Summary
- Added `Color` and `Background` properties to the Avatar widget C# API with fluent extension methods
- Updated the React frontend `AvatarWidget` to apply color/background via inline styles using `getColor` utility
- Added documentation with demo showing avatars with different color and background values

## Review
PASS — Implementation follows established patterns (Colors? props matching Icon, TextBlock, Box; getColor utility for frontend color resolution).

## Test plan
- [x] C# build: succeeded (0 warnings, 0 errors)
- [x] dotnet test: Passed (8/8 tests)
- [x] No new TypeScript errors in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)