### PR TITLE
[01655] Cache or optimize recommendations count

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/RecommendationServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/RecommendationServiceTests.cs
@@ -116,4 +116,39 @@ public class RecommendationServiceTests : IDisposable
     {
         _service.UpdateRecommendationState("99999-DoesNotExist", "Title", "Accepted");
     }
+
+    [Fact]
+    public void GetPendingRecommendationsCount_MatchesFullDeserializationCount()
+    {
+        var yaml1 = "- title: Pending item\n  description: Needs work\n  state: Pending\n- title: Accepted item\n  description: Done\n  state: Accepted\n";
+        var yaml2 = "- title: No state item\n  description: Defaults to Pending\n";
+        CreatePlanWithRecommendations("01610-CountTest1", yaml1);
+        CreatePlanWithRecommendations("01611-CountTest2", yaml2);
+
+        var countOnly = _service.GetPendingRecommendationsCount();
+        var fullList = _service.GetRecommendations();
+        var fullListCount = fullList.Count(r => r.State == "Pending");
+
+        Assert.Equal(fullListCount, countOnly);
+        Assert.Equal(2, countOnly);
+    }
+
+    [Fact]
+    public void GetPendingRecommendationsCount_ReturnsZero_WhenNoPendingItems()
+    {
+        var yaml = "- title: Accepted item\n  description: Done\n  state: Accepted\n- title: Declined item\n  description: Nope\n  state: Declined\n";
+        CreatePlanWithRecommendations("01612-NoPending", yaml);
+
+        var count = _service.GetPendingRecommendationsCount();
+
+        Assert.Equal(0, count);
+    }
+
+    [Fact]
+    public void GetPendingRecommendationsCount_ReturnsZero_WhenNoRecommendationFiles()
+    {
+        var count = _service.GetPendingRecommendationsCount();
+
+        Assert.Equal(0, count);
+    }
 }

--- a/src/tendril/Ivy.Tendril/Services/PlanCountsService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanCountsService.cs
@@ -44,13 +44,12 @@ public class PlanCountsService : IDisposable
     {
         var plans = _planReaderService.GetPlans();
         var jobs = _jobService.GetJobs();
-        var recommendations = _planReaderService.GetRecommendations();
         return new PlanCounts(
             Drafts: plans.Count(p => p.Status == PlanStatus.Draft),
             RunningJobs: jobs.Count(j => j.Status == "Running"),
             Reviews: plans.Count(p => p.Status is PlanStatus.ReadyForReview or PlanStatus.Failed),
             Icebox: plans.Count(p => p.Status == PlanStatus.Icebox),
-            Recommendations: recommendations.Count(r => r.State == "Pending")
+            Recommendations: _planReaderService.GetPendingRecommendationsCount()
         );
     }
 

--- a/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
@@ -539,6 +539,39 @@ public class PlanReaderService(ConfigService config)
         return recommendations.OrderByDescending(r => r.Date).ToList();
     }
 
+    public int GetPendingRecommendationsCount()
+    {
+        if (!Directory.Exists(PlansDirectory)) return 0;
+
+        var count = 0;
+
+        foreach (var dir in Directory.GetDirectories(PlansDirectory))
+        {
+            var recommendationsPath = Path.Combine(dir, "artifacts", "recommendations.yaml");
+            if (!File.Exists(recommendationsPath)) continue;
+
+            try
+            {
+                var yaml = File.ReadAllText(recommendationsPath);
+                var items = YamlDeserializer.Deserialize<List<RecommendationYaml>>(yaml);
+                if (items == null) continue;
+
+                foreach (var item in items)
+                {
+                    var state = string.IsNullOrWhiteSpace(item.State) ? "Pending" : item.State;
+                    if (state.Equals("Pending", StringComparison.OrdinalIgnoreCase))
+                        count++;
+                }
+            }
+            catch
+            {
+                // Skip malformed YAML files
+            }
+        }
+
+        return count;
+    }
+
     public void UpdateRecommendationState(string planFolderName, string recommendationTitle, string newState)
     {
         var recommendationsPath = Path.Combine(PlansDirectory, planFolderName, "artifacts", "recommendations.yaml");


### PR DESCRIPTION
# Summary

## Changes

Added a lightweight `GetPendingRecommendationsCount()` method to `PlanReaderService` that reads `recommendations.yaml` files directly from disk without calling `GetPlans()`, avoiding the expensive full plan deserialization on every refresh. Updated `PlanCountsService.ComputeCounts()` to use this new method instead of `GetRecommendations()`.

## API Changes

- Added `PlanReaderService.GetPendingRecommendationsCount()` — returns `int` count of pending recommendations by reading YAML files directly from the plans directory.

## Files Modified

- **Services/PlanReaderService.cs** — Added `GetPendingRecommendationsCount()` method that iterates plan directories directly and counts pending recommendations using YAML deserialization without full plan loading.
- **Services/PlanCountsService.cs** — Replaced `GetRecommendations()` call with `GetPendingRecommendationsCount()` in `ComputeCounts()`, removing the unnecessary full recommendation list allocation.
- **Ivy.Tendril.Test/RecommendationServiceTests.cs** — Added 3 tests: count matches full deserialization, returns zero when no pending items, returns zero when no recommendation files exist.

## Commits

- 3ea63753299f4df5f7063b03a1031fc53e952fbc [01655] Optimize recommendations count with lightweight method