### PR TITLE
[01595] Adjust confetti animation defaults to last 2/3 as long

### DIFF
--- a/src/frontend/src/widgets/effects/ConfettiWidget.tsx
+++ b/src/frontend/src/widgets/effects/ConfettiWidget.tsx
@@ -19,8 +19,9 @@ const ConfettiWidget: React.FC<ConfettiWidgetProps> = ({ children, trigger = "Au
 
   const confettiConfig = useMemo(
     () => ({
-      particleCount: 100,
+      particleCount: 75,
       spread: 70,
+      ticks: 133,
       shapes: [quadrant],
       colors: ["#00CC92", "#0D4A2F"],
     }),


### PR DESCRIPTION
# Summary

## Changes

Reduced confetti animation duration to 2/3 of the default by setting `ticks: 133` (down from the library default of 200) and decreased `particleCount` from 100 to 75 in the ConfettiWidget frontend component.

## API Changes

None.

## Files Modified

- **Frontend:** `src/frontend/src/widgets/effects/ConfettiWidget.tsx` — adjusted `particleCount` and added `ticks` to confetti config

## Commits

- 66c27080 [01595] Reduce confetti animation duration and particle count

## Artifacts

### Screenshots

![basic-confetti-after-animation](https://stivytelemetry.blob.core.windows.net/ivy-tendril/basic-confetti-after-animation.png?se=2026-05-03&sp=r&spr=https&sv=2026-02-06&sr=c&sig=0gBjzc34qyu7pgf%2B9rRqXYi1giQ3anNHqpP66WkuAns%3D)

![basic-confetti-auto-trigger](https://stivytelemetry.blob.core.windows.net/ivy-tendril/basic-confetti-auto-trigger.png?se=2026-05-03&sp=r&spr=https&sv=2026-02-06&sr=c&sig=0gBjzc34qyu7pgf%2B9rRqXYi1giQ3anNHqpP66WkuAns%3D)

![basic-confetti-during-animation](https://stivytelemetry.blob.core.windows.net/ivy-tendril/basic-confetti-during-animation.png?se=2026-05-03&sp=r&spr=https&sv=2026-02-06&sr=c&sig=0gBjzc34qyu7pgf%2B9rRqXYi1giQ3anNHqpP66WkuAns%3D)

![integration-after-toggle](https://stivytelemetry.blob.core.windows.net/ivy-tendril/integration-after-toggle.png?se=2026-05-03&sp=r&spr=https&sv=2026-02-06&sr=c&sig=0gBjzc34qyu7pgf%2B9rRqXYi1giQ3anNHqpP66WkuAns%3D)

![integration-initial](https://stivytelemetry.blob.core.windows.net/ivy-tendril/integration-initial.png?se=2026-05-03&sp=r&spr=https&sv=2026-02-06&sr=c&sig=0gBjzc34qyu7pgf%2B9rRqXYi1giQ3anNHqpP66WkuAns%3D)

![triggers-after-click](https://stivytelemetry.blob.core.windows.net/ivy-tendril/triggers-after-click.png?se=2026-05-03&sp=r&spr=https&sv=2026-02-06&sr=c&sig=0gBjzc34qyu7pgf%2B9rRqXYi1giQ3anNHqpP66WkuAns%3D)

![triggers-after-hover](https://stivytelemetry.blob.core.windows.net/ivy-tendril/triggers-after-hover.png?se=2026-05-03&sp=r&spr=https&sv=2026-02-06&sr=c&sig=0gBjzc34qyu7pgf%2B9rRqXYi1giQ3anNHqpP66WkuAns%3D)

![triggers-after-second-click](https://stivytelemetry.blob.core.windows.net/ivy-tendril/triggers-after-second-click.png?se=2026-05-03&sp=r&spr=https&sv=2026-02-06&sr=c&sig=0gBjzc34qyu7pgf%2B9rRqXYi1giQ3anNHqpP66WkuAns%3D)

![triggers-all-types](https://stivytelemetry.blob.core.windows.net/ivy-tendril/triggers-all-types.png?se=2026-05-03&sp=r&spr=https&sv=2026-02-06&sr=c&sig=0gBjzc34qyu7pgf%2B9rRqXYi1giQ3anNHqpP66WkuAns%3D)