### PR TITLE
[01423] Fix .ToDetails() showing type names for navigation properties

### DIFF
--- a/src/Ivy.Tests/Views/DetailsBuilderNavigationTests.cs
+++ b/src/Ivy.Tests/Views/DetailsBuilderNavigationTests.cs
@@ -1,0 +1,125 @@
+using Ivy.Views.Builders;
+
+namespace Ivy.Tests.Views;
+
+public class DetailsBuilderNavigationTests
+{
+    #region Test models
+
+    private class CategoryWithName
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = "";
+    }
+
+    private class CategoryWithTitle
+    {
+        public int Id { get; set; }
+        public string Title { get; set; } = "";
+    }
+
+    private class CategoryWithDisplayName
+    {
+        public int Id { get; set; }
+        public string DisplayName { get; set; } = "";
+    }
+
+    private class CategoryWithToString
+    {
+        public int Id { get; set; }
+        public override string ToString() => $"Custom({Id})";
+    }
+
+    private class CategoryWithIdOnly
+    {
+        public int Id { get; set; }
+    }
+
+    private class CategoryEmpty;
+
+    private class Product
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = "";
+        public decimal Price { get; set; }
+        public CategoryWithName? Category { get; set; }
+        public List<string> Tags { get; set; } = [];
+    }
+
+    #endregion
+
+    [Fact]
+    public void ResolveDisplayValue_WithNameProperty_ReturnsName()
+    {
+        var category = new CategoryWithName { Id = 1, Name = "Beer" };
+        var result = NavigationPropertyBuilder<object>.ResolveDisplayValue(category);
+        Assert.Equal("Beer", result);
+    }
+
+    [Fact]
+    public void ResolveDisplayValue_WithTitleProperty_ReturnsTitle()
+    {
+        var category = new CategoryWithTitle { Id = 1, Title = "Beverages" };
+        var result = NavigationPropertyBuilder<object>.ResolveDisplayValue(category);
+        Assert.Equal("Beverages", result);
+    }
+
+    [Fact]
+    public void ResolveDisplayValue_WithDisplayNameProperty_ReturnsDisplayName()
+    {
+        var category = new CategoryWithDisplayName { Id = 1, DisplayName = "My Category" };
+        var result = NavigationPropertyBuilder<object>.ResolveDisplayValue(category);
+        Assert.Equal("My Category", result);
+    }
+
+    [Fact]
+    public void ResolveDisplayValue_WithToStringOverride_UsesToString()
+    {
+        var category = new CategoryWithToString { Id = 42 };
+        var result = NavigationPropertyBuilder<object>.ResolveDisplayValue(category);
+        Assert.Equal("Custom(42)", result);
+    }
+
+    [Fact]
+    public void ResolveDisplayValue_WithIdOnly_ReturnsEntityHash()
+    {
+        var category = new CategoryWithIdOnly { Id = 7 };
+        var result = NavigationPropertyBuilder<object>.ResolveDisplayValue(category);
+        Assert.Equal("Entity #7", result);
+    }
+
+    [Fact]
+    public void ResolveDisplayValue_Null_ReturnsNull()
+    {
+        var result = NavigationPropertyBuilder<object>.ResolveDisplayValue(null);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void NavigationPropertyBuilder_Build_ResolvesDisplayValue()
+    {
+        var builder = new NavigationPropertyBuilder<Product>();
+        var product = new Product { Id = 1, Name = "Test", Category = new CategoryWithName { Id = 1, Name = "Beer" } };
+        var result = builder.Build(product.Category, product);
+        Assert.Equal("Beer", result);
+    }
+
+    [Fact]
+    public void NavigationPropertyBuilder_Build_NullValue_ReturnsNull()
+    {
+        var builder = new NavigationPropertyBuilder<Product>();
+        var product = new Product { Id = 1, Name = "Test" };
+        var result = builder.Build(null, product);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ScalarProperties_StillUseDefaultBuilder()
+    {
+        // Verify that simple types are not affected by the navigation property logic
+        var defaultBuilder = new DefaultBuilder<Product>();
+        Assert.Equal(42, defaultBuilder.Build(42, new Product()));
+        Assert.Equal("hello", defaultBuilder.Build("hello", new Product()));
+        Assert.Equal(3.14m, defaultBuilder.Build(3.14m, new Product()));
+    }
+}

--- a/src/Ivy/Views/Builders/DetailsBuilder.cs
+++ b/src/Ivy/Views/Builders/DetailsBuilder.cs
@@ -3,6 +3,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using Ivy.Core;
 using Ivy.Core.Hooks;
+using Ivy.Views.Builders;
 
 // ReSharper disable once CheckNamespace
 namespace Ivy;
@@ -77,13 +78,23 @@ public class DetailsBuilder<TModel> : ViewBase, IStateless
         foreach (var field in fields)
         {
             var label = StringHelper.LabelFor(field.Name, field.Type);
-            _items[field.Name] =
-                new Item(
-                    label,
-                    new DefaultBuilder<TModel>(),
-                    field.FieldInfo,
-                    field.PropertyInfo
-                );
+            var item = new Item(
+                label,
+                new DefaultBuilder<TModel>(),
+                field.FieldInfo,
+                field.PropertyInfo
+            );
+
+            if (TypeHelper.IsCollectionType(field.Type))
+            {
+                item.IsRemoved = true;
+            }
+            else if (!TypeHelper.IsSimpleType(field.Type) && field.Type != typeof(string) && field.Type.IsClass)
+            {
+                item.Builder = new NavigationPropertyBuilder<TModel>();
+            }
+
+            _items[field.Name] = item;
         }
 
     }

