### PR TITLE
[01529] Add default OrderBy fallback in QueryProcessor for pagination

### DIFF
--- a/src/Ivy.Test/DataTables/QueryProcessorTests.cs
+++ b/src/Ivy.Test/DataTables/QueryProcessorTests.cs
@@ -991,4 +991,61 @@ public class QueryProcessorTests
         Assert.Equal("Badge", stringArray.GetString(3));
         Assert.Equal("42", stringArray.GetString(4));
     }
+
+    [Fact]
+    public void Query_WithPagination_NoSort_AppliesDefaultOrderBy()
+    {
+        // Arrange
+        var products = TestDataGenerator.GenerateProducts(20);
+        var queryable = products.AsQueryable();
+        var processor = new QueryProcessor(logger: null);
+
+        var query = new DataTableQuery
+        {
+            SourceId = "test-products",
+            Offset = 0,
+            Limit = 10
+            // No Sort specified
+        };
+
+        // Act — should not throw and should return deterministic results
+        var result1 = processor.ProcessQuery(queryable, query);
+        var result2 = processor.ProcessQuery(queryable, query);
+
+        // Assert — both calls return the same rows in the same order
+        Assert.Equal(10, result1.RowCount);
+        Assert.Equal(20, result1.TotalRows);
+
+        var batch1 = ArrowTestHelper.ParseArrowData(result1.ArrowData);
+        var batch2 = ArrowTestHelper.ParseArrowData(result2.ArrowData);
+
+        var ids1 = ArrowTestHelper.GetColumnValues(batch1, "Id");
+        var ids2 = ArrowTestHelper.GetColumnValues(batch2, "Id");
+        Assert.Equal(ids1, ids2);
+    }
+
+    [Fact]
+    public void Query_WithExplicitSort_DoesNotApplyDefaultSort()
+    {
+        // Arrange
+        var products = TestDataGenerator.GenerateProducts(10);
+        var queryable = products.AsQueryable();
+        var processor = new QueryProcessor(logger: null);
+
+        var queryDescending = new DataTableQuery
+        {
+            SourceId = "test-products",
+            Offset = 0,
+            Limit = 10,
+            Sort = { new ProtoSortOrder { Column = "Id", Direction = Ivy.Protos.DataTable.SortDirection.Desc } }
+        };
+
+        // Act
+        var result = processor.ProcessQuery(queryable, queryDescending);
+
+        // Assert — results should be in descending Id order, proving explicit sort is used
+        var batch = ArrowTestHelper.ParseArrowData(result.ArrowData);
+        var ids = ArrowTestHelper.GetColumnValues(batch, "Id");
+        Assert.Equal(new object[] { 10, 9, 8, 7, 6, 5, 4, 3, 2, 1 }, ids);
+    }
 }

--- a/src/Ivy/Views/DataTables/QueryProcessor.cs
+++ b/src/Ivy/Views/DataTables/QueryProcessor.cs
@@ -115,6 +115,12 @@ public class QueryProcessor(ILogger<QueryProcessor>? logger = null, IDistributed
             {
                 processedQuery = ApplySort(processedQuery, query.Sort);
             }
+            else
+            {
+                // Apply default ordering by first property to prevent EF Core Query[10102]
+                // warnings when Skip/Take are used without an explicit OrderBy.
+                processedQuery = ApplyDefaultSort(processedQuery);
+            }
 
             // Serialize count + data queries for EF Core providers to prevent concurrent DbContext access.
             var useGuard = IsEfCoreProvider(queryable);
@@ -273,6 +279,23 @@ public class QueryProcessor(ILogger<QueryProcessor>? logger = null, IDistributed
         }
 
         return query;
+    }
+
+    private IQueryable ApplyDefaultSort(IQueryable query)
+    {
+        var elementType = query.ElementType;
+        var firstProperty = elementType.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .FirstOrDefault();
+
+        if (firstProperty == null)
+            return query;
+
+        var parameter = System.Linq.Expressions.Expression.Parameter(elementType, "x");
+        var propertyAccess = System.Linq.Expressions.Expression.Property(parameter, firstProperty);
+        var lambda = System.Linq.Expressions.Expression.Lambda(propertyAccess, parameter);
+
+        var method = GetGenericMethod(s_orderByMethod, elementType, firstProperty.PropertyType);
+        return (IQueryable)method.Invoke(null, new object[] { query, lambda })!;
     }
 
     private IQueryable ApplyFilter(IQueryable query, Filter filter)


### PR DESCRIPTION
# Summary

Added a default `OrderBy` fallback in `QueryProcessor.ProcessQuery()` that applies `OrderBy` on the first property of the element type when no explicit sort columns are specified. This prevents EF Core `Query[10102]` warnings and ensures deterministic row ordering across paginated queries.

## API Changes

None. The change is internal to `QueryProcessor` — no public API surface was added or modified.

## Files Modified

- **Core fix:** `src/Ivy/Views/DataTables/QueryProcessor.cs` — added `ApplyDefaultSort()` method and else-branch in `ProcessQuery()`
- **Tests:** `src/Ivy.Test/DataTables/QueryProcessorTests.cs` — added `Query_WithPagination_NoSort_AppliesDefaultOrderBy` and `Query_WithExplicitSort_DoesNotApplyDefaultSort`

## Commits

- e2dc7267 [01529] Add default OrderBy fallback in QueryProcessor for pagination

## Artifacts

### Screenshots

![basic-pagination-initial](https://stivytelemetry.blob.core.windows.net/ivy-tendril/basic-pagination-initial.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![basic-pagination-scrolled](https://stivytelemetry.blob.core.windows.net/ivy-tendril/basic-pagination-scrolled.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![edge-cases-initial](https://stivytelemetry.blob.core.windows.net/ivy-tendril/edge-cases-initial.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![edge-cases-scrolled](https://stivytelemetry.blob.core.windows.net/ivy-tendril/edge-cases-scrolled.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![explicit-sort-initial](https://stivytelemetry.blob.core.windows.net/ivy-tendril/explicit-sort-initial.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![integration-initial](https://stivytelemetry.blob.core.windows.net/ivy-tendril/integration-initial.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![large-dataset-initial](https://stivytelemetry.blob.core.windows.net/ivy-tendril/large-dataset-initial.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)

![large-dataset-scrolled](https://stivytelemetry.blob.core.windows.net/ivy-tendril/large-dataset-scrolled.png?se=2026-05-02&sp=r&spr=https&sv=2026-02-06&sr=c&sig=ii6/up%2B6EB7XfEPogzcMcVibr7Vt6l9Nx8q6toB49UE%3D)