### PR TITLE
[01269] Fix DataTable decimal scaling bug

### DIFF
--- a/src/frontend/src/widgets/dataTables/dataTableContext/hooks/useRowData.ts
+++ b/src/frontend/src/widgets/dataTables/dataTableContext/hooks/useRowData.ts
@@ -1,11 +1,16 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import * as arrow from "apache-arrow";
 import { DataRow } from "../../types/types";
+import { buildDecimalScales, convertDecimalValue } from "../../utils/tableDataMapper";
 
 /**
  * Hook for accessing row data from Arrow table
  */
 export const useRowData = (arrowTableRef: React.RefObject<arrow.Table | null>) => {
+  const decimalScalesRef = useMemo(() => {
+    return { current: new Map<number, number>() };
+  }, []);
+
   const getRowData = useCallback(
     (rowIndex: number): DataRow | null => {
       const table = arrowTableRef.current;
@@ -13,17 +18,26 @@ export const useRowData = (arrowTableRef: React.RefObject<arrow.Table | null>) =
         return null;
       }
 
+      // Rebuild decimal scales when schema changes (cheap for small field counts)
+      if (decimalScalesRef.current.size === 0 && table.schema.fields.length > 0) {
+        decimalScalesRef.current = buildDecimalScales(table.schema);
+      }
+
       const values: (string | number | boolean | Date | string[] | null)[] = [];
       for (let j = 0; j < table.numCols; j++) {
         const column = table.getChildAt(j);
         if (column) {
-          const value = column.get(rowIndex);
+          let value = column.get(rowIndex);
+          const scale = decimalScalesRef.current.get(j);
+          if (scale !== undefined && value != null && typeof value === "object") {
+            value = convertDecimalValue(value, scale);
+          }
           values.push(value);
         }
       }
       return { values };
     },
-    [arrowTableRef],
+    [arrowTableRef, decimalScalesRef],
   );
 
   return { getRowData };

--- a/src/frontend/src/widgets/dataTables/utils/tableDataMapper.test.ts
+++ b/src/frontend/src/widgets/dataTables/utils/tableDataMapper.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import * as arrow from "apache-arrow";
-import { convertArrowTableToData } from "./tableDataMapper";
+import { convertArrowTableToData, convertDecimalValue } from "./tableDataMapper";
 import { ColType } from "../types/types";
 
 describe("tableDataMapper", () => {
@@ -313,6 +313,91 @@ describe("tableDataMapper", () => {
         const result = convertArrowTableToData(mockTable, 5);
         expect(result.columns[0].type).toBe(expectedType);
       });
+    });
+  });
+
+  describe("convertDecimalValue", () => {
+    it("should use valueOf(scale) when it returns a number", () => {
+      const value = {
+        valueOf: (scale: number) => 95000 / Math.pow(10, scale - scale) || 95000,
+        toString: () => "9500000000000000000000000000000000",
+      };
+      // Simulate valueOf returning the correct number directly
+      value.valueOf = (_scale: number) => 95000;
+      expect(convertDecimalValue(value, 28)).toBe(95000);
+    });
+
+    it("should handle valueOf(scale) returning bigint", () => {
+      const value = {
+        valueOf: (_scale: number) => 95000n,
+        toString: () => "95000",
+      };
+      expect(convertDecimalValue(value, 28)).toBe(95000);
+    });
+
+    it("should fall back to string parsing when valueOf throws RangeError", () => {
+      const value = {
+        valueOf: () => {
+          throw new RangeError("byte offset is not aligned");
+        },
+        toString: () => "9500000000000000000000000000000000",
+      };
+      // scale=28, str="9500000000000000000000000000000000" (34 chars)
+      // abs.slice(0, -28) = "950000", abs.slice(-28) = "0000000000000000000000000000"
+      // → "950000.0000000000000000000000000000" → 950000
+      expect(convertDecimalValue(value, 28)).toBe(950000);
+    });
+
+    it("should handle small fractional values in string fallback", () => {
+      // Value "1" with scale 2 → "0.01"
+      const value = {
+        valueOf: () => {
+          throw new RangeError("alignment");
+        },
+        toString: () => "1",
+      };
+      expect(convertDecimalValue(value, 2)).toBe(0.01);
+    });
+
+    it("should handle negative values in string fallback", () => {
+      const value = {
+        valueOf: () => {
+          throw new Error();
+        },
+        toString: () => "-12345",
+      };
+      // scale=2 → "-123.45"
+      expect(convertDecimalValue(value, 2)).toBe(-123.45);
+    });
+
+    it("should handle zero scale in string fallback", () => {
+      const value = {
+        valueOf: () => {
+          throw new Error();
+        },
+        toString: () => "42",
+      };
+      expect(convertDecimalValue(value, 0)).toBe(42);
+    });
+
+    it("should handle zero value", () => {
+      const value = {
+        valueOf: (_scale: number) => 0,
+        toString: () => "0",
+      };
+      expect(convertDecimalValue(value, 28)).toBe(0);
+    });
+
+    it("should return null when both paths fail", () => {
+      const value = {
+        valueOf: () => {
+          throw new Error();
+        },
+        toString: () => {
+          throw new Error();
+        },
+      };
+      expect(convertDecimalValue(value, 2)).toBeNull();
     });
   });
 });

