### PR TITLE
Add HTML5 details/summary tag support in Markdown

### DIFF
--- a/src/frontend/src/components/MarkdownRenderer.tsx
+++ b/src/frontend/src/components/MarkdownRenderer.tsx
@@ -207,6 +207,26 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content, onLinkClic
       hr: memo((props: React.HTMLAttributes<HTMLHRElement>) => (
         <hr className={typography.hr} {...props} />
       )),
+      details: memo(({ children, ...props }: React.DetailsHTMLAttributes<HTMLDetailsElement>) => (
+        <details className={typography.details} {...props}>
+          {children}
+        </details>
+      )),
+      summary: memo(({ children, ...props }: React.HTMLAttributes<HTMLElement>) => (
+        <summary className={typography.summary} {...props}>
+          <div className="flex items-center gap-2">
+            <svg
+              className="h-4 w-4 shrink-0 transition-transform [[open]>summary_&]:rotate-90"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+            </svg>
+            {children}
+          </div>
+        </summary>
+      )),
     }),
     [
       typography.h1,
@@ -227,6 +247,8 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content, onLinkClic
       typography.th,
       typography.img,
       typography.hr,
+      typography.details,
+      typography.summary,
     ],
   );
 

--- a/src/frontend/src/index.css
+++ b/src/frontend/src/index.css
@@ -368,6 +368,20 @@ ivy-widget {
   }
 }
 
+/* Details/Summary styling for markdown collapsible sections */
+details > :not(summary) {
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+details > :last-child {
+  padding-bottom: 1rem;
+}
+
+details[open] summary svg {
+  transform: rotate(90deg);
+}
+
 /* Prevent dialog from getting focus rings when elements inside are focused */
 @layer components {
   [data-radix-dialog-content] {

--- a/src/frontend/src/lib/styles.ts
+++ b/src/frontend/src/lib/styles.ts
@@ -709,6 +709,11 @@ export const typography: Record<string, string> = {
   // Media
   img: "max-w-full h-auto cursor-zoom-in",
   hr: "border-t border-border",
+
+  // Expandable sections
+  details: "my-4 rounded-lg border border-border bg-card shadow-sm overflow-hidden",
+  summary:
+    "cursor-pointer select-none px-4 py-3 font-medium hover:bg-accent/50 transition-colors list-none [&::-webkit-details-marker]:hidden",
 };
 
 export const articleTypography: Record<string, string> = {


### PR DESCRIPTION
## Summary

- Add support for HTML5 `<details>` and `<summary>` tags in the Markdown renderer
- Enables collapsible sections in markdown content