### PR TITLE
[01521] Match Table Widget styling to Markdown tables

### DIFF
--- a/src/frontend/src/widgets/tables/TableCellWidget.tsx
+++ b/src/frontend/src/widgets/tables/TableCellWidget.tsx
@@ -82,8 +82,8 @@ export const TableCellWidget: React.FC<TableCellWidgetProps> = ({
   const shouldShowTooltip =
     !multiline && (typeof children === "string" || typeof children === "number");
 
-  const cellClasses = cn("border-border force-text-inherit", {
-    "header-cell bg-muted font-semibold": isHeader,
+  const cellClasses = cn("border border-border force-text-inherit", {
+    "header-cell bg-muted font-bold": isHeader,
     "footer-cell bg-muted font-semibold": isFooter,
     "max-w-0 overflow-hidden": shouldTruncate,
   });

--- a/src/frontend/src/widgets/tables/TableRowWidget.tsx
+++ b/src/frontend/src/widgets/tables/TableRowWidget.tsx
@@ -11,5 +11,7 @@ interface TableRowWidgetProps {
 }
 
 export const TableRowWidget: React.FC<TableRowWidgetProps> = ({ children, isHeader = false }) => (
-  <TableRow className={`${isHeader ? "font-medium bg-background" : ""}`}>{children}</TableRow>
+  <TableRow className={`border border-border ${isHeader ? "font-medium bg-background" : ""}`}>
+    {children}
+  </TableRow>
 );

--- a/src/frontend/src/widgets/tables/TableWidget.tsx
+++ b/src/frontend/src/widgets/tables/TableWidget.tsx
@@ -21,7 +21,7 @@ export const TableWidget: React.FC<TableWidgetProps> = ({
   return (
     <Table
       density={density}
-      className={cn("w-full caption-bottom")}
+      className={cn("w-full caption-bottom border-collapse border border-border")}
       style={{
         ...widthStyles,
         ...(widthStyles.width === "100%"


### PR DESCRIPTION
## Summary

Updated the Table Widget frontend components (TableWidget, TableRowWidget, TableCellWidget) to use full cell borders matching the Markdown table renderer style. Added `border-collapse border border-border` to the table element, `border border-border` to rows and cells, and changed header font weight from `font-semibold` to `font-bold`.

## API Changes

None.

## Files Modified

- **Table styling:**
  - `src/frontend/src/widgets/tables/TableWidget.tsx` — added border-collapse and border classes to table element
  - `src/frontend/src/widgets/tables/TableRowWidget.tsx` — added full border classes to row element
  - `src/frontend/src/widgets/tables/TableCellWidget.tsx` — added full border classes to cells, changed header font-weight to bold

## Commits

- b2f8a4f0 [01521] Match Table Widget border styling to Markdown tables

## Artifacts

### Screenshots

![basic-tables](https://stivytelemetry.blob.core.windows.net/ivy-tendril/basic-tables.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![edge-cases-tables](https://stivytelemetry.blob.core.windows.net/ivy-tendril/edge-cases-tables.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![integration-tables](https://stivytelemetry.blob.core.windows.net/ivy-tendril/integration-tables.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![props-density-sizes](https://stivytelemetry.blob.core.windows.net/ivy-tendril/props-density-sizes.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![row-border-classes](https://stivytelemetry.blob.core.windows.net/ivy-tendril/row-border-classes.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)