### PR TITLE
[01607] Change Setup App to Settings with Cogs Icon

### DIFF
--- a/src/tendril/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/tendril/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -431,9 +431,9 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
 
         var commonMenuItems = new[]
         {
-            MenuItem.Default("Setup")
+            MenuItem.Default("Settings")
                 .Tag("$setup")
-                .Icon(Icons.Construction)
+                .Icon(Icons.Settings)
                 .OnSelect(() => navigator.Navigate<SetupApp>()),
             MenuItem.Default("Tendril Feedback")
                 .Tag("$feedback")

--- a/src/tendril/Ivy.Tendril/Apps/SetupApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/SetupApp.cs
@@ -4,7 +4,7 @@ using Ivy.Tendril.Services;
 
 namespace Ivy.Tendril.Apps;
 
-[App(title: "Setup", icon: Icons.Construction, isVisible: false)]
+[App(title: "Settings", icon: Icons.Settings, isVisible: false)]
 public class SetupApp : ViewBase
 {
     public override object? Build()


### PR DESCRIPTION
# Summary

## Changes

Renamed the Setup app to Settings and changed the icon from Construction to Settings (cogs icon) in both the app definition and the app shell menu for consistency with standard UI conventions.

## API Changes

None.

## Files Modified

- **Apps/SetupApp.cs** — Updated App attribute from "Setup" with Construction icon to "Settings" with Settings icon
- **AppShell/TendrilAppShell.cs** — Updated menu item from "Setup" to "Settings" and changed icon from Construction to Settings

## Commits

- [01607] Change Setup app to Settings with cogs icon (ac84c8e0)