### PR TITLE
[01491] Add arrow key navigation to Image overlay for sibling images

### DIFF
--- a/src/frontend/src/components/markdown/ImageOverlay.tsx
+++ b/src/frontend/src/components/markdown/ImageOverlay.tsx
@@ -6,10 +6,22 @@ interface ImageOverlayProps {
   src: string | undefined;
   alt: string | undefined;
   onClose: () => void;
+  images?: { src: string; alt: string }[];
+  currentIndex?: number;
+  onNavigate?: (index: number) => void;
 }
 
-export const ImageOverlay: React.FC<ImageOverlayProps> = ({ src, alt, onClose }) => {
+export const ImageOverlay: React.FC<ImageOverlayProps> = ({
+  src,
+  alt,
+  onClose,
+  images,
+  currentIndex = 0,
+  onNavigate,
+}) => {
   const overlayRef = useRef<HTMLDivElement>(null);
+
+  const hasNavigation = images && images.length > 1 && onNavigate;
 
   useEffect(() => {
     const overlay = overlayRef.current;
@@ -45,6 +57,16 @@ export const ImageOverlay: React.FC<ImageOverlayProps> = ({ src, alt, onClose })
       if (e.key === "Escape") {
         onClose();
       }
+      if (hasNavigation) {
+        if (e.key === "ArrowLeft") {
+          e.preventDefault();
+          const len = images.length;
+          onNavigate((((currentIndex - 1) % len) + len) % len);
+        } else if (e.key === "ArrowRight") {
+          e.preventDefault();
+          onNavigate((currentIndex + 1) % images.length);
+        }
+      }
       handleTabKey(e);
     };
 
@@ -52,7 +74,7 @@ export const ImageOverlay: React.FC<ImageOverlayProps> = ({ src, alt, onClose })
     return () => {
       document.removeEventListener("keydown", handleKeyDown);
     };
-  }, [onClose]);
+  }, [onClose, hasNavigation, images, currentIndex, onNavigate]);
 
   // Validate and sanitize image URL to prevent open redirect vulnerabilities
   const validatedSrc = src ? validateImageUrl(src) : null;
@@ -61,7 +83,7 @@ export const ImageOverlay: React.FC<ImageOverlayProps> = ({ src, alt, onClose })
     return null;
   }
 
-  return createPortal(
+  const content = (
     <div
       ref={overlayRef}
       className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 cursor-zoom-out"
@@ -72,16 +94,77 @@ export const ImageOverlay: React.FC<ImageOverlayProps> = ({ src, alt, onClose })
       aria-modal="true"
       aria-label="Image Overlay"
     >
-      <div className="relative max-w-[90vw] max-h-[90vh]">
-        <img src={validatedSrc} alt={alt} className="max-w-full max-h-[90vh] object-contain" />
-        <button
-          className="absolute top-4 right-4 bg-black/50 text-white rounded-full w-8 h-8 flex items-center justify-center"
-          onClick={onClose}
-        >
-          ✕
-        </button>
+      <div className="relative max-w-[90vw] max-h-[90vh] flex items-center">
+        {hasNavigation && (
+          <button
+            className="absolute -left-12 top-1/2 -translate-y-1/2 bg-black/50 hover:bg-black/70 text-white rounded-full w-10 h-10 flex items-center justify-center transition-colors z-10"
+            onClick={(e) => {
+              e.stopPropagation();
+              const len = images.length;
+              onNavigate((((currentIndex - 1) % len) + len) % len);
+            }}
+            aria-label="Previous image"
+          >
+            <svg
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <polyline points="15 18 9 12 15 6" />
+            </svg>
+          </button>
+        )}
+        <div className="relative">
+          <img src={validatedSrc} alt={alt} className="max-w-full max-h-[90vh] object-contain" />
+          <button
+            className="absolute top-4 right-4 bg-black/50 hover:bg-black/70 text-white rounded-full w-8 h-8 flex items-center justify-center transition-colors"
+            onClick={onClose}
+          >
+            ✕
+          </button>
+          {hasNavigation && (
+            <div className="absolute bottom-4 left-1/2 -translate-x-1/2 bg-black/50 text-white text-sm px-3 py-1 rounded-full">
+              {currentIndex + 1} / {images.length}
+            </div>
+          )}
+        </div>
+        {hasNavigation && (
+          <button
+            className="absolute -right-12 top-1/2 -translate-y-1/2 bg-black/50 hover:bg-black/70 text-white rounded-full w-10 h-10 flex items-center justify-center transition-colors z-10"
+            onClick={(e) => {
+              e.stopPropagation();
+              onNavigate((currentIndex + 1) % images.length);
+            }}
+            aria-label="Next image"
+          >
+            <svg
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <polyline points="9 18 15 12 9 6" />
+            </svg>
+          </button>
+        )}
       </div>
-    </div>,
-    document.body,
+    </div>
   );
+
+  // When used standalone (not via context provider), wrap in portal
+  // When used via context provider, the provider handles the portal
+  if (!images) {
+    return createPortal(content, document.body);
+  }
+
+  return content;
 };

