### PR TITLE
[01105] Custom AppShell with sidebar badges for Plans, Jobs, Review

### DIFF
--- a/src/Ivy/Shared/MenuItem.cs
+++ b/src/Ivy/Shared/MenuItem.cs
@@ -33,6 +33,7 @@ public record MenuItem(
     bool Checked = false,
     bool Disabled = false,
     string? Shortcut = null,
+    string? Badge = null,
     bool Expanded = false,
     string? Tooltip = null,
     EventHandler<MenuItem>? OnSelect = null,
@@ -172,6 +173,11 @@ public static class MenuItemExtensions
     public static MenuItem Tooltip(this MenuItem menuItem, string tooltip)
     {
         return menuItem with { Tooltip = tooltip };
+    }
+
+    public static MenuItem Badge(this MenuItem menuItem, string? badge)
+    {
+        return menuItem with { Badge = badge };
     }
 
     public static MenuItem Expanded(this MenuItem menuItem, bool expanded = true)

--- a/src/frontend/src/types/widgets.ts
+++ b/src/frontend/src/types/widgets.ts
@@ -30,6 +30,7 @@ export interface MenuItem {
   disabled: boolean;
   color?: "Default" | "Destructive" | "Primary" | "Secondary" | "Success" | "Warning" | "Info";
   shortcut?: string;
+  badge?: string;
   expanded: boolean;
   path?: string;
   onSelect?: (item: MenuItem) => void;

--- a/src/frontend/src/widgets/layouts/sidebar/SidebarLayoutWidget.tsx
+++ b/src/frontend/src/widgets/layouts/sidebar/SidebarLayoutWidget.tsx
@@ -11,6 +11,7 @@ import { useEventHandler } from "@/components/event-handler";
 import { cn, getAppId } from "@/lib/utils";
 import { getWidth } from "@/lib/styles";
 import { Separator } from "@/components/ui/separator";
+import { SidebarMenuBadge } from "@/components/ui/sidebar";
 
 interface SidebarLayoutWidgetProps {
   slots?: {
@@ -438,6 +439,7 @@ const CollapsibleMenuItem: React.FC<{
         >
           <Icon name={item.icon} size={16} />
           <span className="text-sm">{item.label}</span>
+          {item.badge && <SidebarMenuBadge>{item.badge}</SidebarMenuBadge>}
         </button>
       </li>
     );
@@ -523,6 +525,7 @@ const renderMenuItems = (
             >
               <Icon name={item.icon} size={16} />
               <span className="text-sm">{item.label}</span>
+              {item.badge && <SidebarMenuBadge>{item.badge}</SidebarMenuBadge>}
             </button>
           </li>
         );
@@ -539,6 +542,7 @@ const renderMenuItems = (
             >
               <Icon name={item.icon} size={16} />
               <span className="text-sm">{item.label}</span>
+              {item.badge && <SidebarMenuBadge>{item.badge}</SidebarMenuBadge>}
             </button>
           </li>
         );


### PR DESCRIPTION
## Summary

Adds a `Badge` property to `MenuItem` in Ivy Framework, enabling sidebar menu items to display badge counts. Wires up the existing `SidebarMenuBadge` frontend component to render badge text on leaf menu items.

### Commits
- `5867bcfd` — Add Badge property to MenuItem with frontend rendering

Part of a two-repo change. Tendril PR adds the custom AppShell that uses this badge support.