### PR TITLE
[01636] Comment out Tendril Feedback for now [FORCE]

### DIFF
--- a/src/tendril/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/tendril/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -408,10 +408,10 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
                 .Tag("$setup")
                 .Icon(Icons.Settings)
                 .OnSelect(() => navigator.Navigate<SetupApp>()),
-            MenuItem.Default("Tendril Feedback")
-                .Tag("$feedback")
-                .Icon(Icons.MessageSquare)
-                .OnSelect(() => feedbackOpen.Set(true)),
+            // MenuItem.Default("Tendril Feedback")
+            //     .Tag("$feedback")
+            //     .Icon(Icons.MessageSquare)
+            //     .OnSelect(() => feedbackOpen.Set(true)),
             MenuItem.Default("Theme")
                 .Tag("$theme")
                 .Icon(Icons.SunMoon)


### PR DESCRIPTION
# Summary

## Changes

Commented out the "Tendril Feedback" menu item in the Tendril application shell's context menu. The menu item definition (including its tag, icon, and click handler) was commented out in `TendrilAppShell.cs`.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/AppShell/TendrilAppShell.cs` — Commented out the Tendril Feedback `MenuItem` (lines 411-414)

## Commits

- [01636] Comment out Tendril Feedback menu item (2270b40f)