### PR TITLE
[01645] Hide Last Output Timestamp column in Jobs app

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/JobsApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/JobsApp.cs
@@ -64,7 +64,7 @@ public class JobsApp : ViewBase
             .Renderer(t => t.Status, new LabelsDisplayRenderer())
             .Renderer(t => t.PlanId, new ButtonDisplayRenderer())
             .Hidden(t => t.Id)
-            .Hidden(t => t.LastOutput)
+            .Hidden(t => t.LastOutputTimestamp)
             .Filterable(t => t.Timer, false)
             .Filterable(t => t.LastOutput, false)
             .Sortable(t => t.Timer, false)


### PR DESCRIPTION
# Summary

## Changes

Changed the DataTable column visibility in JobsApp.cs: removed `.Hidden(t => t.LastOutput)` and added `.Hidden(t => t.LastOutputTimestamp)`. This makes the relative "Last Output" time column (e.g., "3m 15s") visible to users while hiding the redundant absolute timestamp column.

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/Apps/JobsApp.cs** — Swapped hidden column from LastOutput to LastOutputTimestamp

## Commits

- c5082f3c [01645] Show Last Output column, hide LastOutputTimestamp column in Jobs app