### PR TITLE
[01127] Add padding to details element in Markdown widget

### DIFF
--- a/src/frontend/src/index.css
+++ b/src/frontend/src/index.css
@@ -369,13 +369,16 @@ ivy-widget {
 }
 
 /* Details/Summary styling for markdown collapsible sections */
-details > :not(summary) {
+details {
+  padding: 0 1rem 1rem 1rem;
+}
+details > summary {
+  margin: 0 -1rem;
   padding-left: 1rem;
   padding-right: 1rem;
 }
-
-details > :last-child {
-  padding-bottom: 1rem;
+details:not([open]) {
+  padding-bottom: 0;
 }
 
 /* Prevent dialog from getting focus rings when elements inside are focused */


### PR DESCRIPTION
## Summary

- Fixes padding on `<details>` elements in the Markdown widget where raw text content (not wrapped in `<p>` tags) lacked inner padding
- Replaces child-element padding selectors with padding on the `<details>` element itself, using negative margins on `<summary>` to compensate

## Commits

- `fc82b408` — [01127] Add padding to details element in Markdown widget

## Verification

- [x] DotnetBuild
- [x] DotnetFormat
- [x] DotnetTest
- [x] FrontendLint
- [x] IvyFrameworkVerification