### PR TITLE
[01167] Badges render weirdly in a table

### DIFF
--- a/src/frontend/src/components/ui/badge/variant.ts
+++ b/src/frontend/src/components/ui/badge/variant.ts
@@ -1,7 +1,7 @@
 import { cva } from "class-variance-authority";
 
 export const badgeVariant = cva(
-  "flex items-center rounded-selector border font-normal leading-none transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  "inline-flex items-center rounded-selector border font-normal leading-none transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
   {
     variants: {
       variant: {


### PR DESCRIPTION
## Problem

When a Badge widget is placed inside a Table cell, it stretches to fill the entire column width instead of rendering as a compact inline element. The badge CVA variant uses `flex` as its base display class, and when tables use `tableLayout: "fixed"`, the flex badge expands to fill available width.

## Solution

Changed `flex` to `inline-flex` in the badge variant base class (`variant.ts`), making badges intrinsically sized (shrink-to-fit) rather than expanding to fill their container.

## Commits

- `1e384998` — Fix badge stretching in tables by using inline-flex

## Screenshots

![basic-badges-in-table](https://github.com/Ivy-Interactive/Ivy-Framework/blob/plan-01167-Ivy-Framework/.github/screenshots/basic-badges-in-table.png?raw=true)

## Verification

- [x] DotnetBuild
- [x] DotnetFormat
- [x] DotnetTest
- [x] FrontendLint
- [x] IvyFrameworkVerification