--- a/src/Ivy/Views/Builders/NavigationPropertyBuilder.cs
+++ b/src/Ivy/Views/Builders/NavigationPropertyBuilder.cs
@@ -1,0 +1,47 @@
+using System.Reflection;
+
+// ReSharper disable once CheckNamespace
+namespace Ivy.Views.Builders;
+
+public class NavigationPropertyBuilder<TModel> : IBuilder<TModel>
+{
+    public object? Build(object? value, TModel record)
+    {
+        return ResolveDisplayValue(value);
+    }
+
+    public static string? ResolveDisplayValue(object? value)
+    {
+        if (value == null) return null;
+
+        var type = value.GetType();
+
+        // Look for Name, Title, or DisplayName properties
+        foreach (var propName in new[] { "Name", "Title", "DisplayName" })
+        {
+            var prop = type.GetProperty(propName, BindingFlags.Public | BindingFlags.Instance);
+            if (prop != null && prop.PropertyType == typeof(string))
+            {
+                var result = prop.GetValue(value) as string;
+                if (result != null) return result;
+            }
+        }
+
+        // Check if the type overrides ToString()
+        var toStringMethod = type.GetMethod("ToString", BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly, Type.EmptyTypes);
+        if (toStringMethod != null)
+        {
+            return value.ToString();
+        }
+
+        // Look for an Id property
+        var idProp = type.GetProperty("Id", BindingFlags.Public | BindingFlags.Instance);
+        if (idProp != null)
+        {
+            var idValue = idProp.GetValue(value);
+            if (idValue != null) return $"Entity #{idValue}";
+        }
+
+        return value.ToString();
+    }
+}


### PR DESCRIPTION
## Changes

Added navigation property detection to `DetailsBuilder._Scaffold()` so that `.ToDetails()` displays meaningful values (Name, Title, DisplayName, ToString(), or Entity #Id) instead of raw .NET type names. Collection navigation properties are now automatically excluded from detail views.

## API Changes

- New class `NavigationPropertyBuilder<TModel>` in `Ivy.Views.Builders` namespace — used internally by `DetailsBuilder._Scaffold()` to resolve display values for navigation properties.
- `NavigationPropertyBuilder<TModel>.ResolveDisplayValue(object?)` — public static method that resolves a display string from a navigation property value using Name/Title/DisplayName properties, ToString() overrides, or Id fallback.

## Files Modified

- **Core implementation:**
  - `src/Ivy/Views/Builders/DetailsBuilder.cs` — Modified `_Scaffold()` to detect navigation and collection properties
  - `src/Ivy/Views/Builders/NavigationPropertyBuilder.cs` — New builder with display value resolution logic

- **Tests:**
  - `src/Ivy.Tests/Views/DetailsBuilderNavigationTests.cs` — 9 tests covering all resolution heuristics

## Commits

- fd910df5 [01423] Fix .ToDetails() showing type names for navigation properties

## Artifacts

### Screenshots

![basic-app-overview](https://stivytelemetry.blob.core.windows.net/ivy-tendril/basic-app-overview.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![null-nav-app](https://stivytelemetry.blob.core.windows.net/ivy-tendril/null-nav-app.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![resolution-app-strategies](https://stivytelemetry.blob.core.windows.net/ivy-tendril/resolution-app-strategies.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![scalar-regression-app](https://stivytelemetry.blob.core.windows.net/ivy-tendril/scalar-regression-app.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)