### PR TITLE
[01281] Add HeaderLeft and HeaderRight slots to DataTable

### DIFF
--- a/src/Ivy.Samples.Shared/Apps/Widgets/DataTableApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/DataTableApp.cs
@@ -9,6 +9,7 @@ public class DataTableApp : SampleBase
     {
         return Layout.Tabs(
             new Tab("Overview", new DataTableMainSample()),
+            new Tab("Header Slots", new DataTableHeaderSlotsSample()),
             new Tab("Footer", new DataTableFooterSample()),
             new Tab("Multi Agg", new DataTableMultiAggSample()),
             new Tab("Million Rows", new DataTablesMillionRowsSample())
@@ -184,6 +185,28 @@ public class DataTableMainSample : ViewBase
         {
             mockService.UpdateEmployee(updated);
         })]);
+    }
+}
+
+public class DataTableHeaderSlotsSample : ViewBase
+{
+    public override object? Build()
+    {
+        var products = new[]
+        {
+            new { Id = 1, Product = "Widget A", Price = 29.99m, Stock = 150 },
+            new { Id = 2, Product = "Widget B", Price = 49.99m, Stock = 85 },
+            new { Id = 3, Product = "Widget C", Price = 19.99m, Stock = 320 },
+            new { Id = 4, Product = "Gadget X", Price = 99.99m, Stock = 42 },
+            new { Id = 5, Product = "Gadget Y", Price = 149.99m, Stock = 18 },
+        }.AsQueryable();
+
+        return products.ToDataTable()
+            .HeaderLeft(ctx => new Button("Export", icon: Icons.Download).Small())
+            .HeaderRight(ctx => Layout.Horizontal().Gap(2)
+                | new Badge($"{products.Count()} items")
+                | new Button("Settings", icon: Icons.Settings).Small())
+            .Height(Size.Units(80));
     }
 }
 

