### PR TITLE
[01140] Dialog Width Support In Ivy

### DIFF
--- a/src/frontend/src/widgets/dialogs/DialogWidget.tsx
+++ b/src/frontend/src/widgets/dialogs/DialogWidget.tsx
@@ -14,8 +14,10 @@ export const DialogWidget: React.FC<DialogWidgetProps> = ({ id, children, width 
   const eventHandler = useEventHandler();
   const isVisible = true;
 
+  const widthStyles = getWidth(width);
   const styles = {
-    ...getWidth(width),
+    ...widthStyles,
+    ...(width && widthStyles.width && !widthStyles.maxWidth ? { maxWidth: widthStyles.width } : {}),
   };
 
   return (


### PR DESCRIPTION
## Summary

- **Fix:** Dialog's custom width was being silently capped by the `max-w-xl` CSS class (36rem) on `DialogContent`. When an inline width style is present, `maxWidth` is now also set inline to override the CSS constraint, allowing dialogs to render at any custom width.

## Commit
- `34a85b2` — Fix Dialog custom width being capped by max-w-xl CSS class