### PR TITLE
Switch main theme to shadcn palette, keep ivy green only for branding

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/12_Theming.md
+++ b/src/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/12_Theming.md
@@ -123,9 +123,7 @@ var server = new Server()
                 Card = "#FFFFFF",
                 CardForeground = "#1A1A1A",
                 Popover = "#FFFFFF",
-                PopoverForeground = "#1A1A1A",
-                Brand = "#22C55E",
-                BrandForeground = "#FFFFFF"
+                PopoverForeground = "#1A1A1A"
             },
             Dark = new ThemeColors
             {
@@ -153,9 +151,7 @@ var server = new Server()
                 Card = "#0F2A4A",
                 CardForeground = "#E8F4FD",
                 Popover = "#001122",
-                PopoverForeground = "#E8F4FD",
-                Brand = "#4ADE80",
-                BrandForeground = "#001122"
+                PopoverForeground = "#E8F4FD"
             }
         };
     });

--- a/src/Ivy.Docs.Shared/Docs/04_ApiReference/Ivy/Colors.md
+++ b/src/Ivy.Docs.Shared/Docs/04_ApiReference/Ivy/Colors.md
@@ -12,7 +12,7 @@ searchHints:
 
 Ivy provides predefined colors with light/dark [theme](../../../01_Onboarding/02_Concepts/12_Theming.md) support.
 
-The system includes neutral (Black, White, grayscale), chromatic (Red to Rose spectrum), and semantic (Primary, Secondary, Destructive, Success, Warning, Info, Brand) colors.
+The system includes neutral (Black, White, grayscale), chromatic (Red to Rose spectrum), semantic (Primary, Secondary, Destructive, Success, Warning, Info), and the internal IvyGreen branding color.
 
 All colors meet WCAG accessibility standards and automatically adapt to light/dark themes. Use them with [widgets](../../../01_Onboarding/02_Concepts/03_Widgets.md) such as [Box](../../../02_Widgets/01_Primitives/04_Box.md) (`.Background()`, `.Background()`) and [Button](../../../02_Widgets/03_Common/01_Button.md) variants.
 
