### PR TITLE
[01631] Recommendations: Convert from DataTable to SidebarLayout with keyboard shortcuts

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Recommendations/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Recommendations/ContentView.cs
@@ -1,0 +1,109 @@
+using Ivy;
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Apps.Recommendations;
+
+public class ContentView(
+    Recommendation? selectedRecommendation,
+    List<Recommendation> allRecommendations,
+    IState<Recommendation?> selectedState,
+    PlanReaderService planService,
+    Action refresh) : ViewBase
+{
+    private readonly Recommendation? _selected = selectedRecommendation;
+    private readonly List<Recommendation> _all = allRecommendations;
+    private readonly IState<Recommendation?> _selectedState = selectedState;
+    private readonly PlanReaderService _planService = planService;
+    private readonly Action _refresh = refresh;
+
+    public override object? Build()
+    {
+        var nav = this.UseNavigation();
+
+        if (_selected is null)
+        {
+            return Layout.Vertical().AlignContent(Align.Center).Height(Size.Full())
+                | Text.Muted("Select a recommendation from the sidebar");
+        }
+
+        var currentIndex = _all.FindIndex(r => r.PlanId == _selected.PlanId && r.Title == _selected.Title);
+
+        var stateBadgeVariant = _selected.State switch
+        {
+            "Accepted" => BadgeVariant.Success,
+            "Declined" => BadgeVariant.Destructive,
+            _ => BadgeVariant.Outline
+        };
+
+        // Header
+        var header = Layout.Horizontal().Width(Size.Full()).Padding(1).Gap(2)
+            | Text.Block(_selected.Title).Bold()
+            | new Badge(_selected.State).Variant(stateBadgeVariant)
+            | new Badge($"#{_selected.PlanId}").Variant(BadgeVariant.Outline)
+            | new Spacer().Width(Size.Grow())
+            | Text.Rich()
+                .Bold($"{currentIndex + 1}/{_all.Count}", word: true)
+                .Muted("recommendations", word: true);
+
+        // Content
+        var scrollableContent = Layout.Vertical().Width(Size.Auto().Max(Size.Units(200))).Gap(4).Padding(2);
+
+        // Source plan info
+        scrollableContent |= Layout.Vertical().Gap(1)
+            | Text.Block("Source Plan").Bold()
+            | Layout.Horizontal().Gap(2)
+                | Text.Muted($"Plan #{_selected.PlanId}: {_selected.PlanTitle}")
+                | Text.Muted($"Date: {_selected.Date:yyyy-MM-dd HH:mm}");
+
+        // Description
+        scrollableContent |= new Separator();
+        scrollableContent |= new Markdown(_selected.Description);
+
+        // Action bar
+        var actionBar = Layout.Horizontal().AlignContent(Align.Center).Gap(2).Padding(1)
+            | new Button("Accept").Icon(Icons.Check).Primary().ShortcutKey("a").OnClick(() =>
+            {
+                _planService.UpdateRecommendationState(_selected.PlanFolderName, _selected.Title, "Accepted");
+                _refresh();
+                GoToNext();
+            })
+            | new Button("Decline").Icon(Icons.X).Outline().ShortcutKey("x").OnClick(() =>
+            {
+                _planService.UpdateRecommendationState(_selected.PlanFolderName, _selected.Title, "Declined");
+                _refresh();
+                GoToNext();
+            })
+            | new Button("View Plan").Icon(Icons.ExternalLink).Outline().ShortcutKey("d").OnClick(() =>
+            {
+                var fullPath = Path.Combine(_planService.PlansDirectory, _selected.PlanFolderName);
+                if (Directory.Exists(fullPath))
+                    nav.Navigate<PlanViewerApp>(new PlanViewerAppArgs(fullPath));
+            })
+            | new Button("Previous").Icon(Icons.ChevronLeft).Outline().ShortcutKey("p").OnClick(() => GoToPrevious())
+            | new Button("Next").Icon(Icons.ChevronRight, Align.Right).Outline().ShortcutKey("n").OnClick(() => GoToNext());
+
+        return new HeaderLayout(
+            header: header,
+            content: new FooterLayout(
+                footer: actionBar,
+                content: scrollableContent
+            ).Size(Size.Full())
+        ).Scroll(Scroll.None).Size(Size.Full());
+    }
+
+    private void GoToNext()
+    {
+        if (_all.Count == 0) return;
+        var currentIndex = _all.FindIndex(r => r.PlanId == _selected?.PlanId && r.Title == _selected?.Title);
+        var nextIndex = (currentIndex + 1) % _all.Count;
+        _selectedState.Set(_all[nextIndex]);
+    }
+
+    private void GoToPrevious()
+    {
+        if (_all.Count == 0) return;
+        var currentIndex = _all.FindIndex(r => r.PlanId == _selected?.PlanId && r.Title == _selected?.Title);
+        var prevIndex = (currentIndex - 1 + _all.Count) % _all.Count;
+        _selectedState.Set(_all[prevIndex]);
+    }
+}