--- a/src/frontend/src/components/markdown/ImageOverlayContext.tsx
+++ b/src/frontend/src/components/markdown/ImageOverlayContext.tsx
@@ -1,0 +1,80 @@
+import React, { createContext, useCallback, useContext, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { ImageOverlay } from "./ImageOverlay";
+
+interface ImageEntry {
+  src: string;
+  alt: string;
+}
+
+interface ImageOverlayContextValue {
+  register: (id: string, src: string, alt: string) => void;
+  unregister: (id: string) => void;
+  open: (id: string) => void;
+}
+
+const ImageOverlayContext = createContext<ImageOverlayContextValue | null>(null);
+
+export const useImageOverlayContext = () => useContext(ImageOverlayContext);
+
+export const ImageOverlayProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const imagesRef = useRef<Map<string, ImageEntry>>(new Map());
+  const [overlayState, setOverlayState] = useState<{
+    images: ImageEntry[];
+    currentIndex: number;
+  } | null>(null);
+
+  const register = useCallback((id: string, src: string, alt: string) => {
+    imagesRef.current.set(id, { src, alt });
+  }, []);
+
+  const unregister = useCallback((id: string) => {
+    imagesRef.current.delete(id);
+  }, []);
+
+  const open = useCallback((id: string) => {
+    const images = Array.from(imagesRef.current.entries());
+    const index = images.findIndex(([key]) => key === id);
+    if (index === -1) return;
+    setOverlayState({
+      images: images.map(([, entry]) => entry),
+      currentIndex: index,
+    });
+  }, []);
+
+  const handleNavigate = useCallback((index: number) => {
+    setOverlayState((prev) => {
+      if (!prev) return null;
+      const len = prev.images.length;
+      const newIndex = ((index % len) + len) % len;
+      return { ...prev, currentIndex: newIndex };
+    });
+  }, []);
+
+  const handleClose = useCallback(() => {
+    setOverlayState(null);
+  }, []);
+
+  const contextValue = useMemo(
+    () => ({ register, unregister, open }),
+    [register, unregister, open],
+  );
+
+  return (
+    <ImageOverlayContext.Provider value={contextValue}>
+      {children}
+      {overlayState &&
+        createPortal(
+          <ImageOverlay
+            src={overlayState.images[overlayState.currentIndex].src}
+            alt={overlayState.images[overlayState.currentIndex].alt}
+            images={overlayState.images}
+            currentIndex={overlayState.currentIndex}
+            onNavigate={handleNavigate}
+            onClose={handleClose}
+          />,
+          document.body,
+        )}
+    </ImageOverlayContext.Provider>
+  );
+};

