### PR TITLE
[01234] Use primary color for popover link styling

### DIFF
--- a/src/frontend/src/components/markdown/PopoverLink.tsx
+++ b/src/frontend/src/components/markdown/PopoverLink.tsx
@@ -15,8 +15,8 @@ export const PopoverLink: React.FC<PopoverLinkProps> = ({ content, children }) =
           style={{
             textDecoration: "underline dotted",
             textUnderlineOffset: "3px",
-            textDecorationColor: "green",
-            color: "green",
+            textDecorationColor: "var(--primary)",
+            color: "var(--primary)",
           }}
           role="button"
           tabIndex={0}


### PR DESCRIPTION
## Summary

Changed the popover link color from hardcoded `green` to `var(--primary)` in PopoverLink.tsx, so the dotted underline and text color follow the theme's primary color.

## Files Modified

- `src/frontend/src/components/markdown/PopoverLink.tsx` — changed `textDecorationColor` and `color` from `"green"` to `"var(--primary)"`

## Commits

- e2ed6b1d [01234] Use primary color for popover link styling

## Artifacts

### Screenshots

![basic-initial](https://stivytelemetry.blob.core.windows.net/ivy-tendril/basic-initial.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![basic-popover-open](https://stivytelemetry.blob.core.windows.net/ivy-tendril/basic-popover-open.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![edge-cases-bold-popover](https://stivytelemetry.blob.core.windows.net/ivy-tendril/edge-cases-bold-popover.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![edge-cases-italic-popover](https://stivytelemetry.blob.core.windows.net/ivy-tendril/edge-cases-italic-popover.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![styling-initial](https://stivytelemetry.blob.core.windows.net/ivy-tendril/styling-initial.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

### Videos

[clicking-popover-link-shows-content.webm](https://stivytelemetry.blob.core.windows.net/ivy-tendril/clicking-popover-link-shows-content.webm?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

[popover-links-do-not-trigger-onlinkclick.webm](https://stivytelemetry.blob.core.windows.net/ivy-tendril/popover-links-do-not-trigger-onlinkclick.webm?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)