### PR TITLE
[01628] Add Open in File Manager, Terminal, and Editor menu items to Draft plans

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Plans/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Plans/ContentView.cs
@@ -175,6 +175,23 @@ public class ContentView(
                     var url = downloadUrl.Value;
                     if (!string.IsNullOrEmpty(url)) client.OpenUrl(url);
                 }),
+                new MenuItem("Open in File Manager", Icon: Icons.FolderOpen, Tag: "OpenInExplorer").OnSelect(() =>
+                {
+                    PlatformHelper.OpenInFileManager(_selectedPlan.FolderPath);
+                }),
+                new MenuItem("Open in Terminal", Icon: Icons.Terminal, Tag: "OpenInTerminal").OnSelect(() =>
+                {
+                    PlatformHelper.OpenInTerminal(_selectedPlan.FolderPath);
+                }),
+                new MenuItem($"Open in {_config.Editor.Label}", Icon: Icons.Code, Tag: "OpenInEditor").OnSelect(() =>
+                {
+                    System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+                    {
+                        FileName = _config.Editor.Command,
+                        Arguments = $"\"{_selectedPlan.FolderPath}\"",
+                        UseShellExecute = true
+                    });
+                }),
                 new MenuItem("Copy Path to Clipboard", Icon: Icons.ClipboardCopy, Tag: "CopyPath").OnSelect(() =>
                 {
                     copyToClipboard(_selectedPlan.FolderPath);


### PR DESCRIPTION
# Summary

## Changes

Added three navigation menu items ("Open in File Manager", "Open in Terminal", "Open in {Editor}") to the Draft plans dropdown menu in Plans/ContentView.cs, matching the existing implementation in Review/ContentView.cs.

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/Apps/Plans/ContentView.cs** -- Added three new MenuItem entries to the dropdown menu

## Commits

- 7c296d29 [01628] Add Open in File Manager, Terminal, and Editor menu items to Draft plans