### PR TITLE
[01421] Fix DataTable .Header() navigation property and ternary expression support

### DIFF
--- a/src/Ivy.Test/Helpers/TypeHelperTests.cs
+++ b/src/Ivy.Test/Helpers/TypeHelperTests.cs
@@ -165,9 +165,66 @@ public class TypeHelperTests
         Assert.Equal("Column With Spaces", name);
     }
 
+    [Fact]
+    public void GetNameFromMemberExpression_NavigationProperty_ReturnsRootMemberName()
+    {
+        Expression<Func<TestModel, object>> expr = m => m.Owner!.Name;
+        var name = TypeHelper.GetNameFromMemberExpression(expr.Body);
+        Assert.Equal("Owner", name);
+    }
+
+    [Fact]
+    public void GetNameFromMemberExpression_ConditionalExpression_ReturnsRootMemberName()
+    {
+        Expression<Func<TestModel, object>> expr = m => m.Owner != null ? m.Owner.Name : "";
+        var name = TypeHelper.GetNameFromMemberExpression(expr.Body);
+        Assert.Equal("Owner", name);
+    }
+
+    [Fact]
+    public void GetNameFromMemberExpression_DeepNavigation_ReturnsRootMemberName()
+    {
+        Expression<Func<TestModel, object>> expr = m => m.Owner!.Address!.City;
+        var name = TypeHelper.GetNameFromMemberExpression(expr.Body);
+        Assert.Equal("Owner", name);
+    }
+
+    [Fact]
+    public void IsComplexExpression_SimpleProperty_ReturnsFalse()
+    {
+        Expression<Func<TestModel, object>> expr = m => m.Name;
+        Assert.False(TypeHelper.IsComplexExpression(expr.Body));
+    }
+
+    [Fact]
+    public void IsComplexExpression_NavigationProperty_ReturnsTrue()
+    {
+        Expression<Func<TestModel, object>> expr = m => m.Owner!.Name;
+        Assert.True(TypeHelper.IsComplexExpression(expr.Body));
+    }
+
+    [Fact]
+    public void IsComplexExpression_ConditionalExpression_ReturnsTrue()
+    {
+        Expression<Func<TestModel, object>> expr = m => m.Owner != null ? m.Owner.Name : "";
+        Assert.True(TypeHelper.IsComplexExpression(expr.Body));
+    }
+
     private class TestModel
     {
         public string Name { get; set; } = "";
         public int Age { get; set; }
+        public TestOwner? Owner { get; set; }
+    }
+
+    private class TestOwner
+    {
+        public string Name { get; set; } = "";
+        public TestAddress? Address { get; set; }
+    }
+
+    private class TestAddress
+    {
+        public string City { get; set; } = "";
     }
 }

--- a/src/Ivy/Helpers/TypeHelper.cs
+++ b/src/Ivy/Helpers/TypeHelper.cs
@@ -222,9 +222,18 @@ public static class TypeHelper
             switch (expression)
             {
                 case MemberExpression memberExpression:
+                    // Walk up the chain to the root member (the one whose Expression is a ParameterExpression)
+                    while (memberExpression.Expression is MemberExpression parent)
+                    {
+                        memberExpression = parent;
+                    }
                     return memberExpression.Member.Name;
                 case UnaryExpression unaryExpression:
                     expression = unaryExpression.Operand;
+                    continue;
+                case ConditionalExpression conditionalExpression:
+                    // For ternary expressions, extract the member from the IfTrue branch
+                    expression = conditionalExpression.IfTrue;
                     continue;
                 case MethodCallExpression methodCall when methodCall.Method.Name == "get_Item"
                     && methodCall.Arguments.Count == 1
@@ -234,5 +243,19 @@ public static class TypeHelper
 
             throw new ArgumentException("Invalid expression.");
         }
+    }
+
+    internal static bool IsComplexExpression(Expression expression)
+    {
+        // Unwrap Convert/ConvertChecked
+        while (expression is UnaryExpression unary)
+            expression = unary.Operand;
+
+        return expression switch
+        {
+            MemberExpression member => member.Expression is MemberExpression,
+            ConditionalExpression => true,
+            _ => false
+        };
     }
 }

