### PR TITLE
[01102] Fix minor issues with image click/overlay in Markdown

### DIFF
--- a/src/frontend/src/components/markdown/ImageOverlay.tsx
+++ b/src/frontend/src/components/markdown/ImageOverlay.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
 import { validateImageUrl } from "@/lib/url";
 
 interface ImageOverlayProps {
@@ -60,7 +61,7 @@ export const ImageOverlay: React.FC<ImageOverlayProps> = ({ src, alt, onClose })
     return null;
   }
 
-  return (
+  return createPortal(
     <div
       ref={overlayRef}
       className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 cursor-zoom-out"
@@ -80,6 +81,7 @@ export const ImageOverlay: React.FC<ImageOverlayProps> = ({ src, alt, onClose })
           ✕
         </button>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 };


### PR DESCRIPTION
## Summary

- Render `ImageOverlay` via a React portal (`createPortal` to `document.body`) so it escapes the tab content's z-index stacking context
- Fixes the issue where the active tab header rendered above the overlay backdrop when clicking images in Markdown

## Commits

- `9d2abc6f` — [01102] Render ImageOverlay via React portal to fix z-index stacking