### PR TITLE
[01611] Display all recommendations from plans - newest on top

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/RecommendationsApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/RecommendationsApp.cs
@@ -1,0 +1,85 @@
+using Ivy;
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Apps;
+
+public class RecommendationRow
+{
+    public string Id { get; set; } = "";
+    public string Date { get; set; } = "";
+    public string PlanId { get; set; } = "";
+    public string PlanFolderName { get; set; } = "";
+    public string Title { get; set; } = "";
+    public string Description { get; set; } = "";
+}
+
+[App(title: "Recommendations", icon: Icons.Lightbulb, group: new[] { "Tools" }, order: 15)]
+public class RecommendationsApp : ViewBase
+{
+    public override object? Build()
+    {
+        var planService = UseService<PlanReaderService>();
+        var nav = this.UseNavigation();
+        var refreshToken = UseRefreshToken();
+
+        UseInterval(() => refreshToken.Refresh(), TimeSpan.FromMinutes(1));
+
+        var recommendations = planService.GetRecommendations();
+
+        var rows = recommendations.Select(r => new RecommendationRow
+        {
+            Id = $"{r.PlanId}-{r.Title.GetHashCode()}",
+            Date = r.Date.ToString("yyyy-MM-dd HH:mm"),
+            PlanId = r.PlanId,
+            PlanFolderName = r.PlanFolderName,
+            Title = r.Title,
+            Description = r.Description.Length > 200 ? r.Description.Substring(0, 200) + "..." : r.Description
+        }).ToList();
+
+        var dataTable = rows.AsQueryable()
+            .ToDataTable(idSelector: r => r.Id)
+            .RefreshToken(refreshToken)
+            .Width(Size.Full())
+            .Height(Size.Full())
+            .Header(r => r.Date, "Date")
+            .Header(r => r.PlanId, "Plan")
+            .Header(r => r.Title, "Title")
+            .Header(r => r.Description, "Description")
+            .Hidden(r => r.Id)
+            .Hidden(r => r.PlanFolderName)
+            .Config(c =>
+            {
+                c.AllowSorting = true;
+                c.AllowFiltering = true;
+                c.ShowSearch = true;
+                c.SelectionMode = SelectionModes.None;
+                c.ShowIndexColumn = true;
+                c.BatchSize = 50;
+                c.EnableCellClickEvents = true;
+            })
+            .Renderer(r => r.PlanId, new ButtonDisplayRenderer())
+            .OnCellClick(e =>
+            {
+                if (e.Value.ColumnName == "Plan")
+                {
+                    var planId = e.Value.CellValue?.ToString();
+                    if (!string.IsNullOrEmpty(planId))
+                    {
+                        var row = rows.FirstOrDefault(r => r.PlanId == planId);
+                        if (row != null)
+                        {
+                            var fullPath = Path.Combine(planService.PlansDirectory, row.PlanFolderName);
+                            if (Directory.Exists(fullPath))
+                                nav.Navigate<PlanViewerApp>(new PlanViewerAppArgs(fullPath));
+                        }
+                    }
+                }
+                return ValueTask.CompletedTask;
+            });
+
+        return new HeaderLayout(
+            header: Text.Block($"All Recommendations ({recommendations.Count})").Bold(),
+            content: dataTable
+        );
+    }
+}

--- a/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
@@ -434,6 +434,43 @@ public class PlanReaderService(ConfigService config)
             .ToList();
     }
 
+    public List<Recommendation> GetRecommendations()
+    {
+        var recommendations = new List<Recommendation>();
+        var plans = GetPlans();
+
+        foreach (var plan in plans)
+        {
+            var recommendationsPath = Path.Combine(plan.FolderPath, "artifacts", "recommendations.yaml");
+            if (!File.Exists(recommendationsPath)) continue;
+
+            try
+            {
+                var yaml = File.ReadAllText(recommendationsPath);
+                var items = YamlDeserializer.Deserialize<List<RecommendationYaml>>(yaml);
+                if (items == null) continue;
+
+                foreach (var item in items)
+                {
+                    recommendations.Add(new Recommendation(
+                        Title: item.Title,
+                        Description: item.Description,
+                        PlanId: plan.Id.ToString("D5"),
+                        PlanTitle: plan.Title,
+                        PlanFolderName: plan.FolderName,
+                        Date: plan.Updated
+                    ));
+                }
+            }
+            catch
+            {
+                // Skip malformed YAML files
+            }
+        }
+
+        return recommendations.OrderByDescending(r => r.Date).ToList();
+    }
+
     private static DateTime? ExtractCompletedTimestamp(string logFilePath)
     {
         try
@@ -471,4 +508,19 @@ public class HourlyTokenBurn
     public DateTime Hour { get; set; }
     public decimal Cost { get; set; }
     public int Tokens { get; set; }
+}
+
+public record Recommendation(
+    string Title,
+    string Description,
+    string PlanId,
+    string PlanTitle,
+    string PlanFolderName,
+    DateTime Date
+);
+
+public class RecommendationYaml
+{
+    public string Title { get; set; } = "";
+    public string Description { get; set; } = "";
 }


### PR DESCRIPTION
# Summary

## Changes

Added a new RecommendationsApp to Tendril that displays all recommendations from completed plans in a centralized DataTable view, sorted by date (newest first). The app scans all plan folders for `artifacts/recommendations.yaml` files and provides navigation to the source plans.

## API Changes

**New classes:**
- `RecommendationsApp` - New app in Tools group (order 15) for viewing all recommendations
- `Recommendation` record - Data model with Title, Description, PlanId, PlanTitle, PlanFolderName, Date
- `RecommendationYaml` class - Deserialization model for YAML files

**New methods:**
- `PlanReaderService.GetRecommendations()` - Returns list of all recommendations from plan artifacts, sorted by date descending

## Files Modified

**Services:**
- `Services/PlanReaderService.cs` - Added GetRecommendations() method and supporting types

**Apps:**
- `Apps/RecommendationsApp.cs` - New app with DataTable displaying recommendations, clickable Plan IDs navigate to PlanViewerApp

## Commits

- c1986323 [01611] Display all recommendations from plans - newest on top