### PR TITLE
[01514] BarChart vertical bars — fix inverted axis logic in frontend

### DIFF
--- a/src/frontend/src/widgets/charts/sharedUtils.ts
+++ b/src/frontend/src/widgets/charts/sharedUtils.ts
@@ -334,15 +334,22 @@ export const generateXAxis = (
 
   return {
     position: axis.orientation?.toLowerCase() === "top" ? "top" : "bottom",
-    type: isVertical ? "value" : "category",
+    type: isVertical ? "category" : "value",
     boundaryGap: chartType === "bar" ? true : false,
-    data: isVertical ? undefined : categories,
+    data: isVertical ? categories : undefined,
     ...(minOpt !== undefined && { min: minOpt }),
     ...(maxOpt !== undefined && { max: maxOpt }),
     axisLabel: {
       show: axis.hideTickLabels ? false : true,
       formatter: isVertical
-        ? (value: number | string) => {
+        ? (value: string | number) => {
+            if (axis.tickFormatter) {
+              return formatTickLabel(value, axis.tickFormatter);
+            }
+            const strVal = String(value);
+            return strVal.length > 10 ? strVal.match(/.{1,10}/g)?.join("\n") : strVal;
+          }
+        : (value: number | string) => {
             if (axis.tickFormatter) {
               return formatTickLabel(value, axis.tickFormatter);
             }
@@ -351,13 +358,6 @@ export const generateXAxis = (
             if (Math.abs(numVal) >= 1e6) return (numVal / 1e6).toFixed(0) + "M";
             if (Math.abs(numVal) >= 1e3) return (numVal / 1e3).toFixed(0) + "K";
             return String(value);
-          }
-        : (value: string | number) => {
-            if (axis.tickFormatter) {
-              return formatTickLabel(value, axis.tickFormatter);
-            }
-            const strVal = String(value);
-            return strVal.length > 10 ? strVal.match(/.{1,10}/g)?.join("\n") : strVal;
           },
       interval: "auto",
       ...generateAxisLabelStyle(themeColors?.mutedForeground, themeColors?.fontSans),
@@ -412,8 +412,8 @@ export const generateYAxis = (
   }
 
   return {
-    type: isVertical ? "category" : "value",
-    data: isVertical ? categories : undefined,
+    type: isVertical ? "value" : "category",
+    data: isVertical ? undefined : categories,
     ...(minOpt !== undefined && { min: minOpt }),
     ...(maxOpt !== undefined && { max: maxOpt }),
     axisLabel: {


### PR DESCRIPTION
## Summary

Fixed the BarChart widget's inverted axis logic in `sharedUtils.ts`. The ECharts axis configuration had `isVertical` mapping backwards — vertical bars need X=category/Y=value, but the code had X=value/Y=category. Swapped the ternaries in both `generateXAxis` and `generateYAxis`, including their formatters.

## API Changes

None.

## Files Modified

- **src/frontend/src/widgets/charts/sharedUtils.ts** — Swapped `isVertical` ternaries for axis `type`, `data`, and `formatter` in `generateXAxis` (~line 337) and `generateYAxis` (~line 415)

## Commits

- 918f80f0 [01514] Fix BarChart vertical bars by swapping inverted ECharts axis logic

## Artifacts

### Screenshots

![basic-vertical-bars](https://stivytelemetry.blob.core.windows.net/ivy-tendril/basic-vertical-bars.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![edge-large-values](https://stivytelemetry.blob.core.windows.net/ivy-tendril/edge-large-values.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![edge-many-categories-horizontal](https://stivytelemetry.blob.core.windows.net/ivy-tendril/edge-many-categories-horizontal.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![edge-many-categories-vertical](https://stivytelemetry.blob.core.windows.net/ivy-tendril/edge-many-categories-vertical.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![edge-single-item](https://stivytelemetry.blob.core.windows.net/ivy-tendril/edge-single-item.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![events-initial-vertical](https://stivytelemetry.blob.core.windows.net/ivy-tendril/events-initial-vertical.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![events-toggled-back-vertical](https://stivytelemetry.blob.core.windows.net/ivy-tendril/events-toggled-back-vertical.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![events-toggled-horizontal](https://stivytelemetry.blob.core.windows.net/ivy-tendril/events-toggled-horizontal.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![integration-chart-in-card](https://stivytelemetry.blob.core.windows.net/ivy-tendril/integration-chart-in-card.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![integration-side-by-side](https://stivytelemetry.blob.core.windows.net/ivy-tendril/integration-side-by-side.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![props-horizontal-stacked](https://stivytelemetry.blob.core.windows.net/ivy-tendril/props-horizontal-stacked.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![props-stacked-layouts](https://stivytelemetry.blob.core.windows.net/ivy-tendril/props-stacked-layouts.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![props-vertical-layout](https://stivytelemetry.blob.core.windows.net/ivy-tendril/props-vertical-layout.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)