### PR TITLE
[01449] Tooltip should set aria-label on icon-only buttons

### DIFF
--- a/src/frontend/src/hoc/withTooltip.tsx
+++ b/src/frontend/src/hoc/withTooltip.tsx
@@ -12,8 +12,10 @@ function withTooltip<P extends React.JSX.IntrinsicAttributes>(Component: Compone
   return function TooltipHOC(props: WithTooltipProps<P>) {
     const { tooltipText, className, style, ...restProps } = props;
 
+    const ariaLabel = tooltipText && !(restProps as any)["aria-label"] ? tooltipText : undefined;
+
     const componentWithStyles = (
-      <Component className={className} style={style} {...(restProps as P)} />
+      <Component className={className} style={style} aria-label={ariaLabel} {...(restProps as P)} />
     );
 
     if (!tooltipText) {

--- a/src/frontend/src/widgets/tooltip/TooltipWidget.tsx
+++ b/src/frontend/src/widgets/tooltip/TooltipWidget.tsx
@@ -9,6 +9,15 @@ interface TooltipWidgetProps {
   };
 }
 
+function extractText(nodes: React.ReactNode[]): string | undefined {
+  const parts: string[] = [];
+  for (const node of nodes) {
+    if (typeof node === "string") parts.push(node);
+    else if (typeof node === "number") parts.push(String(node));
+  }
+  return parts.length > 0 ? parts.join("") : undefined;
+}
+
 export const TooltipWidget: React.FC<TooltipWidgetProps> = ({ slots }) => {
   if (!slots?.Trigger || !slots?.Content) {
     return (
@@ -16,13 +25,17 @@ export const TooltipWidget: React.FC<TooltipWidgetProps> = ({ slots }) => {
     );
   }
 
+  const ariaLabel = extractText(slots.Content);
+
   // asChild + span: we need a single DOM node that receives ref/handlers (slot widgets like ButtonWidget don't forward ref).
   // A span wrapper avoids TooltipTrigger's default <button> so we don't get invalid button-in-button.
   return (
     <TooltipProvider>
       <Tooltip>
         <TooltipTrigger asChild>
-          <span style={{ display: "inline-block" }}>{slots.Trigger}</span>
+          <span style={{ display: "inline-block" }} aria-label={ariaLabel}>
+            {slots.Trigger}
+          </span>
         </TooltipTrigger>
         <TooltipContent className="bg-popover text-popover-foreground shadow-md">
           {slots.Content}


### PR DESCRIPTION
# Summary

Modified the `withTooltip` HOC to automatically set `aria-label` on wrapped components when a tooltip is present and no explicit `aria-label` is already provided. Also updated the explicit `TooltipWidget` to extract text content from its Content slot and apply it as `aria-label` on the trigger span wrapper.

## API Changes

- `withTooltip` HOC now passes `aria-label={tooltipText}` to wrapped components (non-breaking — only adds attribute when tooltip exists and no explicit aria-label is set)
- `TooltipWidget` span wrapper now includes `aria-label` extracted from text content in the Content slot

## Files Modified

- **src/frontend/src/hoc/withTooltip.tsx** — Added aria-label propagation from tooltip text to wrapped component
- **src/frontend/src/widgets/tooltip/TooltipWidget.tsx** — Added `extractText` helper and aria-label on trigger span

## Commits

- `95bc9738` [01449] Add aria-label to tooltip-wrapped components for accessibility