### PR TITLE
Fix: Package raw docs from Docs folder

### DIFF
--- a/src/Ivy/Ivy.csproj
+++ b/src/Ivy/Ivy.csproj
@@ -40,6 +40,7 @@
     <None Include="../../README.md" Pack="true" PackagePath="" />
     <EmbeddedResource Include="../../AGENTS.md" Link="AGENTS.md" />
     <None Include="../../AGENTS.md" Pack="true" PackagePath="" />
+    <None Include="../Ivy.Docs.Shared/Docs/**/*.md" Pack="true" PackagePath="docs/generated" Visible="false" />
     <EmbeddedResource Include="../frontend/src/routing-constants.json" LogicalName="RoutingConstants" Visible="false" />
   </ItemGroup>
   
@@ -168,18 +169,6 @@
     <!-- Warn loudly if NO native binaries were found during packaging -->
     <Warning Text="No native Rust binaries were found for packaging! The NuGet package will be missing critical components." 
              Condition="'@(Content->WithMetadataValue('Pack', 'true')->WithMetadataValue('PackagePath', 'runtimes/win-x64/native'))' == '' AND '@(Content->WithMetadataValue('Pack', 'true')->WithMetadataValue('PackagePath', 'runtimes/linux-x64/native'))' == ''" />
-  </Target>
-
-  <PropertyGroup>
-    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);InjectDocsIntoPackageRoot</TargetsForTfmSpecificContentInPackage>
-  </PropertyGroup>
-
-  <Target Name="InjectDocsIntoPackageRoot">
-    <ItemGroup>
-      <TfmSpecificPackageFile Include="../Ivy.Docs.Shared/Generated/**/*.md">
-        <PackagePath>docs/generated</PackagePath>
-      </TfmSpecificPackageFile>
-    </ItemGroup>
   </Target>
 
 </Project>


### PR DESCRIPTION
Removes `UseGitIgnore=false` globally to satisfy explicit rules. Fixes the underlying missing payload issue dynamically introduced during the Rust PR, where LLM-specific `.md` file generation was removed from the compilation output, making the `Generated/**/*.md` glob natively omit the packaging. By migrating the `<None>` glob explicitly to `Docs/**/*.md` we safely embed the raw unmutated `.md` files directly into the NuGet package without engaging GitIgnore logic.