### PR TITLE
docs: add supported languages list to CodeInput and CodeBlock

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/10_CodeBlock.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/10_CodeBlock.md
@@ -63,5 +63,33 @@ Layout.Vertical()
       .Language(Languages.Csharp)
 ```
 
+## Supported Languages
+
+<Details>
+<Summary>
+Detailed language support
+</Summary>
+<Body>
+
+The `CodeBlock` widget supports syntax highlighting and formatting for the following languages via the `Languages` enum:
+
+- `Csharp`
+- `Javascript`
+- `Typescript`
+- `Python`
+- `Sql`
+- `Html`
+- `Css`
+- `Json`
+- `Dbml`
+- `Markdown` (standard markdown with code block support)
+- `Text` (plain text with monospaced font)
+- `Xml`
+- `Yaml`
+- `Csv`
+
+</Body>
+</Details>
+
 <WidgetDocs Type="Ivy.CodeBlock" ExtensionTypes="Ivy.CodeBlockExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Primitives/CodeBlock.cs"/>
 

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/04_Inputs/11_CodeInput.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/04_Inputs/11_CodeInput.md
@@ -187,4 +187,32 @@ public class CodeInputWithValidation : ViewBase
 }
 ```
 
+## Supported Languages
+
+<Details>
+<Summary>
+Detailed language support
+</Summary>
+<Body>
+
+The `CodeInput` widget supports syntax highlighting and formatting for the following languages via the `Languages` enum:
+
+- `Csharp`
+- `Javascript`
+- `Typescript`
+- `Python`
+- `Sql`
+- `Html`
+- `Css`
+- `Json`
+- `Dbml`
+- `Markdown` (standard markdown with code block support)
+- `Text` (plain text with monospaced font)
+- `Xml`
+- `Yaml`
+- `Csv`
+
+</Body>
+</Details>
+
 <WidgetDocs Type="Ivy.CodeInput" ExtensionTypes="Ivy.CodeInputExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Inputs/CodeInput.cs"/>


### PR DESCRIPTION
Resolves #95. Adds a comprehensive list of supported languages to the documentation for CodeInput and CodeBlock widgets to improve [38;5;9mError:[0m Command 'question' is missing required argument
'QUESTION'. results.