### PR TITLE
[01635] Hide the Claude App in the menu [FORCE]

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/ClaudeApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/ClaudeApp.cs
@@ -3,7 +3,7 @@ using Ivy.Hooks.Pty;
 
 namespace Ivy.Tendril.Apps;
 
-[App(title: "Claude", icon: Icons.Terminal, group: new[] { "Tools" }, order: 35)]
+[App(title: "Claude", icon: Icons.Terminal, group: new[] { "Tools" }, order: 35, isVisible: false)]
 public class ClaudeApp : ViewBase
 {
     public override object? Build()


### PR DESCRIPTION
# Summary

## Changes

Added `isVisible: false` to the `[App]` attribute on `ClaudeApp.cs` to hide the Claude app from the Tendril TUI menu. The app still exists and can be navigated to directly, but no longer appears in the menu sidebar.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Apps/ClaudeApp.cs` — Added `isVisible: false` parameter to `[App]` attribute

## Commits

- 55e9896a [01635] Hide the Claude App from the menu