### PR TITLE
[01651] Wrap StackedProgress in box with padding

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/DashboardApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/DashboardApp.cs
@@ -133,7 +133,7 @@ public class DashboardApp : ViewBase
             .Width(Size.Full());
 
         var content = Layout.Vertical().Gap(2)
-            | projectProgress
+            | new Box(projectProgress).Padding(5)
             | dataTable
             | combinedChart;
 


### PR DESCRIPTION
# Summary

## Changes

Wrapped the `projectProgress` StackedProgress widget in a `Box` with 5 units of padding in the Tendril Dashboard, providing visual separation from surrounding elements.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Apps/DashboardApp.cs` — Wrapped `projectProgress` in `new Box(projectProgress).Padding(5)` on line 136

---

## Commits

- 0f85393b [01651] Wrap StackedProgress in Box with padding