--- a/src/Ivy/Views/DataTables/DataTableBuilder.cs
+++ b/src/Ivy/Views/DataTables/DataTableBuilder.cs
@@ -123,13 +123,29 @@ public class DataTableBuilder<TModel>(
     private InternalColumn GetColumn(Expression<Func<TModel, object>> field)
     {
         var name = TypeHelper.GetNameFromMemberExpression(field.Body);
-        return _columns[name];
+        var column = _columns[name];
+
+        if (TypeHelper.IsComplexExpression(field.Body))
+        {
+            var compiled = field.Compile();
+            column.Column.ValueAccessor = obj => compiled((TModel)obj);
+        }
+
+        return column;
     }
 
     private InternalColumn GetColumn<TValue>(Expression<Func<TModel, TValue>> field)
     {
         var name = TypeHelper.GetNameFromMemberExpression(field.Body);
-        return _columns[name];
+        var column = _columns[name];
+
+        if (TypeHelper.IsComplexExpression(field.Body))
+        {
+            var compiled = field.Compile();
+            column.Column.ValueAccessor = obj => compiled((TModel)obj);
+        }
+
+        return column;
     }
 
     public DataTableBuilder<TModel> Header(Expression<Func<TModel, object>> field, string label)

--- a/src/Ivy/Views/DataTables/DataTableConnectionService.cs
+++ b/src/Ivy/Views/DataTables/DataTableConnectionService.cs
@@ -9,6 +9,7 @@ public interface IDataTableService
     (IDisposable cleanup, DataTableConnection connection) AddQueryable(IQueryable queryable);
     (IDisposable cleanup, DataTableConnection connection) AddQueryable(IQueryable queryable, Func<object, object?>? idSelector);
     (IDisposable cleanup, DataTableConnection connection) AddQueryable(IQueryable queryable, Func<object, object?>? idSelector, string[]? columnNames);
+    (IDisposable cleanup, DataTableConnection connection) AddQueryable(IQueryable queryable, Func<object, object?>? idSelector, string[]? columnNames, Dictionary<string, Func<object, object?>>? valueAccessors);
 }
 
 public class DataTableConnectionService(IQueryableRegistry queryableRegistry, ServerArgs serverArgs, string connectionId, ILogger<DataTableConnectionService>? logger = null) : IDataTableService
