### PR TITLE
[01535] Make Detail constructor multiline parameter optional (default false)

### DIFF
--- a/src/Ivy/Widgets/Details/Detail.cs
+++ b/src/Ivy/Widgets/Details/Detail.cs
@@ -8,7 +8,7 @@ namespace Ivy;
 /// </summary>
 public record Detail : WidgetBase<Detail>
 {
-    public Detail(string? label, object? value, bool multiline) : base(value != null ? [value] : [])
+    public Detail(string? label, object? value, bool multiline = false) : base(value != null ? [value] : [])
     {
         Label = label;
         Multiline = multiline;


### PR DESCRIPTION
# Summary

## Changes

Made the `multiline` parameter in the `Detail` constructor optional with a default value of `false`. This allows agents and developers to construct `Detail` instances with just label and value arguments (e.g., `new Detail("Author", post.Author.FirstName)`) without specifying `multiline` explicitly.

## API Changes

- `Detail(string? label, object? value, bool multiline)` changed to `Detail(string? label, object? value, bool multiline = false)` — the parameter is now optional with default `false`.

## Files Modified

- `src/Ivy/Widgets/Details/Detail.cs` — added default value to constructor parameter

## Commits

- 226a500b

## Artifacts

### Screenshots

![basic-detail-overview](https://stivytelemetry.blob.core.windows.net/ivy-tendril/basic-detail-overview.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![edge-cases-detail-overview](https://stivytelemetry.blob.core.windows.net/ivy-tendril/edge-cases-detail-overview.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![integration-detail-overview](https://stivytelemetry.blob.core.windows.net/ivy-tendril/integration-detail-overview.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![props-detail-overview](https://stivytelemetry.blob.core.windows.net/ivy-tendril/props-detail-overview.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)