### PR TITLE
[01177] Fix DiffView jsx-runtime error by exposing ReactJsxRuntime global

### DIFF
--- a/src/frontend/src/index.tsx
+++ b/src/frontend/src/index.tsx
@@ -1,6 +1,7 @@
 import React, { StrictMode } from "react";
 import * as ReactDOMClient from "react-dom/client";
 import * as ReactDOM from "react-dom";
+import * as ReactJsxRuntime from "react/jsx-runtime";
 import "./index.css";
 import { App } from "./components/App";
 
@@ -11,11 +12,13 @@ import { App } from "./components/App";
   ...ReactDOM,
   ...ReactDOMClient,
 };
+(window as unknown as Record<string, unknown>).ReactJsxRuntime = ReactJsxRuntime;
 
 // Polyfill require for Vite-Plus Rolldown CJS externals bug in IIFE widget bundles
 (window as any).require = (moduleName: string) => {
   if (moduleName === "react") return React;
   if (moduleName === "react-dom") return { ...ReactDOM, ...ReactDOMClient };
+  if (moduleName === "react/jsx-runtime") return ReactJsxRuntime;
   throw new Error(`Module '${moduleName}' not found in Ivy browser require polyfill`);
 };
 

--- a/src/widgets/Ivy.Widgets.DiffView/frontend/vite.config.ts
+++ b/src/widgets/Ivy.Widgets.DiffView/frontend/vite.config.ts
@@ -28,7 +28,7 @@ export default defineConfig({
         globals: {
           react: "React",
           "react-dom": "ReactDOM",
-          "react/jsx-runtime": "React",
+          "react/jsx-runtime": "ReactJsxRuntime",
         },
         extend: false,
       },


### PR DESCRIPTION
## Summary

Exposed `react/jsx-runtime` as `window.ReactJsxRuntime` in the host app entry point and fixed the DiffView external widget's vite config to map `react/jsx-runtime` to the `ReactJsxRuntime` global instead of incorrectly mapping it to `React`. Also added `react/jsx-runtime` to the `require` polyfill for CJS compatibility.

## Files Modified

- **Host app entry:** `src/frontend/src/index.tsx` — added `ReactJsxRuntime` global export and require polyfill entry
- **DiffView widget config:** `src/widgets/Ivy.Widgets.DiffView/frontend/vite.config.ts` — fixed `react/jsx-runtime` global mapping from `"React"` to `"ReactJsxRuntime"`

## Commits

- `02d95f34` [01177] Fix DiffView jsx-runtime error by exposing ReactJsxRuntime global

## Artifacts

### Screenshots

![basic-content](https://stivytelemetry.blob.core.windows.net/ivy-tendril/basic-content.png?se=2026-04-29&sp=r&spr=https&sv=2026-02-06&sr=c&sig=JOgnjAo7JJwhtdYQsAIq7/M2d%2BcAlgBC9PnaFhje2lw%3D)

![basic-initial](https://stivytelemetry.blob.core.windows.net/ivy-tendril/basic-initial.png?se=2026-04-29&sp=r&spr=https&sv=2026-02-06&sr=c&sig=JOgnjAo7JJwhtdYQsAIq7/M2d%2BcAlgBC9PnaFhje2lw%3D)

![edge-empty-diff](https://stivytelemetry.blob.core.windows.net/ivy-tendril/edge-empty-diff.png?se=2026-04-29&sp=r&spr=https&sv=2026-02-06&sr=c&sig=JOgnjAo7JJwhtdYQsAIq7/M2d%2BcAlgBC9PnaFhje2lw%3D)

![edge-large-diff](https://stivytelemetry.blob.core.windows.net/ivy-tendril/edge-large-diff.png?se=2026-04-29&sp=r&spr=https&sv=2026-02-06&sr=c&sig=JOgnjAo7JJwhtdYQsAIq7/M2d%2BcAlgBC9PnaFhje2lw%3D)

![events-initial](https://stivytelemetry.blob.core.windows.net/ivy-tendril/events-initial.png?se=2026-04-29&sp=r&spr=https&sv=2026-02-06&sr=c&sig=JOgnjAo7JJwhtdYQsAIq7/M2d%2BcAlgBC9PnaFhje2lw%3D)

![integration-indexts](https://stivytelemetry.blob.core.windows.net/ivy-tendril/integration-indexts.png?se=2026-04-29&sp=r&spr=https&sv=2026-02-06&sr=c&sig=JOgnjAo7JJwhtdYQsAIq7/M2d%2BcAlgBC9PnaFhje2lw%3D)

![integration-readme](https://stivytelemetry.blob.core.windows.net/ivy-tendril/integration-readme.png?se=2026-04-29&sp=r&spr=https&sv=2026-02-06&sr=c&sig=JOgnjAo7JJwhtdYQsAIq7/M2d%2BcAlgBC9PnaFhje2lw%3D)

![props-back-unified](https://stivytelemetry.blob.core.windows.net/ivy-tendril/props-back-unified.png?se=2026-04-29&sp=r&spr=https&sv=2026-02-06&sr=c&sig=JOgnjAo7JJwhtdYQsAIq7/M2d%2BcAlgBC9PnaFhje2lw%3D)

![props-split](https://stivytelemetry.blob.core.windows.net/ivy-tendril/props-split.png?se=2026-04-29&sp=r&spr=https&sv=2026-02-06&sr=c&sig=JOgnjAo7JJwhtdYQsAIq7/M2d%2BcAlgBC9PnaFhje2lw%3D)

![props-unified](https://stivytelemetry.blob.core.windows.net/ivy-tendril/props-unified.png?se=2026-04-29&sp=r&spr=https&sv=2026-02-06&sr=c&sig=JOgnjAo7JJwhtdYQsAIq7/M2d%2BcAlgBC9PnaFhje2lw%3D)

### Videos

[no-critical-console-errors-across-all-apps.webm](https://stivytelemetry.blob.core.windows.net/ivy-tendril/no-critical-console-errors-across-all-apps.webm?se=2026-04-29&sp=r&spr=https&sv=2026-02-06&sr=c&sig=JOgnjAo7JJwhtdYQsAIq7/M2d%2BcAlgBC9PnaFhje2lw%3D)

[renders-diffview-without-errors.webm](https://stivytelemetry.blob.core.windows.net/ivy-tendril/renders-diffview-without-errors.webm?se=2026-04-29&sp=r&spr=https&sv=2026-02-06&sr=c&sig=JOgnjAo7JJwhtdYQsAIq7/M2d%2BcAlgBC9PnaFhje2lw%3D)

[renders-empty-diff-without-crash.webm](https://stivytelemetry.blob.core.windows.net/ivy-tendril/renders-empty-diff-without-crash.webm?se=2026-04-29&sp=r&spr=https&sv=2026-02-06&sr=c&sig=JOgnjAo7JJwhtdYQsAIq7/M2d%2BcAlgBC9PnaFhje2lw%3D)

[renders-event-test-app.webm](https://stivytelemetry.blob.core.windows.net/ivy-tendril/renders-event-test-app.webm?se=2026-04-29&sp=r&spr=https&sv=2026-02-06&sr=c&sig=JOgnjAo7JJwhtdYQsAIq7/M2d%2BcAlgBC9PnaFhje2lw%3D)

[renders-first-file-diff.webm](https://stivytelemetry.blob.core.windows.net/ivy-tendril/renders-first-file-diff.webm?se=2026-04-29&sp=r&spr=https&sv=2026-02-06&sr=c&sig=JOgnjAo7JJwhtdYQsAIq7/M2d%2BcAlgBC9PnaFhje2lw%3D)

[renders-large-diff.webm](https://stivytelemetry.blob.core.windows.net/ivy-tendril/renders-large-diff.webm?se=2026-04-29&sp=r&spr=https&sv=2026-02-06&sr=c&sig=JOgnjAo7JJwhtdYQsAIq7/M2d%2BcAlgBC9PnaFhje2lw%3D)

[renders-with-unified-view-mode.webm](https://stivytelemetry.blob.core.windows.net/ivy-tendril/renders-with-unified-view-mode.webm?se=2026-04-29&sp=r&spr=https&sv=2026-02-06&sr=c&sig=JOgnjAo7JJwhtdYQsAIq7/M2d%2BcAlgBC9PnaFhje2lw%3D)

[shows-diff-content-without-typeerror.webm](https://stivytelemetry.blob.core.windows.net/ivy-tendril/shows-diff-content-without-typeerror.webm?se=2026-04-29&sp=r&spr=https&sv=2026-02-06&sr=c&sig=JOgnjAo7JJwhtdYQsAIq7/M2d%2BcAlgBC9PnaFhje2lw%3D)

[switches-back-to-unified-view.webm](https://stivytelemetry.blob.core.windows.net/ivy-tendril/switches-back-to-unified-view.webm?se=2026-04-29&sp=r&spr=https&sv=2026-02-06&sr=c&sig=JOgnjAo7JJwhtdYQsAIq7/M2d%2BcAlgBC9PnaFhje2lw%3D)

[switches-between-files.webm](https://stivytelemetry.blob.core.windows.net/ivy-tendril/switches-between-files.webm?se=2026-04-29&sp=r&spr=https&sv=2026-02-06&sr=c&sig=JOgnjAo7JJwhtdYQsAIq7/M2d%2BcAlgBC9PnaFhje2lw%3D)

[switches-to-split-view.webm](https://stivytelemetry.blob.core.windows.net/ivy-tendril/switches-to-split-view.webm?se=2026-04-29&sp=r&spr=https&sv=2026-02-06&sr=c&sig=JOgnjAo7JJwhtdYQsAIq7/M2d%2BcAlgBC9PnaFhje2lw%3D)