### PR TITLE
[01133] Sidebar badge needs a little padding

### DIFF
--- a/src/frontend/src/components/ui/sidebar/sidebar.tsx
+++ b/src/frontend/src/components/ui/sidebar/sidebar.tsx
@@ -582,7 +582,7 @@ const SidebarMenuBadge = React.forwardRef<HTMLDivElement, React.ComponentProps<"
       ref={ref}
       data-sidebar="menu-badge"
       className={cn(
-        "absolute right-1 flex h-5 min-w-5 items-center justify-center rounded-md px-1 text-xs font-medium tabular-nums text-foreground select-none pointer-events-none",
+        "absolute right-1 flex h-5 min-w-5 items-center justify-center rounded-md px-1.5 text-xs font-medium tabular-nums text-foreground select-none pointer-events-none",
         "peer-data-[size=sm]/menu-button:top-1",
         "peer-data-[size=default]/menu-button:top-1.5",
         "peer-data-[size=lg]/menu-button:top-2.5",


### PR DESCRIPTION
## Summary

The sidebar navigation badges (plan count, review count, job count) appeared visually cramped with only `px-1` (4px) horizontal padding.

Updated `SidebarMenuBadge` component in `sidebar.tsx` to use `px-1.5` (6px) for better breathing room.

## Commits

- `1caaedab` — Add padding to sidebar menu badge (px-1 → px-1.5)