### PR TITLE
[01278] Rename CardHoverVariant to HoverEffect and move to Shared

### DIFF
--- a/src/.releases/Refactors/Upcoming/Rename-CardHoverVariant-To-HoverEffect.md
+++ b/src/.releases/Refactors/Upcoming/Rename-CardHoverVariant-To-HoverEffect.md
@@ -1,0 +1,32 @@
+# Rename CardHoverVariant → HoverEffect
+
+## Summary
+
+`CardHoverVariant` has been renamed to `HoverEffect` and moved from `Card.cs` to `Ivy.Shared`. This enum is now used by Card, Box, and Image widgets.
+
+## What Changed
+
+### Backend (C#)
+
+- `CardHoverVariant` → `HoverEffect`
+- Enum moved from `Ivy.Widgets.Card` namespace scope to `Ivy` namespace (in `Shared/HoverEffect.cs`)
+- Extension method signatures unchanged (`.Hover(HoverEffect variant)`)
+
+### Frontend (TypeScript)
+
+- `BoxHoverVariant` type → `HoverEffect` type
+
+## Before
+
+box.Hover(CardHoverVariant.Shadow)
+image.Hover(CardHoverVariant.Pointer)
+
+## After
+
+box.Hover(HoverEffect.Shadow)
+image.Hover(HoverEffect.Pointer)
+
+## Migration Path
+
+1. Replace all `CardHoverVariant` with `HoverEffect` in C# code
+2. No namespace change needed (both are in `Ivy` namespace)

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/04_Box.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/04_Box.md
@@ -180,7 +180,7 @@ public class InteractiveBoxView : ViewBase
 
         return Layout.Vertical().Gap(8)
             | new Box("Pointer + Translate Hover")
-                .Hover(CardHoverVariant.PointerAndTranslate)
+                .Hover(HoverEffect.PointerAndTranslate)
                 .OnClick(_ => client.Toast("Box clicked!"))
                 .Padding(8)
             | Layout.Horizontal().Gap(4)
@@ -194,7 +194,7 @@ public class InteractiveBoxView : ViewBase
         return new Box(label)
             .Background(isSelected ? Colors.Primary : Colors.Muted)
             .BorderThickness(isSelected ? 2 : 1)