@@ -96,7 +96,7 @@ public class SemanticColorsView : ViewBase
 {
     public override object? Build()
     {
-        var semanticColors = new Colors[] { Colors.Primary, Colors.Secondary, Colors.Destructive, Colors.Success, Colors.Warning, Colors.Info, Colors.Brand };
+        var semanticColors = new Colors[] { Colors.Primary, Colors.Secondary, Colors.Destructive, Colors.Success, Colors.Warning, Colors.Info, Colors.IvyGreen };
         
         return Layout.Vertical(
             semanticColors.Select(color =>
@@ -198,7 +198,7 @@ public class ButtonColorsView : ViewBase
 3. **Consider color meaning** - use red/destructive for errors, green for success
 4. **Maintain consistency** - stick to a chosen color scheme throughout your project
 5. **Accessibility first** - ensure proper contrast ratios for text and backgrounds
-6. **Use Brand color** for Ivy branding elements only (logo, "Made with Ivy" corner) — it preserves the original Ivy green while Primary follows the shadcn palette
+6. **IvyGreen is reserved** for internal Ivy branding elements (logo, "Made with Ivy" corner) and should not be used in application code
 
 ## Technical Implementation
 

--- a/src/Ivy.Samples.Shared/Apps/Demos/ThemeCustomizer.cs
+++ b/src/Ivy.Samples.Shared/Apps/Demos/ThemeCustomizer.cs
@@ -165,9 +165,7 @@ public class ThemeCustomizer : SampleBase
             Card = source.Card,
             CardForeground = source.CardForeground,
             Popover = source.Popover,
-            PopoverForeground = source.PopoverForeground,
-            Brand = source.Brand,
-            BrandForeground = source.BrandForeground
+            PopoverForeground = source.PopoverForeground
         };
     }
 
@@ -258,9 +256,7 @@ public class ThemeCustomizer : SampleBase
                             | new ThemeColorPicker(currentColors.Secondary ?? "#000000", e => UpdateColor(c => c.Secondary = e.Value), placeholder: "Secondary").AllowAlpha().WithField().Medium().Description("Secondary").WithTooltip($"Secondary: {currentColors.Secondary ?? "#000000"}")
                             | new ThemeColorPicker(currentColors.SecondaryForeground ?? "#000000", e => UpdateColor(c => c.SecondaryForeground = e.Value), placeholder: "Secondary Foreground").Foreground(true).AllowAlpha().WithField().Medium().Description("\u00A0").WithTooltip($"Secondary Foreground: {currentColors.SecondaryForeground ?? "#000000"}")
                             | new ThemeColorPicker(currentColors.Background ?? "#000000", e => UpdateColor(c => c.Background = e.Value), placeholder: "Background").AllowAlpha().WithField().Medium().Description("Background").WithTooltip($"Background: {currentColors.Background ?? "#000000"}")
-                            | new ThemeColorPicker(currentColors.Foreground ?? "#000000", e => UpdateColor(c => c.Foreground = e.Value), placeholder: "Foreground").Foreground(true).AllowAlpha().WithField().Medium().Description("\u00A0").WithTooltip($"Foreground: {currentColors.Foreground ?? "#000000"}")
-                            | new ThemeColorPicker(currentColors.Brand ?? "#000000", e => UpdateColor(c => c.Brand = e.Value), placeholder: "Brand").AllowAlpha().WithField().Medium().Description("Brand").WithTooltip($"Brand: {currentColors.Brand ?? "#000000"}")
-                            | new ThemeColorPicker(currentColors.BrandForeground ?? "#000000", e => UpdateColor(c => c.BrandForeground = e.Value), placeholder: "Brand Foreground").Foreground(true).AllowAlpha().WithField().Medium().Description("\u00A0").WithTooltip($"Brand Foreground: {currentColors.BrandForeground ?? "#000000"}"))
+                            | new ThemeColorPicker(currentColors.Foreground ?? "#000000", e => UpdateColor(c => c.Foreground = e.Value), placeholder: "Foreground").Foreground(true).AllowAlpha().WithField().Medium().Description("\u00A0").WithTooltip($"Foreground: {currentColors.Foreground ?? "#000000"}"))
 
                         | new Separator()
 
@@ -474,8 +470,7 @@ public class ThemeCustomizer : SampleBase
                     | new ColorPreview("Warning", theme.Colors.Light.Warning, theme.Colors.Light.WarningForeground)
                     | new ColorPreview("Info", theme.Colors.Light.Info, theme.Colors.Light.InfoForeground)
                     | new ColorPreview("Muted", theme.Colors.Light.Muted, theme.Colors.Light.MutedForeground)
-                    | new ColorPreview("Accent", theme.Colors.Light.Accent, theme.Colors.Light.AccentForeground)
-                    | new ColorPreview("Brand", theme.Colors.Light.Brand, theme.Colors.Light.BrandForeground))
+                    | new ColorPreview("Accent", theme.Colors.Light.Accent, theme.Colors.Light.AccentForeground))
 
                 | Text.H3("Dark Theme Colors")
                 | (Layout.Grid().Columns(2)
@@ -486,8 +481,7 @@ public class ThemeCustomizer : SampleBase
                     | new ColorPreview("Warning", theme.Colors.Dark.Warning, theme.Colors.Dark.WarningForeground)
                     | new ColorPreview("Info", theme.Colors.Dark.Info, theme.Colors.Dark.InfoForeground)
                     | new ColorPreview("Muted", theme.Colors.Dark.Muted, theme.Colors.Dark.MutedForeground)
-                    | new ColorPreview("Accent", theme.Colors.Dark.Accent, theme.Colors.Dark.AccentForeground)
-                    | new ColorPreview("Brand", theme.Colors.Dark.Brand, theme.Colors.Dark.BrandForeground));
+                    | new ColorPreview("Accent", theme.Colors.Dark.Accent, theme.Colors.Dark.AccentForeground));
         }
     }
 
@@ -876,9 +870,7 @@ var server = new Server()
                 Card = ""{lightColors.Card}"",
                 CardForeground = ""{lightColors.CardForeground}"",
                 Popover = ""{lightColors.Popover}"",
-                PopoverForeground = ""{lightColors.PopoverForeground}"",
-                Brand = ""{lightColors.Brand}"",
-                BrandForeground = ""{lightColors.BrandForeground}""
+                PopoverForeground = ""{lightColors.PopoverForeground}""
             }},
             Dark = new ThemeColors
             {{
@@ -906,9 +898,7 @@ var server = new Server()
                 Card = ""{darkColors.Card}"",
                 CardForeground = ""{darkColors.CardForeground}"",
                 Popover = ""{darkColors.Popover}"",
-                PopoverForeground = ""{darkColors.PopoverForeground}"",
-                Brand = ""{darkColors.Brand}"",
-                BrandForeground = ""{darkColors.BrandForeground}""
+                PopoverForeground = ""{darkColors.PopoverForeground}""
             }}
         }}
         theme.FontFamily = ""{theme.FontFamily}"";

