### PR TITLE
[01132] Fix verification checklist rendering

### DIFF
--- a/src/frontend/src/components/MarkdownRenderer.tsx
+++ b/src/frontend/src/components/MarkdownRenderer.tsx
@@ -131,9 +131,12 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
       ol: memo(({ children }: { children: React.ReactNode }) => (
         <ol className={typography.ol}>{children}</ol>
       )),
-      li: memo(({ children }: { children: React.ReactNode }) => (
-        <li className={typography.li}>{children}</li>
-      )),
+      li: memo(({ children, className }: { children: React.ReactNode; className?: string }) => {
+        const isTaskItem = className?.includes("task-list-item");
+        return (
+          <li className={cn(typography.li, isTaskItem && "list-none")}>{children}</li>
+        );
+      }),
       strong: memo(({ children }: { children: React.ReactNode }) => (
         <strong className={typography.strong}>{children}</strong>
       )),


### PR DESCRIPTION
## Summary

- Hide bullet disc marker on GFM task list items in MarkdownRenderer
- Task list `<li>` elements with `task-list-item` class now get `list-none` to suppress the visible disc alongside the checkbox

## Commits

- `68990bcd` — Hide bullet marker on GFM task list items in MarkdownRenderer