### PR TITLE
fix: handle exceptions in WidgetSerializer default value comparison

### DIFF
--- a/src/Ivy/Core/WidgetSerializer.cs
+++ b/src/Ivy/Core/WidgetSerializer.cs
@@ -80,7 +80,16 @@ public static class WidgetSerializer
             if (property.Get == null)
                 continue;
 
-            var defaultValue = property.Get(defaultInstance);
+            object? defaultValue;
+            try
+            {
+                defaultValue = property.Get(defaultInstance);
+            }
+            catch
+            {
+                continue;
+            }
+
             property.ShouldSerialize = (_, currentValue) => !ValuesAreEqual(currentValue, defaultValue);
         }
     }


### PR DESCRIPTION
## Summary

- **Fixes a crash** (`InvalidOperationException: Trying to access an uninitialized WidgetBase Id`) that occurs when `System.Text.Json` lazily builds type metadata during the first serialization of an `AbstractWidget` subclass (e.g. `Button`)
- The `AddDefaultValueComparison` modifier constructs a default instance of each type to compare property values for diff-based serialization. This default instance is never registered in the widget tree, so its `Id` is null — and the `Id` getter throws by design as a safety check for real widgets
- Wraps `property.Get(defaultInstance)` in a try-catch so properties that throw on uninitialized instances are skipped (always serialized), preserving the safety check on `Id` for actual widget usage

## Test plan

- [x] `dotnet build` passes
- [ ] Verify the crash no longer occurs when serializing a widget type for the first time in a fresh process

🤖 Generated with [Claude Code](https://claude.com/claude-code)