### PR TITLE
[01659] Fix Slack hook PR formatting

### DIFF
--- a/src/tendril/Ivy.Tendril.TeamIvyConfig/Hooks/NotifySlack.ps1
+++ b/src/tendril/Ivy.Tendril.TeamIvyConfig/Hooks/NotifySlack.ps1
@@ -35,7 +35,7 @@ if ($planContent -match "(?m)^project:\s*(.+)$") {
 
 # Parse PRs
 $prs = @()
-if ($planContent -match "(?ms)^prs:\s*\n((?:- .+\n?)*?)(?=\n\w+:|$)") {
+if ($planContent -match "(?m)^prs:\s*\n((?:- .+\n)*?)(?=\w+:|$)") {
     $prs = [regex]::Matches($Matches[1], "- (.+)") | ForEach-Object { $_.Groups[1].Value.Trim() }
 }
 


### PR DESCRIPTION
# Summary

## Changes

Fixed the regex in NotifySlack.ps1 that parses the `prs:` section from plan.yaml. The lookahead was failing to stop at the next YAML key (`commits:`, `verifications:`), causing commit hashes and verification names to be included in the Slack PR field.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril.TeamIvyConfig/Hooks/NotifySlack.ps1` — Fixed PR-parsing regex lookahead on line 38

## Commits

- 2b32b247 [01659] Fix Slack hook PR regex lookahead to stop at next YAML key