### PR TITLE
[01286] Add light border on images in Markdown widget

### DIFF
--- a/src/frontend/src/lib/styles.ts
+++ b/src/frontend/src/lib/styles.ts
@@ -710,7 +710,7 @@ export const typography: Record<string, string> = {
   td: "border border-border px-4 py-2 text-sm",
 
   // Media
-  img: "max-w-full h-auto cursor-zoom-in",
+  img: "max-w-full h-auto cursor-zoom-in border border-border rounded-md",
   hr: "border-t border-border",
 
   // Expandable sections


### PR DESCRIPTION
## Summary

Added a light border and subtle rounding to images rendered inside the Markdown widget's typography styles. This makes image boundaries visible against the page background, especially for screenshots or images with light edges.

## Changes

- **src/frontend/src/lib/styles.ts** — Added `border border-border rounded-md` classes to the `img` entry in the typography object.

## Commits

- f186925f [01286] Add light border on images in Markdown widget

## Artifacts

### Screenshots

![basic-image-border](https://stivytelemetry.blob.core.windows.net/ivy-tendril/basic-image-border.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![edge-cases-all-bordered](https://stivytelemetry.blob.core.windows.net/ivy-tendril/edge-cases-all-bordered.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![events-link-click](https://stivytelemetry.blob.core.windows.net/ivy-tendril/events-link-click.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![integration-all-contexts](https://stivytelemetry.blob.core.windows.net/ivy-tendril/integration-all-contexts.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![props-all-images-bordered](https://stivytelemetry.blob.core.windows.net/ivy-tendril/props-all-images-bordered.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

![props-border-style-consistency](https://stivytelemetry.blob.core.windows.net/ivy-tendril/props-border-style-consistency.png?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

### Videos

[basic-image-border.webm](https://stivytelemetry.blob.core.windows.net/ivy-tendril/basic-image-border.webm?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)

[integration-layout-contexts.webm](https://stivytelemetry.blob.core.windows.net/ivy-tendril/integration-layout-contexts.webm?se=2026-04-30&sp=r&spr=https&sv=2026-02-06&sr=c&sig=DYdAqQB97YZ2Gt3FUvRL%2BsIue8GWea1po34vqDDdM%2B0%3D)