### PR TITLE
[01609] Move Trash app to Settings menu in sidebar

### DIFF
--- a/Apps/TrashApp.cs
+++ b/Apps/TrashApp.cs
@@ -5,7 +5,7 @@ namespace Ivy.Tendril.Apps;
 
 public record TrashFileInfo(string FilePath, string FileName, DateTime Date, string OriginalRequest, string DuplicateOf, string Project, string Content);
 
-[App(title: "Trash", icon: Icons.Trash2, group: new[] { "Tools" }, order: 40)]
+[App(title: "Trash", icon: Icons.Trash2, group: new[] { "Settings" }, order: 10)]
 public class TrashApp : ViewBase
 {
     public override object? Build()


### PR DESCRIPTION
# Summary

## Changes

Modified the TrashApp's `[App]` attribute to move it from the "Tools" menu group to a new "Settings" menu group in the sidebar. The order was changed from 40 to 10 to position it as the first item in the Settings group.

## API Changes

- **TrashApp** (`Apps/TrashApp.cs:8`): Changed `[App]` attribute's `group` parameter from `"Tools"` to `"Settings"` and `order` from `40` to `10`.

## Files Modified

- `Apps/TrashApp.cs` — Updated app grouping and ordering

## Commits

- 1526d31f [01609] Move Trash app from Tools to Settings menu