### PR TITLE
[01505] Frontend logging not respecting toggleDeveloperLogging

### DIFF
--- a/src/frontend/src/hooks/use-backend.tsx
+++ b/src/frontend/src/hooks/use-backend.tsx
@@ -975,7 +975,7 @@ export const useBackend = (
 
   const eventHandler: WidgetEventHandlerType = useCallback(
     (eventName, widgetId, args) => {
-      logger.info("[Event] Sending:", { eventName, widgetId, args });
+      logger.debug("[Event] Sending:", { eventName, widgetId, args });
       logger.debug(`[${connectionId}] Event: ${eventName}`, { widgetId, args });
       if (!connection) {
         logger.warn("[Event] No SignalR connection available for event:", {

--- a/src/frontend/src/services/grpcTableService.ts
+++ b/src/frontend/src/services/grpcTableService.ts
@@ -617,7 +617,7 @@ export class GrpcTableService extends EventEmitter {
     if (fullResult.arrow_ipc_stream) {
       try {
         table = arrow.tableFromIPC(fullResult.arrow_ipc_stream);
-        logger.info("gRPC Table Service - Successfully parsed Arrow table:", {
+        logger.debug("gRPC Table Service - Successfully parsed Arrow table:", {
           numRows: table.numRows,
           numCols: table.numCols,
           schema: table.schema.fields.map((f: arrow.Field) => f.name),

--- a/src/frontend/src/widgets/ExternalWidgetWrapper.tsx
+++ b/src/frontend/src/widgets/ExternalWidgetWrapper.tsx
@@ -26,7 +26,7 @@ export const ExternalWidgetWrapper: React.FC<ExternalWidgetWrapperProps> = ({
   // Debug: log when external widget gets events prop
   React.useEffect(() => {
     if (props.events && (props.events as string[]).length > 0) {
-      logger.info("[ExternalWidgetWrapper] Rendering with events:", {
+      logger.debug("[ExternalWidgetWrapper] Rendering with events:", {
         events: props.events,
         eventHandlerPresent: !!eventHandler,
       });


### PR DESCRIPTION
## Summary

Downgraded three diagnostic `logger.info()` calls to `logger.debug()` so they respect the `toggleDeveloperLogging` gate. Connection state messages (`SignalR reconnected`, `WebSocket connection established`, `Setting theme globally`) remain as `logger.info()` since they represent important state changes.

## Files Modified

- **src/frontend/src/hooks/use-backend.tsx** - Changed `[Event] Sending` log from info to debug
- **src/frontend/src/services/grpcTableService.ts** - Changed Arrow table parse success log from info to debug
- **src/frontend/src/widgets/ExternalWidgetWrapper.tsx** - Changed external widget rendering log from info to debug

## Commits

- 01accca9 — Downgrade diagnostic logger.info() to logger.debug() to respect toggleDeveloperLogging