### PR TITLE
[01524] Fix markdown table rendering inside code blocks

### DIFF
--- a/src/frontend/src/components/markdown/CodeBlock.tsx
+++ b/src/frontend/src/components/markdown/CodeBlock.tsx
@@ -85,6 +85,28 @@ export const CodeBlock = memo(
         );
       }
 
+      const language = match ? match[1] : "text";
+      const useHighlighter = language !== "markdown" && language !== "md";
+
+      if (!useHighlighter) {
+        return (
+          <div className="relative">
+            <div className="absolute top-2 right-2 z-10">
+              <CopyToClipboardButton textToCopy={content} />
+            </div>
+            <ScrollArea className="w-full border border-border rounded-md">
+              <pre
+                className="p-4 rounded-md font-mono text-sm"
+                style={{ margin: 0, whiteSpace: "pre", overflowX: "auto" }}
+              >
+                {content}
+              </pre>
+              <ScrollBar orientation="horizontal" />
+            </ScrollArea>
+          </div>
+        );
+      }
+
       return (
         <Suspense
           fallback={
@@ -105,7 +127,7 @@ export const CodeBlock = memo(
             </div>
             <ScrollArea className="w-full border border-border rounded-md">
               <SyntaxHighlighter
-                language={match ? match[1] : "text"}
+                language={language}
                 style={dynamicTheme}
                 customStyle={{
                   margin: 0,


### PR DESCRIPTION
## Summary

Skipped Prism syntax highlighting for `markdown` and `md` language code blocks in the CodeBlock component, falling back to plain `<pre>` text rendering. Prism's markdown tokenizer produces complex multi-line token structures for tables that destroy the table layout when rendered by react-syntax-highlighter.

## API Changes

None.

## Files Modified

- **Frontend:** `src/frontend/src/components/markdown/CodeBlock.tsx` — added plain text fallback for markdown/md language code blocks

## Commits

- d66cc9e4 [01524] Fix markdown table rendering inside code blocks

## Artifacts

### Screenshots

![basic-overview](https://stivytelemetry.blob.core.windows.net/ivy-tendril/basic-overview.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![complex-table-overview](https://stivytelemetry.blob.core.windows.net/ivy-tendril/complex-table-overview.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![integration-overview](https://stivytelemetry.blob.core.windows.net/ivy-tendril/integration-overview.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![variants-overview](https://stivytelemetry.blob.core.windows.net/ivy-tendril/variants-overview.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)