### PR TITLE
[01107] Fix CreateContext state propagation to child components

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/03_Hooks/02_Core/12_UseContext.md
+++ b/src/Ivy.Docs.Shared/Docs/03_Hooks/02_Core/12_UseContext.md
@@ -325,12 +325,57 @@ public class ConditionalAuthView : ViewBase
 }
 ```
 
+## Reactive Context Pattern
+
+`CreateContext` re-evaluates the factory on every render, so child components automatically receive updated context when the parent re-renders:
+
+```csharp demo-below
+public class AuthContext
+{
+    public string UserName { get; set; } = "";
+    public bool IsLoggedIn { get; set; }
+}
+
+public class AuthProvider : ViewBase
+{
+    public override object? Build()
+    {
+        var currentUser = UseState("Guest");
+        var isLoggedIn = UseState(false);
+
+        // Factory captures state values — re-evaluated on each render
+        CreateContext(() => new AuthContext
+        {
+            UserName = currentUser.Value,
+            IsLoggedIn = isLoggedIn.Value
+        });
+
+        return Layout.Vertical()
+            | new Button(isLoggedIn.Value ? "Logout" : "Login", onClick: _ =>
+            {
+                isLoggedIn.Set(!isLoggedIn.Value);
+                currentUser.Set(isLoggedIn.Value ? "Guest" : "Alice");
+            })
+            | new AuthConsumer();
+    }
+}
+
+public class AuthConsumer : ViewBase
+{
+    public override object? Build()
+    {
+        var auth = UseContext<AuthContext>();
+        return Text.P($"User: {auth.UserName}, Logged in: {auth.IsLoggedIn}");
+    }
+}
+```
+
 ## Best Practices
 
 - **Use context for component-scoped data** - Use services for app-wide data
-- **Keep context values simple** - Data containers or lightweight services; use DI for heavy services
+- **Keep context values simple** - Data containers or lightweight services
 - **Use type safety** - Always use `UseContext<T>()` instead of runtime type checking
-- **Avoid frequently changing data** - Use [state](./03_UseState.md) for reactive updates
+- **Context automatically propagates state changes** - When parent re-renders, CreateContext factory runs again and children receive the updated context
 - **Document context dependencies** - Make it clear when a component requires a parent context
 
 ## See Also

--- a/src/Ivy.Test/ViewContextTests.cs
+++ b/src/Ivy.Test/ViewContextTests.cs
@@ -45,6 +45,48 @@ public class ViewContextTests
         Assert.IsType<TestServiceImpl>(service);
     }
 
+    [Fact]
+    public void CreateContext_ReEvaluatesFactoryOnReRender()
+    {
+        var ctx = CreateViewContext();
+        var stateValue = 0;
+
+        ctx.Reset();
+        var context1 = ctx.CreateContext(() => new TestContext { Value = stateValue });
+        Assert.Equal(0, context1.Value);
+
+        stateValue = 42;
+        ctx.Reset();
+        var context2 = ctx.CreateContext(() => new TestContext { Value = stateValue });
+        Assert.Equal(42, context2.Value);
+    }
+
+    [Fact]
+    public void CreateContext_UpdatesServiceContainerForUseContext()
+    {
+        var parentCtx = CreateViewContext();
+        var stateValue = 0;
+
+        parentCtx.Reset();
+        parentCtx.CreateContext(() => new TestContext { Value = stateValue });
+
+        var childCtx = new ViewContext(() => { }, parentCtx, new ServiceCollection().BuildServiceProvider());
+        childCtx.Reset();
+        Assert.Equal(0, childCtx.UseContext<TestContext>().Value);
+
+        stateValue = 100;
+        parentCtx.Reset();
+        parentCtx.CreateContext(() => new TestContext { Value = stateValue });
+
+        childCtx.Reset();
+        Assert.Equal(100, childCtx.UseContext<TestContext>().Value);
+    }
+
+    private class TestContext
+    {
+        public int Value { get; set; }
+    }
+
     private interface ITestService;
 
     private class TestServiceImpl : ITestService;

--- a/src/Ivy/Core/Hooks/ContextHook.cs
+++ b/src/Ivy/Core/Hooks/ContextHook.cs
@@ -1,0 +1,30 @@
+namespace Ivy.Core.Hooks;
+
+public class ContextHook
+{
+    public int Identity { get; }
+    public Type ContextType { get; }
+    public object ContextInstance { get; private set; }
+    private IDisposable? _disposable;
+
+    public ContextHook(int identity, Type contextType, object contextInstance)
+    {
+        Identity = identity;
+        ContextType = contextType;
+        ContextInstance = contextInstance;
+        if (contextInstance is IDisposable disposable)
+            _disposable = disposable;
+    }
+
+    public void UpdateInstance(object newInstance)
+    {
+        ContextInstance = newInstance;
+        if (newInstance is IDisposable disposable)
+            _disposable = disposable;
+    }
+
+    public void Dispose()
+    {
+        _disposable?.Dispose();
+    }
+}

--- a/src/Ivy/Core/Hooks/ViewContext.cs
+++ b/src/Ivy/Core/Hooks/ViewContext.cs
@@ -15,6 +15,7 @@ public class ViewContext : IViewContext
     private readonly AsyncDisposables _asyncDisposables = new();
     private readonly Dictionary<int, StateHook> _hooks = new();
     private readonly Dictionary<int, EffectHook> _effects = new();
+    private readonly Dictionary<int, ContextHook> _contextHooks = new();
     private readonly EffectQueue _effectQueue;
     private readonly IServiceContainer _services;
     private readonly HashSet<Type> _registeredServices;
@@ -151,16 +152,39 @@ public class ViewContext : IViewContext
     {
         ArgumentNullException.ThrowIfNull(factory);
 
+        var callingIndex = _callingIndex++;
         var type = typeof(T);
 
-        if (_registeredServices.Contains(type))
+        if (_contextHooks.TryGetValue(callingIndex, out var existingHook))
         {
-            return (T)_services.GetService(type)!;
+            // Re-evaluate factory to get fresh context with updated state
+            T newContext = factory()!;
+            existingHook.UpdateInstance(newContext);
+
+            // Update service container so UseContext finds the new instance
+            var services = (_services as ServiceContainer)!;
+            services.RemoveService(type);
+            services.AddService(type, newContext);
+
+            return newContext;
         }
 
+        // First call at this position - create new context hook
         T context = factory()!;
-        _services.AddService(type, context);
-        _registeredServices.Add(type);
+        var hook = new ContextHook(callingIndex, type, context);
+        _contextHooks[callingIndex] = hook;
+
+        if (!_registeredServices.Contains(type))
+        {
+            _services.AddService(type, context);
+            _registeredServices.Add(type);
+        }
+        else
+        {
+            var services = (_services as ServiceContainer)!;
+            services.RemoveService(type);
+            services.AddService(type, context);
+        }
 
         if (context is IDisposable disposable)
         {
@@ -298,7 +322,12 @@ public class ViewContext : IViewContext
     {
         _disposables.Dispose();
         await _asyncDisposables.DisposeAsync();
+
+        foreach (var hook in _contextHooks.Values)
+            hook.Dispose();
+
         _hooks.Clear();
         _effects.Clear();
+        _contextHooks.Clear();
     }
 }


### PR DESCRIPTION
## Summary

- **Problem:** `CreateContext<T>()` cached context instances by type and never re-evaluated the factory on re-render, causing child components using `UseContext<T>()` to receive stale values when parent state changed
- **Solution:** Transformed `CreateContext` into a proper hook using `_callingIndex` tracking that re-evaluates the factory on every render, updating the service container so children always get fresh context
- **Tests:** Added `CreateContext_ReEvaluatesFactoryOnReRender` and `CreateContext_UpdatesServiceContainerForUseContext` unit tests

## Commits

- `7c3ed55c` — Fix CreateContext state propagation to child components

## Verification

- ✅ DotnetBuild
- ✅ DotnetFormat
- ✅ DotnetTest
- ✅ FrontendLint
- ✅ IvyFrameworkVerification