### PR TITLE
[01585] Xterm widget background inherits parent theme instead of using terminal theme

### DIFF
--- a/src/widgets/Ivy.Widgets.Xterm/Terminal.cs
+++ b/src/widgets/Ivy.Widgets.Xterm/Terminal.cs
@@ -29,6 +29,8 @@ public record Terminal : WidgetBase<Terminal>
     [Prop] public string? InitialContent { get; init; }
     [Prop] public bool Closed { get; init; }
     [Prop] public bool AllowClipboard { get; init; } = true;
+    [Prop] public Colors? Background { get; init; }
+    [Prop] public Colors? Foreground { get; init; }
 
     [Prop] public IWriteStream<byte[]>? Stream { get; init; }
 
@@ -62,6 +64,12 @@ public static class TerminalExtensions
 
     public static Terminal AllowClipboard(this Terminal widget, bool allowClipboard = true) =>
         widget with { AllowClipboard = allowClipboard };
+
+    public static Terminal Background(this Terminal widget, Colors color) =>
+        widget with { Background = color };
+
+    public static Terminal Foreground(this Terminal widget, Colors color) =>
+        widget with { Foreground = color };
 
     public static Terminal Stream(this Terminal widget, IWriteStream<byte[]> stream) =>
         widget with { Stream = stream };

--- a/src/widgets/Ivy.Widgets.Xterm/frontend/src/Terminal.tsx
+++ b/src/widgets/Ivy.Widgets.Xterm/frontend/src/Terminal.tsx
@@ -53,6 +53,8 @@ interface TerminalProps {
   stream?: { id: string };
   closed?: boolean;
   allowClipboard?: boolean;
+  background?: string;
+  foreground?: string;
 }
 
 const defaultTheme: TerminalTheme = {
@@ -110,6 +112,8 @@ export const Terminal: React.FC<TerminalProps> = ({
   stream,
   closed = false,
   allowClipboard = true,
+  background,
+  foreground,
 }) => {
   const hostRef = useRef<HTMLDivElement>(null);
   const shadowRootRef = useRef<ShadowRoot | null>(null);
@@ -229,6 +233,24 @@ export const Terminal: React.FC<TerminalProps> = ({
     terminalReadyRef.current = false;
 
     const mergedTheme = { ...defaultTheme, ...theme };
+
+    // Set CSS variables on the container to scope them to the terminal
+    if (background) {
+      const bg = `var(--${background.toLowerCase()})`;
+      container.style.setProperty("--background", bg);
+      const computedBg = getComputedStyle(container).getPropertyValue("--" + background.toLowerCase()).trim();
+      if (computedBg) mergedTheme.background = computedBg;
+    } else {
+      container.style.setProperty("--background", mergedTheme.background || "#000000");
+    }
+    if (foreground) {
+      const fg = `var(--${foreground.toLowerCase()})`;
+      container.style.setProperty("--foreground", fg);
+      const computedFg = getComputedStyle(container).getPropertyValue("--" + foreground.toLowerCase()).trim();
+      if (computedFg) mergedTheme.foreground = computedFg;
+    } else {
+      container.style.setProperty("--foreground", mergedTheme.foreground || "#d4d4d4");
+    }
 
     const term = new XTerm({
       ...(cols !== undefined && { cols }),


### PR DESCRIPTION
## Changes

Added `Background` and `Foreground` properties (as `Colors?`) to the Xterm Terminal widget, and fixed the frontend CSS variable scoping so the terminal defaults to its own theme colors (black background) instead of inheriting the parent framework theme. When the new props are set, they resolve to framework CSS variables; when unset, the terminal uses its built-in theme.

## API Changes

- `Terminal.Background` — new `Colors?` prop with fluent extension `Terminal.Background(Colors color)`
- `Terminal.Foreground` — new `Colors?` prop with fluent extension `Terminal.Foreground(Colors color)`

## Files Modified

- **Backend:** `src/widgets/Ivy.Widgets.Xterm/Terminal.cs` — added props and extension methods
- **Frontend:** `src/widgets/Ivy.Widgets.Xterm/frontend/src/Terminal.tsx` — added prop destructuring, CSS variable scoping logic, and xterm theme override

## Commits

- 4706e46f [01585] Add Background/Foreground props to Terminal widget and fix CSS variable scoping

## Artifacts

### Screenshots

![01-basic-default](https://stivytelemetry.blob.core.windows.net/ivy-tendril/01-basic-default.png?se=2026-05-03&sp=r&spr=https&sv=2026-02-06&sr=c&sig=0gBjzc34qyu7pgf%2B9rRqXYi1giQ3anNHqpP66WkuAns%3D)

![02-props-colors](https://stivytelemetry.blob.core.windows.net/ivy-tendril/02-props-colors.png?se=2026-05-03&sp=r&spr=https&sv=2026-02-06&sr=c&sig=0gBjzc34qyu7pgf%2B9rRqXYi1giQ3anNHqpP66WkuAns%3D)

![03-events](https://stivytelemetry.blob.core.windows.net/ivy-tendril/03-events.png?se=2026-05-03&sp=r&spr=https&sv=2026-02-06&sr=c&sig=0gBjzc34qyu7pgf%2B9rRqXYi1giQ3anNHqpP66WkuAns%3D)

![04-integration-blue](https://stivytelemetry.blob.core.windows.net/ivy-tendril/04-integration-blue.png?se=2026-05-03&sp=r&spr=https&sv=2026-02-06&sr=c&sig=0gBjzc34qyu7pgf%2B9rRqXYi1giQ3anNHqpP66WkuAns%3D)

![05-integration-green](https://stivytelemetry.blob.core.windows.net/ivy-tendril/05-integration-green.png?se=2026-05-03&sp=r&spr=https&sv=2026-02-06&sr=c&sig=0gBjzc34qyu7pgf%2B9rRqXYi1giQ3anNHqpP66WkuAns%3D)

![06-integration-black](https://stivytelemetry.blob.core.windows.net/ivy-tendril/06-integration-black.png?se=2026-05-03&sp=r&spr=https&sv=2026-02-06&sr=c&sig=0gBjzc34qyu7pgf%2B9rRqXYi1giQ3anNHqpP66WkuAns%3D)

![07-edge-cases](https://stivytelemetry.blob.core.windows.net/ivy-tendril/07-edge-cases.png?se=2026-05-03&sp=r&spr=https&sv=2026-02-06&sr=c&sig=0gBjzc34qyu7pgf%2B9rRqXYi1giQ3anNHqpP66WkuAns%3D)