### PR TITLE
[01181] Align ColorInput height variants with standard input heights

### DIFF
--- a/src/frontend/src/components/ui/input/color-input-variant.ts
+++ b/src/frontend/src/components/ui/input/color-input-variant.ts
@@ -5,9 +5,9 @@ export const colorInputVariant = cva(
   {
     variants: {
       density: {
-        Small: "h-8 py-1 text-xs",
+        Small: "h-7 py-1 text-xs",
         Medium: "h-9 py-1 text-sm",
-        Large: "h-10 py-2 text-base",
+        Large: "h-11 py-2 text-base",
       },
     },
     defaultVariants: {
@@ -19,9 +19,9 @@ export const colorInputVariant = cva(
 export const colorInputPickerVariant = cva("", {
   variants: {
     density: {
-      Small: "w-8 h-8",
-      Medium: "w-10 h-10",
-      Large: "w-12 h-12",
+      Small: "w-7 h-7",
+      Medium: "w-9 h-9",
+      Large: "w-11 h-11",
     },
   },
   defaultVariants: {


### PR DESCRIPTION
## Summary

Aligned ColorInput height variants with the standard input heights used by NumberInput. Updated `colorInputVariant` (Small: `h-8`->`h-7`, Large: `h-10`->`h-11`) and `colorInputPickerVariant` (Small: `w-8 h-8`->`w-7 h-7`, Medium: `w-10 h-10`->`w-9 h-9`, Large: `w-12 h-12`->`w-11 h-11`) so both components render at identical heights (`h-7`/`h-9`/`h-11`) at all density levels.

## Files Modified

- `src/frontend/src/components/ui/input/color-input-variant.ts` — aligned height and size variants

## Commits

- cb1b01dc [01181] Align ColorInput height variants with standard input heights