### PR TITLE
[01637] Move Trash app to the bottom menu

### DIFF
--- a/src/tendril/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/tendril/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -408,6 +408,10 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
                 .Tag("$setup")
                 .Icon(Icons.Settings)
                 .OnSelect(() => navigator.Navigate<SetupApp>()),
+            MenuItem.Default("Trash")
+                .Tag("$trash")
+                .Icon(Icons.Trash2)
+                .OnSelect(() => navigator.Navigate<TrashApp>()),
             // MenuItem.Default("Tendril Feedback")
             //     .Tag("$feedback")
             //     .Icon(Icons.MessageSquare)

--- a/src/tendril/Ivy.Tendril/Apps/TrashApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/TrashApp.cs
@@ -5,7 +5,7 @@ namespace Ivy.Tendril.Apps;
 
 public record TrashFileInfo(string FilePath, string FileName, DateTime Date, string OriginalRequest, string DuplicateOf, string Project, string Content);
 
-[App(title: "Trash", icon: Icons.Trash2, group: new[] { "Tools" }, order: 40)]
+[App(title: "Trash", icon: Icons.Trash2, group: new[] { "Tools" }, order: 40, isVisible: false)]
 public class TrashApp : ViewBase
 {
     public override object? Build()


### PR DESCRIPTION
# Summary

## Changes

Moved the Trash app from the main sidebar menu to the footer dropdown menu (alongside Settings and Theme). The TrashApp is now hidden from the sidebar via `isVisible: false` and added as a menu item in the footer dropdown in TendrilAppShell.

## API Changes

None.

## Files Modified

- **Apps/TrashApp.cs** - Added `isVisible: false` to the `[App]` attribute to hide from sidebar
- **AppShell/TendrilAppShell.cs** - Added Trash `MenuItem` to the `commonMenuItems` array in the footer dropdown

## Commits

- [01637] Move Trash app to footer dropdown menu (572833ae)