--- a/src/frontend/src/widgets/layouts/GridLayoutWidget.tsx
+++ b/src/frontend/src/widgets/layouts/GridLayoutWidget.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { ImageOverlayProvider } from "@/components/markdown/ImageOverlayContext";
 import {
   Align,
   getRowGap,
@@ -110,22 +111,24 @@ export const GridLayoutWidget: React.FC<GridLayoutWidgetProps> = ({
   };
 
   return (
-    <div style={styles} className={className}>
-      {React.Children.map(children, (child, index) => (
-        <GridLayoutCell
-          column={childColumn[index]}
-          columnSpan={childColumnSpan[index]}
-          row={childRow[index]}
-          rowSpan={childRowSpan[index]}
-          alignSelf={childAlignSelf[index]}
-          className={
-            React.isValidElement(child) ? (child.props as { className?: string }).className : ""
-          }
-        >
-          {child}
-        </GridLayoutCell>
-      ))}
-    </div>
+    <ImageOverlayProvider>
+      <div style={styles} className={className}>
+        {React.Children.map(children, (child, index) => (
+          <GridLayoutCell
+            column={childColumn[index]}
+            columnSpan={childColumnSpan[index]}
+            row={childRow[index]}
+            rowSpan={childRowSpan[index]}
+            alignSelf={childAlignSelf[index]}
+            className={
+              React.isValidElement(child) ? (child.props as { className?: string }).className : ""
+            }
+          >
+            {child}
+          </GridLayoutCell>
+        ))}
+      </div>
+    </ImageOverlayProvider>
   );
 };
 

--- a/src/frontend/src/widgets/layouts/StackLayoutWidget.tsx
+++ b/src/frontend/src/widgets/layouts/StackLayoutWidget.tsx
@@ -19,6 +19,7 @@ import {
   getBoxRadius,
 } from "@/lib/styles";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { ImageOverlayProvider } from "@/components/markdown/ImageOverlayContext";
 
 const EMPTY_ARRAY: never[] = [];
 
@@ -118,20 +119,24 @@ export const StackLayoutWidget: React.FC<StackLayoutWidgetProps> = ({
     };
 
     return (
-      <ScrollArea
-        className={removeParentPadding ? "remove-parent-padding" : ""}
-        style={outerStyles}
-        type="scroll"
-        scrollHideDelay={600}
-      >
-        <div style={flexStyles}>{wrappedChildren}</div>
-      </ScrollArea>
+      <ImageOverlayProvider>
+        <ScrollArea
+          className={removeParentPadding ? "remove-parent-padding" : ""}
+          style={outerStyles}
+          type="scroll"
+          scrollHideDelay={600}
+        >
+          <div style={flexStyles}>{wrappedChildren}</div>
+        </ScrollArea>
+      </ImageOverlayProvider>
     );
   }
 
   return (
-    <div style={baseStyles} className={removeParentPadding ? "remove-parent-padding" : ""}>
-      {wrappedChildren}
-    </div>
+    <ImageOverlayProvider>
+      <div style={baseStyles} className={removeParentPadding ? "remove-parent-padding" : ""}>
+        {wrappedChildren}
+      </div>
+    </ImageOverlayProvider>
   );
 };

--- a/src/frontend/src/widgets/primitives/ImageWidget.tsx
+++ b/src/frontend/src/widgets/primitives/ImageWidget.tsx
@@ -21,7 +21,8 @@ import { useEventHandler } from "@/components/event-handler";
 import type { HoverEffect } from "@/widgets/primitives/BoxWidget";
 import { cardStyles } from "@/widgets/card/styles";
 import { ImageOverlay } from "@/components/markdown/ImageOverlay";
