### PR TITLE
[01650] Remove axis labels and grid from dashboard chart

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/DashboardApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/DashboardApp.cs
@@ -115,6 +115,7 @@ public class DashboardApp : ViewBase
                 style: BarChartStyles.Default,
                 polish: chart => chart with
                 {
+                    CartesianGrid = null,
                     Bars =
                     [
                         new Bar("Cost ($)").Radius(4).FillOpacity(0.8).YAxisIndex(0),
@@ -122,8 +123,8 @@ public class DashboardApp : ViewBase
                     ],
                     YAxis =
                     [
-                        new YAxis("Cost ($)").TickFormatter("C2"),
-                        new YAxis("Tokens").Orientation(YAxis.Orientations.Right),
+                        new YAxis("Cost ($)").TickFormatter("C2").Hide(),
+                        new YAxis("Tokens").Orientation(YAxis.Orientations.Right).Hide(),
                     ]
                 })
             .Dimension("Hour", e => e.Hour.ToString("MM/dd HH"))


### PR DESCRIPTION
# Summary

## Changes

Removed axis labels and grid lines from the dashboard's hourly cost & tokens bar chart in DashboardApp.cs. Both Y-axes (Cost and Tokens) are now hidden via `.Hide()`, and the CartesianGrid is set to `null` to remove grid lines.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Apps/DashboardApp.cs` — Updated chart polish function to hide Y-axes and remove CartesianGrid

## Commits

- 2e1b6939 [01650] Remove axis labels and grid from dashboard chart