### PR TITLE
fix(fe): resolve lodash-es Prototype Pollution (alert 62)

### DIFF
--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -125,18 +125,6 @@
     "vite-plus": "0.1.13",
     "vitest": "npm:@voidzero-dev/vite-plus-test@0.1.13"
   },
-  "overrides": {
-    "@swc/helpers": "0.5.17",
-    "dompurify": "3.3.2",
-    "lodash-es": "4.17.23",
-    "minimatch": "9.0.7",
-    "remark-mermaid-plugin": {
-      "mermaid": "11.12.1"
-    },
-    "rollup": ">=4.59.0",
-    "vite": "npm:@voidzero-dev/vite-plus-core@0.1.13",
-    "vitest": "npm:@voidzero-dev/vite-plus-test@0.1.13"
-  },
   "lint-staged": {
     "src/**/*.{js,jsx,ts,tsx}": [
       "vp lint --fix",
@@ -146,5 +134,17 @@
       "vp fmt"
     ]
   },
-  "packageManager": "pnpm@10.32.1"
+  "packageManager": "pnpm@10.32.1",
+  "pnpm": {
+    "overrides": {
+      "@swc/helpers": "0.5.17",
+      "dompurify": "3.3.2",
+      "lodash-es": "4.17.23",
+      "minimatch": "9.0.7",
+      "remark-mermaid-plugin>mermaid": "11.12.1",
+      "rollup": ">=4.59.0",
+      "vite": "npm:@voidzero-dev/vite-plus-core@0.1.13",
+      "vitest": "npm:@voidzero-dev/vite-plus-test@0.1.13"
+    }
+  }
 }

--- a/src/frontend/pnpm-lock.yaml
+++ b/src/frontend/pnpm-lock.yaml
@@ -4,6 +4,16 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@swc/helpers': 0.5.17
+  dompurify: 3.3.2
+  lodash-es: 4.17.23
+  minimatch: 9.0.7
+  remark-mermaid-plugin>mermaid: 11.12.1
+  rollup: '>=4.59.0'
+  vite: npm:@voidzero-dev/vite-plus-core@0.1.13
+  vitest: npm:@voidzero-dev/vite-plus-test@0.1.13
+
 importers:
 
   .:
@@ -1942,11 +1952,13 @@ packages:
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
 
-  brace-expansion@2.0.2:
-    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+  brace-expansion@5.0.5:
+    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -2271,8 +2283,9 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
-  dompurify@3.3.3:
-    resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
+  dompurify@3.3.2:
+    resolution: {integrity: sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==}
+    engines: {node: '>=20'}
 
   echarts-for-react@3.0.5:
     resolution: {integrity: sha512-YpEI5Ty7O/2nvCfQ7ybNa+S90DwE8KYZWacGvJW4luUqywP7qStQ+pxDlYOmr4jGDu10mhEkiAuMKcUlT4W5vg==}
@@ -2739,9 +2752,6 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
-  lodash-es@4.17.21:
-    resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
-
   lodash-es@4.17.23:
     resolution: {integrity: sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==}
 
@@ -2934,8 +2944,8 @@ packages:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
 
