### PR TITLE
[01360] Sheet animation should slide from direction instead of dialog-style scale

### DIFF
--- a/src/frontend/src/widgets/sheet/SheetWidget.tsx
+++ b/src/frontend/src/widgets/sheet/SheetWidget.tsx
@@ -64,7 +64,7 @@ export const SheetWidget: React.FC<SheetWidgetProps> = ({
       <SheetContent
         side={normalizedSide}
         style={styles}
-        className={cn("flex flex-col p-0 gap-0 alert-animate-enter", isHorizontal && "h-full")}
+        className={cn("flex flex-col p-0 gap-0", isHorizontal && "h-full")}
         data-sheet-side={normalizedSide}
         onOpenAutoFocus={(e) => {
           e.preventDefault();

--- a/src/frontend/src/widgets/sheet/sheet.css
+++ b/src/frontend/src/widgets/sheet/sheet.css
@@ -79,79 +79,38 @@
   }
 }
 
-/* Sheet animations using Radix UI data-state attributes */
 /* Right side (default) */
-[data-radix-dialog-content][data-state="open"],
-[data-radix-dialog-content][data-sheet-side="right"][data-state="open"] {
+[data-sheet-side="right"][data-state="open"] {
   animation: slideInFromRight 300ms ease-out;
 }
 
-[data-radix-dialog-content][data-state="closed"],
-[data-radix-dialog-content][data-sheet-side="right"][data-state="closed"] {
+[data-sheet-side="right"][data-state="closed"] {
   animation: slideOutToRight 300ms ease-in;
 }
 
 /* Left side */
-[data-radix-dialog-content][data-sheet-side="left"][data-state="open"] {
+[data-sheet-side="left"][data-state="open"] {
   animation: slideInFromLeft 300ms ease-out;
 }
 
-[data-radix-dialog-content][data-sheet-side="left"][data-state="closed"] {
+[data-sheet-side="left"][data-state="closed"] {
   animation: slideOutToLeft 300ms ease-in;
 }
 
 /* Top side */
-[data-radix-dialog-content][data-sheet-side="top"][data-state="open"] {
+[data-sheet-side="top"][data-state="open"] {
   animation: slideInFromTop 300ms ease-out;
 }
 
-[data-radix-dialog-content][data-sheet-side="top"][data-state="closed"] {
+[data-sheet-side="top"][data-state="closed"] {
   animation: slideOutToTop 300ms ease-in;
 }
 
 /* Bottom side */
-[data-radix-dialog-content][data-sheet-side="bottom"][data-state="open"] {
+[data-sheet-side="bottom"][data-state="open"] {
   animation: slideInFromBottom 300ms ease-out;
 }
 
-[data-radix-dialog-content][data-sheet-side="bottom"][data-state="closed"] {
+[data-sheet-side="bottom"][data-state="closed"] {
   animation: slideOutToBottom 300ms ease-in;
-}
-
-/* Sheet overlay animations */
-[data-radix-dialog-overlay][data-state="open"] {
-  animation: fadeIn 300ms ease-out;
-}
-
-[data-radix-dialog-overlay][data-state="closed"] {
-  animation: fadeOut 300ms ease-in;
-}
-
-@keyframes fadeIn {
-  from {
-    opacity: 0;
-  }
-
-  to {
-    opacity: 1;
-  }
-}
-
-@keyframes fadeOut {
-  from {
-    opacity: 1;
-  }
-
-  to {
-    opacity: 0;
-  }
-}
-
-/* Sheet animation classes */
-.sheet-animate-enter {
-  animation: slideInFromRight 300ms ease-out;
-}
-
-.sheet-animate-exit {
-  animation: slideOutToRight 300ms ease-in;
 }


### PR DESCRIPTION
## Summary

Fixed sheet directional slide animations that were completely broken due to CSS selectors targeting `[data-radix-dialog-content]`, an attribute not set by Radix UI v1.1.15. Replaced all selectors with `[data-sheet-side]` which is already set on the SheetContent element. Also removed the `alert-animate-enter` class from SheetWidget and deleted unused `.sheet-animate-enter`/`.sheet-animate-exit` utility classes and overlay animation selectors.

## API Changes

None.

## Files Modified

- **src/frontend/src/widgets/sheet/sheet.css** — Replaced `[data-radix-dialog-content]` selectors with `[data-sheet-side]` selectors, removed overlay animation selectors and unused utility classes
- **src/frontend/src/widgets/sheet/SheetWidget.tsx** — Removed `alert-animate-enter` from className

## Commits

- e33c143d [01360] Fix sheet directional slide animation selectors

## Artifacts

### Screenshots

![basic-before-open](https://stivytelemetry.blob.core.windows.net/ivy-tendril/basic-before-open.png?se=2026-05-01&sp=r&spr=https&sv=2026-02-06&sr=c&sig=CKGQKqQ8XxPHk0T9N7Z3X4Lpf5MwIaKPt4fsugYJ%2BXU%3D)

![directions-initial](https://stivytelemetry.blob.core.windows.net/ivy-tendril/directions-initial.png?se=2026-05-01&sp=r&spr=https&sv=2026-02-06&sr=c&sig=CKGQKqQ8XxPHk0T9N7Z3X4Lpf5MwIaKPt4fsugYJ%2BXU%3D)

![events-after-close](https://stivytelemetry.blob.core.windows.net/ivy-tendril/events-after-close.png?se=2026-05-01&sp=r&spr=https&sv=2026-02-06&sr=c&sig=CKGQKqQ8XxPHk0T9N7Z3X4Lpf5MwIaKPt4fsugYJ%2BXU%3D)

![events-sheet-open](https://stivytelemetry.blob.core.windows.net/ivy-tendril/events-sheet-open.png?se=2026-05-01&sp=r&spr=https&sv=2026-02-06&sr=c&sig=CKGQKqQ8XxPHk0T9N7Z3X4Lpf5MwIaKPt4fsugYJ%2BXU%3D)

![integration-item-selected](https://stivytelemetry.blob.core.windows.net/ivy-tendril/integration-item-selected.png?se=2026-05-01&sp=r&spr=https&sv=2026-02-06&sr=c&sig=CKGQKqQ8XxPHk0T9N7Z3X4Lpf5MwIaKPt4fsugYJ%2BXU%3D)

![integration-sheet-open](https://stivytelemetry.blob.core.windows.net/ivy-tendril/integration-sheet-open.png?se=2026-05-01&sp=r&spr=https&sv=2026-02-06&sr=c&sig=CKGQKqQ8XxPHk0T9N7Z3X4Lpf5MwIaKPt4fsugYJ%2BXU%3D)

![withsheet-initial](https://stivytelemetry.blob.core.windows.net/ivy-tendril/withsheet-initial.png?se=2026-05-01&sp=r&spr=https&sv=2026-02-06&sr=c&sig=CKGQKqQ8XxPHk0T9N7Z3X4Lpf5MwIaKPt4fsugYJ%2BXU%3D)