### PR TITLE
fix: add SignalR id to reserved query params

### DIFF
--- a/src/Ivy/Core/Server/AppHub.cs
+++ b/src/Ivy/Core/Server/AppHub.cs
@@ -26,7 +26,7 @@ public class AppHub(
 {
     private static readonly HashSet<string> ReservedQueryParams = new(StringComparer.OrdinalIgnoreCase)
     {
-        "appId", "machineId", "parentId", "shell", "appArgs", "oauthLogin"
+        "appId", "machineId", "parentId", "shell", "appArgs", "oauthLogin", "id"
     };
 
     private AppContext GetAppArgs(string connectionId, string machineId, string appId, string? navigationAppId, HttpContext httpContext, string requestScheme)


### PR DESCRIPTION
## Summary
- The SignalR connection negotiation sends an `id` query parameter on the HTTP request
- `AppHub.GetAppArgs()` was picking this up and building `{"id":"..."}` as the app args JSON
- This prevented the fallback to `server.Args.Args` (the actual `StudioAppArgs`), causing `BaseUrl` and `ProjectDirectory` to be empty strings
- Adds `"id"` to the `ReservedQueryParams` hashset so it's excluded from auto-built query args

## Test plan
- [ ] Open Ivy Studio locally — sidebar should show projects, model selector should render
- [ ] Verify other apps using `UseArgs<T>()` still receive correct args

🤖 Generated with [Claude Code](https://claude.com/claude-code)