### PR TITLE
[01644] Remove project and level badges from Draft and Review plans

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Plans/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Plans/ContentView.cs
@@ -94,10 +94,6 @@ public class ContentView(
 
         var header = Layout.Horizontal().Width(Size.Full()).Padding(1).Gap(2)
             | Text.Block($"#{_selectedPlan.Id} {_selectedPlan.Title}").Bold();
-        if (_selectedPlan.Status != PlanStatus.Draft)
-            header |= new Badge(_selectedPlan.Status.ToString()).Variant(_selectedPlan.Status == PlanStatus.Failed ? BadgeVariant.Destructive : BadgeVariant.Outline);
-        header |= new Badge(_selectedPlan.Project).Variant(BadgeVariant.Outline).WithProjectColor(_config, _selectedPlan.Project);
-        header |= new Badge(_selectedPlan.Level).Variant(_config.GetBadgeVariant(_selectedPlan.Level));
         header |= Text.Muted($"rev:{_selectedPlan.RevisionCount}");
 
         if (_selectedPlan.DependsOn.Count > 0)


### PR DESCRIPTION
# Summary

## Changes

Removed all badges (Status, Project, Level) from the plan detail header in ContentView.cs for all plan statuses. Badges remain visible in the sidebar. This addresses feedback that badges in the header are redundant since they're already shown in the sidebar.

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/Apps/Plans/ContentView.cs** — Deleted 4 lines that added Status, Project, and Level badges to the header layout.

## Commits

- 453ba6cc [01644] Remove all badges from plan header for all statuses