--- a/src/tendril/Ivy.Tendril/Apps/Recommendations/SidebarView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Recommendations/SidebarView.cs
@@ -1,0 +1,50 @@
+using Ivy;
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Apps.Recommendations;
+
+public class SidebarView(
+    List<Recommendation> recommendations,
+    IState<Recommendation?> selectedState,
+    IState<string?> textFilter) : ViewBase
+{
+    private readonly List<Recommendation> _recommendations = recommendations;
+    private readonly IState<Recommendation?> _selectedState = selectedState;
+    private readonly IState<string?> _textFilter = textFilter;
+
+    public object BuildHeader()
+    {
+        return Layout.Vertical()
+            | _textFilter.ToSearchInput().Placeholder("Search recommendations...");
+    }
+
+    public override object Build()
+    {
+        var filtered = _recommendations.AsEnumerable();
+        if (!string.IsNullOrWhiteSpace(_textFilter.Value))
+        {
+            var search = _textFilter.Value.Trim();
+            filtered = filtered.Where(r =>
+                r.Title.Contains(search, StringComparison.OrdinalIgnoreCase) ||
+                r.Description.Contains(search, StringComparison.OrdinalIgnoreCase));
+        }
+
+        return new List(filtered.Select(rec =>
+        {
+            var clickableRec = rec;
+            var stateBadgeVariant = rec.State switch
+            {
+                "Accepted" => BadgeVariant.Success,
+                "Declined" => BadgeVariant.Destructive,
+                _ => BadgeVariant.Outline
+            };
+
+            return new ListItem(rec.Title)
+                .Content(Layout.Horizontal().Gap(1)
+                    | new Badge(rec.State).Variant(stateBadgeVariant).Small()
+                    | new Badge($"#{rec.PlanId}").Variant(BadgeVariant.Outline).Small()
+                )
+                .OnClick(() => _selectedState.Set(clickableRec));
+        }));
+    }
+}

--- a/src/tendril/Ivy.Tendril/Apps/RecommendationsApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/RecommendationsApp.cs
@@ -1,18 +1,8 @@
 using Ivy;
+using Ivy.Tendril.Apps.Recommendations;
 using Ivy.Tendril.Services;
 
 namespace Ivy.Tendril.Apps;
-
-public class RecommendationRow
-{
-    public string Id { get; set; } = "";
-    public string Date { get; set; } = "";
-    public string State { get; set; } = "";
-    public string PlanId { get; set; } = "";
-    public string PlanFolderName { get; set; } = "";
-    public string Title { get; set; } = "";
-    public string Description { get; set; } = "";
-}
 
 [App(title: "Recommendations", icon: Icons.Lightbulb, group: new[] { "Tools" }, order: 15)]
 public class RecommendationsApp : ViewBase
@@ -20,9 +10,10 @@ public class RecommendationsApp : ViewBase
     public override object? Build()
     {
         var planService = UseService<PlanReaderService>();
-        var nav = this.UseNavigation();
         var refreshToken = UseRefreshToken();
         var stateFilter = UseState<string?>(null);
+        var selectedState = UseState<Recommendation?>(null);
+        var textFilter = UseState<string?>("");
 
         UseInterval(() => refreshToken.Refresh(), TimeSpan.FromMinutes(1));
 
@@ -32,88 +23,23 @@ public class RecommendationsApp : ViewBase
             ? recommendations.Where(r => r.State == filter).ToList()
             : recommendations;
 
-        var rows = filtered.Select(r => new RecommendationRow
+        // If selected recommendation is no longer in filtered list, adjust selection
+        if (selectedState.Value is { } selected && !filtered.Any(r => r.PlanId == selected.PlanId && r.Title == selected.Title))
         {
-            Id = $"{r.PlanId}-{r.Title.GetHashCode()}",
-            Date = r.Date.ToString("yyyy-MM-dd HH:mm"),
-            State = r.State,
-            PlanId = r.PlanId,
-            PlanFolderName = r.PlanFolderName,
-            Title = r.Title,
-            Description = r.Description.Length > 200 ? r.Description.Substring(0, 200) + "..." : r.Description
-        }).ToList();
+            selectedState.Set(filtered.Count > 0 ? filtered[0] : null);
+        }
 