--- a/src/Ivy/Services/ThemeConfig.cs
+++ b/src/Ivy/Services/ThemeConfig.cs
@@ -74,8 +74,8 @@ public class ThemeColors
     public string? CardForeground { get; set; }
     public string? Popover { get; set; }
     public string? PopoverForeground { get; set; }
-    public string? Brand { get; set; }
-    public string? BrandForeground { get; set; }
+    public string? IvyGreen { get; set; }
+    public string? IvyGreenForeground { get; set; }
 
     public static ThemeColors DefaultLight => new()
     {
@@ -104,8 +104,8 @@ public class ThemeColors
         CardForeground = IvyFrameworkLightThemeTokens.Color.CardForeground,
         Popover = IvyFrameworkLightThemeTokens.Color.Popover,
         PopoverForeground = IvyFrameworkLightThemeTokens.Color.PopoverForeground,
-        Brand = IvyFrameworkLightThemeTokens.Color.Primary,
-        BrandForeground = IvyFrameworkLightThemeTokens.Color.PrimaryForeground
+        IvyGreen = IvyFrameworkLightThemeTokens.Color.Primary,
+        IvyGreenForeground = IvyFrameworkLightThemeTokens.Color.PrimaryForeground
     };
 
     public static ThemeColors DefaultDark => new()
@@ -135,7 +135,7 @@ public class ThemeColors
         CardForeground = IvyFrameworkDarkThemeTokens.Color.CardForeground,
         Popover = IvyFrameworkDarkThemeTokens.Color.Popover,
         PopoverForeground = IvyFrameworkDarkThemeTokens.Color.PopoverForeground,
-        Brand = IvyFrameworkDarkThemeTokens.Color.Primary,
-        BrandForeground = IvyFrameworkDarkThemeTokens.Color.PrimaryForeground
+        IvyGreen = IvyFrameworkDarkThemeTokens.Color.Primary,
+        IvyGreenForeground = IvyFrameworkDarkThemeTokens.Color.PrimaryForeground
     };
 }

--- a/src/Ivy/Services/ThemeService.cs
+++ b/src/Ivy/Services/ThemeService.cs
@@ -112,9 +112,9 @@ public class ThemeService : IThemeService
         AppendColorVariable(sb, "--popover", colors.Popover ?? defaults.Popover);
         AppendColorVariable(sb, "--popover-foreground", colors.PopoverForeground ?? defaults.PopoverForeground);
 
-        // Brand colors (Ivy green for logo and branding elements)
-        AppendColorVariable(sb, "--brand", colors.Brand ?? defaults.Brand);
-        AppendColorVariable(sb, "--brand-foreground", colors.BrandForeground ?? defaults.BrandForeground);
+        // Ivy green for logo and branding elements
+        AppendColorVariable(sb, "--ivy-green", colors.IvyGreen ?? defaults.IvyGreen);
+        AppendColorVariable(sb, "--ivy-green-foreground", colors.IvyGreenForeground ?? defaults.IvyGreenForeground);
     }
 
     private void AppendNeutralColors(StringBuilder sb)

