### PR TITLE
Rename query parameter from ?appshell to ?shell

### DIFF
--- a/src/.releases/Refactors/1.2.26/Shorten-AppShell-Parameter.md
+++ b/src/.releases/Refactors/1.2.26/Shorten-AppShell-Parameter.md
@@ -1,0 +1,34 @@
+# Shorten AppShell Query Parameter
+
+## Summary
+
+The query parameter for controlling AppShell visibility has been shortened from `?appshell=false` to `?shell=false` for better usability and conciseness.
+
+## What Changed
+
+### Frontend (TypeScript)
+- Query parameter `?appshell=true|false` renamed to `?shell=true|false`
+- Utility function `getAppShellParam()` renamed to `getShellParam()`
+
+### Backend (C#)
+- URL generation updated to use `shell=false` instead of `appshell=false`
+- Query parameter parsing updated to read `shell` instead of `appshell`
+
+## Before
+
+```typescript
+const isAppShell = getAppShellParam();
+// URL: http://localhost:5000?appshell=false
+```
+
+## After
+
+```typescript
+const isShell = getShellParam();
+// URL: http://localhost:5000?shell=false
+```
+
+## Migration Path
+
+1. **Update URL parameters**: Replace `?appshell=false` with `?shell=false` in bookmarks, tests, and documentation
+2. **Update code**: Replace `getAppShellParam()` calls with `getShellParam()` in custom frontend code