-        var dataTable = rows.AsQueryable()
-            .ToDataTable(idSelector: r => r.Id)
-            .RefreshToken(refreshToken)
-            .Width(Size.Full())
-            .Height(Size.Full())
-            .Header(r => r.State, "State")
-            .Header(r => r.Date, "Date")
-            .Header(r => r.PlanId, "Plan")
-            .Header(r => r.Title, "Title")
-            .Header(r => r.Description, "Description")
-            .Hidden(r => r.Id)
-            .Hidden(r => r.PlanFolderName)
-            .Config(c =>
-            {
-                c.AllowSorting = true;
-                c.AllowFiltering = true;
-                c.ShowSearch = true;
-                c.SelectionMode = SelectionModes.None;
-                c.ShowIndexColumn = true;
-                c.BatchSize = 50;
-                c.EnableCellClickEvents = true;
-            })
-            .Renderer(r => r.State, new LabelsDisplayRenderer())
-            .Renderer(r => r.PlanId, new ButtonDisplayRenderer())
-            .OnCellClick(e =>
-            {
-                if (e.Value.ColumnName == "Plan")
-                {
-                    var planId = e.Value.CellValue?.ToString();
-                    if (!string.IsNullOrEmpty(planId))
-                    {
-                        var row = rows.FirstOrDefault(r => r.PlanId == planId);
-                        if (row != null)
-                        {
-                            var fullPath = Path.Combine(planService.PlansDirectory, row.PlanFolderName);
-                            if (Directory.Exists(fullPath))
-                                nav.Navigate<PlanViewerApp>(new PlanViewerAppArgs(fullPath));
-                        }
-                    }
-                }
-                return ValueTask.CompletedTask;
-            })
-            .RowActions(
-                new MenuItem(Label: "Accept", Icon: Icons.Check, Tag: "accept"),
-                new MenuItem(Label: "Decline", Icon: Icons.X, Tag: "decline")
-            )
-            .OnRowAction(e =>
-            {
-                var tag = e.Value.Tag?.ToString();
-                var id = e.Value.Id?.ToString();
-                var row = rows.FirstOrDefault(r => r.Id == id);
-
-                if (row != null && tag is "accept" or "decline")
-                {
-                    var newState = tag == "accept" ? "Accepted" : "Declined";
-                    planService.UpdateRecommendationState(row.PlanFolderName, row.Title, newState);
-                    refreshToken.Refresh();
-                }
-                return ValueTask.CompletedTask;
-            });
+        void Refresh() => refreshToken.Refresh();
 
         var pendingCount = recommendations.Count(r => r.State == "Pending");
         var acceptedCount = recommendations.Count(r => r.State == "Accepted");
         var declinedCount = recommendations.Count(r => r.State == "Declined");
 
-        var header = Layout.Horizontal().Gap(2) | new object?[]
+        var filterBar = Layout.Horizontal().Gap(2) | new object?[]
         {
-            Text.Block($"Recommendations ({filtered.Count})").Bold(),
             stateFilter.Value == null
-                ? (object)new Button("All").OnClick(() => stateFilter.Set(null))
-                : new Button("All").Ghost().OnClick(() => stateFilter.Set(null)),
+                ? (object)new Button($"All ({recommendations.Count})").OnClick(() => stateFilter.Set(null))
+                : new Button($"All ({recommendations.Count})").Ghost().OnClick(() => stateFilter.Set(null)),
             stateFilter.Value == "Pending"
                 ? (object)new Button($"Pending ({pendingCount})").OnClick(() => stateFilter.Set("Pending"))
                 : new Button($"Pending ({pendingCount})").Ghost().OnClick(() => stateFilter.Set("Pending")),
@@ -125,9 +51,16 @@ public class RecommendationsApp : ViewBase
                 : new Button($"Declined ({declinedCount})").Ghost().OnClick(() => stateFilter.Set("Declined"))
         };
 
-        return new HeaderLayout(
-            header: header,
-            content: dataTable
+        var sidebar = new Recommendations.SidebarView(filtered, selectedState, textFilter);
+
+        var sidebarHeader = Layout.Vertical().Gap(2)
+            | sidebar.BuildHeader()
+            | filterBar;
+
+        return new SidebarLayout(
+            mainContent: new Recommendations.ContentView(selectedState.Value, filtered, selectedState, planService, Refresh),
+            sidebarContent: sidebar,
+            sidebarHeader: sidebarHeader
         );
     }
 }


### PR DESCRIPTION
# Summary

## Changes

Refactored RecommendationsApp from a DataTable-based layout to a SidebarLayout pattern, matching the UX of the Drafts (PlansApp) and Review apps. Added keyboard shortcuts for Accept (a), Decline (x), View Plan (d), Previous (p), and Next (n) actions.

## API Changes

- New class `Ivy.Tendril.Apps.Recommendations.SidebarView` — sidebar component displaying recommendation list with state badges and search filtering.
- New class `Ivy.Tendril.Apps.Recommendations.ContentView` — content panel showing recommendation details, source plan info, and action buttons with keyboard shortcuts.
- Removed `RecommendationRow` helper class (no longer needed).
- `RecommendationsApp.Build()` now returns `SidebarLayout` instead of `HeaderLayout` with a `DataTable`.

## Files Modified

- **New:** `Apps/Recommendations/SidebarView.cs` — sidebar list view for recommendations
- **New:** `Apps/Recommendations/ContentView.cs` — detail/content view with actions and shortcuts
- **Modified:** `Apps/RecommendationsApp.cs` — refactored to use SidebarLayout, state filter buttons in sidebar header

## Commits

- 21b8d746 [01631] Convert Recommendations from DataTable to SidebarLayout with keyboard shortcuts