### PR TITLE
Fix MultipleSelector dropdown scroll position on open

### DIFF
--- a/src/frontend/src/components/ui/multiselect.tsx
+++ b/src/frontend/src/components/ui/multiselect.tsx
@@ -111,6 +111,17 @@ const MultipleSelector = React.forwardRef<
     }, [open]);
 
     React.useEffect(() => {
+      if (open && dropdownRef.current) {
+        requestAnimationFrame(() => {
+          const scrollableElement = dropdownRef.current?.querySelector("[cmdk-group]");
+          if (scrollableElement) {
+            scrollableElement.scrollTop = 0;
+          }
+        });
+      }
+    }, [open]);
+
+    React.useEffect(() => {
       if (maxVisibleBadges !== undefined) {
         setVisibleCount(maxVisibleBadges);
         return;


### PR DESCRIPTION
## Summary

- Reset scroll position to top when MultipleSelector dropdown opens, preventing it from retaining scroll position from previous interactions