### PR TITLE
[01652] Dashboard table has to be sorted by date and today needs to be on top

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/DashboardApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/DashboardApp.cs
@@ -68,7 +68,7 @@ public class DashboardApp : ViewBase
                 Cost = dayCost > 0 ? $"${dayCost:F2}" : "",
                 Tokens = dayTokens > 0 ? FormatTokens(dayTokens) : ""
             };
-        }).ToList();
+        }).OrderByDescending(r => r.SortDate).ToList();
 
         var dataTable = rows.AsQueryable()
             .ToDataTable(idSelector: t => t.SortDate)


### PR DESCRIPTION
# Summary

## Changes

Added explicit descending date sorting to the Dashboard's daily activity table. The rows are now sorted by `SortDate` (DateTime) in descending order before being rendered, ensuring "Today" appears at the top followed by "Yesterday" and then older dates in reverse chronological order.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Apps/DashboardApp.cs` — Added `.OrderByDescending(r => r.SortDate)` to the rows LINQ query (line 71)

## Commits

- 8d2161f0 [01652] Sort dashboard table by date descending with today on top