### PR TITLE
[01116] Fix details/summary chevron rotation using Tailwind group-open

### DIFF
--- a/src/frontend/src/components/MarkdownRenderer.tsx
+++ b/src/frontend/src/components/MarkdownRenderer.tsx
@@ -213,7 +213,7 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
         <hr className={typography.hr} {...props} />
       )),
       details: memo(({ children, ...props }: React.DetailsHTMLAttributes<HTMLDetailsElement>) => (
-        <details className={typography.details} {...props}>
+        <details className={cn(typography.details, "group")} {...props}>
           {children}
         </details>
       )),
@@ -221,7 +221,7 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
         <summary className={typography.summary} {...props}>
           <div className="flex items-center gap-2">
             <svg
-              className="h-4 w-4 shrink-0 transition-transform [[open]>summary_&]:rotate-90"
+              className="h-4 w-4 shrink-0 transition-transform group-open:rotate-90"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"

--- a/src/frontend/src/index.css
+++ b/src/frontend/src/index.css
@@ -378,10 +378,6 @@ details > :last-child {
   padding-bottom: 1rem;
 }
 
-details[open] summary svg {
-  transform: rotate(90deg);
-}
-
 /* Prevent dialog from getting focus rings when elements inside are focused */
 @layer components {
   [data-radix-dialog-content] {


### PR DESCRIPTION
## Summary

The `<details>`/`<summary>` chevron in the Markdown renderer was not rotating correctly when expanded. The Tailwind arbitrary variant `[[open]>summary_&]:rotate-90` was invalid and never matched.

**Fix:** Use Tailwind's `group`/`group-open` pattern instead — add `group` class to `<details>` and `group-open:rotate-90` to the SVG. Removed the now-redundant CSS fallback in `index.css`.

## Changes

- `src/frontend/src/components/MarkdownRenderer.tsx` — Fix chevron rotation using `group`/`group-open` pattern
- `src/frontend/src/index.css` — Remove redundant `details[open] summary svg` CSS override

## Commits

- `c4816552` — [01116] Fix details/summary chevron rotation using Tailwind group-open