### PR TITLE
[01649] Make the logo 70% of its current size

### DIFF
--- a/src/tendril/Ivy.Tendril/Program.cs
+++ b/src/tendril/Ivy.Tendril/Program.cs
@@ -99,7 +99,7 @@ var version = typeof(TendrilAppShell).Assembly.GetName().Version!.ToString();
 var appShellSettings = new AppShellSettings()
     .Header(
         Layout.Horizontal(
-            new Image("/tendril/assets/Tendril.svg").Width(Size.Units(30)).Height(Size.Auto()),
+            new Image("/tendril/assets/Tendril.svg").Width(Size.Units(21)).Height(Size.Auto()),
             Text.Muted($"v{version}")
         ).Gap(2).Padding(2).AlignContent(Align.Left)
     )


### PR DESCRIPTION
# Summary

## Changes

Reduced the Tendril logo width in the app shell header from 30 units to 21 units (70% of original size). The aspect ratio is preserved via `Height(Size.Auto())`.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Program.cs` — Changed logo `Width(Size.Units(30))` to `Width(Size.Units(21))`

## Commits

- b4679d68 [01649] Reduce Tendril logo width from 30 to 21 units (70%)