### PR TITLE
[01653] Remove search and filtering on recommendations

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Recommendations/SidebarView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Recommendations/SidebarView.cs
@@ -5,43 +5,19 @@ namespace Ivy.Tendril.Apps.Recommendations;
 
 public class SidebarView(
     List<Recommendation> recommendations,
-    IState<Recommendation?> selectedState,
-    IState<string?> textFilter) : ViewBase
+    IState<Recommendation?> selectedState) : ViewBase
 {
     private readonly List<Recommendation> _recommendations = recommendations;
     private readonly IState<Recommendation?> _selectedState = selectedState;
-    private readonly IState<string?> _textFilter = textFilter;
-
-    public object BuildHeader()
-    {
-        return Layout.Vertical()
-            | _textFilter.ToSearchInput().Placeholder("Search recommendations...");
-    }
 
     public override object Build()
     {
-        var filtered = _recommendations.AsEnumerable();
-        if (!string.IsNullOrWhiteSpace(_textFilter.Value))
-        {
-            var search = _textFilter.Value.Trim();
-            filtered = filtered.Where(r =>
-                r.Title.Contains(search, StringComparison.OrdinalIgnoreCase) ||
-                r.Description.Contains(search, StringComparison.OrdinalIgnoreCase));
-        }
-
-        return new List(filtered.Select(rec =>
+        return new List(_recommendations.Select(rec =>
         {
             var clickableRec = rec;
-            var stateBadgeVariant = rec.State switch
-            {
-                "Accepted" => BadgeVariant.Success,
-                "Declined" => BadgeVariant.Destructive,
-                _ => BadgeVariant.Outline
-            };
 
             return new ListItem(rec.Title)
                 .Content(Layout.Horizontal().Gap(1)
-                    | new Badge(rec.State).Variant(stateBadgeVariant).Small()
                     | new Badge($"#{rec.PlanId}").Variant(BadgeVariant.Outline).Small()
                 )
                 .OnClick(() => _selectedState.Set(clickableRec));

--- a/src/tendril/Ivy.Tendril/Apps/RecommendationsApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/RecommendationsApp.cs
@@ -11,17 +11,13 @@ public class RecommendationsApp : ViewBase
     {
         var planService = UseService<PlanReaderService>();
         var refreshToken = UseRefreshToken();
-        var stateFilter = UseState<string?>(null);
         var selectedState = UseState<Recommendation?>(null);
-        var textFilter = UseState<string?>("");
 
         UseInterval(() => refreshToken.Refresh(), TimeSpan.FromMinutes(1));
 
         var recommendations = planService.GetRecommendations();
 
-        var filtered = stateFilter.Value is { } filter
-            ? recommendations.Where(r => r.State == filter).ToList()
-            : recommendations;
+        var filtered = recommendations.Where(r => r.State == "Pending").ToList();
 
         // If selected recommendation is no longer in filtered list, adjust selection
         if (selectedState.Value is { } selected && !filtered.Any(r => r.PlanId == selected.PlanId && r.Title == selected.Title))
@@ -31,36 +27,11 @@ public class RecommendationsApp : ViewBase
 
         void Refresh() => refreshToken.Refresh();
 
-        var pendingCount = recommendations.Count(r => r.State == "Pending");
-        var acceptedCount = recommendations.Count(r => r.State == "Accepted");
-        var declinedCount = recommendations.Count(r => r.State == "Declined");
-
-        var filterBar = Layout.Horizontal().Gap(2) | new object?[]
-        {
-            stateFilter.Value == null
-                ? (object)new Button($"All ({recommendations.Count})").OnClick(() => stateFilter.Set(null))
-                : new Button($"All ({recommendations.Count})").Ghost().OnClick(() => stateFilter.Set(null)),
-            stateFilter.Value == "Pending"
-                ? (object)new Button($"Pending ({pendingCount})").OnClick(() => stateFilter.Set("Pending"))
-                : new Button($"Pending ({pendingCount})").Ghost().OnClick(() => stateFilter.Set("Pending")),
-            stateFilter.Value == "Accepted"
-                ? (object)new Button($"Accepted ({acceptedCount})").OnClick(() => stateFilter.Set("Accepted"))
-                : new Button($"Accepted ({acceptedCount})").Ghost().OnClick(() => stateFilter.Set("Accepted")),
-            stateFilter.Value == "Declined"
-                ? (object)new Button($"Declined ({declinedCount})").OnClick(() => stateFilter.Set("Declined"))
-                : new Button($"Declined ({declinedCount})").Ghost().OnClick(() => stateFilter.Set("Declined"))
-        };
-
-        var sidebar = new Recommendations.SidebarView(filtered, selectedState, textFilter);
-
-        var sidebarHeader = Layout.Vertical().Gap(2)
-            | sidebar.BuildHeader()
-            | filterBar;
+        var sidebar = new Recommendations.SidebarView(filtered, selectedState);
 
         return new SidebarLayout(
             mainContent: new Recommendations.ContentView(selectedState.Value, filtered, selectedState, planService, Refresh),
-            sidebarContent: sidebar,
-            sidebarHeader: sidebarHeader
+            sidebarContent: sidebar
         );
     }
 }


### PR DESCRIPTION
# Summary

## Changes

Removed the state filter buttons (All/Pending/Accepted/Declined), text search input, and `BuildHeader()` method from the Recommendations app. The app now filters to only show pending recommendations, so accepted/declined items automatically disappear from the list.

## API Changes

- `SidebarView` constructor: removed `textFilter` parameter (`IState<string?>`)
- `SidebarView.BuildHeader()`: removed entirely
- `RecommendationsApp`: removed `stateFilter` and `textFilter` state variables; removed `sidebarHeader` from `SidebarLayout`

## Files Modified

- `src/tendril/Ivy.Tendril/Apps/RecommendationsApp.cs` — removed filter state, filter bar UI, and sidebar header
- `src/tendril/Ivy.Tendril/Apps/Recommendations/SidebarView.cs` — removed text filter parameter, `BuildHeader()`, and text search filtering logic; removed state badge from list items (since all items are now Pending)

## Commits

- c9344d3e [01653] Remove search and filtering on recommendations, show only pending