### PR TITLE
[Security]: resolve warnings

### DIFF
--- a/src/Ivy.Docs.Tools/rust_cli/Cargo.lock
+++ b/src/Ivy.Docs.Tools/rust_cli/Cargo.lock
@@ -62,12 +62,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -226,9 +220,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8655f91cd07f2b9d0c24137bd650fe69617773435ee5ec83022377777ce65ef1"
+checksum = "1a79f2aff40c18ab8615ddc5caa9eb5b96314aef18fe5823090f204ad988e813"
 dependencies = [
  "typenum",
 ]
@@ -266,16 +260,6 @@ name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
-
-[[package]]
-name = "libyml"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
-dependencies = [
- "anyhow",
- "version_check",
-]
 
 [[package]]
 name = "markdown"
@@ -387,7 +371,7 @@ dependencies = [
  "regex",
  "roxmltree",
  "serde",
- "serde_yml",
+ "serde_yaml_ng",
  "sha2",
  "walkdir",
 ]
@@ -438,18 +422,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yml"
-version = "0.0.12"
+name = "serde_yaml_ng"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
  "indexmap",
  "itoa",
- "libyml",
- "memchr",
  "ryu",
  "serde",
- "version_check",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -499,16 +481,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"

--- a/src/Ivy.Docs.Tools/rust_cli/Cargo.toml
+++ b/src/Ivy.Docs.Tools/rust_cli/Cargo.toml
@@ -14,7 +14,7 @@ rayon = "1.11.0"
 regex = "1.12.3"
 roxmltree = "0.21.1"
 serde = { version = "1.0.228", features = ["derive"] }
-serde_yml = "0.0.12"
+serde_yaml_ng = "0.10"
 sha2 = "0.11.0"
 walkdir = "2.5.0"
 

