### PR TITLE
[01626] Worktree cleanup after successful MakePr and terminal states

### DIFF
--- a/src/tendril/Ivy.Tendril.TeamIvyConfig/Hooks/CleanupWorktrees.ps1
+++ b/src/tendril/Ivy.Tendril.TeamIvyConfig/Hooks/CleanupWorktrees.ps1
@@ -1,0 +1,115 @@
+# CleanupWorktrees.ps1 — Periodic cleanup of stale worktrees from completed plans
+# Run via Task Scheduler (e.g. weekly) or manually:
+#   pwsh -NoProfile -File %TENDRIL_HOME%/Hooks/CleanupWorktrees.ps1
+#
+# Optional: -MaxAgeDays <int> (default: 7)
+
+param(
+    [int]$MaxAgeDays = 7
+)
+
+$ErrorActionPreference = "Continue"
+
+# Resolve plans directory
+$tendrilHome = $env:TENDRIL_HOME
+if (-not $tendrilHome) {
+    Write-Error "TENDRIL_HOME environment variable is not set."
+    exit 1
+}
+
+$plansDir = Join-Path $tendrilHome "Plans"
+if (-not (Test-Path $plansDir)) {
+    Write-Host "Plans directory not found: $plansDir" -ForegroundColor Yellow
+    exit 0
+}
+
+$terminalStates = @("Completed", "Failed", "Skipped", "Icebox")
+$cutoffDate = (Get-Date).AddDays(-$MaxAgeDays)
+$cleanedTotal = 0
+$failedTotal = 0
+
+$planFolders = Get-ChildItem -Path $plansDir -Directory | Where-Object { $_.Name -match '^\d{5}-' }
+
+foreach ($planFolder in $planFolders) {
+    $worktreesDir = Join-Path $planFolder.FullName "worktrees"
+    if (-not (Test-Path $worktreesDir)) { continue }
+
+    $planYamlPath = Join-Path $planFolder.FullName "plan.yaml"
+    if (-not (Test-Path $planYamlPath)) { continue }
+
+    $planContent = Get-Content $planYamlPath -Raw
+
+    # Check state
+    $stateMatch = [regex]::Match($planContent, '(?m)^state:\s*(.+)$')
+    $state = if ($stateMatch.Success) { $stateMatch.Groups[1].Value.Trim() } else { "Unknown" }
+    if ($state -notin $terminalStates) { continue }
+
+    # Check age (use updated timestamp)
+    $updatedMatch = [regex]::Match($planContent, '(?m)^updated:\s*(.+)$')
+    if ($updatedMatch.Success) {
+        $updated = [datetime]::Parse($updatedMatch.Groups[1].Value.Trim())
+        if ($updated -gt $cutoffDate) { continue }
+    }
+
+    # Extract plan ID
+    $planId = if ($planFolder.Name -match '^(\d+)') { $Matches[1] } else { "" }
+
+    # Extract repo paths
+    $repoMatches = [regex]::Matches($planContent, '(?m)^\s*-\s*((?:[A-Za-z]:\\|/).+)$')
+    $repoPaths = @()
+    foreach ($m in $repoMatches) {
+        $p = $m.Groups[1].Value.Trim()
+        $p = [Environment]::ExpandEnvironmentVariables($p)
+        if (Test-Path $p) { $repoPaths += $p }
+    }
+
+    Write-Host "Cleaning plan $($planFolder.Name) (state: $state)" -ForegroundColor Cyan
+
+    $worktreeDirs = Get-ChildItem -Path $worktreesDir -Directory -ErrorAction SilentlyContinue
+    foreach ($wtDir in $worktreeDirs) {
+        $repoName = $wtDir.Name
+        $originalRepo = $repoPaths | Where-Object { (Split-Path $_ -Leaf) -eq $repoName } | Select-Object -First 1
+
+        if ($originalRepo) {
+            try {
+                Push-Location $originalRepo
+                $branchName = "plan-$planId-$repoName"
+                git worktree remove $wtDir.FullName --force 2>&1 | Out-Null
+                git branch -D $branchName 2>&1 | Out-Null
+                Pop-Location
+                $cleanedTotal++
+                Write-Host "  Removed: $repoName" -ForegroundColor Green
+            }
+            catch {
+                Pop-Location
+                try {
+                    Remove-Item -Path $wtDir.FullName -Recurse -Force -ErrorAction Stop
+                    $cleanedTotal++
+                    Write-Host "  Removed (fallback): $repoName" -ForegroundColor Yellow
+                }
+                catch {
+                    $failedTotal++
+                    Write-Host "  Failed: $repoName - $_" -ForegroundColor Red
+                }
+            }
+        }
+        else {
+            try {
+                Remove-Item -Path $wtDir.FullName -Recurse -Force -ErrorAction Stop
+                $cleanedTotal++
+                Write-Host "  Removed (no repo match): $repoName" -ForegroundColor Yellow
+            }
+            catch {
+                $failedTotal++
+                Write-Host "  Failed: $repoName - $_" -ForegroundColor Red
+            }
+        }
+    }
+
+    # Remove worktrees dir if empty
+    if ((Get-ChildItem $worktreesDir -ErrorAction SilentlyContinue | Measure-Object).Count -eq 0) {
+        Remove-Item $worktreesDir -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Write-Host "`nWorktree cleanup complete: $cleanedTotal removed, $failedTotal failed." -ForegroundColor $(if ($failedTotal -gt 0) { "Yellow" } else { "Green" })

--- a/src/tendril/Ivy.Tendril/.promptwares/CleanupPlan.ps1
+++ b/src/tendril/Ivy.Tendril/.promptwares/CleanupPlan.ps1
@@ -1,0 +1,104 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$PlanPath
+)
+
+. "$PSScriptRoot/.shared/Utils.ps1"
+
+$planYamlPath = ValidatePlanPath $PlanPath
+$planInfo = ReadPlanProject $planYamlPath
+
+# Check plan state
+$stateMatch = [regex]::Match($planInfo.Content, '(?m)^state:\s*(.+)$')
+$currentState = if ($stateMatch.Success) { $stateMatch.Groups[1].Value.Trim() } else { "Unknown" }
+
+$terminalStates = @("Completed", "Failed", "Skipped", "Icebox")
+if ($currentState -notin $terminalStates) {
+    Write-Host "Plan is not in a terminal state (current: $currentState). Cleanup skipped." -ForegroundColor Yellow
+    Write-Host "Cleanup only runs for states: $($terminalStates -join ', ')" -ForegroundColor Yellow
+    exit 1
+}
+
+$worktreesDir = Join-Path $PlanPath "worktrees"
+if (-not (Test-Path $worktreesDir)) {
+    Write-Host "No worktrees directory found. Nothing to clean up." -ForegroundColor Green
+    exit 0
+}
+
+# Extract plan ID from folder name (e.g. "01626" from "01626-WorktreeCleanup")
+$planFolderName = Split-Path $PlanPath -Leaf
+$planId = if ($planFolderName -match '^(\d+)') { $Matches[1] } else { "" }
+
+# Extract repo paths from plan.yaml
+$repoMatches = [regex]::Matches($planInfo.Content, '(?m)^\s*-\s*((?:[A-Za-z]:\\|/).+)$')
+$repoPaths = @()
+foreach ($m in $repoMatches) {
+    $p = $m.Groups[1].Value.Trim()
+    # Expand %REPOS_HOME% if present
+    $p = [Environment]::ExpandEnvironmentVariables($p)
+    if (Test-Path $p) { $repoPaths += $p }
+}
+
+$worktreeDirs = Get-ChildItem -Path $worktreesDir -Directory -ErrorAction SilentlyContinue
+$cleanedCount = 0
+$failedCount = 0
+
+foreach ($wtDir in $worktreeDirs) {
+    $repoName = $wtDir.Name
+    Write-Host "Cleaning up worktree: $repoName" -ForegroundColor Cyan
+
+    # Find the original repo path
+    $originalRepo = $repoPaths | Where-Object { (Split-Path $_ -Leaf) -eq $repoName } | Select-Object -First 1
+
+    if ($originalRepo) {
+        # Remove worktree via git
+        try {
+            Push-Location $originalRepo
+            $branchName = "plan-$planId-$repoName"
+            git worktree remove $wtDir.FullName --force 2>&1 | Write-Host
+            git branch -D $branchName 2>&1 | Write-Host
+            Pop-Location
+            $cleanedCount++
+            Write-Host "  Removed worktree and branch: $branchName" -ForegroundColor Green
+        }
+        catch {
+            Pop-Location
+            Write-Host "  Git worktree remove failed: $_" -ForegroundColor Yellow
+            # Fallback: try to just remove the directory
+            try {
+                Remove-Item -Path $wtDir.FullName -Recurse -Force -ErrorAction Stop
+                $cleanedCount++
+                Write-Host "  Removed directory directly" -ForegroundColor Yellow
+            }
+            catch {
+                $failedCount++
+                Write-Host "  Failed to remove directory: $_" -ForegroundColor Red
+            }
+        }
+    }
+    else {
+        # No matching repo found, just remove the directory
+        Write-Host "  No matching repo path found for '$repoName'. Removing directory only." -ForegroundColor Yellow
+        try {
+            # Try git worktree prune from any repo that might own it
+            Remove-Item -Path $wtDir.FullName -Recurse -Force -ErrorAction Stop
+            $cleanedCount++
+        }
+        catch {
+            $failedCount++
+            Write-Host "  Failed to remove directory: $_" -ForegroundColor Red
+        }
+    }
+}
+
+# Remove the worktrees directory if empty
+if ((Get-ChildItem $worktreesDir -ErrorAction SilentlyContinue | Measure-Object).Count -eq 0) {
+    Remove-Item $worktreesDir -Force -ErrorAction SilentlyContinue
+    Write-Host "Removed empty worktrees directory" -ForegroundColor Green
+}
+
+# Write cleanup log
+WritePlanLog $PlanPath "CleanupPlan" "Cleaned $cleanedCount worktree(s), $failedCount failed."
+
+Write-Host "`nCleanup complete: $cleanedCount removed, $failedCount failed." -ForegroundColor $(if ($failedCount -gt 0) { "Yellow" } else { "Green" })
+exit $(if ($failedCount -gt 0) { 1 } else { 0 })

--- a/src/tendril/Ivy.Tendril/.promptwares/MakePr/Program.md
+++ b/src/tendril/Ivy.Tendril/.promptwares/MakePr/Program.md
@@ -105,13 +105,35 @@ git pull origin <default-branch>
 
 **If `default`:** PR stays open for manual review.
 
-### 5. Update plan.yaml
+### 5. Clean Up Worktrees
+
+After successful `yolo` merges (or custom options with `merge: true`), clean up the worktrees to reclaim disk space:
+
+For each repo where the PR was merged:
+
+```bash
+cd <original-repo-path>
+git worktree remove "<PlanFolder>/worktrees/<repo-folder-name>" --force
+git branch -D "plan-<planId>-<repo-folder-name>" 2>/dev/null
+```
+
+If **all** worktrees were cleaned up, remove the now-empty `worktrees/` directory:
+
+```bash
+rm -rf "<PlanFolder>/worktrees"
+```
+
+**Skip cleanup** for repos using the `default` PR rule (or custom options with `merge: false`) — the worktree is still needed for potential review revisions.
+
+If cleanup fails (e.g. locked files on Windows), log a warning but do not fail the overall MakePr execution.
+
+### 6. Update plan.yaml
 
 Append each PR URL to the `prs` list in `plan.yaml`.
 
 ### Rules
 
-- **ALL 6 steps are mandatory** (including 2.5) — do not stop after creating the PR
+- **ALL 7 steps are mandatory** (including 2.5) — do not stop after creating the PR
 - One PR per repo worktree that has commits
 - Skip worktrees with no commits ahead of the base branch
 - Use `gh` CLI for all GitHub operations


### PR DESCRIPTION
# Summary

## Changes

Added worktree cleanup capability in three places: MakePr now cleans up worktrees after successful yolo merges (new step 5 in Program.md), a new `CleanupPlan.ps1` promptware enables on-demand cleanup of individual plans in terminal states, and a new `CleanupWorktrees.ps1` hook script provides periodic bulk cleanup of stale worktrees older than 7 days.

## API Changes

- New promptware: `CleanupPlan.ps1` — accepts `-PlanPath <path>`, cleans worktrees for plans in terminal states (Completed, Failed, Skipped, Icebox)
- New hook: `Hooks/CleanupWorktrees.ps1` — accepts optional `-MaxAgeDays <int>` (default: 7), scans all plan folders for stale worktrees
- MakePr Program.md: Added step 5 (worktree cleanup), renumbered step 5 to step 6

## Files Modified

- **MakePr instructions** — `src/tendril/Ivy.Tendril/.promptwares/MakePr/Program.md` (added step 5 for worktree cleanup after yolo merge)
- **New promptware** — `src/tendril/Ivy.Tendril/.promptwares/CleanupPlan.ps1` (on-demand cleanup for individual plans)
- **New hook** — `src/tendril/Ivy.Tendril.TeamIvyConfig/Hooks/CleanupWorktrees.ps1` (periodic bulk cleanup)

## Commits

- c5e463e9 [01626] Add worktree cleanup to MakePr and create cleanup scripts