-import React, { useCallback, useState } from "react";
+import { useImageOverlayContext } from "@/components/markdown/ImageOverlayContext";
+import React, { useCallback, useEffect, useState } from "react";
 
 interface ImageWidgetProps {
   id: string;
@@ -125,14 +126,30 @@ export const ImageWidget: React.FC<ImageWidgetProps> = ({
   const eventHandler = useEventHandler();
   const hasOnClick = events?.includes("OnClick") ?? false;
   const [showOverlay, setShowOverlay] = useState(false);
+  const imageOverlayContext = useImageOverlayContext();
+
+  const validatedSrc = getImageUrl(src);
+  const altText = alt ?? caption ?? "";
+
+  // Register with context for sibling navigation
+  useEffect(() => {
+    if (overlay && validatedSrc && imageOverlayContext) {
+      imageOverlayContext.register(id, validatedSrc, altText);
+      return () => imageOverlayContext.unregister(id);
+    }
+  }, [overlay, validatedSrc, altText, id, imageOverlayContext]);
 
   const handleClick = useCallback(() => {
     if (overlay) {
-      setShowOverlay(true);
+      if (imageOverlayContext) {
+        imageOverlayContext.open(id);
+      } else {
+        setShowOverlay(true);
+      }
     } else if (hasOnClick) {
       eventHandler("OnClick", id, []);
     }
-  }, [id, eventHandler, hasOnClick, overlay]);
+  }, [id, eventHandler, hasOnClick, overlay, imageOverlayContext]);
 
   const outerStyles: React.CSSProperties = {
     ...getWidth(width),
@@ -154,9 +171,7 @@ export const ImageWidget: React.FC<ImageWidgetProps> = ({
       }
     : {};
 
-  // getImageUrl handles null/undefined and validates the URL internally
-  const validatedImageSrc = getImageUrl(src);
-  if (!validatedImageSrc) {
+  if (!validatedSrc) {
     // Show error message for missing or invalid URLs
     return (
       <div
@@ -174,8 +189,6 @@ export const ImageWidget: React.FC<ImageWidgetProps> = ({
   // Overlay takes precedence over OnClick and Link
   const linkProps = !overlay && !hasOnClick && link ? getLinkProps(link) : null;
 
-  const altText = alt ?? caption ?? "";
-
   const imgStyles: React.CSSProperties = objectFit
     ? {
         width: "100%",
@@ -186,7 +199,7 @@ export const ImageWidget: React.FC<ImageWidgetProps> = ({
 
   const hoverClass = getHoverClass(hoverVariant);
 
-  const imgElement = <img src={validatedImageSrc} alt={altText} style={imgStyles} />;
+  const imgElement = <img src={validatedSrc} alt={altText} style={imgStyles} />;
 
   const wrappedImg = linkProps ? (
     <a {...linkProps} style={{ cursor: "pointer" }}>
@@ -203,17 +216,18 @@ export const ImageWidget: React.FC<ImageWidgetProps> = ({
     </figure>
   ) : linkProps ? (
     <a {...linkProps} style={{ cursor: "pointer" }}>
-      <img src={validatedImageSrc} alt={altText} style={imgStyles} />
+      <img src={validatedSrc} alt={altText} style={imgStyles} />
     </a>
   ) : (
-    <img src={validatedImageSrc} alt={altText} style={imgStyles} />
+    <img src={validatedSrc} alt={altText} style={imgStyles} />
   );
 
   const isClickable = overlay || hasOnClick || linkProps;
 
+  // Only render standalone overlay when no context is available (fallback for single images)
   const overlayElement =
-    overlay && showOverlay ? (
-      <ImageOverlay src={validatedImageSrc} alt={altText} onClose={() => setShowOverlay(false)} />
+    overlay && showOverlay && !imageOverlayContext ? (
+      <ImageOverlay src={validatedSrc} alt={altText} onClose={() => setShowOverlay(false)} />
     ) : null;
 
   if (needsContainer || overlay || hasOnClick) {
@@ -249,5 +263,5 @@ export const ImageWidget: React.FC<ImageWidgetProps> = ({
   }
 
   // Simple case: no border, no hover, no click
-  return <img src={validatedImageSrc} key={id} style={outerStyles} alt={altText} />;
+  return <img src={validatedSrc} key={id} style={outerStyles} alt={altText} />;
 };


### PR DESCRIPTION
# Summary

## Changes

Added arrow key (Left/Right) navigation to the Image overlay so users can browse all overlay-enabled sibling images within the same layout container. Created an `ImageOverlayContext` that layout widgets provide, allowing `ImageWidget` instances to register themselves and enabling a shared overlay with navigation controls (chevron buttons, keyboard arrows, image counter).

## API Changes

None. This is a frontend-only change with no new backend APIs. The existing `Image.Overlay(true)` C# API automatically gains navigation when multiple overlay images are in the same layout.

## Files Modified

- **New:** `src/frontend/src/components/markdown/ImageOverlayContext.tsx` - React context + provider for sibling image registration and overlay management
- **Modified:** `src/frontend/src/components/markdown/ImageOverlay.tsx` - Added `images`, `currentIndex`, `onNavigate` props; arrow key handlers; chevron nav buttons; image counter
- **Modified:** `src/frontend/src/widgets/primitives/ImageWidget.tsx` - Register/unregister with context on mount; use context.open() when available, fallback to standalone overlay
- **Modified:** `src/frontend/src/widgets/layouts/StackLayoutWidget.tsx` - Wrapped with `ImageOverlayProvider`
- **Modified:** `src/frontend/src/widgets/layouts/GridLayoutWidget.tsx` - Wrapped with `ImageOverlayProvider`

## Commits

- 23b45cc9 [01491] Add arrow key navigation to Image overlay for sibling images

## Artifacts

### Screenshots

![basic-app-initial](https://stivytelemetry.blob.core.windows.net/ivy-tendril/basic-app-initial.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![basic-click-arrows](https://stivytelemetry.blob.core.windows.net/ivy-tendril/basic-click-arrows.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![basic-nav-arrows-and-counter](https://stivytelemetry.blob.core.windows.net/ivy-tendril/basic-nav-arrows-and-counter.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![basic-nav-left-back-to-2](https://stivytelemetry.blob.core.windows.net/ivy-tendril/basic-nav-left-back-to-2.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![basic-nav-right-to-2](https://stivytelemetry.blob.core.windows.net/ivy-tendril/basic-nav-right-to-2.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![basic-overlay-closed](https://stivytelemetry.blob.core.windows.net/ivy-tendril/basic-overlay-closed.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![basic-overlay-open](https://stivytelemetry.blob.core.windows.net/ivy-tendril/basic-overlay-open.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![basic-wrap-to-first](https://stivytelemetry.blob.core.windows.net/ivy-tendril/basic-wrap-to-first.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![basic-wrap-to-last](https://stivytelemetry.blob.core.windows.net/ivy-tendril/basic-wrap-to-last.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![edge-grid-last-image](https://stivytelemetry.blob.core.windows.net/ivy-tendril/edge-grid-last-image.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![edge-grid-wrap-to-first](https://stivytelemetry.blob.core.windows.net/ivy-tendril/edge-grid-wrap-to-first.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![edge-two-images-wrap](https://stivytelemetry.blob.core.windows.net/ivy-tendril/edge-two-images-wrap.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![events-onclick](https://stivytelemetry.blob.core.windows.net/ivy-tendril/events-onclick.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![events-overlay-nav](https://stivytelemetry.blob.core.windows.net/ivy-tendril/events-overlay-nav.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![integration-initial](https://stivytelemetry.blob.core.windows.net/ivy-tendril/integration-initial.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![integration-nav](https://stivytelemetry.blob.core.windows.net/ivy-tendril/integration-nav.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![props-6-images-counter](https://stivytelemetry.blob.core.windows.net/ivy-tendril/props-6-images-counter.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![props-app-initial](https://stivytelemetry.blob.core.windows.net/ivy-tendril/props-app-initial.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![props-single-in-shared-context](https://stivytelemetry.blob.core.windows.net/ivy-tendril/props-single-in-shared-context.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)