### PR TITLE
[01089] Fix DataTable row action tooltips to show on hover

### DIFF
--- a/src/Ivy.Samples.Shared/Apps/Widgets/DataTableApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/DataTableApp.cs
@@ -139,10 +139,10 @@ public class DataTableMainSample : ViewBase
                 config.ShowSearch = true;
             })
             .RowActions(
-                MenuItem.Default(Icons.Pencil).Tag(RowAction.Edit),
-                MenuItem.Default(Icons.Trash2).Tag(RowAction.Delete),
-                MenuItem.Default(Icons.Eye).Tag(RowAction.View),
-                MenuItem.Default(Icons.EllipsisVertical).Tag(RowAction.Menu)
+                MenuItem.Default(Icons.Pencil).Tag(RowAction.Edit).Tooltip("Edit employee"),
+                MenuItem.Default(Icons.Trash2).Tag(RowAction.Delete).Tooltip("Delete employee"),
+                MenuItem.Default(Icons.Eye).Tag(RowAction.View).Tooltip("View details"),
+                MenuItem.Default(Icons.EllipsisVertical).Tag(RowAction.Menu).Tooltip("More actions")
                     .Children([
                         MenuItem.Default(Icons.Archive).Tag(RowAction.Archive).Label("Archive"),
                         MenuItem.Default(Icons.Download).Tag(RowAction.Export).Label("Export"),

--- a/src/frontend/src/widgets/dataTables/dataTableRowAction/actionButton.tsx
+++ b/src/frontend/src/widgets/dataTables/dataTableRowAction/actionButton.tsx
@@ -1,7 +1,15 @@
-import React from "react";
+import React, { forwardRef } from "react";
 import Icon from "@/components/Icon";
 import { MenuItem } from "@/types/widgets";
 import { ACTION_BUTTON_CLASSES } from "./utils";
+import withTooltip from "@/hoc/withTooltip";
+
+const NativeButton = forwardRef<HTMLButtonElement, React.ButtonHTMLAttributes<HTMLButtonElement>>(
+  (props, ref) => <button ref={ref} {...props} />,
+);
+NativeButton.displayName = "NativeButton";
+
+const ButtonWithTooltip = withTooltip(NativeButton);
 
 interface ActionButtonProps {
   action: MenuItem;
@@ -27,15 +35,15 @@ export const ActionButton: React.FC<ActionButtonProps> = ({ action, actionId, on
   };
 
   return (
-    <button
+    <ButtonWithTooltip
       className={ACTION_BUTTON_CLASSES}
       onClick={handleClick}
       onMouseDown={handleMouseDown}
       aria-label={action.label || actionId}
-      title={action.tooltip}
+      tooltipText={action.tooltip}
       type="button"
     >
       {action.icon && <Icon name={action.icon} size={16} className="text-(--color-foreground)" />}
-    </button>
+    </ButtonWithTooltip>
   );
 };


### PR DESCRIPTION
## Summary

Replaced the native HTML `title` attribute with the Ivy Framework's `withTooltip` HOC in the DataTable row action button component. This makes row action tooltips appear immediately on hover with styled appearance, matching the behavior of toolbar buttons and other framework components. Added tooltip text to the sample app's row actions.

## API Changes

None. The existing `Tooltip` property on `MenuItem` was already available; this change only affects how it renders on the frontend.

## Files Modified

- **Frontend:**
  - `src/frontend/src/widgets/dataTables/dataTableRowAction/actionButton.tsx` — Replaced `title={action.tooltip}` with `withTooltip` HOC wrapping the button, using `tooltipText` prop

- **Samples:**
  - `src/Ivy.Samples.Shared/Apps/Widgets/DataTableApp.cs` — Added `.Tooltip()` calls to Edit, Delete, View, and Menu row actions

## Commits

- `2b8812575`