### PR TITLE
[01484] Dashboard table still not showing data rows

### DIFF
--- a/src/frontend/src/widgets/dataTables/hooks/useContainerSize.ts
+++ b/src/frontend/src/widgets/dataTables/hooks/useContainerSize.ts
@@ -58,13 +58,21 @@ export const useContainerSize = () => {
 
     resizeObserver.observe(containerRef.current);
 
-    // Synchronous initial measurement to avoid first render with height=0.
-    // Without this, the deferred requestAnimationFrame in the ResizeObserver callback
-    // causes DataEditor to render with height=undefined, showing only headers.
-    const { width: initWidth, height: initHeight } = containerRef.current.getBoundingClientRect();
-    if ((initWidth > 0 || initHeight > 0) && !hasAppliedInitialRef.current) {
-      apply(initWidth, initHeight);
-    }
+    // Retry initial measurement until layout settles (max ~100ms).
+    // In nested flex layouts (e.g. HeaderLayout → Vertical → DataTable), the container
+    // may still have height=0 at mount time. Retrying across animation frames ensures
+    // we catch the moment the layout resolves.
+    let retries = 0;
+    const tryInit = () => {
+      if (hasAppliedInitialRef.current || !containerRef.current) return;
+      const { width, height } = containerRef.current.getBoundingClientRect();
+      if (width > 0 || height > 0) {
+        apply(width, height);
+      } else if (retries++ < 5) {
+        requestAnimationFrame(tryInit);
+      }
+    };
+    tryInit();
 
     requestAnimationFrame(observeScrollArea);
 


### PR DESCRIPTION
# Summary

Fixed the Dashboard DataTable showing only column headers with no data rows. The root cause was that `.Height(Size.Full())` relied on flex height resolution, but the DataTable's container had zero height at mount time because it was inside a nested vertical layout with a sibling chart. Also improved the Framework's `useContainerSize` hook to retry initial measurement across animation frames instead of failing silently when the container has zero height at mount.

## Files Modified

- **Ivy-Framework**
  - `src/frontend/src/widgets/dataTables/hooks/useContainerSize.ts` — Replaced synchronous initial measurement with a retry loop (up to 5 animation frames) for containers that start with zero dimensions

## Commits

- 2cff24eb [01484] Retry initial container measurement for nested flex layouts