### PR TITLE
docs: add PackageReadmeFile to Ivy.Desktop.csproj

### DIFF
--- a/src/Ivy.Desktop/Ivy.Desktop.csproj
+++ b/src/Ivy.Desktop/Ivy.Desktop.csproj
@@ -14,6 +14,7 @@
     <RepositoryUrl>https://github.com/Ivy-Interactive/Ivy</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <IsPackable>true</IsPackable>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
This PR adds the missing `PackageReadmeFile` property to the `Ivy.Desktop.csproj` file, ensuring that the existing `README.md` is correctly recognized as the package readme by NuGet.

Following best practices from https://aka.ms/nuget/authoring-best-practices/readme.