### PR TITLE
Fix pnpm install failure in CI

### DIFF
--- a/src/Ivy/Build/Ivy.ExternalWidget.targets
+++ b/src/Ivy/Build/Ivy.ExternalWidget.targets
@@ -11,7 +11,7 @@
   <Target Name="NpmInstall" BeforeTargets="BuildFrontend" Condition="Exists('frontend/package.json')"
           Inputs="frontend\package.json;frontend\pnpm-lock.yaml"
           Outputs="frontend\node_modules\.modules.yaml">
-    <Exec Command="npx -y pnpm@10.32.1 install" WorkingDirectory="frontend" />
+    <Exec Command="npx -y pnpm@10.32.1 install --frozen-lockfile" WorkingDirectory="frontend" />
   </Target>
 
   <Target Name="BuildFrontend" BeforeTargets="AssignTargetPaths" Condition="Exists('frontend/package.json')"


### PR DESCRIPTION
Adds --frozen-lockfile to pnpm install for consistent builds.

Made with [Cursor](https://cursor.com)