### PR TITLE
[01100] Fix Assembly.Location for single-file desktop publishing

### DIFF
--- a/src/Ivy/Server.cs
+++ b/src/Ivy/Server.cs
@@ -277,7 +277,7 @@ public class Server
         try
         {
             // Load all "Ivy.Auth.*" assemblies eagerly to ensure their handlers are registered in the DI container
-            var assemblyDirectory = AppContext.BaseDirectory;
+            var assemblyDirectory = System.AppContext.BaseDirectory;
             if (!string.IsNullOrEmpty(assemblyDirectory))
             {
                 var authAssemblyFiles = Directory.GetFiles(assemblyDirectory, "Ivy.Auth.*.dll");


### PR DESCRIPTION
## Problem

`DeployDesktop` workflow fails with IL3000 errors during single-file publish because `Assembly.Location` returns an empty string in single-file apps, breaking OAuth token handler discovery in `Server.cs`.

## Solution

Replace `Assembly.Location`-based directory discovery with `AppContext.BaseDirectory` in `DiscoverAndRegisterOAuthTokenHandlers()`. This works correctly for both single-file and normal publish scenarios.

## Commits

- `a78392f8` — Replace Assembly.Location with AppContext.BaseDirectory for single-file publish
- `0b849030` — Fix AppContext namespace collision with System.AppContext