@@ -25,8 +26,13 @@ public class DataTableConnectionService(IQueryableRegistry queryableRegistry, Se
 
     public (IDisposable cleanup, DataTableConnection connection) AddQueryable(IQueryable queryable, Func<object, object?>? idSelector, string[]? columnNames)
     {
+        return AddQueryable(queryable, idSelector, columnNames, null);
+    }
+
+    public (IDisposable cleanup, DataTableConnection connection) AddQueryable(IQueryable queryable, Func<object, object?>? idSelector, string[]? columnNames, Dictionary<string, Func<object, object?>>? valueAccessors)
+    {
         logger?.LogInformation("Adding queryable with connectionId: {ConnectionId}", connectionId);
-        var sourceId = queryableRegistry.RegisterQueryable(queryable, idSelector, columnNames);
+        var sourceId = queryableRegistry.RegisterQueryable(queryable, idSelector, columnNames, valueAccessors);
 
         var cleanup = queryableRegistry.AddCleanup(sourceId, Disposable.Empty);
 

--- a/src/Ivy/Views/DataTables/DataTableService.cs
+++ b/src/Ivy/Views/DataTables/DataTableService.cs
@@ -39,6 +39,7 @@ public class DataTableService(
 
             var idSelector = queryableRegistry.GetIdSelector(request.SourceId);
             var columnNames = queryableRegistry.GetColumnNames(request.SourceId);
+            var valueAccessors = queryableRegistry.GetValueAccessors(request.SourceId);
 
             // If column names are stored, use them; otherwise fall back to request's SelectColumns
             DataTableQuery queryToUse = request;
@@ -50,7 +51,7 @@ public class DataTableService(
             }
 
             var queryProcessor = new QueryProcessor(logger: null, cache: cache);
-            var queryResult = queryProcessor.ProcessQuery(queryable, queryToUse, idSelector);
+            var queryResult = queryProcessor.ProcessQuery(queryable, queryToUse, idSelector, valueAccessors);
 
             var tableResult = new DataTableResult
             {

--- a/src/Ivy/Views/DataTables/QueryProcessor.cs
+++ b/src/Ivy/Views/DataTables/QueryProcessor.cs
@@ -77,7 +77,7 @@ public class QueryProcessor(ILogger<QueryProcessor>? logger = null, IDistributed
             (openMethod, typeArgs[0], typeArgs.Length > 1 ? typeArgs[1] : typeof(void)),
             _ => openMethod.MakeGenericMethod(typeArgs));
 
-    public QueryResult ProcessQuery(IQueryable queryable, DataTableQuery query, Func<object, object?>? idSelector = null)
+    public QueryResult ProcessQuery(IQueryable queryable, DataTableQuery query, Func<object, object?>? idSelector = null, Dictionary<string, Func<object, object?>>? valueAccessors = null)
     {
         try
         {
@@ -151,7 +151,7 @@ public class QueryProcessor(ILogger<QueryProcessor>? logger = null, IDistributed
 
             // Convert to Arrow table
             logger?.LogDebug("Converting to Arrow table");
-            var arrowData = ConvertToArrowTable(results, query.SelectColumns, queryable.ElementType, idSelector);
+            var arrowData = ConvertToArrowTable(results, query.SelectColumns, queryable.ElementType, idSelector, valueAccessors);
             logger?.LogInformation("Arrow conversion complete, {ByteCount} bytes", arrowData.Length);
 
             var result = new QueryResult
@@ -891,7 +891,7 @@ public class QueryProcessor(ILogger<QueryProcessor>? logger = null, IDistributed
         }
     }
 
-    private byte[] ConvertToArrowTable(List<object> data, IEnumerable<string> selectColumns, SystemType elementType, Func<object, object?>? idSelector = null)
+    private byte[] ConvertToArrowTable(List<object> data, IEnumerable<string> selectColumns, SystemType elementType, Func<object, object?>? idSelector = null, Dictionary<string, Func<object, object?>>? valueAccessors = null)
     {
         logger?.LogDebug("Converting {DataCount} items to Arrow table", data.Count);
 
@@ -909,13 +909,20 @@ public class QueryProcessor(ILogger<QueryProcessor>? logger = null, IDistributed
         // Create schema and empty arrays even when there's no data
         foreach (var prop in properties)
         {
-            var arrowType = QueryHelpers.GetArrowType(prop.PropertyType);
+            Func<object, object?>? accessor = null;
+            var hasAccessor = valueAccessors?.TryGetValue(prop.Name, out accessor) == true;
+            var arrowType = hasAccessor ? (IArrowType)StringType.Default : QueryHelpers.GetArrowType(prop.PropertyType);
             fields.Add(new ArrowField(prop.Name, arrowType, nullable: true));
 
-            // Create empty array if no data, otherwise create array with data
             if (!data.Any())
             {
                 arrays.Add(QueryHelpers.CreateEmptyArrowArray(arrowType));
+            }
+            else if (hasAccessor)
+            {
+                // Use custom accessor for navigation/ternary expressions
+                var values = data.Select(item => accessor!(item)).ToList();
+                arrays.Add(QueryHelpers.CreateStringArray(values));
             }
             else
             {

--- a/src/Ivy/Views/DataTables/QueryableRegistry.cs
+++ b/src/Ivy/Views/DataTables/QueryableRegistry.cs
@@ -9,9 +9,11 @@ public interface IQueryableRegistry
     string RegisterQueryable(IQueryable queryable);
     string RegisterQueryable(IQueryable queryable, Func<object, object?>? idSelector);
     string RegisterQueryable(IQueryable queryable, Func<object, object?>? idSelector, string[]? columnNames);
+    string RegisterQueryable(IQueryable queryable, Func<object, object?>? idSelector, string[]? columnNames, Dictionary<string, Func<object, object?>>? valueAccessors);
     IQueryable? GetQueryable(string sourceId);
     Func<object, object?>? GetIdSelector(string sourceId);
     string[]? GetColumnNames(string sourceId);
+    Dictionary<string, Func<object, object?>>? GetValueAccessors(string sourceId);
     IDisposable AddCleanup(string sourceId, IDisposable cleanup);
 }
 
@@ -21,6 +23,7 @@ public class QueryableRegistry : IQueryableRegistry
     private readonly ConcurrentDictionary<string, CompositeDisposable> _cleanups = new();
     private readonly ConcurrentDictionary<string, Func<object, object?>?> _idSelectors = new();
     private readonly ConcurrentDictionary<string, string[]?> _columnNames = new();
+    private readonly ConcurrentDictionary<string, Dictionary<string, Func<object, object?>>?> _valueAccessors = new();
 
     public string RegisterQueryable(IQueryable queryable)
     {
@@ -34,11 +37,17 @@ public class QueryableRegistry : IQueryableRegistry
 
     public string RegisterQueryable(IQueryable queryable, Func<object, object?>? idSelector, string[]? columnNames)
     {
+        return RegisterQueryable(queryable, idSelector, columnNames, null);
+    }
+
+    public string RegisterQueryable(IQueryable queryable, Func<object, object?>? idSelector, string[]? columnNames, Dictionary<string, Func<object, object?>>? valueAccessors)
+    {
         var sourceId = Guid.NewGuid().ToString();
         _queryables[sourceId] = queryable;
         _cleanups[sourceId] = new CompositeDisposable();
         _idSelectors[sourceId] = idSelector;
         _columnNames[sourceId] = columnNames;
+        _valueAccessors[sourceId] = valueAccessors;
         return sourceId;
     }
 
@@ -57,6 +66,11 @@ public class QueryableRegistry : IQueryableRegistry
         return _columnNames.GetValueOrDefault(sourceId);
     }
 
+    public Dictionary<string, Func<object, object?>>? GetValueAccessors(string sourceId)
+    {
+        return _valueAccessors.GetValueOrDefault(sourceId);
+    }
+
     public IDisposable AddCleanup(string sourceId, IDisposable cleanup)
     {
         if (_cleanups.TryGetValue(sourceId, out var compositeDisposable))
@@ -73,6 +87,7 @@ public class QueryableRegistry : IQueryableRegistry
             _queryables.TryRemove(sourceId, out _);
             _idSelectors.TryRemove(sourceId, out _);
             _columnNames.TryRemove(sourceId, out _);
+            _valueAccessors.TryRemove(sourceId, out _);
         });
     }
 }

--- a/src/Ivy/Views/DataTables/UseDataTable.cs
+++ b/src/Ivy/Views/DataTables/UseDataTable.cs
@@ -42,7 +42,11 @@ public static class UseDataTableExtensions
             cleanup.Value?.Dispose();
 
             var columnNames = columns?.Select(c => c.Name).ToArray();
-            var (newCleanup, newConnection) = dataTableService.AddQueryable(queryable, idSelector, columnNames);
+            var valueAccessors = columns?
+                .Where(c => c.ValueAccessor != null)
+                .ToDictionary(c => c.Name, c => c.ValueAccessor!);
+            if (valueAccessors?.Count == 0) valueAccessors = null;
+            var (newCleanup, newConnection) = dataTableService.AddQueryable(queryable, idSelector, columnNames, valueAccessors);
             resultConnection = newConnection with { VersionToken = versionToken };
 
             connection.Set(resultConnection);

--- a/src/Ivy/Widgets/DataTables/DataTableColumn.cs
+++ b/src/Ivy/Widgets/DataTables/DataTableColumn.cs
@@ -36,6 +36,9 @@ public class DataTableColumn
 
     [JsonIgnore]
     public IDataTableColumnRenderer? Renderer { get; set; } = null;
+
+    [JsonIgnore]
+    public Func<object, object?>? ValueAccessor { get; set; } = null;
 }
 
 public enum SortDirection


### PR DESCRIPTION
Fixed DataTable rendering of navigation properties and ternary expressions. The first fix makes `GetNameFromMemberExpression` walk member chains to the root property and handle `ConditionalExpression` nodes. The second fix stores compiled expression accessors on columns with complex expressions, threading them through the registry and service layers so the Arrow conversion pipeline uses the full expression instead of simple property reflection.

## API Changes

- `DataTableColumn.ValueAccessor` — new `[JsonIgnore] Func<object, object?>?` property for custom value extraction
- `IQueryableRegistry.RegisterQueryable` — new overload accepting `Dictionary<string, Func<object, object?>>? valueAccessors`
- `IQueryableRegistry.GetValueAccessors(string sourceId)` — new method
- `IDataTableService.AddQueryable` — new overload accepting `Dictionary<string, Func<object, object?>>? valueAccessors`
- `QueryProcessor.ProcessQuery` — new optional `valueAccessors` parameter

## Files Modified

**Expression resolution:**
- `src/Ivy/Helpers/TypeHelper.cs` — chain-walking + ConditionalExpression handling in `GetNameFromMemberExpression`

**Rendering pipeline:**
- `src/Ivy/Widgets/DataTables/DataTableColumn.cs` — added `ValueAccessor` property
- `src/Ivy/Views/DataTables/DataTableBuilder.cs` — detect complex expressions, compile and store accessors
- `src/Ivy/Views/DataTables/QueryableRegistry.cs` — store and retrieve value accessors
- `src/Ivy/Views/DataTables/DataTableConnectionService.cs` — pass value accessors to registry
- `src/Ivy/Views/DataTables/UseDataTable.cs` — extract value accessors from columns
- `src/Ivy/Views/DataTables/DataTableService.cs` — pass value accessors to QueryProcessor
- `src/Ivy/Views/DataTables/QueryProcessor.cs` — use value accessors in ConvertToArrowTable

**Tests:**
- `src/Ivy.Test/Helpers/TypeHelperTests.cs` — 6 new tests for nested/conditional expressions and `IsComplexExpression`

## Commits

- `20c58a42` — [01421] Fix DataTable navigation property and ternary expression support

## Artifacts

### Screenshots

![basic-nav-property](https://stivytelemetry.blob.core.windows.net/ivy-tendril/basic-nav-property.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![combined-expressions](https://stivytelemetry.blob.core.windows.net/ivy-tendril/combined-expressions.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![deep-nesting](https://stivytelemetry.blob.core.windows.net/ivy-tendril/deep-nesting.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![edge-cases](https://stivytelemetry.blob.core.windows.net/ivy-tendril/edge-cases.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![integration-combined](https://stivytelemetry.blob.core.windows.net/ivy-tendril/integration-combined.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![ternary-expressions](https://stivytelemetry.blob.core.windows.net/ivy-tendril/ternary-expressions.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)