### PR TITLE
[01231] Reduce <details> block margins in Markdown widget

### DIFF
--- a/src/frontend/src/lib/styles.ts
+++ b/src/frontend/src/lib/styles.ts
@@ -714,7 +714,7 @@ export const typography: Record<string, string> = {
   hr: "border-t border-border",
 
   // Expandable sections
-  details: "my-4 rounded-lg border border-border bg-card shadow-sm overflow-hidden",
+  details: "my-2 rounded-lg border border-border bg-card shadow-sm overflow-hidden",
   summary:
     "cursor-pointer select-none px-4 py-3 font-medium hover:bg-accent/50 transition-colors list-none [&::-webkit-details-marker]:hidden",
 };


### PR DESCRIPTION
## Problem

When multiple `<details>` blocks are rendered in the Markdown widget, there is excessive vertical spacing between them. The `my-4` Tailwind class on the `details` typography style adds 1rem (16px) margin on both top and bottom, resulting in ~32px of combined gap between consecutive `<details>` elements.

## Solution

Changed the `details` typography class from `my-4` to `my-2` in `src/frontend/src/lib/styles.ts`, reducing vertical margin from 1rem to 0.5rem (8px) on each side.

## Commits

- 366cbbc3 [01231] Reduce details block margins from my-4 to my-2

## Artifacts

### Screenshots

![basic-details-closed](https://stivytelemetry.blob.core.windows.net/ivy-tendril/basic-details-closed.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)
![basic-details-margins-measured](https://stivytelemetry.blob.core.windows.net/ivy-tendril/basic-details-margins-measured.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)
![multiple-consecutive-closed](https://stivytelemetry.blob.core.windows.net/ivy-tendril/multiple-consecutive-closed.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)
![multiple-consecutive-margins](https://stivytelemetry.blob.core.windows.net/ivy-tendril/multiple-consecutive-margins.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)
![multiple-consecutive-some-expanded](https://stivytelemetry.blob.core.windows.net/ivy-tendril/multiple-consecutive-some-expanded.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)