### PR TITLE
[01252] Add Badge(string) extension method for buttons

### DIFF
--- a/src/Ivy.Samples.Shared/Apps/Widgets/ButtonApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/ButtonApp.cs
@@ -133,6 +133,13 @@ public class ButtonApp() : SampleBase
                    | new Button("Full Rounded", eventHandler, variant: ButtonVariant.Ai).BorderRadius(BorderRadius.Full)
                )
 
+               | Text.H2("Badges")
+               | (Layout.Horizontal().Gap(8)
+                   | new Button("Inbox", eventHandler).Badge("3").ShortcutKey("i")
+                   | new Button("Notifications", eventHandler, variant: ButtonVariant.Secondary).Badge("99+")
+                   | new Button("Updates", eventHandler, variant: ButtonVariant.Outline).Badge("New")
+               )
+
                | Text.H2("Keyboard Shortcuts")
                | (Layout.Horizontal().Gap(8)
                    | new Button("Search", eventHandler, variant: ButtonVariant.Primary).ShortcutKey("Ctrl+K")

--- a/src/Ivy/Widgets/Button.cs
+++ b/src/Ivy/Widgets/Button.cs
@@ -90,6 +90,8 @@ public record Button : WidgetBase<Button>
 
     [Prop] public string? ShortcutKey { get; set; }
 
+    [Prop] public string? Badge { get; set; }
+
     [Prop] public BorderRadius BorderRadius { get; set; } = BorderRadius.Rounded;
 
     [Event] public EventHandler<Event<Button>>? OnClick { get; set; }
@@ -183,6 +185,8 @@ public static class ButtonExtensions
     public static Button OnClick(this Button button, Func<ValueTask> onClick) => button with { OnClick = new(_ => onClick()) };
 
     public static Button ShortcutKey(this Button button, string shortcutKey) => button with { ShortcutKey = shortcutKey };
+
+    public static Button Badge(this Button button, string? badge) => button with { Badge = badge };
 
     public static Button Tag(this Button button, object tag) => button with { Tag = tag };
 

--- a/src/frontend/src/widgets/button/ButtonWidget.tsx
+++ b/src/frontend/src/widgets/button/ButtonWidget.tsx
@@ -14,6 +14,7 @@ import {
 import { useEventHandler } from "@/components/event-handler";
 import withTooltip from "@/hoc/withTooltip";
 import { Loader2 } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
 import { BorderRadius, getColor, getWidth } from "@/lib/styles";
 import { Densities } from "@/types/density";
 import {
@@ -47,6 +48,7 @@ interface ButtonWidgetProps {
   target?: "Blank" | "Self";
   width?: string;
   shortcutKey?: string;
+  badge?: string;
   children?: React.ReactNode;
   borderRadius?: BorderRadius;
   "data-testid"?: string;
@@ -100,6 +102,7 @@ export const ButtonWidget: React.FC<ButtonWidgetProps> = ({
   loading = false,
   width,
   shortcutKey,
+  badge,
   children,
   borderRadius = "Rounded",
   density = Densities.Medium,
@@ -255,6 +258,11 @@ export const ButtonWidget: React.FC<ButtonWidgetProps> = ({
             <span className="truncate">{title}</span>
           ) : (
             title
+          )}
+          {badge && (
+            <Badge variant="secondary" className="ml-1 w-min whitespace-nowrap">
+              {badge}
+            </Badge>
           )}
           {shortcutKey && title && (
             <kbd className="ml-1 px-1 py-0.5 text-[0.65rem] font-medium text-muted-foreground bg-muted border border-border rounded-selector">


### PR DESCRIPTION
Added a `Badge` property and `Badge(string?)` extension method to the `Button` widget, following the established Tab widget pattern. The frontend `ButtonWidget.tsx` renders the badge using the `secondary` variant (neutral background) as a pill between the button label and the shortcut `<kbd>` element. A sample section was added to `ButtonApp.cs` demonstrating badge usage with various button variants and shortcut key coexistence.

## API Changes

- **New property:** `Button.Badge` (`string?`) — sets a badge text on the button
- **New extension method:** `ButtonExtensions.Badge(this Button, string?)` — fluent API for setting the badge

## Files Modified

- `src/Ivy/Widgets/Button.cs` — Added `Badge` property and extension method
- `src/frontend/src/widgets/button/ButtonWidget.tsx` — Added badge rendering using the `Badge` UI component with `secondary` variant
- `src/Ivy.Samples.Shared/Apps/Widgets/ButtonApp.cs` — Added "Badges" sample section

## Commits

- `758a3689` [01252] Add Badge(string) extension method for buttons

## Artifacts

### Screenshots
![basic-badges-after-click](https://stivytelemetry.blob.core.windows.net/ivy-tendril/basic-badges-after-click.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)
![basic-badges](https://stivytelemetry.blob.core.windows.net/ivy-tendril/basic-badges.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)
![edge-dynamic-badge](https://stivytelemetry.blob.core.windows.net/ivy-tendril/edge-dynamic-badge.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)
![edge-icon-only-badge](https://stivytelemetry.blob.core.windows.net/ivy-tendril/edge-icon-only-badge.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)
![edge-long-disabled](https://stivytelemetry.blob.core.windows.net/ivy-tendril/edge-long-disabled.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)
![events-after-interactions](https://stivytelemetry.blob.core.windows.net/ivy-tendril/events-after-interactions.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)
![integration-badge-shortcut](https://stivytelemetry.blob.core.windows.net/ivy-tendril/integration-badge-shortcut.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)
![integration-card-badges](https://stivytelemetry.blob.core.windows.net/ivy-tendril/integration-card-badges.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)
![props-all-variants](https://stivytelemetry.blob.core.windows.net/ivy-tendril/props-all-variants.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)
![props-icons-with-badges](https://stivytelemetry.blob.core.windows.net/ivy-tendril/props-icons-with-badges.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)
![props-null-empty-badge](https://stivytelemetry.blob.core.windows.net/ivy-tendril/props-null-empty-badge.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)