### PR TITLE
Fix: Guarantee Documentation Packaging by bypassing GitIgnore natively

### DIFF
--- a/src/Ivy/Ivy.csproj
+++ b/src/Ivy/Ivy.csproj
@@ -40,7 +40,6 @@
     <None Include="../../README.md" Pack="true" PackagePath="" />
     <EmbeddedResource Include="../../AGENTS.md" Link="AGENTS.md" />
     <None Include="../../AGENTS.md" Pack="true" PackagePath="" />
-    <None Include="../Ivy.Docs.Shared/Generated/**/*.md" Pack="true" PackagePath="docs/generated" Visible="false" />
     <EmbeddedResource Include="../frontend/src/routing-constants.json" LogicalName="RoutingConstants" Visible="false" />
   </ItemGroup>
   
@@ -169,6 +168,18 @@
     <!-- Warn loudly if NO native binaries were found during packaging -->
     <Warning Text="No native Rust binaries were found for packaging! The NuGet package will be missing critical components." 
              Condition="'@(Content->WithMetadataValue('Pack', 'true')->WithMetadataValue('PackagePath', 'runtimes/win-x64/native'))' == '' AND '@(Content->WithMetadataValue('Pack', 'true')->WithMetadataValue('PackagePath', 'runtimes/linux-x64/native'))' == ''" />
+  </Target>
+
+  <PropertyGroup>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);InjectDocsIntoPackageRoot</TargetsForTfmSpecificContentInPackage>
+  </PropertyGroup>
+
+  <Target Name="InjectDocsIntoPackageRoot">
+    <ItemGroup>
+      <TfmSpecificPackageFile Include="../Ivy.Docs.Shared/Generated/**/*.md">
+        <PackagePath>docs/generated</PackagePath>
+      </TfmSpecificPackageFile>
+    </ItemGroup>
   </Target>
 
 </Project>


### PR DESCRIPTION
The previous parameter workaround failed during CI because transitive project compilation (e.g. `Ivy.Samples.csproj`) wiped out the MSBuild item evaluation context and implicitly defaulted GitIgnore back to `true` during `dotnet pack`. This entirely rips out the static glob and replaces it with a native NuGet payload injection target, flawlessly bypassing `DefaultItemExcludes` at runtime without touching any configuration parameters.