### PR TITLE
[01561] Catch all exceptions in WidgetTree.RefreshRequested

### DIFF
--- a/src/Ivy/Core/WidgetTree.cs
+++ b/src/Ivy/Core/WidgetTree.cs
@@ -143,6 +143,11 @@ public class WidgetTree : IWidgetTree, IObservable<WidgetTreeChanged[]>
         {
             //ignore
         }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[ERROR] WidgetTree.RefreshRequested failed: {ex}");
+            // Don't rethrow — this runs from async void, rethrowing would crash the process
+        }
         finally
         {
             try


### PR DESCRIPTION
## Summary

Added a catch-all exception handler in `WidgetTree.RefreshRequested` (Ivy-Framework) to prevent unhandled exceptions from the `async void` re-render callback from crashing the entire Ivy session.

**The problem:** `RefreshRequested` runs inside an `async void OnNext` callback. Only `ObjectDisposedException` was caught — any other exception became unhandled, crashing the process and killing the SignalR connection. This was the root cause of the "connection lost" crash when opening plans from Jobs.

**The fix:** Added a general `catch (Exception ex)` block that logs the error without rethrowing, preventing session crashes from re-render failures.

## Commits

- `a1f60315` — Catch all exceptions in WidgetTree.RefreshRequested to prevent async void crashes

## Files Modified

- `src/Ivy/Core/WidgetTree.cs` — added `catch (Exception)` block in `RefreshRequested`