### PR TITLE
[01271] Add grow-in animation to sheets matching dialog behavior

### DIFF
--- a/src/frontend/src/widgets/sheet/SheetWidget.tsx
+++ b/src/frontend/src/widgets/sheet/SheetWidget.tsx
@@ -64,7 +64,7 @@ export const SheetWidget: React.FC<SheetWidgetProps> = ({
       <SheetContent
         side={normalizedSide}
         style={styles}
-        className={cn("flex flex-col p-0 gap-0", isHorizontal && "h-full")}
+        className={cn("flex flex-col p-0 gap-0 alert-animate-enter", isHorizontal && "h-full")}
         data-sheet-side={normalizedSide}
         onOpenAutoFocus={(e) => {
           e.preventDefault();


### PR DESCRIPTION
## Summary

Added the `alert-animate-enter` CSS class to the `SheetContent` component in `SheetWidget.tsx`, giving sheets the same subtle grow-in animation (scale 0.8→1 + opacity fade, 200ms) that dialogs already have.

## API Changes

None.

## Files Modified

- **Frontend:** `src/frontend/src/widgets/sheet/SheetWidget.tsx` — added `alert-animate-enter` class to SheetContent className

## Commits

- d4462534 [01271] Add grow-in animation to sheets matching dialog behavior

## Artifacts

### Screenshots

![basic-sheet-bottom-open](https://stivytelemetry.blob.core.windows.net/ivy-tendril/basic-sheet-bottom-open.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![basic-sheet-initial](https://stivytelemetry.blob.core.windows.net/ivy-tendril/basic-sheet-initial.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![basic-sheet-left-open](https://stivytelemetry.blob.core.windows.net/ivy-tendril/basic-sheet-left-open.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![basic-sheet-right-open](https://stivytelemetry.blob.core.windows.net/ivy-tendril/basic-sheet-right-open.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![basic-sheet-top-open](https://stivytelemetry.blob.core.windows.net/ivy-tendril/basic-sheet-top-open.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![comparison-dialog-open](https://stivytelemetry.blob.core.windows.net/ivy-tendril/comparison-dialog-open.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![comparison-initial](https://stivytelemetry.blob.core.windows.net/ivy-tendril/comparison-initial.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![comparison-sheet-open](https://stivytelemetry.blob.core.windows.net/ivy-tendril/comparison-sheet-open.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![props-narrow-sheet](https://stivytelemetry.blob.core.windows.net/ivy-tendril/props-narrow-sheet.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![props-wide-sheet](https://stivytelemetry.blob.core.windows.net/ivy-tendril/props-wide-sheet.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)