### PR TITLE
[01487] UseQuery and DataTables should not be combined in docs/samples

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,6 +248,8 @@ QueryResult<T> properties:
 - .Error — exception if the fetch failed
 - .Mutator — provides .Revalidate(), .Invalidate(), .Mutate(value, revalidate)
 
+**Do not combine UseQuery with DataTable for EF Core data.** When a DataTable can receive an EF Core `IQueryable` directly, pass it to `.ToDataTable()` without UseQuery. DataTables handle their own server-side data loading. (API data fetched via UseQuery → `.ToDataTable()` is fine.)
+
 Key conventions:
 
 - String: `"my-data"`

--- a/src/Ivy.Docs.Shared/Docs/03_Hooks/02_Core/09_UseQuery.md
+++ b/src/Ivy.Docs.Shared/Docs/03_Hooks/02_Core/09_UseQuery.md
@@ -497,7 +497,7 @@ var query = UseQuery(async () =>
 if (query.Loading) return Text.P("Loading...");
 if (query.Value is not { } items) return Callout.Info("No data.");
 
-return items.ToDataTable();
+return items.ToTable();
 ```
 
 **Key points:**
@@ -506,6 +506,8 @@ return items.ToDataTable();
 - Pass a `RefreshToken` as a dependency to re-fetch data after mutations
 - Always call `.ToListAsync()` inside the query lambda — do NOT return `IQueryable` directly
 - For mutations (add/edit/delete), use a separate method that creates its own `DbContext` from the factory, calls `db.SaveChangesAsync()`, then `refreshToken.Refresh()`
+
+> **EF Core + DataTable:** When displaying EF Core data in a DataTable, pass the `IQueryable` directly to `.ToDataTable()` — do not wrap it in UseQuery. DataTables handle pagination, sorting, and filtering server-side on the `IQueryable`. However, if you're fetching data from an API via UseQuery and then displaying it in a DataTable, that's fine — there's no server-side `IQueryable` to leverage.
 
 </Body>
 </Details>

--- a/src/Ivy.Docs.Shared/Docs/05_Other/BestPractises.md
+++ b/src/Ivy.Docs.Shared/Docs/05_Other/BestPractises.md
@@ -43,6 +43,8 @@ if (query.Loading) return Text.Muted("Loading...");
 if (query.Error is { } error) return Callout.Error(error.Message);
 ```
 
+> **Exception: EF Core + DataTable.** When displaying EF Core data in a DataTable, pass the `IQueryable` directly to `.ToDataTable()` instead of wrapping it in UseQuery. DataTables handle pagination, sorting, and filtering server-side. (Fetching from an API via UseQuery and then using `.ToDataTable()` is fine.)
+
 For conditional fetching, pass `null` as the key to disable the query:
 
 ```csharp


### PR DESCRIPTION
# Summary

## Changes

Updated documentation and agent instructions to clarify that EF Core `IQueryable` data should be passed directly to `.ToDataTable()` without wrapping in `UseQuery`. Changed the UseQuery FAQ example from `.ToDataTable()` to `.ToTable()` and added explanatory notes across three files.

## API Changes

None.

## Files Modified

- **Documentation:**
  - `src/Ivy.Docs.Shared/Docs/03_Hooks/02_Core/09_UseQuery.md` — Changed EF Core FAQ example from `.ToDataTable()` to `.ToTable()`, added EF Core + DataTable note
  - `src/Ivy.Docs.Shared/Docs/05_Other/BestPractises.md` — Added EF Core + DataTable exception to "Use UseQuery for Data Fetching" section
- **Agent instructions:**
  - `AGENTS.md` — Added UseQuery + DataTable guidance after UseQuery section

## Commits

- ead50c60 [01487] Fix UseQuery + DataTable anti-pattern in docs and agent instructions