### PR TITLE
Improve DataTable column width handling

### DIFF
--- a/src/frontend/src/widgets/dataTables/dataTableContext/hooks/useColumnManagement.ts
+++ b/src/frontend/src/widgets/dataTables/dataTableContext/hooks/useColumnManagement.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { GridColumn } from "@glideapps/glide-data-grid";
 import { DataColumn } from "../../types/types";
-import { parseSize } from "../utils/parseSize";
+import { parseSize, estimateHeaderWidth } from "../utils/parseSize";
 
 interface UseColumnManagementProps {
   columnsProp: DataColumn[];
@@ -68,7 +68,13 @@ export const useColumnManagement = ({
       // First time loading, initialize with default widths
       const widths: Record<string, number> = {};
       mergedColumns.forEach((col, index) => {
-        widths[index.toString()] = parseSize(col.width);
+        const explicitWidth = parseSize(col.width);
+        const headerMinWidth = estimateHeaderWidth(col.header || col.name);
+        // Use explicit width if set, otherwise use header-based width
+        // If explicit width is the default (150), use the larger of explicit and header-based
+        widths[index.toString()] = col.width
+          ? explicitWidth
+          : Math.max(explicitWidth, headerMinWidth);
       });
       return widths;
     });

--- a/src/frontend/src/widgets/dataTables/dataTableContext/utils/parseSize.ts
+++ b/src/frontend/src/widgets/dataTables/dataTableContext/utils/parseSize.ts
@@ -17,3 +17,17 @@ export function parseSize(size: number | string | undefined): number {
 
   return 150; // fallback to default
 }
+
+/**
+ * Estimates minimum column width needed to display header text without truncation.
+ * Uses approximate character width (8px per char) plus padding for icon + sort indicator.
+ */
+export function estimateHeaderWidth(headerText: string): number {
+  const CHAR_WIDTH = 8; // approximate px per character in header font
+  const HEADER_PADDING = 40; // padding for icon, sort arrow, cell padding
+  const MIN_WIDTH = 60; // absolute minimum
+  const MAX_AUTO_WIDTH = 300; // cap auto-width to prevent excessively wide columns
+
+  const estimated = headerText.length * CHAR_WIDTH + HEADER_PADDING;
+  return Math.max(MIN_WIDTH, Math.min(estimated, MAX_AUTO_WIDTH));
+}

--- a/src/frontend/src/widgets/dataTables/utils/columnHelpers.ts
+++ b/src/frontend/src/widgets/dataTables/utils/columnHelpers.ts
@@ -1,5 +1,6 @@
 import { GridColumn, GridColumnIcon } from "@glideapps/glide-data-grid";
 import type { DataColumn } from "../types/types";
+import { estimateHeaderWidth } from "../dataTableContext/utils/parseSize";
 
 /**
  * Maps column icon names or types to appropriate icons
@@ -121,9 +122,9 @@ export function convertToGridColumns(
     // Ensure width is always a number
     let numericBaseWidth = typeof baseWidth === "string" ? parseFloat(baseWidth) : baseWidth;
 
-    // Fix NaN width - default to 150 if parsing fails
+    // Fix NaN width - use header-based width if parsing fails
     if (isNaN(numericBaseWidth) || !numericBaseWidth) {
-      numericBaseWidth = 150;
+      numericBaseWidth = estimateHeaderWidth(col.header || col.name);
     }
 
     // Make the last column fill the remaining space using grow (avoids gap from


### PR DESCRIPTION
## Summary
- Improve DataTable column width calculation to prevent header text truncation
- Account for header padding and sort icon width in minimum column size

Closes #1283