### PR TITLE
Fix shell=false query parameter app selection

### DIFF
--- a/src/Ivy/Core/Apps/AppRouter.cs
+++ b/src/Ivy/Core/Apps/AppRouter.cs
@@ -132,7 +132,7 @@ public class AppRouter(global::Ivy.Server server)
 
             if (appId == AppIds.AppShell && (parentId != null || !appShell))
             {
-                appId = appShellDefaultAppId;
+                appId = appShellDefaultAppId ?? GetFirstVisibleAppId();
             }
             else if (appShell && navigationAppId == null)
             {
@@ -248,5 +248,15 @@ public class AppRouter(global::Ivy.Server server)
             return appShellView.Settings.DefaultAppId;
         }
         return null;
+    }
+
+    private string? GetFirstVisibleAppId()
+    {
+        return server.AppRepository.All()
+            .Where(app => app.IsVisible && !AppIds.ShouldNotBeAutoDefaultApps.Contains(app.Id))
+            .OrderBy(app => app.Order)
+            .ThenBy(app => app.Title)
+            .Select(app => app.Id)
+            .FirstOrDefault();
     }
 }


### PR DESCRIPTION
## Summary
- Fix ?shell=false query parameter to select the first visible app when AppShell DefaultAppId is not configured