### PR TITLE
[01139] Create SKILLS.md for ivy question and ivy docs CLI commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -330,7 +330,14 @@ userNameState.ToTextInput().Required().MaxLength(50).Placeholder("Enter your nam
 
 ## CLI Commands
 
-Prefer using `ivy cli explain` for command discovery over MCP server tools as it provides a reliable, built-in structural breakdown.
+The Ivy CLI provides powerful tools for exploring framework documentation and getting contextual answers:
+
+- `ivy docs list` — list all available documentation paths
+- `ivy docs <path>` — retrieve raw Markdown content for a specific doc page
+- `ivy ask "question"` — semantic search against the framework knowledge base (alias: `ivy question`)
+- `ivy cli explain` — structural breakdown of available CLI commands
+
+For detailed usage and examples, see [src/skills/ivy/SKILLS.md](src/skills/ivy/SKILLS.md).
 
 ## Further Reading
 

--- a/src/skills/ivy/SKILLS.md
+++ b/src/skills/ivy/SKILLS.md
@@ -1,0 +1,47 @@
+# Ivy CLI Skills
+
+This document teaches AI agents and developers how to use the Ivy CLI to access framework documentation and get contextual answers. These commands complement [AGENTS.md](../../../AGENTS.md) for deeper exploration of the framework.
+
+## ivy docs
+
+Access and retrieve Ivy Framework documentation directly from the terminal.
+
+### ivy docs list
+
+Lists all available documentation paths as structured YAML output. Use this to discover valid paths for `ivy docs <path>`.
+
+```bash
+ivy docs list
+```
+
+### ivy docs \<path\>
+
+Retrieves the raw Markdown content for a specific documentation page.
+
+```bash
+ivy docs "docs/ApiReference/IvyShared/Colors.md"
+```
+
+Paths can be discovered via `ivy docs list`. You can also convert any `docs.ivy.app` URL to a raw Markdown path by appending `.md` to the URL slug.
+
+## ivy question / ivy ask
+
+Semantic search against the framework knowledge base using Local RAG. Takes a natural language question in double quotes and returns contextual answers cross-referencing `Ivy.Docs.Shared`.
+
+```bash
+ivy ask "How do I implement a new Application Shell in Ivy?"
+```
+
+```bash
+ivy question "What is the command to create an auto-incrementing migration in Ivy?"
+```
+
+## When to use which
+
+| Scenario | Command |
+|---|---|
+| You know the topic and want the full reference page | `ivy docs <path>` |
+| You need to browse what documentation exists | `ivy docs list` |
+| You have a "how do I..." question and need a synthesized answer | `ivy ask "your question"` |
+
+Use `ivy docs` for targeted lookups when you know what you're looking for. Use `ivy ask` when you need the framework to synthesize an answer from across the knowledge base.


### PR DESCRIPTION
## Summary

- Creates `src/skills/ivy/SKILLS.md` documenting the `ivy question` and `ivy docs` CLI commands as first-class agent skills
- Updates `AGENTS.md` CLI Commands section to reference the new skills file
- Documentation-only change — no code modifications

## Commits

- `8c60b46` — Add SKILLS.md for ivy question and ivy docs CLI commands