### PR TITLE
[01502] Fix Sheet width not applied when using Resizable

### DIFF
--- a/src/frontend/src/widgets/sheet/SheetWidget.tsx
+++ b/src/frontend/src/widgets/sheet/SheetWidget.tsx
@@ -164,7 +164,10 @@ export const SheetWidget: React.FC<SheetWidgetProps> = ({
       <SheetContent
         side={normalizedSide}
         style={styles}
-        className={cn("flex flex-col p-0 gap-0", isHorizontal && "h-full")}
+        className={cn(
+          "flex flex-col p-0 gap-0",
+          isHorizontal ? "h-full w-auto sm:max-w-none" : "max-h-none",
+        )}
         data-sheet-side={normalizedSide}
         onOpenAutoFocus={(e) => {
           e.preventDefault();


### PR DESCRIPTION
## Summary

Fixed the Sheet widget's width not being applied when using the Resizable feature (and also for non-resizable sheets). The `sheetVariant` in the shadcn `sheet.tsx` component applies `w-3/4` and `sm:max-w-sm` Tailwind classes that conflicted with the inline `style` width set by `SheetWidget.tsx`. Added `w-auto` and `sm:max-w-none` to the `className` prop so `tailwind-merge` removes the conflicting variant classes, allowing the inline styles to control width for both resizable and non-resizable paths.

## API Changes

None.

## Files Modified

- **Frontend:**
  - `src/frontend/src/widgets/sheet/SheetWidget.tsx` — Added Tailwind class overrides (`w-auto`, `sm:max-w-none`, `max-h-none`) to the `SheetContent` className to prevent variant width classes from conflicting with inline styles

## Commits

- 621a13ce [01502] Fix Sheet width not applied by overriding Tailwind variant classes

## Artifacts

### Screenshots

![01-basic-before-open](https://stivytelemetry.blob.core.windows.net/ivy-tendril/01-basic-before-open.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![02-basic-sheet-open](https://stivytelemetry.blob.core.windows.net/ivy-tendril/02-basic-sheet-open.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![03-props-custom-32rem](https://stivytelemetry.blob.core.windows.net/ivy-tendril/03-props-custom-32rem.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![04-props-wide-600px](https://stivytelemetry.blob.core.windows.net/ivy-tendril/04-props-wide-600px.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![05-props-left-28rem](https://stivytelemetry.blob.core.windows.net/ivy-tendril/05-props-left-28rem.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![06-props-top-300px](https://stivytelemetry.blob.core.windows.net/ivy-tendril/06-props-top-300px.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![07-resizable-default](https://stivytelemetry.blob.core.windows.net/ivy-tendril/07-resizable-default.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![08-resizable-custom-40rem](https://stivytelemetry.blob.core.windows.net/ivy-tendril/08-resizable-custom-40rem.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![09-resizable-left](https://stivytelemetry.blob.core.windows.net/ivy-tendril/09-resizable-left.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![10-events-before](https://stivytelemetry.blob.core.windows.net/ivy-tendril/10-events-before.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![11-events-sheet-open](https://stivytelemetry.blob.core.windows.net/ivy-tendril/11-events-sheet-open.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![12-events-after-close](https://stivytelemetry.blob.core.windows.net/ivy-tendril/12-events-after-close.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![13-integration-sheet-open](https://stivytelemetry.blob.core.windows.net/ivy-tendril/13-integration-sheet-open.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![14-integration-after-select](https://stivytelemetry.blob.core.windows.net/ivy-tendril/14-integration-after-select.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)