--- a/src/Ivy/Shared/Colors.cs
+++ b/src/Ivy/Shared/Colors.cs
@@ -38,5 +38,5 @@ public enum Colors
     Warning,
     Info,
     Muted,
-    Brand
+    IvyGreen
 }

--- a/src/Ivy/Widgets/Internal/IvyLogo.cs
+++ b/src/Ivy/Widgets/Internal/IvyLogo.cs
@@ -5,7 +5,7 @@ namespace Ivy;
 
 public record IvyLogo : WidgetBase<IvyLogo>
 {
-    public IvyLogo(Colors color = Colors.Brand) : this()
+    public IvyLogo(Colors color = Colors.IvyGreen) : this()
     {
         Color = color;
     }
@@ -16,5 +16,5 @@ public record IvyLogo : WidgetBase<IvyLogo>
         Height = Size.Auto();
     }
 
-    [Prop] public Colors Color { get; set; } = Colors.Brand;
+    [Prop] public Colors Color { get; set; } = Colors.IvyGreen;
 }

--- a/src/frontend/src/components/MadeWithIvy.tsx
+++ b/src/frontend/src/components/MadeWithIvy.tsx
@@ -46,7 +46,7 @@ export default function MadeWithIvy() {
 
   return (
     <div
-      className="bg-brand fixed bottom-0 right-0 z-100 overflow-hidden rounded-tl-full "
+      className="bg-ivy-green fixed bottom-0 right-0 z-100 overflow-hidden rounded-tl-full "
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >
@@ -62,7 +62,7 @@ export default function MadeWithIvy() {
           origin-bottom-right
           cursor-pointer
           ${isHovered ? "w-48 h-48" : "w-16 h-16"}
-          ${isHovered ? "bg-primary-foreground" : "bg-brand"}
+          ${isHovered ? "bg-primary-foreground" : "bg-ivy-green"}
         `}
         onClick={handleClick}
         role="button"
@@ -70,7 +70,7 @@ export default function MadeWithIvy() {
         onKeyDown={handleKeyDown}
       >
         <div
-          style={{ color: "var(--brand)" }}
+          style={{ color: "var(--ivy-green)" }}
           className={`
             flex
             flex-col

--- a/src/frontend/src/index.css
+++ b/src/frontend/src/index.css
@@ -76,8 +76,8 @@ ivy-widget {
     --color-border: var(--border);
     --color-input: var(--input);
     --color-ring: var(--ring);
-    --color-brand: var(--brand);
-    --color-brand-foreground: var(--brand-foreground);
+    --color-ivy-green: var(--ivy-green);
+    --color-ivy-green-foreground: var(--ivy-green-foreground);
 
     /* Neutral colors - reference CSS variables injected by the backend */
     --color-black: var(--black);
@@ -166,11 +166,11 @@ ivy-widget {
 
   /* Ensure sidebar icons and logo use primary brand color */
   [data-sidebar="sidebar"] .text-primary {
-    color: var(--brand) !important;
+    color: var(--ivy-green) !important;
   }
 
   [data-sidebar="sidebar"] svg[fill="currentColor"] {
-    color: var(--brand);
+    color: var(--ivy-green);
   }
 }
 


### PR DESCRIPTION
## Summary

- Replace the primary ivy green color with the shadcn color palette as the default theme for all apps built on the Ivy framework
- Ivy green is preserved exclusively for logo and "IvyT corner" branding elements (, , )
- Updated , , and  to reflect the new default palette

## Test Plan

- [ ] Run the framework and verify apps no longer show ivy green as the primary color
- [ ] Confirm the Ivy logo and "Made with Ivy" branding still render in ivy green
- [ ] Check that the  CSS variables correctly reflect the shadcn color tokens
- [ ] Verify no visual regressions in existing Ivy framework sample apps
