### PR TITLE
[01625] Move [Force] marker to end of plan description

### DIFF
--- a/src/tendril/Ivy.Tendril/.promptwares/MakePlan/Program.md
+++ b/src/tendril/Ivy.Tendril/.promptwares/MakePlan/Program.md
@@ -43,7 +43,7 @@ The plan ID is pre-allocated by the launcher script and provided in the firmware
 
 ### 3. Research
 
-- **Check for duplicate plans** first — **unless the description starts with `[FORCE]`**, in which case skip duplicate detection entirely and strip the `[FORCE] ` prefix before using the description. List existing plan folders in `PlansDirectory` and scan their `plan.yaml` titles. If an existing plan already covers the same issue (same problem, same project), perform **state-aware duplicate detection** before deciding:
+- **Check for duplicate plans** first — **unless the description starts with `[FORCE]`**, in which case skip duplicate detection entirely and move `[FORCE]` to the end of the description (format: `<description> [FORCE]`). List existing plan folders in `PlansDirectory` and scan their `plan.yaml` titles. If an existing plan already covers the same issue (same problem, same project), perform **state-aware duplicate detection** before deciding:
 
   #### Step 1: Read existing plan state
   


### PR DESCRIPTION
# Summary

## Changes

Changed the `[FORCE]` handling in MakePlan's Program.md from stripping the prefix entirely to moving it to the end of the description. This preserves the force-creation marker in the plan metadata while keeping it less visible in UI displays.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/.promptwares/MakePlan/Program.md` -- Updated [FORCE] handling instruction in step 3 (Research section)

## Commits

- 779afad4 [01625] Move [FORCE] marker to end of plan description