### PR TITLE
[TextInput]: textarea height prop resizes container only, not content area

### DIFF
--- a/src/frontend/src/widgets/inputs/TextInputWidget/variants/TextareaVariant.tsx
+++ b/src/frontend/src/widgets/inputs/TextInputWidget/variants/TextareaVariant.tsx
@@ -51,8 +51,11 @@ export const TextareaVariant: React.FC<TextareaVariantProps> = ({
     onChange(syntheticEvent);
   });
 
-  const styles: React.CSSProperties = {
+  const wrapperStyles: React.CSSProperties = {
     ...getWidth(props.width),
+  };
+
+  const textareaStyles: React.CSSProperties = {
     ...getHeight(props.height),
   };
 
@@ -64,7 +67,7 @@ export const TextareaVariant: React.FC<TextareaVariantProps> = ({
     <div className="relative w-full select-none">
       <div
         className="rounded-field border border-input bg-transparent shadow-sm dark:bg-white/5 dark:border-white/10"
-        style={styles}
+        style={wrapperStyles}
       >
         <Textarea
           ref={elementRef as React.RefObject<HTMLTextAreaElement>}
@@ -79,9 +82,11 @@ export const TextareaVariant: React.FC<TextareaVariantProps> = ({
           onBlur={onBlur}
           onFocus={onFocus}
           onPaste={handlePaste}
+          style={textareaStyles}
           className={cn(
             textareaSizeVariant({ density }),
-            "border-0 shadow-none dark:bg-transparent h-full",
+            "border-0 shadow-none dark:bg-transparent",
+            !props.height && "h-full",
             props.invalid && inputStyles.invalidInput,
             (props.invalid || showClear) && "pr-8",
             props.shortcutKey && !isFocused && !hasValue && !showClear && !props.invalid && "pr-16",


### PR DESCRIPTION
## Problem
When a `TextareaInput` had an explicit `.Height(...)` set, dragging the native resize handle would only move the border of the wrapper `<div>` — the actual textarea content area stayed the same size. This happened because the height style was applied to the wrapper `<div>` while the `<textarea>` used `h-full` to fill it. The browser's resize handle sets an inline style on the `<textarea>` element itself, not on the parent, so the two were out of sync.

## Fix
Move the height style from the wrapper `<div>` directly onto the `<Textarea>` element. The wrapper now only carries the width, and its height grows naturally to wrap the textarea. `h-full` is preserved on the textarea only when no explicit height prop is provided.

https://github.com/user-attachments/assets/42dffb6b-73a2-432a-aa44-0f9a8fd38793


