### PR TITLE
[01608] Change New Draft shortcut from CTRL+ALT+I to CTRL+ALT+D

### DIFF
--- a/src/tendril/Ivy.Tendril/Views/NewPlanFooterButton.cs
+++ b/src/tendril/Ivy.Tendril/Views/NewPlanFooterButton.cs
@@ -22,7 +22,7 @@ public class NewPlanFooterButton : ViewBase
                 .Width(Size.Full())
                 .Variant(ButtonVariant.Primary)
                 .OnClick(() => dialogOpen.Set(true))
-                .ShortcutKey("CTRL+ALT+I")
+                .ShortcutKey("CTRL+ALT+D")
         };
 
         if (dialogOpen.Value)


### PR DESCRIPTION
# Summary

## Changes

Changed the keyboard shortcut for the "New Draft" button in the Jobs app from CTRL+ALT+I to CTRL+ALT+D.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Views/NewPlanFooterButton.cs` — Updated `.ShortcutKey()` parameter from "CTRL+ALT+I" to "CTRL+ALT+D"

## Commits

- 9076a00b [01608] Change New Draft shortcut from CTRL+ALT+I to CTRL+ALT+D