### PR TITLE
fix(fe): ensure SpacerWidget grows by default

### DIFF
--- a/src/frontend/src/widgets/primitives/SpacerWidget.tsx
+++ b/src/frontend/src/widgets/primitives/SpacerWidget.tsx
@@ -6,5 +6,15 @@ interface SpacerWidgetProps {
 }
 
 export const SpacerWidget: React.FC<SpacerWidgetProps> = ({ width, height }) => {
-  return <div style={{ ...getWidth(width), ...getHeight(height) }} />;
+  return (
+    <div
+      style={{
+        flexGrow: 1,
+        flexShrink: 1,
+        flexBasis: "0%",
+        ...getWidth(width),
+        ...getHeight(height),
+      }}
+    />
+  );
 };


### PR DESCRIPTION
Fixes the issue where `Spacer` width growth was failing because its default `Width = Size.Grow()` was not being serialized by the backend. The fix adds resilient defaults to `SpacerWidget.tsx` to ensure it grows even when the prop is missing.