### PR TITLE
[01193] Improve Option<T> and AsyncSelectInput documentation

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/04_Inputs/06_AsyncSelectInput.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/04_Inputs/06_AsyncSelectInput.md
@@ -54,6 +54,27 @@ public class AsyncSelectBasicDemo : ViewBase
 }
 ```
 
+## Option Parameter Order
+
+When creating options for `AsyncSelectInput`, use the `Option<T>` constructor with the parameter order `(label, value)`:
+
+- **label** — the display text shown to the user in the dropdown
+- **value** — the underlying value stored when the option is selected
+
+```csharp
+// Correct: label first, value second
+new Option<string>("Germany", "DE")           // displays "Germany", stores "DE"
+new Option<int>("Year 2024", 2024)            // displays "Year 2024", stores 2024
+new Option<Guid>("John Doe", userId)          // displays "John Doe", stores the Guid
+
+// Single-parameter shortcut: uses value.ToString() as the label
+new Option<string>("Electronics")             // displays "Electronics", stores "Electronics"
+```
+
+<Callout Type="warning">
+A common mistake is reversing the parameters: `new Option<string>(code, name)` instead of `new Option<string>(name, code)`. When both the label and value are strings, the compiler won't catch this — but the value will display as the label in the dropdown.
+</Callout>
+
 ## Data Types
 
 AsyncSelectInput supports various data types. Here's an example showing String, Integer, and Enum-based AsyncSelects:

--- a/src/Ivy/Widgets/Inputs/AsyncSelectInput.cs
+++ b/src/Ivy/Widgets/Inputs/AsyncSelectInput.cs
@@ -17,8 +17,33 @@ public delegate QueryResult<Option<T>[]> AsyncSelectSearchDelegate<T>(IViewConte
 public delegate QueryResult<Option<T>?> AsyncSelectLookupDelegate<T>(IViewContext context, T id);
 
 /// <summary>
-/// A selection input that fetches options asynchronously.
+/// A selection input that fetches options asynchronously. Ideal for large datasets,
+/// foreign key lookups, or any scenario where options are loaded on-demand.
 /// </summary>
+/// <remarks>
+/// Requires two delegates: a <c>search</c> delegate that returns matching options for a query string,
+/// and a <c>lookup</c> delegate that resolves a single value back to its display option.
+/// <para>
+/// Options are created using <see cref="Option{TValue}"/> with the parameter order <c>(label, value)</c>:
+/// the label is displayed to the user, and the value is stored when selected.
+/// </para>
+/// <example>
+/// <code>
+/// var country = UseState&lt;string?&gt;(default(string));
+///
+/// QueryResult&lt;Option&lt;string&gt;[]&gt; SearchCountries(IViewContext ctx, string query) =&gt;
+///     ctx.UseQuery&lt;Option&lt;string&gt;[], (string, string)&gt;(
+///         key: ("countries", query),
+///         fetcher: ct =&gt; Task.FromResult(countries
+///             .Where(c =&gt; c.Name.Contains(query, StringComparison.OrdinalIgnoreCase))
+///             .Select(c =&gt; new Option&lt;string&gt;(c.Name, c.Code))  // label: Name, value: Code
+///             .ToArray()));
+///
+/// country.ToAsyncSelectInput(SearchCountries, LookupCountry, "Search countries...");
+/// </code>
+/// </example>
+/// </remarks>
+/// <typeparam name="TValue">The type of the selected value.</typeparam>
 public class AsyncSelectInputView<TValue> : ViewBase, IAnyAsyncSelectInputBase, IInput<TValue>
 {
     public Type[] SupportedStateTypes() => [];

--- a/src/Ivy/Widgets/Inputs/Option.cs
+++ b/src/Ivy/Widgets/Inputs/Option.cs
@@ -22,8 +22,17 @@ public interface IAnyOption
     public string? Tooltip { get; set; }
 }
 
+/// <summary>
+/// Represents a selectable option with a display label and a typed value.
+/// Used with <see cref="AsyncSelectInputView{TValue}"/>, SelectInput, and other selection widgets.
+/// </summary>
+/// <typeparam name="TValue">The type of the underlying value.</typeparam>
 public class Option<TValue> : IAnyOption
 {
+    /// <summary>
+    /// Creates an option using <c>value.ToString()</c> as the display label.
+    /// </summary>
+    /// <param name="value">The value for this option. Its <c>ToString()</c> result is used as the label.</param>
     public Option(TValue value) : this(value?.ToString() ?? "?", value, null)
     {
     }
@@ -33,6 +42,29 @@ public class Option<TValue> : IAnyOption
         Value = null!;
     }
 
+    /// <summary>
+    /// Creates an option with an explicit label and value.
+    /// </summary>
+    /// <remarks>
+    /// The parameter order is <c>(label, value)</c> — the label is what the user sees in the dropdown,
+    /// and the value is what gets stored/returned when the option is selected.
+    /// <example>
+    /// <code>
+    /// // label: "Germany", value: "DE"
+    /// new Option&lt;string&gt;("Germany", "DE")
+    ///
+    /// // label: "John Doe", value: userId (Guid)
+    /// new Option&lt;Guid&gt;("John Doe", userId, group: "Engineering")
+    /// </code>
+    /// </example>
+    /// </remarks>
+    /// <param name="label">The display text shown to the user in the dropdown.</param>
+    /// <param name="value">The underlying value stored when this option is selected.</param>
+    /// <param name="group">Optional group name for categorizing options.</param>
+    /// <param name="description">Optional description shown below the label.</param>
+    /// <param name="icon">Optional icon displayed next to the label.</param>
+    /// <param name="disabled">Whether this option is disabled and cannot be selected.</param>
+    /// <param name="tooltip">Optional tooltip shown on hover.</param>
     public Option(string? label, TValue value, string? group = null, string? description = null, Icons? icon = null, bool disabled = false, string? tooltip = null)
     {
         Label = label;


### PR DESCRIPTION
## Summary

Added XML documentation comments to `Option<T>` constructors and `AsyncSelectInputView<T>` to clarify the `(label, value)` parameter order. Updated the AsyncSelectInput documentation page with a new "Option Parameter Order" section including examples and a warning about the common mistake of reversing parameters.

## API Changes

None. Documentation-only change — no behavioral or API surface changes.

## Files Modified

- **C# source:**
  - `src/Ivy/Widgets/Inputs/Option.cs` — Added `<summary>`, `<param>`, and `<example>` XML doc comments to `Option<T>` class and its constructors
  - `src/Ivy/Widgets/Inputs/AsyncSelectInput.cs` — Added `<summary>`, `<remarks>`, and `<example>` XML doc comments to `AsyncSelectInputView<T>`
- **Documentation:**
  - `src/Ivy.Docs.Shared/Docs/02_Widgets/04_Inputs/06_AsyncSelectInput.md` — Added "Option Parameter Order" section with usage examples and common pitfall callout

## Commits

- b2d60a35 [01193] Improve Option<T> and AsyncSelectInput documentation