### PR TITLE
[01495] Fix dialog textarea sluggish on blur — replays previous keystrokes

### DIFF
--- a/src/frontend/src/widgets/dialogs/DialogWidget.tsx
+++ b/src/frontend/src/widgets/dialogs/DialogWidget.tsx
@@ -26,6 +26,8 @@ export const DialogWidget: React.FC<DialogWidgetProps> = ({ id, children, width 
         style={styles}
         className={cn(isVisible && "alert-animate-enter")}
         aria-describedby={undefined}
+        onOpenAutoFocus={(e) => e.preventDefault()}
+        onCloseAutoFocus={(e) => e.preventDefault()}
       >
         {children}
       </DialogContent>

--- a/src/frontend/src/widgets/inputs/shared/useOptimisticValue.ts
+++ b/src/frontend/src/widgets/inputs/shared/useOptimisticValue.ts
@@ -19,7 +19,7 @@ export function useOptimisticValue<T>(
 
   useEffect(() => {
     if (!isActive && !eq(serverValue, localValue)) {
-      queueMicrotask(() => setLocalValue(serverValue));
+      setLocalValue(serverValue);
     }
   }, [serverValue, isActive]); // oxlint-disable-line react-hooks/exhaustive-deps
 


### PR DESCRIPTION
# Summary

## Changes

Removed the `queueMicrotask` wrapper in `useOptimisticValue` that caused a race condition on blur — the async microtask reset the textarea to a stale server value while buffered keystrokes replayed. Added `onOpenAutoFocus` and `onCloseAutoFocus` `preventDefault` handlers to `DialogWidget` to prevent Radix UI's focus trap from causing spurious focus cycling, consistent with other dialog-like widgets (SheetWidget, SmartSearch, IconInputWidget).

## API Changes

None.

## Files Modified

- **src/frontend/src/widgets/inputs/shared/useOptimisticValue.ts** — Replaced `queueMicrotask(() => setLocalValue(serverValue))` with direct `setLocalValue(serverValue)` call
- **src/frontend/src/widgets/dialogs/DialogWidget.tsx** — Added `onOpenAutoFocus` and `onCloseAutoFocus` handlers with `e.preventDefault()` to `DialogContent`

## Commits

- `4ba6799c` [01495] Fix dialog textarea sluggish on blur by removing queueMicrotask race

## Artifacts

### Screenshots

![01-basic-initial](https://stivytelemetry.blob.core.windows.net/ivy-tendril/01-basic-initial.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![02-basic-dialog-open](https://stivytelemetry.blob.core.windows.net/ivy-tendril/02-basic-dialog-open.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![03-basic-typed-text](https://stivytelemetry.blob.core.windows.net/ivy-tendril/03-basic-typed-text.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![04-basic-after-blur](https://stivytelemetry.blob.core.windows.net/ivy-tendril/04-basic-after-blur.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![05-basic-after-submit](https://stivytelemetry.blob.core.windows.net/ivy-tendril/05-basic-after-submit.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![06-basic-multiple-blurs](https://stivytelemetry.blob.core.windows.net/ivy-tendril/06-basic-multiple-blurs.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![07-props-initial](https://stivytelemetry.blob.core.windows.net/ivy-tendril/07-props-initial.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![08-props-dialog-open](https://stivytelemetry.blob.core.windows.net/ivy-tendril/08-props-dialog-open.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![09-props-filled](https://stivytelemetry.blob.core.windows.net/ivy-tendril/09-props-filled.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![10-props-after-close](https://stivytelemetry.blob.core.windows.net/ivy-tendril/10-props-after-close.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![11-events-initial](https://stivytelemetry.blob.core.windows.net/ivy-tendril/11-events-initial.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![12-events-after-type](https://stivytelemetry.blob.core.windows.net/ivy-tendril/12-events-after-type.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![13-events-after-save](https://stivytelemetry.blob.core.windows.net/ivy-tendril/13-events-after-save.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![14-integration-initial](https://stivytelemetry.blob.core.windows.net/ivy-tendril/14-integration-initial.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![15-integration-dialog-open](https://stivytelemetry.blob.core.windows.net/ivy-tendril/15-integration-dialog-open.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![16-integration-filled](https://stivytelemetry.blob.core.windows.net/ivy-tendril/16-integration-filled.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![17-integration-after-create](https://stivytelemetry.blob.core.windows.net/ivy-tendril/17-integration-after-create.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![18-edge-initial](https://stivytelemetry.blob.core.windows.net/ivy-tendril/18-edge-initial.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![19-edge-after-blur](https://stivytelemetry.blob.core.windows.net/ivy-tendril/19-edge-after-blur.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![20-edge-after-submit](https://stivytelemetry.blob.core.windows.net/ivy-tendril/20-edge-after-submit.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)