### PR TITLE
[01130] Remove DataTable bottom lip caused by empty row rounding

### DIFF
--- a/src/frontend/src/widgets/dataTables/components/GridContainer.tsx
+++ b/src/frontend/src/widgets/dataTables/components/GridContainer.tsx
@@ -114,6 +114,7 @@ export const GridContainer: React.FC<GridContainerProps> = ({
         display: "flex",
         flexDirection: "column",
         position: "relative",
+        overflow: "hidden",
       }}
       data-has-empty-rows={hasEmptyRows || undefined}
     >

--- a/src/frontend/src/widgets/dataTables/hooks/useEmptyRows.ts
+++ b/src/frontend/src/widgets/dataTables/hooks/useEmptyRows.ts
@@ -11,7 +11,7 @@ interface UseEmptyRowsProps {
 
 /**
  * Calculates empty filler rows to fill the container when data is sparse.
- * Uses floor to avoid overflow (extra row would trigger unwanted scrollbar).
+ * Uses ceil so filler rows fully cover remaining whitespace (no visible lip).
  */
 export const useEmptyRows = ({
   scrollContainerHeight,
@@ -32,7 +32,7 @@ export const useEmptyRows = ({
 
   const emptyRowsCount = useMemo(() => {
     if (whitespaceHeight <= 0) return 0;
-    return Math.floor(whitespaceHeight / rowHeight);
+    return Math.ceil(whitespaceHeight / rowHeight);
   }, [whitespaceHeight, rowHeight]);
 
   return {


### PR DESCRIPTION
## Summary

Fix DataTable bottom lip caused by empty row rounding. Changed `Math.floor` to `Math.ceil` in `useEmptyRows.ts` so the last filler row fully covers remaining whitespace, and added `overflow: hidden` on the DataGrid scroll container to prevent extra scrollbars.

## Commits

- `3bd64201` — [01130] Fix DataTable bottom lip by using ceil for empty row count

## Artifacts

### Screenshots
![empty-table-full](https://stivytelemetry.blob.core.windows.net/ivy-tendril/empty-table-full.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![exact-fill-full](https://stivytelemetry.blob.core.windows.net/ivy-tendril/exact-fill-full.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![few-rows-bottom-edge](https://stivytelemetry.blob.core.windows.net/ivy-tendril/few-rows-bottom-edge.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![few-rows-full](https://stivytelemetry.blob.core.windows.net/ivy-tendril/few-rows-full.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![few-rows-table-only](https://stivytelemetry.blob.core.windows.net/ivy-tendril/few-rows-table-only.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![grouped-rows-full](https://stivytelemetry.blob.core.windows.net/ivy-tendril/grouped-rows-full.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![many-rows-full](https://stivytelemetry.blob.core.windows.net/ivy-tendril/many-rows-full.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

### Videos

[▶ empty-table---renders-correctly.webm](https://stivytelemetry.blob.core.windows.net/ivy-tendril/empty-table---renders-correctly.webm?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

[▶ exact-fill---no-lip--no-scrollbar.webm](https://stivytelemetry.blob.core.windows.net/ivy-tendril/exact-fill---no-lip--no-scrollbar.webm?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

[▶ few-rows---no-lip-visible.webm](https://stivytelemetry.blob.core.windows.net/ivy-tendril/few-rows---no-lip-visible.webm?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

[▶ grouped-rows---no-lip-with-group-headers.webm](https://stivytelemetry.blob.core.windows.net/ivy-tendril/grouped-rows---no-lip-with-group-headers.webm?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

[▶ many-rows---scrollable--no-lip.webm](https://stivytelemetry.blob.core.windows.net/ivy-tendril/many-rows---scrollable--no-lip.webm?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

[▶ no-console-errors-across-all-apps.webm](https://stivytelemetry.blob.core.windows.net/ivy-tendril/no-console-errors-across-all-apps.webm?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

[▶ visual-comparison---bottom-edge-pixel-check.webm](https://stivytelemetry.blob.core.windows.net/ivy-tendril/visual-comparison---bottom-edge-pixel-check.webm?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)