-  minimatch@9.0.9:
-    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+  minimatch@9.0.7:
+    resolution: {integrity: sha512-MOwgjc8tfrpn5QQEvjijjmDVtMw2oL88ugTevzxQnzRLm6l3fVEF2gzU0kYeYYKD8C66+IdGX6peJ4MyUlUnPg==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   mlly@1.8.2:
@@ -3629,12 +3639,12 @@ snapshots:
     dependencies:
       '@chevrotain/gast': 11.0.3
       '@chevrotain/types': 11.0.3
-      lodash-es: 4.17.21
+      lodash-es: 4.17.23
 
   '@chevrotain/gast@11.0.3':
     dependencies:
       '@chevrotain/types': 11.0.3
-      lodash-es: 4.17.21
+      lodash-es: 4.17.23
 
   '@chevrotain/regexp-to-ast@11.0.3': {}
 
@@ -3933,7 +3943,7 @@ snapshots:
       '@linaria/core': 6.3.0
       '@wyw-in-js/processor-utils': 0.6.0
       '@wyw-in-js/shared': 0.6.0
-      minimatch: 9.0.9
+      minimatch: 9.0.7
       react: 19.2.3
       react-html-attributes: 1.4.6
       resolve: 1.22.11
@@ -5131,7 +5141,7 @@ snapshots:
     dependencies:
       debug: 4.4.3
       find-up: 5.0.0
-      minimatch: 9.0.9
+      minimatch: 9.0.7
     transitivePeerDependencies:
       - supports-color
 
@@ -5179,11 +5189,11 @@ snapshots:
 
   bail@2.0.2: {}
 
-  balanced-match@1.0.2: {}
+  balanced-match@4.0.4: {}
 
-  brace-expansion@2.0.2:
+  brace-expansion@5.0.5:
     dependencies:
-      balanced-match: 1.0.2
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -5226,7 +5236,7 @@ snapshots:
       '@chevrotain/regexp-to-ast': 11.0.3
       '@chevrotain/types': 11.0.3
       '@chevrotain/utils': 11.0.3
-      lodash-es: 4.17.21
+      lodash-es: 4.17.23
 
   class-variance-authority@0.7.1:
     dependencies:
@@ -5529,7 +5539,7 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  dompurify@3.3.3:
+  dompurify@3.3.2:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -5987,8 +5997,6 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
-  lodash-es@4.17.21: {}
-
   lodash-es@4.17.23: {}
 
   lodash.camelcase@4.3.0: {}
@@ -6208,7 +6216,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.13
       dayjs: 1.11.20
-      dompurify: 3.3.3
+      dompurify: 3.3.2
       katex: 0.16.25
       khroma: 2.1.0
       lodash-es: 4.17.23
@@ -6426,9 +6434,9 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
-  minimatch@9.0.9:
+  minimatch@9.0.7:
     dependencies:
-      brace-expansion: 2.0.2
+      brace-expansion: 5.0.5
 
   mlly@1.8.2:
     dependencies:

--- a/src/widgets/Ivy.Widgets.Leaflet/frontend/package.json
+++ b/src/widgets/Ivy.Widgets.Leaflet/frontend/package.json
@@ -28,10 +28,13 @@
     "react": "19.2.3",
     "react-dom": "19.2.3"
   },
-  "overrides": {
-    "rollup": ">=4.59.0",
-    "vite": "npm:@voidzero-dev/vite-plus-core@0.1.13",
-    "vitest": "npm:@voidzero-dev/vite-plus-test@0.1.13"
+  "pnpm": {
+    "overrides": {
+      "lodash-es": "4.17.23",
+      "rollup": ">=4.59.0",
+      "vite": "npm:@voidzero-dev/vite-plus-core@0.1.13",
+      "vitest": "npm:@voidzero-dev/vite-plus-test@0.1.13"
+    }
   },
   "packageManager": "pnpm@10.32.1"
 }

--- a/src/widgets/Ivy.Widgets.Leaflet/frontend/pnpm-lock.yaml
+++ b/src/widgets/Ivy.Widgets.Leaflet/frontend/pnpm-lock.yaml
@@ -4,6 +4,12 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  lodash-es: 4.17.23
+  rollup: '>=4.59.0'
+  vite: npm:@voidzero-dev/vite-plus-core@0.1.13
+  vitest: npm:@voidzero-dev/vite-plus-test@0.1.13
+
 importers:
 
   .:

--- a/src/widgets/Ivy.Widgets.ScreenshotFeedback/frontend/package.json
+++ b/src/widgets/Ivy.Widgets.ScreenshotFeedback/frontend/package.json
@@ -23,9 +23,12 @@
     "react": "19.2.4",
     "react-dom": "19.2.4"
   },
