### PR TITLE
[01296] Add badge rendering to Tab Content variant

### DIFF
--- a/src/frontend/src/widgets/layouts/tabs/components/DropdownMenu.tsx
+++ b/src/frontend/src/widgets/layouts/tabs/components/DropdownMenu.tsx
@@ -9,6 +9,7 @@ import { cn } from "@/lib/utils";
 import { ChevronDown } from "lucide-react";
 import { DndContext, closestCenter } from "@dnd-kit/core";
 import { SortableContext } from "@dnd-kit/sortable";
+import { Badge } from "@/components/ui/badge";
 import { SortableDropdownMenuItem } from "./Sortable";
 import { getTabProps } from "../utils/tabUtils";
 
@@ -58,7 +59,7 @@ export const TabsDropdownMenu: React.FC<TabsDropdownMenuProps> = ({
                 if (!React.isValidElement(tabWidget)) return null;
                 const props = getTabProps(tabWidget);
                 if (!props?.id) return null;
-                const { title, id } = props;
+                const { title, id, badge } = props;
 
                 // Only render tabs that are hidden
                 if (!hiddenTabs.includes(id)) return null;
@@ -75,7 +76,14 @@ export const TabsDropdownMenu: React.FC<TabsDropdownMenuProps> = ({
                     isActive={activeTabId === id}
                     showClose={showClose}
                   >
-                    {title}
+                    <span className="flex items-center">
+                      {title}
+                      {badge && (
+                        <Badge variant="primary" className="ml-2 w-min whitespace-nowrap">
+                          {badge}
+                        </Badge>
+                      )}
+                    </span>
                   </SortableDropdownMenuItem>
                 );
               })}

--- a/src/frontend/src/widgets/layouts/tabs/components/Variants.tsx
+++ b/src/frontend/src/widgets/layouts/tabs/components/Variants.tsx
@@ -4,6 +4,7 @@ import { cn } from "@/lib/utils";
 import { getPadding, getWidth } from "@/lib/styles";
 import { DndContext, closestCenter } from "@dnd-kit/core";
 import { SortableContext } from "@dnd-kit/sortable";
+import { Badge } from "@/components/ui/badge";
 import { SortableTabTrigger } from "./Sortable";
 import { getTabProps } from "../utils/tabUtils";
 
@@ -126,7 +127,7 @@ export const ContentVariant: React.FC<ContentVariantProps> = ({
             if (!React.isValidElement(tabWidget)) return null;
             const props = getTabProps(tabWidget);
             if (!props?.id) return null;
-            const { title, id } = props;
+            const { title, id, badge } = props;
 
             // Only render tabs that are visible
             if (!visibleTabs.includes(id)) return null;
@@ -157,6 +158,11 @@ export const ContentVariant: React.FC<ContentVariantProps> = ({
               >
                 <div className="text-sm font-medium leading-4 whitespace-nowrap flex items-center justify-center h-full">
                   {title}
+                  {badge && (
+                    <Badge variant="primary" className="ml-2 w-min whitespace-nowrap">
+                      {badge}
+                    </Badge>
+                  )}
                 </div>
               </button>
             );

--- a/src/frontend/src/widgets/layouts/tabs/hooks/useTabCalculation.test.ts
+++ b/src/frontend/src/widgets/layouts/tabs/hooks/useTabCalculation.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { estimateTabWidth } from "../utils/tabUtils";
 
 describe("useTabCalculation", () => {
   it("should accept correct parameters", () => {
@@ -24,5 +25,32 @@ describe("useTabCalculation", () => {
   it("should accept Content variant", () => {
     const variant = "Content" as const;
     expect(variant).toBe("Content");
+  });
+});
+
+describe("estimateTabWidth", () => {
+  it("should account for badge width in Content variant", () => {
+    const widthWithoutBadge = estimateTabWidth("Tab", undefined, undefined, false, "Content");
+    const widthWithBadge = estimateTabWidth("Tab", undefined, "New", false, "Content");
+
+    // Badge should add width: ml-2 (8px) + badge content
+    expect(widthWithBadge).toBeGreaterThan(widthWithoutBadge);
+
+    // Verify the badge adds at least 8px (margin) + 24px (min badge width)
+    expect(widthWithBadge - widthWithoutBadge).toBeGreaterThanOrEqual(32);
+  });
+
+  it("should account for badge width in Tabs variant", () => {
+    const widthWithoutBadge = estimateTabWidth("Tab", undefined, undefined, false, "Tabs");
+    const widthWithBadge = estimateTabWidth("Tab", undefined, "New", false, "Tabs");
+
+    expect(widthWithBadge).toBeGreaterThan(widthWithoutBadge);
+  });
+
+  it("should scale badge width with longer badge text", () => {
+    const shortBadge = estimateTabWidth("Tab", undefined, "3", false, "Content");
+    const longBadge = estimateTabWidth("Tab", undefined, "99 items", false, "Content");
+
+    expect(longBadge).toBeGreaterThan(shortBadge);
   });
 });

--- a/src/frontend/src/widgets/layouts/tabs/utils/tabUtils.ts
+++ b/src/frontend/src/widgets/layouts/tabs/utils/tabUtils.ts
@@ -186,6 +186,12 @@ export function estimateTabWidth(
     // Title width
     estimatedWidth += Math.ceil(title.length * avgCharWidth);
 
+    // Badge width
+    if (badge) {
+      const badgeWidth = Math.max(24, 16 + badge.length * avgCharWidth);
+      estimatedWidth += 8 + badgeWidth; // ml-2 (8px) + badge
+    }
+
     // Gap between tabs
     estimatedWidth += 6;
   }


### PR DESCRIPTION
## Summary

Added badge rendering support to the Tab widget's Content variant and DropdownMenu, matching the existing badge rendering in the Tabs variant. Also updated the `estimateTabWidth` utility to account for badge width in Content variant width calculations, and added corresponding tests.

## API Changes

None. The backend already supports the `Badge` property on Tab items — this change only affects frontend rendering.

## Files Modified

- **Tab rendering:**
  - `src/frontend/src/widgets/layouts/tabs/components/Variants.tsx` — Added badge destructuring and rendering in ContentVariant
  - `src/frontend/src/widgets/layouts/tabs/components/DropdownMenu.tsx` — Added badge rendering in hidden tabs dropdown
- **Width estimation:**
  - `src/frontend/src/widgets/layouts/tabs/utils/tabUtils.ts` — Added badge width calculation for Content variant
- **Tests:**
  - `src/frontend/src/widgets/layouts/tabs/hooks/useTabCalculation.test.ts` — Added tests for badge width estimation in Content variant

## Commits

- e4313184 [01296] Add badge rendering to Tab Content variant and DropdownMenu