--- a/src/Ivy.Tests/Views/DataTables/DataTableHeaderSlotTests.cs
+++ b/src/Ivy.Tests/Views/DataTables/DataTableHeaderSlotTests.cs
@@ -1,0 +1,69 @@
+using Ivy;
+
+namespace Ivy.Tests.Views.DataTables;
+
+public class DataTableHeaderSlotTests
+{
+    private record TestRow(int Id, string Name);
+
+    [Fact]
+    public void HeaderLeft_StoresFactory()
+    {
+        var data = new[] { new TestRow(1, "A") }.AsQueryable();
+        var builder = data.ToDataTable()
+            .HeaderLeft(ctx => new Badge("Left"));
+
+        var field = builder.GetType()
+            .GetField("_headerLeftFactory", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        Assert.NotNull(field);
+        Assert.NotNull(field.GetValue(builder));
+    }
+
+    [Fact]
+    public void HeaderRight_StoresFactory()
+    {
+        var data = new[] { new TestRow(1, "A") }.AsQueryable();
+        var builder = data.ToDataTable()
+            .HeaderRight(ctx => new Badge("Right"));
+
+        var field = builder.GetType()
+            .GetField("_headerRightFactory", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        Assert.NotNull(field);
+        Assert.NotNull(field.GetValue(builder));
+    }
+
+    [Fact]
+    public void NoHeaderSlots_FactoriesAreNull()
+    {
+        var data = new[] { new TestRow(1, "A") }.AsQueryable();
+        var builder = data.ToDataTable();
+
+        var leftField = builder.GetType()
+            .GetField("_headerLeftFactory", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var rightField = builder.GetType()
+            .GetField("_headerRightFactory", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+        Assert.NotNull(leftField);
+        Assert.NotNull(rightField);
+        Assert.Null(leftField.GetValue(builder));
+        Assert.Null(rightField.GetValue(builder));
+    }
+
+    [Fact]
+    public void HeaderLeft_ReturnsBuilder_ForChaining()
+    {
+        var data = new[] { new TestRow(1, "A") }.AsQueryable();
+        var builder = data.ToDataTable();
+        var result = builder.HeaderLeft(ctx => new Badge("Left"));
+        Assert.Same(builder, result);
+    }
+
+    [Fact]
+    public void HeaderRight_ReturnsBuilder_ForChaining()
+    {
+        var data = new[] { new TestRow(1, "A") }.AsQueryable();
+        var builder = data.ToDataTable();
+        var result = builder.HeaderRight(ctx => new Badge("Right"));
+        Assert.Same(builder, result);
+    }
+}

--- a/src/Ivy/Views/DataTables/DataTableBuilder.cs
+++ b/src/Ivy/Views/DataTables/DataTableBuilder.cs
@@ -23,6 +23,8 @@ public class DataTableBuilder<TModel>(
     private readonly Dictionary<string, EventHandler<object>> _cellActions = [];
     private RefreshToken? _refreshToken;
     private FuncViewBuilder? _emptyViewFactory;
+    private FuncViewBuilder? _headerLeftFactory;
+    private FuncViewBuilder? _headerRightFactory;
     private Dictionary<string, object>? _footerValuesByColumn;
 
     private readonly string? _idColumnName =
@@ -360,6 +362,18 @@ public class DataTableBuilder<TModel>(
         return this;
     }
 
+    public DataTableBuilder<TModel> HeaderLeft(FuncViewBuilder factory)
+    {
+        _headerLeftFactory = factory;
+        return this;
+    }
+
+    public DataTableBuilder<TModel> HeaderRight(FuncViewBuilder factory)
+    {
+        _headerRightFactory = factory;
+        return this;
+    }
+
     public override object? Build()
     {
         Context.TryUseService<IChatClient>(out var chatClient);
@@ -430,7 +444,9 @@ public class DataTableBuilder<TModel>(
             onRowAction: _onRowAction,
             idSelector: idSelectorForView,
             refreshToken: _refreshToken,
-            emptyViewFactory: _emptyViewFactory);
+            emptyViewFactory: _emptyViewFactory,
+            headerLeftFactory: _headerLeftFactory,
+            headerRightFactory: _headerRightFactory);
     }
 
     public object[] GetMemoValues()

--- a/src/Ivy/Views/DataTables/DataTableView.cs
+++ b/src/Ivy/Views/DataTables/DataTableView.cs
@@ -15,7 +15,9 @@ public class DataTableView(
     Func<Event<DataTable, RowActionClickEventArgs>, ValueTask>? onRowAction = null,
     Func<object, object?>? idSelector = null,
     RefreshToken? refreshToken = null,
-    FuncViewBuilder? emptyViewFactory = null) : ViewBase, IMemoized
+    FuncViewBuilder? emptyViewFactory = null,
+    FuncViewBuilder? headerLeftFactory = null,
+    FuncViewBuilder? headerRightFactory = null) : ViewBase, IMemoized
 {
     public override object? Build()
     {
@@ -33,13 +35,17 @@ public class DataTableView(
             OnRowAction = onRowAction.ToEventHandler()
         };
 
-        // Pass the empty view as a slot so the frontend can render it when TotalRows == 0,
-        // avoiding a synchronous .Count() query on the DbContext during the render cycle.
+        var slots = new List<Slot>();
+
         if (emptyViewFactory != null)
-        {
-            var emptyView = emptyViewFactory(Context);
-            table = table with { Children = [new Slot("EmptyView", emptyView)] };
-        }
+            slots.Add(new Slot("EmptyView", emptyViewFactory(Context)));
+        if (headerLeftFactory != null)
+            slots.Add(new Slot("HeaderLeft", headerLeftFactory(Context)));
+        if (headerRightFactory != null)
+            slots.Add(new Slot("HeaderRight", headerRightFactory(Context)));
+
+        if (slots.Count > 0)
+            table = table with { Children = slots.ToArray<object>() };
 
         return table;
     }

--- a/src/frontend/src/widgets/dataTables/DataTableWidget.tsx
+++ b/src/frontend/src/widgets/dataTables/DataTableWidget.tsx
@@ -39,6 +39,8 @@ const TableLayout: React.FC<TableLayoutProps> = ({ children, emptyView }) => {
 interface DataTableWidgetProps extends TableProps {
   slots?: {
     EmptyView?: React.ReactNode[];
+    HeaderLeft?: React.ReactNode[];
+    HeaderRight?: React.ReactNode[];
   };
 }
 
@@ -94,18 +96,25 @@ export const DataTable: React.FC<DataTableWidgetProps> = ({
       >
         <TableLayout emptyView={slots?.EmptyView}>
           <DataTableHeader>
-            {finalConfig.allowFiltering && (
-              <DataTableOption
-                icon={FilterIcon}
-                label="Filter"
-                tooltip="Filter table data"
-                displayMode="inline"
-                inlineDirection="right"
-                showLabel={false}
-              >
-                <DataTableFilterOption allowLlmFiltering={finalConfig.allowLlmFiltering} />
-              </DataTableOption>
-            )}
+            <div className="flex items-center gap-2 w-full">
+              <div className="flex items-center gap-1">
+                {finalConfig.allowFiltering && (
+                  <DataTableOption
+                    icon={FilterIcon}
+                    label="Filter"
+                    tooltip="Filter table data"
+                    displayMode="inline"
+                    inlineDirection="right"
+                    showLabel={false}
+                  >
+                    <DataTableFilterOption allowLlmFiltering={finalConfig.allowLlmFiltering} />
+                  </DataTableOption>
+                )}
+                {slots?.HeaderLeft}
+              </div>
+              <div className="flex-1" />
+              <div className="flex items-center gap-1">{slots?.HeaderRight}</div>
+            </div>
           </DataTableHeader>
 
           <DataTableEditor


### PR DESCRIPTION
## Summary

Added two new named slots (`HeaderLeft`, `HeaderRight`) to the DataTable widget, allowing users to inject custom content into the header bar. HeaderLeft renders after the filter button; HeaderRight renders on the right side. Follows the same slot pattern as the existing `EmptyView` slot.

## API Changes

- `DataTableBuilder<TModel>.HeaderLeft(FuncViewBuilder factory)` — new builder method to set left header slot content
- `DataTableBuilder<TModel>.HeaderRight(FuncViewBuilder factory)` — new builder method to set right header slot content
- `DataTableView` constructor — new optional parameters `headerLeftFactory` and `headerRightFactory`
- Frontend `DataTableWidgetProps.slots` — extended with `HeaderLeft` and `HeaderRight` arrays

## Files Modified

- **Backend**
  - `src/Ivy/Views/DataTables/DataTableBuilder.cs` — added `_headerLeftFactory`, `_headerRightFactory` fields and builder methods
  - `src/Ivy/Views/DataTables/DataTableView.cs` — added slot parameters and slot assembly logic
- **Frontend**
  - `src/frontend/src/widgets/dataTables/DataTableWidget.tsx` — extended slots interface and rendered slots in header layout
- **Tests**
  - `src/Ivy.Tests/Views/DataTables/DataTableHeaderSlotTests.cs` — 5 tests verifying builder stores factories and supports chaining
- **Samples**
  - `src/Ivy.Samples.Shared/Apps/Widgets/DataTableApp.cs` — added "Header Slots" tab demonstrating the feature

## Commits

- `909b829` [01281] Add HeaderLeft and HeaderRight slots to DataTable

## Artifacts

### Screenshots

![basic-header-slots](https://stivytelemetry.blob.core.windows.net/ivy-tendril/basic-header-slots.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![edge-cases-all](https://stivytelemetry.blob.core.windows.net/ivy-tendril/edge-cases-all.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![events-add-item-clicked](https://stivytelemetry.blob.core.windows.net/ivy-tendril/events-add-item-clicked.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![events-all-buttons-clicked](https://stivytelemetry.blob.core.windows.net/ivy-tendril/events-all-buttons-clicked.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![integration-initial](https://stivytelemetry.blob.core.windows.net/ivy-tendril/integration-initial.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![props-both-slots](https://stivytelemetry.blob.core.windows.net/ivy-tendril/props-both-slots.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![props-header-left-only](https://stivytelemetry.blob.core.windows.net/ivy-tendril/props-header-left-only.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![props-header-right-only](https://stivytelemetry.blob.core.windows.net/ivy-tendril/props-header-right-only.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![props-no-slots-control](https://stivytelemetry.blob.core.windows.net/ivy-tendril/props-no-slots-control.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)