### PR TITLE
[01624] Remove General project mode — consolidate to Auto

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Plans/Dialogs/CreatePlanDialog.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Plans/Dialogs/CreatePlanDialog.cs
@@ -14,7 +14,7 @@ public class CreatePlanDialog(List<string> projectNames, Action<string, string> 
         var createPlanText = UseState("");
         var selectedProject = UseState(_defaultProject);
 
-        var options = new List<string> { "[Auto]", "General" };
+        var options = new List<string> { "[Auto]" };
         options.AddRange(_projectNames);
 
         return new Dialog(

--- a/src/tendril/Ivy.Tendril/Apps/Plans/PlanYaml.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Plans/PlanYaml.cs
@@ -11,7 +11,7 @@ public class PlanVerificationEntry
 public class PlanYaml
 {
     public string State { get; set; } = "Draft";
-    public string Project { get; set; } = "General";
+    public string Project { get; set; } = "[Auto]";
     public string Level { get; set; } = "NiceToHave";
     public string Title { get; set; } = "";
     public List<string> Repos { get; set; } = new();

--- a/src/tendril/Ivy.Tendril/Services/JobService.cs
+++ b/src/tendril/Ivy.Tendril/Services/JobService.cs
@@ -80,7 +80,7 @@ public class JobService
 
         // Extract plan folder and project from args
         var planFile = "";
-        var project = "General";
+        var project = "[Auto]";
 
         // For MakePlan: args are named params like -Description "..." -Project "..."
         // For others: args[0] is the plan folder path
@@ -89,8 +89,7 @@ public class JobService
             planFile = GetNamedArg(args, "-Description") is { } desc
                 ? (desc.Length > 80 ? desc[..80] + "..." : desc)
                 : "New Plan";
-            project = GetNamedArg(args, "-Project") ?? "General";
-            if (project == "[Auto]") project = "General";
+            project = GetNamedArg(args, "-Project") ?? "[Auto]";
         }
         else
         {


### PR DESCRIPTION
# Summary

## Changes

Removed the redundant "General" project mode and consolidated all defaults to "[Auto]". The `[Auto]` mode already handled automatic project detection, making "General" unnecessary.

## API Changes

- `PlanYaml.Project` default changed from `"General"` to `"[Auto]"`
- `CreatePlanDialog` dropdown no longer includes `"General"` as an option
- `JobService.StartJobInternal` defaults to `"[Auto]"` instead of `"General"` and no longer converts `[Auto]` to `General`

## Files Modified

- **Services/JobService.cs** — Changed default project and removed Auto-to-General conversion
- **Apps/Plans/Dialogs/CreatePlanDialog.cs** — Removed "General" from project dropdown options
- **Apps/Plans/PlanYaml.cs** — Changed default Project property value

## Commits

- 53b48a5a [01624] Remove General project mode, consolidate to Auto