### PR TITLE
[01441] Auto-exclude EF Core navigation collection columns from DataTable scaffolding

### DIFF
--- a/src/Ivy.Tests/Views/DataTables/DataTableScaffoldTests.cs
+++ b/src/Ivy.Tests/Views/DataTables/DataTableScaffoldTests.cs
@@ -1,0 +1,98 @@
+using Ivy;
+
+namespace Ivy.Tests.Views.DataTables;
+
+public class DataTableScaffoldTests
+{
+    private class ChildEntity
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = "";
+    }
+
+    private class EntityWithICollection
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = "";
+        public ICollection<ChildEntity> Children { get; set; } = [];
+    }
+
+    private class EntityWithList
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = "";
+        public List<ChildEntity> Children { get; set; } = [];
+    }
+
+    private class EntityWithStringArray
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = "";
+        public string[] Tags { get; set; } = [];
+    }
+
+    private class EntityWithListOfStrings
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = "";
+        public List<string> Tags { get; set; } = [];
+    }
+
+    private class EntityWithPrimitives
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = "";
+        public DateTime CreatedAt { get; set; }
+        public decimal Amount { get; set; }
+    }
+
+    private static bool IsColumnRemoved<T>(DataTableBuilder<T> builder, string columnName)
+    {
+        var flags = System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance;
+        var columnsField = builder.GetType().GetField("_columns", flags)!;
+        var columnsObj = columnsField.GetValue(builder)!;
+        var dictType = columnsObj.GetType();
+        var itemProp = dictType.GetProperty("Item")!;
+        var internalColumn = itemProp.GetValue(columnsObj, [columnName])!;
+        var removedProp = internalColumn.GetType().GetProperty("Removed")!;
+        return (bool)removedProp.GetValue(internalColumn)!;
+    }
+
+    [Fact]
+    public void Scaffold_ExcludesICollectionNavigationProperties()
+    {
+        var builder = new[] { new EntityWithICollection() }.AsQueryable().ToDataTable();
+        Assert.True(IsColumnRemoved(builder, "Children"));
+    }
+
+    [Fact]
+    public void Scaffold_ExcludesListNavigationProperties()
+    {
+        var builder = new[] { new EntityWithList() }.AsQueryable().ToDataTable();
+        Assert.True(IsColumnRemoved(builder, "Children"));
+    }
+
+    [Fact]
+    public void Scaffold_KeepsStringArrayAsLabels()
+    {
+        var builder = new[] { new EntityWithStringArray() }.AsQueryable().ToDataTable();
+        Assert.False(IsColumnRemoved(builder, "Tags"));
+    }
+
+    [Fact]
+    public void Scaffold_KeepsListOfStrings()
+    {
+        var builder = new[] { new EntityWithListOfStrings() }.AsQueryable().ToDataTable();
+        Assert.False(IsColumnRemoved(builder, "Tags"));
+    }
+
+    [Fact]
+    public void Scaffold_KeepsPrimitiveProperties()
+    {
+        var builder = new[] { new EntityWithPrimitives() }.AsQueryable().ToDataTable();
+        Assert.False(IsColumnRemoved(builder, "Id"));
+        Assert.False(IsColumnRemoved(builder, "Name"));
+        Assert.False(IsColumnRemoved(builder, "CreatedAt"));
+        Assert.False(IsColumnRemoved(builder, "Amount"));
+    }
+}

--- a/src/Ivy/Views/DataTables/DataTableBuilder.cs
+++ b/src/Ivy/Views/DataTables/DataTableBuilder.cs
@@ -83,8 +83,13 @@ public class DataTableBuilder<TModel>(
                 align = Ivy.Align.Center;
             }
 
-            var removed = field.Name.StartsWith($"_") && field.Name.Length > 1 && char.IsLetter(field.Name[1]) ||
-                          field.Name == "_hiddenKey";
+            var isNavigationCollection = field.Type.IsCollectionType() &&
+                field.Type.GetCollectionTypeParameter() is { IsClass: true } elementType &&
+                elementType != typeof(string);
+
+            var removed = field.Name.StartsWith("_") && field.Name.Length > 1 && char.IsLetter(field.Name[1]) ||
+                          field.Name == "_hiddenKey" ||
+                          isNavigationCollection;
 
             _columns[field.Name] = new InternalColumn()
             {


### PR DESCRIPTION
## Summary

Added automatic exclusion of EF Core navigation collection properties from DataTable scaffolding. Collections where the element type is a non-string reference type (e.g., `ICollection<Order>`, `List<Employee>`) are now auto-removed during `_Scaffold()`, while `string[]` and `List<string>` are preserved.

## API Changes

None. This is an internal behavior change in `DataTableBuilder._Scaffold()` — navigation collections that previously appeared as empty/type-name columns are now auto-excluded. Users can still explicitly include them via `.Order()` if needed.

## Files Modified

- **Core fix:** `src/Ivy/Views/DataTables/DataTableBuilder.cs` — Added `isNavigationCollection` check in `_Scaffold()`
- **Tests:** `src/Ivy.Tests/Views/DataTables/DataTableScaffoldTests.cs` — 5 new tests verifying exclusion of navigation collections and preservation of string/primitive columns

## Commits

- 2fba4792 [01441] Auto-exclude navigation collection columns from DataTable scaffolding

## Artifacts

### Screenshots
![01-basic-customer-table](https://stivytelemetry.blob.core.windows.net/ivy-tendril/01-basic-customer-table.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)
![02-mixed-collections-table](https://stivytelemetry.blob.core.windows.net/ivy-tendril/02-mixed-collections-table.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)
![03-nested-navigation-table](https://stivytelemetry.blob.core.windows.net/ivy-tendril/03-nested-navigation-table.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)
![04-comparison-tables](https://stivytelemetry.blob.core.windows.net/ivy-tendril/04-comparison-tables.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)
![05-edge-cases-table](https://stivytelemetry.blob.core.windows.net/ivy-tendril/05-edge-cases-table.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)