--- a/src/Ivy.Docs.Tools/rust_cli/src/converter.rs
+++ b/src/Ivy.Docs.Tools/rust_cli/src/converter.rs
@@ -80,7 +80,7 @@ pub fn convert_async(
 
     if let Node::Root(root) = &ast {
         if let Some(Node::Yaml(yaml)) = root.children.first() {
-            if let Ok(meta) = serde_yml::from_str::<AppMeta>(&yaml.value) {
+            if let Ok(meta) = serde_yaml_ng::from_str::<AppMeta>(&yaml.value) {
                 app_meta = meta;
             }
         }

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -116,7 +116,7 @@
     "@types/wicg-file-system-access": "2023.10.7",
     "@vitejs/plugin-react": "6.0.1",
     "canvas-confetti": "1.9.4",
-    "happy-dom": "20.8.8",
+    "happy-dom": "20.8.9",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
     "tailwindcss": "4.1.16",

--- a/src/frontend/pnpm-lock.yaml
+++ b/src/frontend/pnpm-lock.yaml
@@ -305,8 +305,8 @@ importers:
         specifier: 1.9.4
         version: 1.9.4
       happy-dom:
-        specifier: 20.8.8
-        version: 20.8.8
+        specifier: 20.8.9
+        version: 20.8.9
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -324,10 +324,10 @@ importers:
         version: '@voidzero-dev/vite-plus-core@0.1.13(@types/node@24.10.0)(jiti@2.6.1)(typescript@5.9.3)(yaml@2.8.3)'
       vite-plus:
         specifier: 0.1.13
-        version: 0.1.13(@types/node@24.10.0)(@voidzero-dev/vite-plus-core@0.1.13(@types/node@24.10.0)(jiti@2.6.1)(typescript@5.9.3)(yaml@2.8.3))(happy-dom@20.8.8)(jiti@2.6.1)(typescript@5.9.3)(yaml@2.8.3)
+        version: 0.1.13(@types/node@24.10.0)(@voidzero-dev/vite-plus-core@0.1.13(@types/node@24.10.0)(jiti@2.6.1)(typescript@5.9.3)(yaml@2.8.3))(happy-dom@20.8.9)(jiti@2.6.1)(typescript@5.9.3)(yaml@2.8.3)
       vitest:
         specifier: npm:@voidzero-dev/vite-plus-test@0.1.13
-        version: '@voidzero-dev/vite-plus-test@0.1.13(@types/node@24.10.0)(@voidzero-dev/vite-plus-core@0.1.13(@types/node@24.10.0)(jiti@2.6.1)(typescript@5.9.3)(yaml@2.8.3))(happy-dom@20.8.8)(jiti@2.6.1)(typescript@5.9.3)(yaml@2.8.3)'
+        version: '@voidzero-dev/vite-plus-test@0.1.13(@types/node@24.10.0)(@voidzero-dev/vite-plus-core@0.1.13(@types/node@24.10.0)(jiti@2.6.1)(typescript@5.9.3)(yaml@2.8.3))(happy-dom@20.8.9)(jiti@2.6.1)(typescript@5.9.3)(yaml@2.8.3)'
 
 packages:
 
@@ -2439,8 +2439,8 @@ packages:
   hachure-fill@0.5.2:
     resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
 
-  happy-dom@20.8.8:
-    resolution: {integrity: sha512-5/F8wxkNxYtsN0bXfMwIyNLZ9WYsoOYPbmoluqVJqv8KBUbcyKZawJ7uYK4WTX8IHBLYv+VXIwfeNDPy1oKMwQ==}
+  happy-dom@20.8.9:
+    resolution: {integrity: sha512-Tz23LR9T9jOGVZm2x1EPdXqwA37G/owYMxRwU0E4miurAtFsPMQ1d2Jc2okUaSjZqAFz2oEn3FLXC5a0a+siyA==}
     engines: {node: '>=20.0.0'}
 
   has-flag@4.0.0:
@@ -5073,7 +5073,7 @@ snapshots:
   '@voidzero-dev/vite-plus-linux-x64-gnu@0.1.13':
     optional: true
 
-  '@voidzero-dev/vite-plus-test@0.1.13(@types/node@24.10.0)(@voidzero-dev/vite-plus-core@0.1.13(@types/node@24.10.0)(jiti@2.6.1)(typescript@5.9.3)(yaml@2.8.3))(happy-dom@20.8.8)(jiti@2.6.1)(typescript@5.9.3)(yaml@2.8.3)':
+  '@voidzero-dev/vite-plus-test@0.1.13(@types/node@24.10.0)(@voidzero-dev/vite-plus-core@0.1.13(@types/node@24.10.0)(jiti@2.6.1)(typescript@5.9.3)(yaml@2.8.3))(happy-dom@20.8.9)(jiti@2.6.1)(typescript@5.9.3)(yaml@2.8.3)':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
@@ -5091,7 +5091,7 @@ snapshots:
       ws: 8.20.0
     optionalDependencies:
       '@types/node': 24.10.0
-      happy-dom: 20.8.8
+      happy-dom: 20.8.9
     transitivePeerDependencies:
       - '@arethetypeswrong/core'
       - '@tsdown/css'
@@ -5644,7 +5644,7 @@ snapshots:
 
   hachure-fill@0.5.2: {}
 
-  happy-dom@20.8.8:
+  happy-dom@20.8.9:
     dependencies:
       '@types/node': 24.10.0
       '@types/whatwg-mimetype': 3.0.2
@@ -7038,11 +7038,11 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-plus@0.1.13(@types/node@24.10.0)(@voidzero-dev/vite-plus-core@0.1.13(@types/node@24.10.0)(jiti@2.6.1)(typescript@5.9.3)(yaml@2.8.3))(happy-dom@20.8.8)(jiti@2.6.1)(typescript@5.9.3)(yaml@2.8.3):
+  vite-plus@0.1.13(@types/node@24.10.0)(@voidzero-dev/vite-plus-core@0.1.13(@types/node@24.10.0)(jiti@2.6.1)(typescript@5.9.3)(yaml@2.8.3))(happy-dom@20.8.9)(jiti@2.6.1)(typescript@5.9.3)(yaml@2.8.3):
     dependencies:
       '@oxc-project/types': 0.120.0
       '@voidzero-dev/vite-plus-core': 0.1.13(@types/node@24.10.0)(jiti@2.6.1)(typescript@5.9.3)(yaml@2.8.3)
-      '@voidzero-dev/vite-plus-test': 0.1.13(@types/node@24.10.0)(@voidzero-dev/vite-plus-core@0.1.13(@types/node@24.10.0)(jiti@2.6.1)(typescript@5.9.3)(yaml@2.8.3))(happy-dom@20.8.8)(jiti@2.6.1)(typescript@5.9.3)(yaml@2.8.3)
+      '@voidzero-dev/vite-plus-test': 0.1.13(@types/node@24.10.0)(@voidzero-dev/vite-plus-core@0.1.13(@types/node@24.10.0)(jiti@2.6.1)(typescript@5.9.3)(yaml@2.8.3))(happy-dom@20.8.9)(jiti@2.6.1)(typescript@5.9.3)(yaml@2.8.3)
       cac: 7.0.0
       cross-spawn: 7.0.6
       oxfmt: 0.41.0


### PR DESCRIPTION
# PR: Fix Security Warnings — Dependabot Alerts & CodeQL Code Scanning

## Summary

This PR addresses **24 security warnings** detected in the Ivy-Framework repository:
- **4 Dependabot alerts** (`#75–#78`) — fixed by updating dependencies
- **20 CodeQL code scanning alerts** (`#82–#101`) — dismissed as false positives (see justification below)

---

## Part 1: Dependabot Alerts (Fixed)

### #77 — `libyml` crate is unsound and unmaintained (High 8.7)
- **File:** `src/Ivy.Docs.Tools/rust_cli/Cargo.lock`
- **Problem:** `libyml` (Rust wrapper over C LibYAML) contained undefined behavior in `yaml_string_extend`. The project was archived on GitHub.
- **Cause:** Transitive dependency of `serde_yml` — `serde_yml 0.0.12 → libyml 0.0.5`
- **Fix:** Resolved automatically by replacing `serde_yml` (see `#78` below).

### #78 — `serde_yml` crate is unsound and unmaintained (Moderate 6.9)
- **File:** `src/Ivy.Docs.Tools/rust_cli/Cargo.toml`
- **Problem:** `serde_yml` (YAML serialization/deserialization) was archived due to unsoundness — `serde_yml::ser::Serializer.emitter` can cause a segmentation fault.
- **Cause:** Direct dependency in the Rust docs CLI tool, used in one place (`converter.rs:83`) for YAML frontmatter parsing.
- **Fix:** Migrated to `serde_yaml_ng` — a maintained fork with identical API. Changed `Cargo.toml` dependency and updated the `from_str` call in `converter.rs`. This also removes `libyml` from the dependency tree.

### #75, #76 — Happy DOM fetch credentials cookie leak (High 7.5)
- **File:** `src/frontend/package.json`, `src/frontend/pnpm-lock.yaml`
- **Problem:** `happy-dom` < 20.8.9 attaches cookies from the current page origin (`window.location`) instead of the request target URL when `fetch(..., { credentials: "include" })` is used. This can leak cookies between origins.
- **Cause:** `happy-dom` is used as the test environment for Vitest (`vite.config.mjs: environment: "happy-dom"`). Two alerts were created because the package appears in both `package.json` (direct devDependency) and `pnpm-lock.yaml` (transitive via `@voidzero-dev/vite-plus-test`).
- **Fix:** Updated `happy-dom` from `20.8.8` to `>=20.8.9` in `package.json` and ran `pnpm install` to regenerate the lock file.

### Changes Made

| File | Change |
|---|---|
| `src/Ivy.Docs.Tools/rust_cli/Cargo.toml` | `serde_yml = "0.0.12"` → `serde_yaml_ng = "0.10"` |
| `src/Ivy.Docs.Tools/rust_cli/src/converter.rs` | `serde_yml::from_str` → `serde_yaml_ng::from_str` |
| `src/Ivy.Docs.Tools/rust_cli/Cargo.lock` | Regenerated (removed `serde_yml`, `libyml`; added `serde_yaml_ng`) |
| `src/frontend/package.json` | `happy-dom: "20.8.8"` → `">=20.8.9"` |
| `src/frontend/pnpm-lock.yaml` | Regenerated |

### Verification

- `cargo build` — ✅ compiled successfully
- `pnpm install` — ✅ `happy-dom@20.8.9` installed

---

## Part 2: CodeQL Code Scanning Alerts (Dismissed)

All 20 CodeQL alerts are dismissed as **false positives**. Below is the detailed justification for each category.

### "Log entries created from user input" — 18 alerts (High)

**Alerts:** #82–#99

**Files affected:**
- `src/Ivy/Core/Auth/AuthController.cs` — lines 34, 41, 50, 71, 94, 107, 302, 310, 318, 334
- `src/Ivy/Core/HttpTunneling/HttpTunnelingController.cs` — lines 57, 63, 77

**What CodeQL detected:** User-controlled values (`connectionId`, `optionId`, `machineId` from query parameters and HTTP headers) flow into log messages, which could enable log injection (CWE-117).

**Why dismissed:** The code uses **structured logging** (`Microsoft.Extensions.Logging`):
```csharp
logger.LogWarning("Session not found for {ConnectionId}", connectionId);
```
In structured logging, user values are passed as **parameters**, not concatenated into the message string. They are stored as separate structured fields, not inline text. This prevents log injection because:
1. The log message template is a constant string
2. Parameters are handled by the logging framework, not string interpolation
3. Modern logging sinks (Serilog, Application Insights, etc.) properly escape parameter values

Removing these values from logs is not an option — `connectionId` and similar identifiers are essential for debugging and incident response.

---

### "URL redirection from remote source" — 1 alert (#100, Medium)

**File:** `src/Ivy/Core/Auth/AuthController.cs`, line 67

**What CodeQL detected:** `Redirect(uri.ToString())` where `uri` comes from `authService.GetOAuthUriAsync()` — a dynamically generated URL, flagged as a potential Open Redirect vulnerability.

**Why dismissed:** This is a **standard OAuth 2.0 authorization flow**. The redirect URI is generated by:
1. `IAuthService.GetOAuthUriAsync()` — a server-side method
2. The `option` parameter is validated against a whitelist of registered auth options (line 47: `options.FirstOrDefault(o => o.Id == optionId)`)
3. The OAuth URI comes from server configuration (identity provider URLs like Google, GitHub), not from user input

The user controls `optionId` (which option to use), but the actual redirect URL is determined by the server-side auth provider configuration. This is how OAuth works — the redirect to the identity provider is intentional and necessary.

---

### "User-controlled bypass of sensitive method" — 1 alert (#101, High)

**File:** `src/Ivy/Core/Auth/AuthController.cs`, line 191

**What CodeQL detected:** A user-controlled boolean (`request.TriggerMachineBrokeredRefresh`) determines whether the sensitive method `TriggerMachineAuthRefresh()` is called.

**Why dismissed:** This is **by design**. The endpoint `ivy/auth/set-auth-cookies`:
1. Is protected by `CookieJarId` validation (lines 160-164) — requests with an invalid `CookieJarId` are rejected before reaching the boolean check
2. `CookieJarId` is a server-generated token that the client cannot forge
3. The boolean flags (`TriggerMachineReload`, `TriggerMachineBrokeredRefresh`) are part of the intended API contract — the authenticated client instructs the server on what post-login actions to perform

Without a valid `CookieJarId`, no attacker can reach this code path.
