### PR TITLE
Fix Docker publish dropping rustserver native binary

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+**/bin/
+**/obj/
+**/node_modules/
+**/.vs/
+**/.idea/
+**/.vscode/
+**/.git/
+**/RustServer/target/

--- a/.github/docker/Dockerfile.docs
+++ b/.github/docker/Dockerfile.docs
@@ -28,6 +28,8 @@ RUN curl -fsSL https://vite.plus | bash
 ENV PATH="/root/.vite-plus/bin:${PATH}"
 COPY . .
 COPY --from=frontend /src/src/frontend/dist /src/src/frontend/dist
+# Build Rust native libraries before dotnet restore/publish so msbuild can properly pick them up in static ItemGroup evaluation
+RUN cd src/RustServer && cargo build --release
 RUN dotnet restore "src/Ivy.Docs/Ivy.Docs.csproj"
 RUN dotnet publish "src/Ivy.Docs/Ivy.Docs.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
 

--- a/.github/docker/Dockerfile.samples
+++ b/.github/docker/Dockerfile.samples
@@ -28,6 +28,8 @@ RUN curl -fsSL https://vite.plus | bash
 ENV PATH="/root/.vite-plus/bin:${PATH}"
 COPY . .
 COPY --from=frontend /src/src/frontend/dist /src/src/frontend/dist
+# Build Rust native libraries before dotnet restore/publish so msbuild can properly pick them up in static ItemGroup evaluation
+RUN cd src/RustServer && cargo build --release
 RUN dotnet restore "src/Ivy.Samples/Ivy.Samples.csproj"
 RUN dotnet publish "src/Ivy.Samples/Ivy.Samples.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
 


### PR DESCRIPTION
Fixes an issue where `dotnet publish` within Docker fails to package the rustserver native binaries during a clean checkout, because MSBuild static `ItemGroup` evaluation occurs before the `BuildRustServer` target writes the required files. Added a manual `cargo build --release` step before MSBuild invocation to guarantee the `.so` file exists. Also adds a `.dockerignore` to prevent local obj/bin folders from breaking Docker builds with `CS2001` absolute path errors.