### PR TITLE
[01255] Add Badge(string) extension method for Button widget

### DIFF
--- a/src/Ivy.Test/ButtonBadgeTests.cs
+++ b/src/Ivy.Test/ButtonBadgeTests.cs
@@ -1,0 +1,32 @@
+using Ivy;
+using Xunit;
+
+namespace Ivy.Test;
+
+public class ButtonBadgeTests
+{
+    [Fact]
+    public void Badge_SetsProperty()
+    {
+        var button = new Button("Inbox").Badge("3");
+
+        Assert.Equal("3", button.Badge);
+    }
+
+    [Fact]
+    public void Badge_AndShortcutKey_CoexistWithoutConflict()
+    {
+        var button = new Button("Save").Badge("New").ShortcutKey("Ctrl+S");
+
+        Assert.Equal("New", button.Badge);
+        Assert.Equal("Ctrl+S", button.ShortcutKey);
+    }
+
+    [Fact]
+    public void Badge_Null_ClearsProperty()
+    {
+        var button = new Button("Test").Badge("5").Badge(null);
+
+        Assert.Null(button.Badge);
+    }
+}

--- a/src/frontend/src/widgets/button/ButtonWidget.tsx
+++ b/src/frontend/src/widgets/button/ButtonWidget.tsx
@@ -260,7 +260,7 @@ export const ButtonWidget: React.FC<ButtonWidgetProps> = ({
             title
           )}
           {badge && (
-            <Badge variant="secondary" className="ml-1 w-min whitespace-nowrap">
+            <Badge variant="outline" className="ml-1 w-min whitespace-nowrap">
               {badge}
             </Badge>
           )}


### PR DESCRIPTION
# Summary

Changed the Button widget's Badge component from the `secondary` variant to the `outline` variant, giving badges a bordered appearance with transparent background instead of a filled secondary color. This was a review-requested styling change. Added unit tests for the Badge extension method.

## API Changes

None. The backend `Badge` property and `Badge()` extension method remain unchanged.

## Files Modified

- **Frontend:** `src/frontend/src/widgets/button/ButtonWidget.tsx` — changed Badge variant from `secondary` to `outline`
- **Tests:** `src/Ivy.Test/ButtonBadgeTests.cs` — new test class with 3 tests for Badge property, Badge+ShortcutKey coexistence, and null clearing

## Commits

- b55527d1 [01255] Use outline variant for button badge and add unit tests

## Artifacts

### Screenshots

![basic-badges](https://stivytelemetry.blob.core.windows.net/ivy-tendril/basic-badges.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![props-with-shortcut](https://stivytelemetry.blob.core.windows.net/ivy-tendril/props-with-shortcut.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![props-all-variants](https://stivytelemetry.blob.core.windows.net/ivy-tendril/props-all-variants.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![edge-multiple-variants](https://stivytelemetry.blob.core.windows.net/ivy-tendril/edge-multiple-variants.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)