### PR TITLE
Fix UseDownload overload ambiguity

### DIFF
--- a/src/Ivy/Core/ViewBase.Hooks.cs
+++ b/src/Ivy/Core/ViewBase.Hooks.cs
@@ -131,12 +131,14 @@ public abstract partial class ViewBase
         where TKey : notnull =>
         this.Context.UseMutation<TValue, TKey>(key, options);
 
+    [OverloadResolutionPriority(1)]
     protected IState<string?> UseDownload(Func<byte[]> factory, string mimeType, string fileName) =>
         this.Context.UseDownload(() => Task.FromResult(factory()), mimeType, fileName);
 
     protected IState<string?> UseDownload(Func<Task<byte[]>> factory, string mimeType, string fileName) =>
         this.Context.UseDownload(factory, mimeType, fileName);
 
+    [OverloadResolutionPriority(1)]
     protected IState<string?> UseDownload(Func<Stream> factory, string mimeType, string fileName) =>
         this.Context.UseDownload(() => Task.FromResult(factory()), mimeType, fileName);
 


### PR DESCRIPTION
## Summary
- Add OverloadResolutionPriority to sync UseDownload overloads to fix CS0121 ambiguity error