-  "overrides": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@0.1.13",
-    "vitest": "npm:@voidzero-dev/vite-plus-test@0.1.13"
+  "pnpm": {
+    "overrides": {
+      "lodash-es": "4.17.23",
+      "vite": "npm:@voidzero-dev/vite-plus-core@0.1.13",
+      "vitest": "npm:@voidzero-dev/vite-plus-test@0.1.13"
+    }
   },
   "packageManager": "pnpm@10.32.1"
 }

--- a/src/widgets/Ivy.Widgets.ScreenshotFeedback/frontend/pnpm-lock.yaml
+++ b/src/widgets/Ivy.Widgets.ScreenshotFeedback/frontend/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  lodash-es: 4.17.23
+  vite: npm:@voidzero-dev/vite-plus-core@0.1.13
+  vitest: npm:@voidzero-dev/vite-plus-test@0.1.13
+
 importers:
 
   .:

--- a/src/widgets/Ivy.Widgets.Tiptap/frontend/package.json
+++ b/src/widgets/Ivy.Widgets.Tiptap/frontend/package.json
@@ -30,11 +30,14 @@
     "react": "19.2.3",
     "react-dom": "19.2.3"
   },
-  "overrides": {
-    "markdown-it": ">=14.1.1",
-    "rollup": ">=4.59.0",
-    "vite": "npm:@voidzero-dev/vite-plus-core@0.1.13",
-    "vitest": "npm:@voidzero-dev/vite-plus-test@0.1.13"
+  "pnpm": {
+    "overrides": {
+      "lodash-es": "4.17.23",
+      "markdown-it": ">=14.1.1",
+      "rollup": ">=4.59.0",
+      "vite": "npm:@voidzero-dev/vite-plus-core@0.1.13",
+      "vitest": "npm:@voidzero-dev/vite-plus-test@0.1.13"
+    }
   },
   "packageManager": "pnpm@10.32.1"
 }

--- a/src/widgets/Ivy.Widgets.Tiptap/frontend/pnpm-lock.yaml
+++ b/src/widgets/Ivy.Widgets.Tiptap/frontend/pnpm-lock.yaml
@@ -4,6 +4,13 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  lodash-es: 4.17.23
+  markdown-it: '>=14.1.1'
+  rollup: '>=4.59.0'
+  vite: npm:@voidzero-dev/vite-plus-core@0.1.13
+  vitest: npm:@voidzero-dev/vite-plus-test@0.1.13
+
 importers:
 
   .:

--- a/src/widgets/Ivy.Widgets.Xterm/frontend/package.json
+++ b/src/widgets/Ivy.Widgets.Xterm/frontend/package.json
@@ -30,9 +30,12 @@
     "react": "19.2.3",
     "react-dom": "19.2.3"
   },
-  "overrides": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@0.1.13",
-    "vitest": "npm:@voidzero-dev/vite-plus-test@0.1.13"
+  "pnpm": {
+    "overrides": {
+      "lodash-es": "4.17.23",
+      "vite": "npm:@voidzero-dev/vite-plus-core@0.1.13",
+      "vitest": "npm:@voidzero-dev/vite-plus-test@0.1.13"
+    }
   },
   "packageManager": "pnpm@10.32.1"
 }

--- a/src/widgets/Ivy.Widgets.Xterm/frontend/pnpm-lock.yaml
+++ b/src/widgets/Ivy.Widgets.Xterm/frontend/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  lodash-es: 4.17.23
+  vite: npm:@voidzero-dev/vite-plus-core@0.1.13
+  vitest: npm:@voidzero-dev/vite-plus-test@0.1.13
+
 importers:
 
   .:


### PR DESCRIPTION
Fixes Dependabot alert 62 by forcing lodash-es to 4.17.23 in all frontend projects.