### PR TITLE
[01528] Add Graphviz samples and docs to Markdown widget

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/14_Markdown.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/14_Markdown.md
@@ -145,6 +145,35 @@ public class MermaidView : ViewBase
 }
 ```
 
+### Graphviz Diagrams
+
+Graphviz diagrams let you create directed and undirected graphs using the DOT language. Use ` ```dot ` or ` ```graphviz ` code fences. For the full DOT language reference, see the [Graphviz documentation](https://graphviz.org/doc/info/lang.html).
+
+```csharp demo-tabs
+public class GraphvizView : ViewBase
+{
+    public override object? Build()
+    {
+        var markdownContent = 
+            """
+            ```dot
+            digraph G {
+                rankdir=LR;
+                node [shape=box, style="rounded,filled", fillcolor="#f0f0f0"];
+                
+                Client -> Server [label="Request"];
+                Server -> Database [label="Query"];
+                Database -> Server [label="Result"];
+                Server -> Client [label="Response"];
+            }
+            ```
+            """;
+            
+        return new Markdown(markdownContent);
+    }
+}
+```
+
 ### Emojis
 
 Emoji support enhances content with visual elements and expressions. You can use standard emoji shortcodes to add personality and visual appeal to your markdown content.

--- a/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/MarkdownApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/MarkdownApp.cs
@@ -13,6 +13,7 @@ public class MarkdownApp : SampleBase
             new Tab("Code", new CodeBlocksTab()),
             new Tab("Tables", new TablesTab()),
             new Tab("Math", new MathTab()),
+            new Tab("Diagrams", new DiagramsTab()),
             new Tab("Media", new MediaTab())
         ).Variant(TabsVariant.Content);
     }
@@ -310,6 +311,46 @@ public class MathTab : ViewBase
                        $$
                        F(\\omega) = \int_{-\\infty}^{\\infty} f(t) e^{-i\\omega t} dt
                        $$
+                       """;
+
+        return new Markdown(markdown);
+    }
+}
+
+public class DiagramsTab : ViewBase
+{
+    public override object? Build()
+    {
+        var markdown = """
+                       # Diagrams
+
+                       ## Mermaid Diagrams
+
+                       ```mermaid
+                       graph TD
+                           A[Start] --> B{Decision}
+                           B -->|Yes| C[Action]
+                           B -->|No| D[End]
+                           C --> D
+                       ```
+
+                       ## Graphviz Diagrams
+
+                       Use ` ```dot ` or ` ```graphviz ` code fences:
+
+                       ```dot
+                       digraph G {
+                           rankdir=LR;
+                           node [shape=box, style="rounded,filled", fillcolor="#e8f4f8"];
+                           edge [color="#666666"];
+
+                           UI -> API [label="HTTP"];
+                           API -> Auth [label="Validate"];
+                           API -> DB [label="Query"];
+                           DB -> Cache [label="Lookup"];
+                           Cache -> API [label="Result", style=dashed];
+                       }
+                       ```
                        """;
 
         return new Markdown(markdown);


### PR DESCRIPTION
## Summary

Added Graphviz/DOT diagram documentation to the Markdown widget docs page and a new "Diagrams" tab to the MarkdownApp sample showcasing both Mermaid and Graphviz diagrams.

## Changes

- **Documentation:** `src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/14_Markdown.md` — added Graphviz Diagrams section with demo-tabs example after Mermaid Diagrams
- **Samples:** `src/Ivy.Samples.Shared/Apps/Widgets/Primitives/MarkdownApp.cs` — added DiagramsTab class and tab entry

## Commits

- 41ff521e [01528] Add Graphviz samples and docs to Markdown widget