### PR TITLE
Add missing closing braces in `Ivy.Widgets.{Leaflet, Tiptap}` package.json files

### DIFF
--- a/src/widgets/Ivy.Widgets.Leaflet/frontend/package.json
+++ b/src/widgets/Ivy.Widgets.Leaflet/frontend/package.json
@@ -36,3 +36,4 @@
       "vitest": "npm:@voidzero-dev/vite-plus-test@0.1.13"
     }
   }
+}

--- a/src/widgets/Ivy.Widgets.Tiptap/frontend/package.json
+++ b/src/widgets/Ivy.Widgets.Tiptap/frontend/package.json
@@ -39,3 +39,4 @@
       "vitest": "npm:@voidzero-dev/vite-plus-test@0.1.13"
     }
   }
+}


### PR DESCRIPTION
156fa65 fixed this for the other two widgets only. I found this by building `Ivy/Ivy.slnx`, which uses Tiptap.

@rorychatt Do you think these external widget projects should be added to `Ivy-Framework.slnx` to make it easier to detect issues like this? Or would that slow down the build too much?