### PR TITLE
[01407] Languages enum displays raw values in SelectInput

### DIFF
--- a/src/Ivy.Tests/Extensions/OptionExtensionsTests.cs
+++ b/src/Ivy.Tests/Extensions/OptionExtensionsTests.cs
@@ -159,6 +159,16 @@ public class OptionExtensionsTests
     }
 
     [Fact]
+    public void ToOptions_WithLanguagesEnum_UsesDescriptionAttributes()
+    {
+        var values = Enum.GetValues<Languages>();
+        var options = values.ToOptions();
+        Assert.Equal("C#", options.First(o => (Languages)o.TypedValue! == Languages.Csharp).Label);
+        Assert.Equal("JavaScript", options.First(o => (Languages)o.TypedValue! == Languages.Javascript).Label);
+        Assert.Equal("SQL", options.First(o => (Languages)o.TypedValue! == Languages.Sql).Label);
+    }
+
+    [Fact]
     public void ToOptions_TypeOverload_WithDescriptionAttribute_PrefersDescription()
     {
         // Arrange

--- a/src/Ivy/Widgets/Primitives/CodeBlock.cs
+++ b/src/Ivy/Widgets/Primitives/CodeBlock.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using Ivy.Core;
 
 // ReSharper disable once CheckNamespace
@@ -5,19 +6,33 @@ namespace Ivy;
 
 public enum Languages
 {
+    [Description("C#")]
     Csharp,
+    [Description("JavaScript")]
     Javascript,
+    [Description("TypeScript")]
     Typescript,
+    [Description("Python")]
     Python,
+    [Description("SQL")]
     Sql,
+    [Description("HTML")]
     Html,
+    [Description("CSS")]
     Css,
+    [Description("JSON")]
     Json,
+    [Description("DBML")]
     Dbml,
+    [Description("Markdown")]
     Markdown,
+    [Description("Text")]
     Text,
+    [Description("XML")]
     Xml,
+    [Description("YAML")]
     Yaml,
+    [Description("CSV")]
     Csv,
 }
 


### PR DESCRIPTION
## Summary

Added `[Description]` attributes to all 14 values of the `Languages` enum in `CodeBlock.cs` so that `ToSelectInput()` displays human-friendly labels (e.g. "C#", "JavaScript", "SQL") instead of raw enum names. Added a test verifying the description attributes produce correct labels.

## API Changes

None. The `Languages` enum values are unchanged; only display metadata was added via `[Description]` attributes. The existing `EnumHelper.GetDescription()` already reads these attributes.

## Files Modified

- **src/Ivy/Widgets/Primitives/CodeBlock.cs** -- Added `using System.ComponentModel;` and `[Description(...)]` attributes to all `Languages` enum members
- **src/Ivy.Tests/Extensions/OptionExtensionsTests.cs** -- Added `ToOptions_WithLanguagesEnum_UsesDescriptionAttributes` test

## Commits

- 14c380ef [01407] Add Description attributes to Languages enum for display labels

## Artifacts

### Screenshots

![01-basic-initial](https://stivytelemetry.blob.core.windows.net/ivy-tendril/01-basic-initial.png?se=2026-05-01&sp=r&spr=https&sv=2026-02-06&sr=c&sig=CKGQKqQ8XxPHk0T9N7Z3X4Lpf5MwIaKPt4fsugYJ%2BXU%3D)

![02-basic-dropdown-open](https://stivytelemetry.blob.core.windows.net/ivy-tendril/02-basic-dropdown-open.png?se=2026-05-01&sp=r&spr=https&sv=2026-02-06&sr=c&sig=CKGQKqQ8XxPHk0T9N7Z3X4Lpf5MwIaKPt4fsugYJ%2BXU%3D)

![03-basic-javascript-selected](https://stivytelemetry.blob.core.windows.net/ivy-tendril/03-basic-javascript-selected.png?se=2026-05-01&sp=r&spr=https&sv=2026-02-06&sr=c&sig=CKGQKqQ8XxPHk0T9N7Z3X4Lpf5MwIaKPt4fsugYJ%2BXU%3D)

![04-all-labels-radio](https://stivytelemetry.blob.core.windows.net/ivy-tendril/04-all-labels-radio.png?se=2026-05-01&sp=r&spr=https&sv=2026-02-06&sr=c&sig=CKGQKqQ8XxPHk0T9N7Z3X4Lpf5MwIaKPt4fsugYJ%2BXU%3D)

![05-all-labels-sql-selected](https://stivytelemetry.blob.core.windows.net/ivy-tendril/05-all-labels-sql-selected.png?se=2026-05-01&sp=r&spr=https&sv=2026-02-06&sr=c&sig=CKGQKqQ8XxPHk0T9N7Z3X4Lpf5MwIaKPt4fsugYJ%2BXU%3D)

![06-all-labels-csharp-selected](https://stivytelemetry.blob.core.windows.net/ivy-tendril/06-all-labels-csharp-selected.png?se=2026-05-01&sp=r&spr=https&sv=2026-02-06&sr=c&sig=CKGQKqQ8XxPHk0T9N7Z3X4Lpf5MwIaKPt4fsugYJ%2BXU%3D)

![07-props-initial](https://stivytelemetry.blob.core.windows.net/ivy-tendril/07-props-initial.png?se=2026-05-01&sp=r&spr=https&sv=2026-02-06&sr=c&sig=CKGQKqQ8XxPHk0T9N7Z3X4Lpf5MwIaKPt4fsugYJ%2BXU%3D)

![08-props-variants](https://stivytelemetry.blob.core.windows.net/ivy-tendril/08-props-variants.png?se=2026-05-01&sp=r&spr=https&sv=2026-02-06&sr=c&sig=CKGQKqQ8XxPHk0T9N7Z3X4Lpf5MwIaKPt4fsugYJ%2BXU%3D)

![09-integration-initial](https://stivytelemetry.blob.core.windows.net/ivy-tendril/09-integration-initial.png?se=2026-05-01&sp=r&spr=https&sv=2026-02-06&sr=c&sig=CKGQKqQ8XxPHk0T9N7Z3X4Lpf5MwIaKPt4fsugYJ%2BXU%3D)

![10-integration-python-selected](https://stivytelemetry.blob.core.windows.net/ivy-tendril/10-integration-python-selected.png?se=2026-05-01&sp=r&spr=https&sv=2026-02-06&sr=c&sig=CKGQKqQ8XxPHk0T9N7Z3X4Lpf5MwIaKPt4fsugYJ%2BXU%3D)