--- a/src/frontend/src/widgets/dataTables/utils/tableDataMapper.ts
+++ b/src/frontend/src/widgets/dataTables/utils/tableDataMapper.ts
@@ -51,6 +51,55 @@ function mapArrowTypeToColType(arrowType: string): ColType {
   return ColType.Text;
 }
 
+/**
+ * Convert a DecimalBigNum value to a JS number using the column's scale.
+ * Primary path uses Arrow's valueOf(scale); falls back to string-based conversion
+ * when valueOf throws (e.g. RangeError from BigUint64Array alignment on IPC buffers).
+ */
+export function convertDecimalValue(
+  value: { valueOf?: (scale: number) => unknown; toString: () => string },
+  scale: number,
+): number | null {
+  try {
+    // Arrow 21.1.0's valueOf(scale) correctly divides unscaled integer by 10^scale.
+    // May throw RangeError on IPC buffers due to BigUint64Array alignment.
+    const result = typeof value.valueOf === "function" ? value.valueOf(scale) : null;
+    if (typeof result === "number") return result;
+    if (typeof result === "bigint") return Number(result);
+  } catch {
+    // Fall through to string-based fallback
+  }
+  // Fallback: parse the string representation and insert decimal point
+  try {
+    const str = value.toString();
+    const negative = str.startsWith("-");
+    const abs = negative ? str.slice(1) : str;
+    if (scale === 0) {
+      return Number(str);
+    } else if (abs.length <= scale) {
+      return Number(`${negative ? "-" : ""}0.${abs.padStart(scale, "0")}`);
+    } else {
+      return Number(`${negative ? "-" : ""}${abs.slice(0, -scale)}.${abs.slice(-scale)}`);
+    }
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build a map of column index → decimal scale from an Arrow table schema.
+ */
+export function buildDecimalScales(schema: arrow.Schema): Map<number, number> {
+  const scales = new Map<number, number>();
+  for (let j = 0; j < schema.fields.length; j++) {
+    const field = schema.fields[j];
+    if (field.type.toString().toLowerCase().includes("decimal")) {
+      scales.set(j, (field.type as arrow.Decimal).scale);
+    }
+  }
+  return scales;
+}
+
 export function convertArrowTableToData(
   table: arrow.Table,
   requestedCount: number,
@@ -77,16 +126,7 @@ export function convertArrowTableToData(
       };
     });
 
-  // Precompute decimal column scales for proper Decimal128 → JS number conversion.
-  // Arrow's DecimalBigNum.valueOf(scale) needs the scale to divide the unscaled integer.
-  const decimalScales = new Map<number, number>();
-  for (let j = 0; j < table.schema.fields.length; j++) {
-    const field = table.schema.fields[j];
-    if (field.type.toString().toLowerCase().includes("decimal")) {
-      const scale = (field.type as arrow.Decimal).scale;
-      decimalScales.set(j, scale);
-    }
-  }
+  const decimalScales = buildDecimalScales(table.schema);
 
   const rows: DataRow[] = [];
   for (let i = 0; i < table.numRows; i++) {
@@ -95,29 +135,9 @@ export function convertArrowTableToData(
       const column = table.getChildAt(j);
       if (column) {
         let value = column.get(i);
-        // Arrow Decimal128 values are DecimalBigNum objects containing unscaled integers.
-        // We must pass the column's scale to valueOf() so it divides correctly.
         const scale = decimalScales.get(j);
         if (scale !== undefined && value != null && typeof value === "object") {
-          // Try calling valueOf with scale parameter
-          const convertedValue = typeof value.valueOf === "function" ? value.valueOf(scale) : value;
-
-          // Handle different return types from valueOf()
-          if (typeof convertedValue === "bigint") {
-            // Convert bigint to number by dividing by 10^scale
-            value = Number(convertedValue) / Math.pow(10, scale);
-          } else if (typeof convertedValue === "number") {
-            value = convertedValue;
-          } else {
-            // Fallback: parse string representation and convert
-            // This handles cases where valueOf() returns a string or doesn't work as expected
-            try {
-              const unscaledValue = BigInt(value.toString());
-              value = Number(unscaledValue) / Math.pow(10, scale);
-            } catch {
-              value = null; // Unable to convert, set to null
-            }
-          }
+          value = convertDecimalValue(value, scale);
         }
         values.push(value);
       }


### PR DESCRIPTION
## Summary

Fixed DataTable decimal column scaling bug where Decimal128 values displayed as raw unscaled integers. The previous attempt only fixed `convertArrowTableToData()` in tableDataMapper.ts, but cell rendering reads values directly from the Arrow table via `useRowData.ts`, bypassing that fix. This revision applies decimal conversion in both code paths using a shared `convertDecimalValue()` function that tries Arrow's `valueOf(scale)` first and falls back to string-based decimal point insertion when `valueOf` throws due to IPC buffer alignment issues.

## API Changes

None.

## Files Modified

- **Bug fix:** `src/frontend/src/widgets/dataTables/utils/tableDataMapper.ts` — Added exported `convertDecimalValue()` and `buildDecimalScales()` functions; simplified inline conversion to use them
- **Bug fix:** `src/frontend/src/widgets/dataTables/dataTableContext/hooks/useRowData.ts` — Added decimal scaling when reading raw Arrow values for cell rendering
- **Tests:** `src/frontend/src/widgets/dataTables/utils/tableDataMapper.test.ts` — Added 8 new `convertDecimalValue` unit tests (valueOf path, bigint, RangeError fallback, negatives, zero, etc.)

## Commits

- a7461d60 [01269] Fix DataTable decimal scaling with valueOf fallback to string parsing

## Artifacts

### Screenshots

![basic-decimal-table](https://stivytelemetry.blob.core.windows.net/ivy-tendril/basic-decimal-table.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![debug-basic-full](https://stivytelemetry.blob.core.windows.net/ivy-tendril/debug-basic-full.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![decimal-edge-cases-hover](https://stivytelemetry.blob.core.windows.net/ivy-tendril/decimal-edge-cases-hover.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![decimal-edge-cases-no-canvas](https://stivytelemetry.blob.core.windows.net/ivy-tendril/decimal-edge-cases-no-canvas.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![decimal-edge-cases](https://stivytelemetry.blob.core.windows.net/ivy-tendril/decimal-edge-cases.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![decimal-integration-mixed](https://stivytelemetry.blob.core.windows.net/ivy-tendril/decimal-integration-mixed.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![decimal-props-formatting](https://stivytelemetry.blob.core.windows.net/ivy-tendril/decimal-props-formatting.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)