### PR TITLE
[01590] Fix PlanViewer crash on older plans

### DIFF
--- a/src/Ivy/Core/WidgetTree.cs
+++ b/src/Ivy/Core/WidgetTree.cs
@@ -163,54 +163,54 @@ public class WidgetTree : IWidgetTree, IObservable<WidgetTreeChanged[]>
 
     private WidgetTreeChanged? _RefreshView(string viewId, bool isHotReload)
     {
+        try
+        {
 #if DEBUG
-        var stopWatch = Stopwatch.StartNew();
+            var stopWatch = Stopwatch.StartNew();
 #endif
 
-        if (!_nodes.TryGetValue(viewId, out var node))
-            throw new NotSupportedException($"Node '{viewId}' not found.");
+            if (!_nodes.TryGetValue(viewId, out var node))
+                throw new NotSupportedException($"Node '{viewId}' not found.");
 
-        if (!node.IsView)
-            throw new NotSupportedException($"Node '{viewId}' is not a view.");
+            if (!node.IsView)
+                throw new NotSupportedException($"Node '{viewId}' is not a view.");
 
-        var parentId = node.ParentId;
+            var parentId = node.ParentId;
 
-        var indices = node.GetWidgetTreeIndices();
+            var indices = node.GetWidgetTreeIndices();
 
-        var previous = node.GetSerializedWidgetTree();
+            var previous = node.GetSerializedWidgetTree();
 
-        var partial = BuildView(node.View!, node.ParentTreePath.Clone(), node.Index, parentId, node.AncestorContext, isRefreshingView: true, isHotReload);
+            var partial = BuildView(node.View!, node.ParentTreePath.Clone(), node.Index, parentId, node.AncestorContext, isRefreshingView: true, isHotReload);
 
-        if (partial == null) throw new NotSupportedException("View must return an IWidget.");
+            if (partial == null) throw new NotSupportedException("View must return an IWidget.");
 
-        if (parentId == null)
-        {
-            NodeTree = partial;
-        }
-        else
-        {
-            if (_nodes.TryGetValue(parentId, out var parent))
+            if (parentId == null)
             {
-                if (parent.Children.Length <= node.Index)
-                {
-                    // Silent bound guard check
-                }
-                else
-                {
-                    parent.Children[node.Index] = partial;
-
-                    // Invalidate serialization cache for all ancestors since their child changed
-                    InvalidateAncestorCaches(parentId);
-                }
+                NodeTree = partial;
             }
             else
             {
-                // Unresolved parent during active flush loop
-            }
-        }
+                if (_nodes.TryGetValue(parentId, out var parent))
+                {
+                    if (parent.Children.Length <= node.Index)
+                    {
+                        // Silent bound guard check
+                    }
+                    else
+                    {
+                        parent.Children[node.Index] = partial;
 
-        try
-        {
+                        // Invalidate serialization cache for all ancestors since their child changed
+                        InvalidateAncestorCaches(parentId);
+                    }
+                }
+                else
+                {
+                    // Unresolved parent during active flush loop
+                }
+            }
+
             var update = partial.GetSerializedWidgetTree();
 
             var previousId = previous?["id"]?.GetValue<string>();
@@ -261,6 +261,10 @@ public class WidgetTree : IWidgetTree, IObservable<WidgetTreeChanged[]>
         catch (ObjectDisposedException)
         {
             //ignore
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[ERROR] WidgetTree._RefreshView failed for {viewId}: {ex}");
         }
         return null!;
     }


### PR DESCRIPTION
Fixed PlanViewer crash when viewing older plans by wrapping the entire `_RefreshView` method body in a try-catch to prevent post-Build serialization crashes.

## Files Modified

- `src/Ivy/Core/WidgetTree.cs` — wrapped entire `_RefreshView` body in try-catch

## Commits

- 34e9966d [01590] Wrap _RefreshView entire body in try-catch