### PR TITLE
[01356] Fix code block rendering without language specifier

### DIFF
--- a/src/frontend/src/components/MarkdownRenderer.tsx
+++ b/src/frontend/src/components/MarkdownRenderer.tsx
@@ -358,7 +358,9 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
     () => ({
       code: memo((props: React.ComponentProps<"code">) => {
         const { children, className } = props;
-        const inline = !className;
+        const node = (props as any).node;
+        const isInPre = node?.parent?.tagName === "pre";
+        const inline = isInPre ? false : !className && !String(children).includes("\n");
 
         // Detect Icons.X pattern in inline code
         if (inline) {

--- a/src/frontend/src/components/markdown/CodeBlock.tsx
+++ b/src/frontend/src/components/markdown/CodeBlock.tsx
@@ -31,7 +31,7 @@ export const CodeBlock = memo(
     const dynamicTheme = useMemo(() => createPrismTheme(), []);
     const typography = useTypography();
 
-    if (!inline && match && hasCodeBlocks) {
+    if (!inline && hasCodeBlocks) {
       // Handle Mermaid diagrams
       if (isMermaid && hasMermaid) {
         return (
@@ -105,7 +105,7 @@ export const CodeBlock = memo(
             </div>
             <ScrollArea className="w-full border border-border rounded-md">
               <SyntaxHighlighter
-                language={match[1]}
+                language={match ? match[1] : "text"}
                 style={dynamicTheme}
                 customStyle={{
                   margin: 0,


### PR DESCRIPTION
## Changes

Fixed fenced code blocks without a language specifier rendering as inline code instead of block-level code elements. The root cause was that `MarkdownRenderer.tsx` used `!className` to detect inline code, but react-markdown doesn't set a className on code elements without a language — causing fenced blocks to be misidentified as inline. Fixed by checking the AST parent node (`node.parent.tagName === 'pre'`). Also removed the `match` guard in `CodeBlock.tsx` so no-language blocks reach the SyntaxHighlighter with a fallback language of `"text"`.

## API Changes

None.

## Files Modified

- **src/frontend/src/components/MarkdownRenderer.tsx** — Fixed inline detection logic to use AST parent node check instead of className
- **src/frontend/src/components/markdown/CodeBlock.tsx** — Removed `match &&` guard and added `"text"` language fallback

## Commits

- 14edf972 [01356] Fix code block rendering without language specifier

## Artifacts

### Screenshots

![edge-all-apps-final](https://stivytelemetry.blob.core.windows.net/ivy-tendril/edge-all-apps-final.png?se=2026-05-01&sp=r&spr=https&sv=2026-02-06&sr=c&sig=CKGQKqQ8XxPHk0T9N7Z3X4Lpf5MwIaKPt4fsugYJ%2BXU%3D)