-            .Hover(CardHoverVariant.Pointer)
+            .Hover(HoverEffect.Pointer)
             .OnClick(_ => {
                 selected.Set(label);
                 client.Toast($"Selected: {label}");
@@ -292,7 +292,7 @@ public class CardLayoutView : ViewBase
         return new Box(label)
             .Background(isSelected ? Colors.Primary : Colors.Muted)
             .BorderThickness(isSelected ? 2 : 1)
-            .Hover(CardHoverVariant.Pointer)
+            .Hover(HoverEffect.Pointer)
             .OnClick(_ => {
                 selected.Set(label);
                 client.Toast($"Selected: {label}");

--- a/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/BoxApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/BoxApp.cs
@@ -65,11 +65,11 @@ public class BoxApp : SampleBase
                )
 
                | Text.H2("Hover Variants")
-               | new DemoView(_ => box.Hover(CardHoverVariant.PointerAndTranslate).Content("CardHoverVariant.PointerAndTranslate"))
+               | new DemoView(_ => box.Hover(HoverEffect.PointerAndTranslate).Content("HoverEffect.PointerAndTranslate"))
                | (Layout.Horizontal()
-                  | box.Hover(CardHoverVariant.None).Content("None")
-                  | box.Hover(CardHoverVariant.Pointer).Content("Pointer")
-                  | box.Hover(CardHoverVariant.PointerAndTranslate).Content("PointerAndTranslate")
+                  | box.Hover(HoverEffect.None).Content("None")
+                  | box.Hover(HoverEffect.Pointer).Content("Pointer")
+                  | box.Hover(HoverEffect.PointerAndTranslate).Content("PointerAndTranslate")
                )
 
             ;

--- a/src/Ivy.Test/ImageWidgetTests.cs
+++ b/src/Ivy.Test/ImageWidgetTests.cs
@@ -57,7 +57,7 @@ public class ImageWidgetTests(ITestOutputHelper output)
     public void Serialize_WithHoverVariant_IsSerialized()
     {
         var image = new Image("https://example.com/img.png")
-            .Hover(CardHoverVariant.Shadow);
+            .Hover(HoverEffect.Shadow);
 
         var result = SerializeImage(image);
         var props = result["props"]!.AsObject();
@@ -74,17 +74,17 @@ public class ImageWidgetTests(ITestOutputHelper output)
         var image = new Image("https://example.com/img.png")
             .OnClick(() => { });
 
-        Assert.Equal(CardHoverVariant.PointerAndTranslate, image.HoverVariant);
+        Assert.Equal(HoverEffect.PointerAndTranslate, image.HoverVariant);
     }
 
     [Fact]
     public void OnClick_PreservesExisting_HoverVariant()
     {
         var image = new Image("https://example.com/img.png")
-            .Hover(CardHoverVariant.Shadow)
+            .Hover(HoverEffect.Shadow)
             .OnClick(() => { });
 
-        Assert.Equal(CardHoverVariant.Shadow, image.HoverVariant);
+        Assert.Equal(HoverEffect.Shadow, image.HoverVariant);
     }
 
     [Fact]

--- a/src/Ivy/Shared/HoverEffect.cs
+++ b/src/Ivy/Shared/HoverEffect.cs
@@ -1,0 +1,9 @@
+namespace Ivy;
+
+public enum HoverEffect
+{
+    None,
+    Pointer,
+    PointerAndTranslate,
+    Shadow,
+}

--- a/src/Ivy/Widgets/Card.cs
+++ b/src/Ivy/Widgets/Card.cs
@@ -3,15 +3,6 @@ using Ivy.Core;
 // ReSharper disable once CheckNamespace
 namespace Ivy;
 
-public enum CardHoverVariant
-{
-    None,
-    Pointer,
-    PointerAndTranslate,
-    Shadow,
-}
-
-
 /// <summary>
 /// A flexible container with a border and shadow for grouping related content.
 /// </summary>
@@ -34,7 +25,7 @@ public record Card : WidgetBase<Card>
     internal object? Description { get; set; }
     internal object? Icon { get; set; }
 
-    [Prop] public CardHoverVariant HoverVariant { get; set; } = CardHoverVariant.None;
+    [Prop] public HoverEffect HoverVariant { get; set; } = HoverEffect.None;
 
     [Prop] public bool Disabled { get; set; }
 
@@ -112,11 +103,11 @@ public static class CardExtensions
     public static Card Footer(this Card card, object? footer) =>
         card with { Children = WithSlot(card, "Footer", footer) };
 
-    public static Card Hover(this Card card, CardHoverVariant variant) => card with { HoverVariant = variant };
+    public static Card Hover(this Card card, HoverEffect variant) => card with { HoverVariant = variant };
 
     public static Card Disabled(this Card card, bool disabled = true) => card with { Disabled = disabled };
 
-    private static CardHoverVariant HoverVariantWithClick(this Card card) => card.HoverVariant == CardHoverVariant.None ? CardHoverVariant.PointerAndTranslate : card.HoverVariant;
+    private static HoverEffect HoverVariantWithClick(this Card card) => card.HoverVariant == HoverEffect.None ? HoverEffect.PointerAndTranslate : card.HoverVariant;
 
     public static Card OnClick(this Card card, Func<Event<Card>, ValueTask> onClick)
     {

--- a/src/Ivy/Widgets/Primitives/Box.cs
+++ b/src/Ivy/Widgets/Primitives/Box.cs
@@ -36,7 +36,7 @@ public record Box : WidgetBase<Box>
 
     [Prop] public float? BorderOpacity { get; set; }
 
-    [Prop] public CardHoverVariant HoverVariant { get; set; } = CardHoverVariant.None;
+    [Prop] public HoverEffect HoverVariant { get; set; } = HoverEffect.None;
 
     [Event] public EventHandler<Event<Box>>? OnClick { get; set; }
 }
@@ -95,9 +95,9 @@ public static class BoxExtensions
 
     public static Box Grow(this Box box) => box.Width(Size.Grow());
 
-    public static Box Hover(this Box box, CardHoverVariant variant) => box with { HoverVariant = variant };
+    public static Box Hover(this Box box, HoverEffect variant) => box with { HoverVariant = variant };
 
-    private static CardHoverVariant HoverVariantWithClick(this Box box) => box.HoverVariant == CardHoverVariant.None ? CardHoverVariant.PointerAndTranslate : box.HoverVariant;
+    private static HoverEffect HoverVariantWithClick(this Box box) => box.HoverVariant == HoverEffect.None ? HoverEffect.PointerAndTranslate : box.HoverVariant;
 
     public static Box OnClick(this Box box, Func<Event<Box>, ValueTask> onClick)
     {

--- a/src/Ivy/Widgets/Primitives/Image.cs
+++ b/src/Ivy/Widgets/Primitives/Image.cs
@@ -39,7 +39,7 @@ public record Image : WidgetBase<Image>
     [Prop] public BorderRadius BorderRadius { get; set; } = BorderRadius.None;
     [Prop] public BorderStyle BorderStyle { get; set; } = BorderStyle.None;
     [Prop] public Thickness BorderThickness { get; set; } = new(0);
-    [Prop] public CardHoverVariant HoverVariant { get; set; } = CardHoverVariant.None;
+    [Prop] public HoverEffect HoverVariant { get; set; } = HoverEffect.None;
 
     [Event] public EventHandler<Event<Image>>? OnClick { get; set; }
 }
@@ -68,9 +68,9 @@ public static class ImageExtensions
 
     public static Image BorderThickness(this Image image, Thickness thickness) => image with { BorderThickness = thickness };
 
-    public static Image Hover(this Image image, CardHoverVariant variant) => image with { HoverVariant = variant };
+    public static Image Hover(this Image image, HoverEffect variant) => image with { HoverVariant = variant };
 
-    private static CardHoverVariant HoverVariantWithClick(this Image image) => image.HoverVariant == CardHoverVariant.None ? CardHoverVariant.PointerAndTranslate : image.HoverVariant;
+    private static HoverEffect HoverVariantWithClick(this Image image) => image.HoverVariant == HoverEffect.None ? HoverEffect.PointerAndTranslate : image.HoverVariant;
 
     public static Image OnClick(this Image image, Func<Event<Image>, ValueTask> onClick)
         => image with { HoverVariant = image.HoverVariantWithClick(), OnClick = new(onClick) };

--- a/src/frontend/src/widgets/card/CardWidget.tsx
+++ b/src/frontend/src/widgets/card/CardWidget.tsx
@@ -4,6 +4,7 @@ import { cn } from "@/lib/utils";
 import { useEventHandler } from "@/components/event-handler";
 import React, { useCallback } from "react";
 import { Densities } from "@/types/density";
+import type { HoverEffect } from "@/widgets/primitives/BoxWidget";
 import { cardStyles, getSizeClasses } from "./styles";
 
 const EMPTY_ARRAY: never[] = [];
@@ -14,7 +15,7 @@ interface CardWidgetProps {
   width?: string;
   height?: string;
   aspectRatio?: number;
-  hoverVariant?: "None" | "Pointer" | "PointerAndTranslate" | "Shadow";
+  hoverVariant?: HoverEffect;
   density?: Densities;
   disabled?: boolean;
   "data-testid"?: string;

--- a/src/frontend/src/widgets/primitives/BoxWidget.tsx
+++ b/src/frontend/src/widgets/primitives/BoxWidget.tsx
@@ -19,7 +19,7 @@ import { useEventHandler } from "@/components/event-handler";
 
 const EMPTY_ARRAY: never[] = [];
 
-export type BoxHoverVariant = "None" | "Pointer" | "PointerAndTranslate" | "Shadow";
+export type HoverEffect = "None" | "Pointer" | "PointerAndTranslate" | "Shadow";
 
 interface BoxWidgetProps {
   id: string;
@@ -39,7 +39,7 @@ interface BoxWidgetProps {
   className?: string;
   events?: string[];
   aspectRatio?: number;
-  hoverVariant?: BoxHoverVariant;
+  hoverVariant?: HoverEffect;
 }
 
 export const BoxWidget: React.FC<BoxWidgetProps> = ({

--- a/src/frontend/src/widgets/primitives/ImageWidget.tsx
+++ b/src/frontend/src/widgets/primitives/ImageWidget.tsx
@@ -18,7 +18,7 @@ import {
   isAppProtocol,
 } from "@/lib/url";
 import { useEventHandler } from "@/components/event-handler";
-import type { BoxHoverVariant } from "@/widgets/primitives/BoxWidget";
+import type { HoverEffect } from "@/widgets/primitives/BoxWidget";
 import { cardStyles } from "@/widgets/card/styles";
 import React, { useCallback } from "react";
 
@@ -37,7 +37,7 @@ interface ImageWidgetProps {
   borderRadius?: BorderRadius;
   borderStyle?: BorderStyle;
   borderThickness?: string;
-  hoverVariant?: BoxHoverVariant;
+  hoverVariant?: HoverEffect;
 }
 
 const getImageUrl = (url: string | undefined | null): string | null => {
@@ -89,7 +89,7 @@ const objectFitMap: Record<string, React.CSSProperties["objectFit"]> = {
   ScaleDown: "scale-down",
 };
 
-const getHoverClass = (hoverVariant?: BoxHoverVariant): string | null => {
+const getHoverClass = (hoverVariant?: HoverEffect): string | null => {
   if (!hoverVariant || hoverVariant === "None") return null;
   if (hoverVariant === "Pointer") return cardStyles.hover.pointer;
   if (hoverVariant === "Shadow") return cardStyles.hover.shadow;


### PR DESCRIPTION
## Summary

Renamed `CardHoverVariant` enum to `HoverEffect` and moved it from `Card.cs` to a new file `Shared/HoverEffect.cs`. Updated all references across backend (C#), frontend (TypeScript), tests, samples, and documentation. Added a breaking change release note.

## API Changes

- **Removed:** `CardHoverVariant` enum from `Card.cs`
- **Added:** `HoverEffect` enum in `Shared/HoverEffect.cs` (same members: `None`, `Pointer`, `PointerAndTranslate`, `Shadow`)
- **Changed:** All `CardHoverVariant` parameter types → `HoverEffect` in `Card.Hover()`, `Box.Hover()`, `Image.Hover()` extension methods
- **Changed (Frontend):** `BoxHoverVariant` type → `HoverEffect` type in `BoxWidget.tsx`, imported in `CardWidget.tsx` and `ImageWidget.tsx`

## Files Modified

- **New:** `src/Ivy/Shared/HoverEffect.cs` — shared enum definition
- **New:** `src/.releases/Refactors/Upcoming/Rename-CardHoverVariant-To-HoverEffect.md` — breaking change note
- **Backend:** `Card.cs`, `Box.cs`, `Image.cs` — enum type references
- **Tests:** `ImageWidgetTests.cs` — updated assertions
- **Samples:** `BoxApp.cs` — updated demo usage
- **Docs:** `04_Box.md` — updated code examples
- **Frontend:** `BoxWidget.tsx`, `CardWidget.tsx`, `ImageWidget.tsx` — type rename and imports

## Commits

- 84100c04 [01278] Rename CardHoverVariant to HoverEffect and move to Shared

## Artifacts

### Screenshots

![basic-all-cards](https://stivytelemetry.blob.core.windows.net/ivy-tendril/basic-all-cards.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![edge-cases-back-to-none](https://stivytelemetry.blob.core.windows.net/ivy-tendril/edge-cases-back-to-none.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![edge-cases-initial](https://stivytelemetry.blob.core.windows.net/ivy-tendril/edge-cases-initial.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![edge-cases-shadow-hover](https://stivytelemetry.blob.core.windows.net/ivy-tendril/edge-cases-shadow-hover.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![edge-cases-translate-hover](https://stivytelemetry.blob.core.windows.net/ivy-tendril/edge-cases-translate-hover.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![events-box-click](https://stivytelemetry.blob.core.windows.net/ivy-tendril/events-box-click.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![events-card-click](https://stivytelemetry.blob.core.windows.net/ivy-tendril/events-card-click.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![events-image-section](https://stivytelemetry.blob.core.windows.net/ivy-tendril/events-image-section.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![events-shadow-onclick](https://stivytelemetry.blob.core.windows.net/ivy-tendril/events-shadow-onclick.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![integration-button-clicked](https://stivytelemetry.blob.core.windows.net/ivy-tendril/integration-button-clicked.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![integration-card-clicked](https://stivytelemetry.blob.core.windows.net/ivy-tendril/integration-card-clicked.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![integration-initial](https://stivytelemetry.blob.core.windows.net/ivy-tendril/integration-initial.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![props-boxes](https://stivytelemetry.blob.core.windows.net/ivy-tendril/props-boxes.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![props-cards](https://stivytelemetry.blob.core.windows.net/ivy-tendril/props-cards.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![props-hover-box-pointer](https://stivytelemetry.blob.core.windows.net/ivy-tendril/props-hover-box-pointer.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![props-hover-box-shadow](https://stivytelemetry.blob.core.windows.net/ivy-tendril/props-hover-box-shadow.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![props-hover-card-pointer](https://stivytelemetry.blob.core.windows.net/ivy-tendril/props-hover-card-pointer.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![props-hover-card-shadow](https://stivytelemetry.blob.core.windows.net/ivy-tendril/props-hover-card-shadow.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![props-hover-card-translate](https://stivytelemetry.blob.core.windows.net/ivy-tendril/props-hover-card-translate.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![props-images](https://stivytelemetry.blob.core.windows.net/ivy-tendril/props-images.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)