### PR TITLE
[ThemeCustomizer]: add visual stuff to empty boxes

### DIFF
--- a/src/Ivy.Samples.Shared/Apps/Demos/ThemeCustomizer.cs
+++ b/src/Ivy.Samples.Shared/Apps/Demos/ThemeCustomizer.cs
@@ -410,23 +410,15 @@ public class ThemeCustomizer : SampleBase
             var normalizedCurrent = string.IsNullOrWhiteSpace(currentValue) ? "0px" : currentValue;
             var normalizedOption = remValue == "0px" ? "0px" : remValue;
             var isSelected = normalizedCurrent == normalizedOption;
-            var fillColor = isSelected ? "var(--primary)" : "var(--secondary)";
+            var strokeColor = isSelected ? "var(--primary)" : "var(--muted-foreground)";
 
-            // Allow rectangle to be larger than viewbox to support large radii without capping
-            // If rect is 32x32, max radius is 16. If rect is 64x64, max radius is 32.
             var rectSize = SvgViewBox * 2;
-
-            // ViewBox shows the top-left 32x32 area
-            // Radii: 0, 8, 16, 24, 32 will now be visually distinct
-            var svgContent = $@"<svg width='100%' height='100%' viewBox='0 0 {SvgViewBox} {SvgViewBox}' xmlns='http://www.w3.org/2000/svg'>
-                <rect width='{rectSize}' height='{rectSize}' rx='{pxRadius}' fill='{fillColor}' />
-            </svg>";
+            var svgContent = $"<svg width='{PreviewSize}' height='{PreviewSize}' viewBox='0 0 {SvgViewBox} {SvgViewBox}'><rect x='1' y='1' width='{rectSize}' height='{rectSize}' rx='{pxRadius}' fill='none' stroke='{strokeColor}' stroke-width='3'/></svg>";
 
             return new Card(
-                    Layout.Center()
-                        | new Svg(svgContent)
-                            .Width(Size.Px(PreviewSize))
-                            .Height(Size.Px(PreviewSize))
+                    new Svg(svgContent)
+                        .Width(Size.Px(PreviewSize))
+                        .Height(Size.Px(PreviewSize))
                 )
                 .Width(Size.Px(CardSize))
                 .Height(Size.Px(CardSize))


### PR DESCRIPTION
## Issue

In the **Radius** section of the Theme Customizer (Samples), the border-radius preview cards were rendered as empty gray squares with no visual distinction between options. Users couldn't tell which radius they were selecting — all 5 cards in each category (Boxes, Fields, Selectors) looked identical.

**Expected behavior:** each card should contain an arc (curve) in the corner, visualizing the specific border-radius value. Unselected options should be gray, the selected one should be green (primary).

## Root Cause

The issue consisted of two parts:

### 1. SVG fill blended with Card background

The old code drew a `<rect>` with `fill='var(--secondary)'` — the `--secondary` color is nearly identical to the `Card` widget background in both light and dark themes. The SVG was rendering, but was visually indistinguishable from the background.

```csharp
// Old code — fill color blends with Card background
var fillColor = isSelected ? "var(--primary)" : "var(--secondary)";
var svgContent = $"<svg ...><rect ... fill='{fillColor}' /></svg>";
```

### 2. `Layout.Center()` blocked SVG rendering

The SVG widget wrapped in `Layout.Center()` did not render at all. This was discovered during debugging — replacing the SVG with `Text.Block()` inside `Layout.Center()` rendered correctly, but SVG did not. Placing the SVG directly inside the Card (without `Layout.Center()`) made it display properly.

```csharp
// Old code — Layout.Center() broke SVG rendering
return new Card(
    Layout.Center()                          // ← root cause
        | new Svg(svgContent)
            .Width(Size.Px(PreviewSize))
            .Height(Size.Px(PreviewSize))
)
```

## Solution

Replaced the rendering approach in the `CreateOption()` method of the `BorderRadiusSelector` class:

1. **Stroke-only instead of fill** — the `<rect>` is drawn with `fill='none'` and a visible `stroke`. Since the rectangle (64×64) is twice the size of the viewBox (32×32), only the top-left portion is visible — showing the corner arc via the `rx` attribute.

2. **Removed `Layout.Center()`** — the SVG is placed directly as a child of the Card widget.

3. **CSS variables for colors** — `var(--primary)` for the selected option (green), `var(--muted-foreground)` for unselected ones (gray). Works in both light and dark themes.

```csharp
// New code
var strokeColor = isSelected ? "var(--primary)" : "var(--muted-foreground)";
var rectSize = SvgViewBox * 2;
var svgContent = $"<svg width='{PreviewSize}' height='{PreviewSize}' viewBox='0 0 {SvgViewBox} {SvgViewBox}'><rect x='1' y='1' width='{rectSize}' height='{rectSize}' rx='{pxRadius}' fill='none' stroke='{strokeColor}' stroke-width='3'/></svg>";

return new Card(
    new Svg(svgContent)
        .Width(Size.Px(PreviewSize))
        .Height(Size.Px(PreviewSize))
)
```

## Changed Files

- `src/Ivy.Samples.Shared/Apps/Demos/ThemeCustomizer.cs` — `CreateOption()` method in the `BorderRadiusSelector` class (~15 lines)

## Visual Result

Each card now contains an arc with the corresponding radius:

| Option | rx | Visual |
|---|---|---|
| `0px` | 0 | Right angle |
| `0.5rem` | 8 | Slightly rounded arc |
| `1rem` | 16 | Medium arc |
| `1.5rem` | 24 | Large arc |
| `2rem` | 32 | Quarter circle |

<img width="548" height="1235" alt="image" src="https://github.com/user-attachments/assets/8fae5856-db5a-4600-855e-63dad9c184b2" />
