### PR TITLE
[01402] Use a smaller font size in DiffView

### DIFF
--- a/src/widgets/Ivy.Widgets.DiffView/frontend/src/DiffView.tsx
+++ b/src/widgets/Ivy.Widgets.DiffView/frontend/src/DiffView.tsx
@@ -60,7 +60,7 @@ export const DiffView: React.FC<DiffViewProps> = ({
   }
 
   return (
-    <div style={style}>
+    <div style={style} className="text-xs">
       {files.map((file, fileIndex) => {
         const hasHeader = oldRevision || newRevision || file.oldPath || file.newPath;
         return (


### PR DESCRIPTION
## Changes

Added `text-xs` Tailwind CSS class to the DiffView widget's outer content wrapper div, making all diff output render at a smaller font size (0.75rem). The file header already used `text-xs`; the diff body now matches.

## API Changes

None.

## Files Modified

- **Frontend:** `src/widgets/Ivy.Widgets.DiffView/frontend/src/DiffView.tsx` — added `text-xs` className to the diff container div

## Commits

- 191a0c25 [01402] Use smaller font size in DiffView widget