### PR TITLE
fix: install node and vite-plus in docker builds

### DIFF
--- a/src/Ivy.Docs/Dockerfile
+++ b/src/Ivy.Docs/Dockerfile
@@ -1,4 +1,4 @@
-﻿FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
 USER $APP_UID
 WORKDIR /app
 EXPOSE 5010
@@ -8,6 +8,11 @@ ARG BUILD_CONFIGURATION=Release
 ARG IVY_PACKAGE_VERSION
 RUN test -n "$IVY_PACKAGE_VERSION" || (echo "IVY_PACKAGE_VERSION build-arg is required" && exit 1)
 WORKDIR /src
+RUN apt-get update && apt-get install -y curl gnupg && \
+    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
+    apt-get install -y nodejs && \
+    npm install -g pnpm@10.33.0 vite-plus@0.1.14 && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 COPY ["src/Ivy.Docs/Ivy.Docs.csproj", "src/Ivy.Docs/"]
 COPY ["src/Ivy.Docs.Shared/Ivy.Docs.Shared.csproj", "src/Ivy.Docs.Shared/"]
 COPY ["src/Ivy.Docs.Tools/Ivy.Docs.Tools.csproj", "src/Ivy.Docs.Tools/"]

--- a/src/Ivy.Samples/Dockerfile
+++ b/src/Ivy.Samples/Dockerfile
@@ -1,4 +1,4 @@
-﻿FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
 USER $APP_UID
 WORKDIR /app
 EXPOSE 5010
@@ -8,6 +8,11 @@ ARG BUILD_CONFIGURATION=Release
 ARG IVY_PACKAGE_VERSION
 RUN test -n "$IVY_PACKAGE_VERSION" || (echo "IVY_PACKAGE_VERSION build-arg is required" && exit 1)
 WORKDIR /src
+RUN apt-get update && apt-get install -y curl gnupg && \
+    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
+    apt-get install -y nodejs && \
+    npm install -g pnpm@10.33.0 vite-plus@0.1.14 && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 COPY ["src/Ivy.Samples/Ivy.Samples.csproj", "src/Ivy.Samples/"]
 COPY ["src/Ivy.Samples.Shared/Ivy.Samples.Shared.csproj", "src/Ivy.Samples.Shared/"]
 RUN dotnet restore "src/Ivy.Samples.Shared/Ivy.Samples.Shared.csproj" -p:IvyPackageVersion=$IVY_PACKAGE_VERSION


### PR DESCRIPTION
This PR fixes a build failure in GitHub Actions where the VITE+ - The Unified Toolchain for the Web

Usage: vp [COMMAND]

Start:
  create      Create a new project from a template
  migrate     Migrate an existing project to Vite+
  config      Configure hooks and agent integration
  staged      Run linters on staged files
  install, i  Install all dependencies, or add packages if package names are provided
  env         Manage Node.js versions

Develop:
  dev    Run the development server
  check  Run format, lint, and type checks
  lint   Lint code
  fmt    Format code
  test   Run tests

Execute:
  run    Run tasks
  exec   Execute a command from local node_modules/.bin
  dlx    Execute a package binary without installing it as a dependency
  cache  Manage the task cache

Build:
  build    Build for production
  pack     Build library
  preview  Preview production build

Manage Dependencies:
  add                        Add packages to dependencies
  remove, rm, un, uninstall  Remove packages from dependencies
  update, up                 Update packages to their latest versions
  dedupe                     Deduplicate dependencies by removing older versions
  outdated                   Check for outdated packages
  list, ls                   List installed packages
  why, explain               Show why a package is installed
  info, view, show           View package information from the registry
  link, ln                   Link packages for local development
  unlink                     Unlink packages
  pm                         Forward a command to the package manager

Maintain:
  upgrade  Update vp itself to the latest version
  implode  Remove vp and all related data

Documentation: https://viteplus.dev/guide/

Options:
  -V, --version  Print version
  -h, --help     Print help (VitePlus) tool was missing during the Docker build process for  and .

The fix installs Node.js 22, Version 10.33.0
Usage: pnpm [command] [flags]
       pnpm [ -h | --help | -v | --version ]

These are common pnpm commands used in various situations, use 'pnpm help -a' to list all commands

Manage your dependencies:
      add                  Installs a package and any packages that it depends
                           on. By default, any new package is installed as a
                           prod dependency
   i, install              Install all dependencies for a project
  ln, link                 Connect the local project to another one
  rm, remove               Removes packages from node_modules and from the
                           project's package.json
      unlink               Unlinks a package. Like yarn unlink but pnpm
                           re-installs the dependency after removing the
                           external link
  up, update               Updates packages to their latest version based on the
                           specified range

Review your dependencies:
      audit                Checks for known security issues with the installed
                           packages
  ls, list                 Print all the versions of packages that are
                           installed, as well as their dependencies, in a
                           tree-structure
      outdated             Check for outdated packages
      why                  Shows all packages that depend on the specified
                           package

Run your scripts:
      create               Create a project from a "create-*" or "@foo/create-*"
                           starter kit
      dlx                  Fetches a package from the registry without
                           installing it as a dependency, hot loads it, and runs
                           whatever default command binary it exposes
      exec                 Executes a shell command in scope of a project
      run                  Runs a defined package script

Other:
   c, config               Manage the pnpm configuration files
      init                 Create a package.json file
      publish              Publishes a package to the registry
      self-update          Updates pnpm to the latest version

Options:
  -r, --recursive          Run the command for each project in the workspace., and  in the  stage of the Dockerfiles.