### PR TITLE
[01620] Fix PR hook duplicate Slack output

### DIFF
--- a/src/tendril/Ivy.Tendril.TeamIvyConfig/Hooks/NotifySlack.ps1
+++ b/src/tendril/Ivy.Tendril.TeamIvyConfig/Hooks/NotifySlack.ps1
@@ -35,7 +35,7 @@ if ($planContent -match "(?m)^project:\s*(.+)$") {
 
 # Parse PRs
 $prs = @()
-if ($planContent -match "(?ms)^prs:\s*\n((?:- .+\n?)+)") {
+if ($planContent -match "(?ms)^prs:\s*\n((?:- .+\n?)*?)(?=\n\w+:|$)") {
     $prs = [regex]::Matches($Matches[1], "- (.+)") | ForEach-Object { $_.Groups[1].Value.Trim() }
 }
 


### PR DESCRIPTION
# Summary

## Changes

Fixed the PR-parsing regex in `NotifySlack.ps1` that was too greedy — it matched all YAML list items after `prs:` (including `commits:` and `verifications:` entries), causing duplicate/incorrect content in Slack notifications. The regex now uses a non-greedy quantifier with a lookahead to stop at the next YAML key.

## API Changes

None.

## Files Modified

- **Hooks/NotifySlack.ps1** — Changed regex pattern on line 38 from greedy `(?:- .+\n?)+` to non-greedy `(?:- .+\n?)*?` with `(?=\n\w+:|$)` lookahead

## Commits

- f97f440b [01620] Fix PR hook regex to stop capturing commits and verifications as PRs