--- a/src/Ivy/AppShell/Shared.cs
+++ b/src/Ivy/AppShell/Shared.cs
@@ -108,7 +108,7 @@ public record NavigateArgs(string? AppId, object? AppArgs = null, string? TabId 
 
         if (!this.AppShell)
         {
-            queryParams.Add("appshell=false");
+            queryParams.Add("shell=false");
         }
 
         if (queryParams.Any())

--- a/src/Ivy/Core/Apps/AppRouter.cs
+++ b/src/Ivy/Core/Apps/AppRouter.cs
@@ -37,7 +37,7 @@ public class AppRouter(global::Ivy.Server server)
 
     private static bool GetAppShell(HttpContext httpContext)
     {
-        if (httpContext.Request.Query.TryGetValue("appshell", out var appShellParam))
+        if (httpContext.Request.Query.TryGetValue("shell", out var appShellParam))
         {
             return !appShellParam.ToString().Equals("false", StringComparison.OrdinalIgnoreCase);
         }

--- a/src/frontend/e2e/samples/widgets/data-table.spec.ts
+++ b/src/frontend/e2e/samples/widgets/data-table.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from "@playwright/test";
 
 test.describe("DataTable Widget Tests", () => {
   test.skip("should navigate to data table page and find element by testId", async ({ page }) => {
-    await page.goto("/widgets/data-table?chrome=false");
+    await page.goto("/widgets/data-table?shell=false");
     await page.waitForLoadState("networkidle");
     const dataTable = page.getByTestId("data-table");
     await expect(dataTable).toBeVisible();

--- a/src/frontend/src/components/App.tsx
+++ b/src/frontend/src/components/App.tsx
@@ -9,7 +9,7 @@ import { DevTools } from "./DevTools";
 import {
   getAppArgs,
   getAppId,
-  getAppShellParam,
+  getShellParam,
   getParentId,
   wrapAppContent,
   isDevToolsEnabled,
@@ -24,7 +24,7 @@ export function App() {
   const appId = getAppId();
   const appArgs = getAppArgs();
   const parentId = getParentId();
-  const appShell = getAppShellParam();
+  const appShell = getShellParam();
 
   const { connection, widgetTree, eventHandler, subscribeToStream, disconnected } = useBackend(
     appId,
@@ -40,7 +40,7 @@ export function App() {
 
   useEffect(() => {
     const handlePopState = (event: PopStateEvent) => {
-      const appShell = getAppShellParam();
+      const appShell = getShellParam();
       if (appShell) {
         const newAppId = getAppId();
         connection?.invoke("Navigate", newAppId, event.state).catch((err) => {

--- a/src/frontend/src/components/MarkdownRenderer.tsx
+++ b/src/frontend/src/components/MarkdownRenderer.tsx
@@ -270,7 +270,7 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content, onLinkClic
         // Convert app:// URLs to regular paths for href attribute
         let hrefForNavigation = safeHref;
         if (isApp) {
-          // Use the utility function to convert app:// URLs, preserving appshell=false
+          // Use the utility function to convert app:// URLs, preserving shell=false
           hrefForNavigation = convertAppUrlToPath(safeHref);
         }
 

--- a/src/frontend/src/hooks/use-backend.tsx
+++ b/src/frontend/src/hooks/use-backend.tsx
@@ -678,7 +678,7 @@ export const useBackend = (
     const oauthLogin = pageParams.get("oauthLogin");
 
     // Build SignalR connection URL
-    let signalRUrl = `${getIvyHost()}/ivy/messages?appId=${latestAppIdRef.current ?? ""}&appArgs=${appArgs ?? ""}&machineId=${machineId}&parentId=${parentId ?? ""}&appshell=${latestAppShellRef.current}`;
+    let signalRUrl = `${getIvyHost()}/ivy/messages?appId=${latestAppIdRef.current ?? ""}&appArgs=${appArgs ?? ""}&machineId=${machineId}&parentId=${parentId ?? ""}&shell=${latestAppShellRef.current}`;
     if (oauthLogin) {
       signalRUrl += `&oauthLogin=${oauthLogin}`;
       // Clean up the URL by removing the oauthLogin parameter

--- a/src/frontend/src/lib/utils.ts
+++ b/src/frontend/src/lib/utils.ts
@@ -59,9 +59,9 @@ export function getParentId(): string | null {
   return urlParams.get("parentId");
 }
 
-export function getAppShellParam(): boolean {
+export function getShellParam(): boolean {
   const urlParams = new URLSearchParams(window.location.search);
-  return urlParams.get("appshell")?.toLowerCase() !== "false";
+  return urlParams.get("shell")?.toLowerCase() !== "false";
 }
 
 export function wrapAppContent(content: React.ReactNode): React.ReactNode {
@@ -70,10 +70,10 @@ export function wrapAppContent(content: React.ReactNode): React.ReactNode {
 
 /**
  * Converts an app:// URL to a regular browser path.
- * Preserves query parameters from the current URL (especially appshell=false) when in appshell=false mode.
+ * Preserves query parameters from the current URL (especially shell=false) when in shell=false mode.
  *
  * @param appUrl - The app:// URL to convert (e.g., "app://MyApp" or "app://MyApp?param=value")
- * @returns The converted path (e.g., "/MyApp" or "/MyApp?param=value&appshell=false")
+ * @returns The converted path (e.g., "/MyApp" or "/MyApp?param=value&shell=false")
  */
 /**
  * Extracts the content after the app:// protocol prefix using regex.
@@ -96,15 +96,15 @@ export function convertAppUrlToPath(appUrl: string): string {
   // Build the path
   let path = `/${appPath}`;
 
-  // Preserve appshell=false if we're currently in appshell=false mode
-  const isAppShellFalse = !getAppShellParam();
+  // Preserve shell=false if we're currently in shell=false mode
+  const isShellFalse = !getShellParam();
   const queryParams = new URLSearchParams(existingQueryString || "");
 
-  if (isAppShellFalse && !queryParams.has("appshell")) {
-    queryParams.set("appshell", "false");
+  if (isShellFalse && !queryParams.has("shell")) {
+    queryParams.set("shell", "false");
   }
 
-  // Combine existing query params with appshell param
+  // Combine existing query params with shell param
   const finalQueryString = queryParams.toString();
   if (finalQueryString) {
     path += `?${finalQueryString}`;

--- a/src/frontend/src/widgets/article/ArticleFooter.tsx
+++ b/src/frontend/src/widgets/article/ArticleFooter.tsx
@@ -1,7 +1,7 @@
 import { InternalLink } from "@/types/widgets";
 import { Github } from "lucide-react";
 import React from "react";
-import { convertAppUrlToPath, getAppShellParam } from "@/lib/utils";
+import { convertAppUrlToPath, getShellParam } from "@/lib/utils";
 
 interface ArticleFooterProps {
   id: string;
@@ -20,7 +20,7 @@ export const ArticleFooter: React.FC<ArticleFooterProps> = ({
 }) => {
   const handleLinkClick = (appId: string, event: React.MouseEvent<HTMLAnchorElement>) => {
     // When appShell is disabled, use browser navigation
-    if (!getAppShellParam()) {
+    if (!getShellParam()) {
       return;
     }
 


### PR DESCRIPTION
## Summary

- Shorten the `?appshell` query parameter to `?shell` for better usability
- Update all frontend and backend references to use the new parameter name
- Add release note for the refactor

Closes #2679