### PR TITLE
[01646] Add badge number for recommendations

### DIFF
--- a/src/tendril/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/tendril/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -44,7 +44,8 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
             ["plans"] = planCounts.Drafts,
             ["review"] = planCounts.Reviews,
             ["jobs"] = planCounts.RunningJobs,
-            ["icebox"] = planCounts.Icebox
+            ["icebox"] = planCounts.Icebox,
+            ["recommendations"] = planCounts.Recommendations
         };
         return repo.GetMenuItems().Select(m => AddBadge(m, badges)).ToArray();
     }

--- a/src/tendril/Ivy.Tendril/Services/PlanCountsService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanCountsService.cs
@@ -2,7 +2,7 @@ using Ivy.Tendril.Apps.Plans;
 
 namespace Ivy.Tendril.Services;
 
-public record PlanCounts(int Drafts, int RunningJobs, int Reviews, int Icebox);
+public record PlanCounts(int Drafts, int RunningJobs, int Reviews, int Icebox, int Recommendations);
 
 public class PlanCountsService : IDisposable
 {
@@ -44,11 +44,13 @@ public class PlanCountsService : IDisposable
     {
         var plans = _planReaderService.GetPlans();
         var jobs = _jobService.GetJobs();
+        var recommendations = _planReaderService.GetRecommendations();
         return new PlanCounts(
             Drafts: plans.Count(p => p.Status == PlanStatus.Draft),
             RunningJobs: jobs.Count(j => j.Status == "Running"),
             Reviews: plans.Count(p => p.Status is PlanStatus.ReadyForReview or PlanStatus.Failed),
-            Icebox: plans.Count(p => p.Status == PlanStatus.Icebox)
+            Icebox: plans.Count(p => p.Status == PlanStatus.Icebox),
+            Recommendations: recommendations.Count(r => r.State == "Pending")
         );
     }
 


### PR DESCRIPTION
# Summary

## Changes

Added a badge number to the Recommendations navigation item in the Tendril sidebar that displays the count of pending recommendations. The `PlanCounts` record was extended with a `Recommendations` field, computed from `PlanReaderService.GetRecommendations()`, and the badge dictionary in `TendrilAppShell.BuildMenuItems()` was updated to include the new count.

## API Changes

- `PlanCounts` record: added `int Recommendations` parameter (positional record constructor)

## Files Modified

- **Services/PlanCountsService.cs** — Added `Recommendations` field to `PlanCounts` record; added pending recommendations count calculation in `ComputeCounts()`
- **AppShell/TendrilAppShell.cs** — Added `["recommendations"]` entry to the badges dictionary in `BuildMenuItems()`

## Commits

- 13c74302 [01646] Add badge number for recommendations in sidebar