### PR TITLE
[01656] Add CTRL+ENTER shortcut to UpdatePlanDialog

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Plans/Dialogs/UpdatePlanDialog.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Plans/Dialogs/UpdatePlanDialog.cs
@@ -32,7 +32,7 @@ public class UpdatePlanDialog(
             ),
             new DialogFooter(
                 new Button("Cancel").Outline().OnClick(() => { _updateText.Set(""); _dialogOpen.Set(false); }),
-                new Button("Submit Update").Primary().OnClick(() =>
+                new Button("Submit Update").Primary().ShortcutKey("Ctrl+Enter").OnClick(() =>
                 {
                     if (!string.IsNullOrWhiteSpace(_updateText.Value))
                     {


### PR DESCRIPTION
# Summary

## Changes

Added `.ShortcutKey("Ctrl+Enter")` to the "Submit Update" button in `UpdatePlanDialog.cs`, matching the existing pattern from `CreatePlanDialog.cs`. Users can now press CTRL+ENTER to submit update instructions instead of clicking the button.

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/Apps/Plans/Dialogs/UpdatePlanDialog.cs** — Added ShortcutKey to submit button

---

## Commits

- 323173c6 [01656] Add CTRL+ENTER shortcut to UpdatePlanDialog submit button