### PR TITLE
Update lodash-es override to 4.18.1 in widget lockfiles

### DIFF
--- a/src/widgets/Ivy.Widgets.Leaflet/frontend/pnpm-lock.yaml
+++ b/src/widgets/Ivy.Widgets.Leaflet/frontend/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  lodash-es: 4.17.23
+  lodash-es: 4.18.1
   rollup: '>=4.59.0'
   vite: npm:@voidzero-dev/vite-plus-core@0.1.13
   vitest: npm:@voidzero-dev/vite-plus-test@0.1.13

--- a/src/widgets/Ivy.Widgets.ScreenshotFeedback/frontend/pnpm-lock.yaml
+++ b/src/widgets/Ivy.Widgets.ScreenshotFeedback/frontend/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  lodash-es: 4.17.23
+  lodash-es: 4.18.1
   vite: npm:@voidzero-dev/vite-plus-core@0.1.13
   vitest: npm:@voidzero-dev/vite-plus-test@0.1.13
 

--- a/src/widgets/Ivy.Widgets.Tiptap/frontend/pnpm-lock.yaml
+++ b/src/widgets/Ivy.Widgets.Tiptap/frontend/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  lodash-es: 4.17.23
+  lodash-es: 4.18.1
   markdown-it: '>=14.1.1'
   rollup: '>=4.59.0'
   vite: npm:@voidzero-dev/vite-plus-core@0.1.13

--- a/src/widgets/Ivy.Widgets.Xterm/frontend/pnpm-lock.yaml
+++ b/src/widgets/Ivy.Widgets.Xterm/frontend/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  lodash-es: 4.17.23
+  lodash-es: 4.18.1
   vite: npm:@voidzero-dev/vite-plus-core@0.1.13
   vitest: npm:@voidzero-dev/vite-plus-test@0.1.13
 


### PR DESCRIPTION
## Summary

Fixes `Ivy.Console` build.

Regenerates pnpm lockfiles for widget frontends (Leaflet, ScreenshotFeedback, Tiptap, Xterm) to update the `lodash-es` override from `4.17.23` to `4.18.1`, resolving peer dependency warnings.

---
🤖 *This description is AI-drafted and human-reviewed.*
