### PR TITLE
(docs): give instructions for common ivy command not found on Mac issue

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/01_Onboarding/01_GettingStarted/02_Installation.md
+++ b/src/Ivy.Docs.Shared/Docs/01_Onboarding/01_GettingStarted/02_Installation.md
@@ -114,22 +114,22 @@ The primary Ivy Framework package is installed via NuGet and provides the founda
 >dotnet add package Ivy
 ```
 
-| Component | Description |
-| :--- | :--- |
-| **Core Framework** | High-performance server-side engine and application system |
-| **Widget System** | Library of strongly-typed UI components (Shadcn/Tailwind) |
-| **SignalR Hub** | Real-time state synchronization between C# and React |
-| **Embedded Assets** | Pre-built frontend bundle embedded in the DLL |
-| **Auth Interfaces** | extensible framework for security and identity |
+| Component           | Description                                                |
+| :------------------ | :--------------------------------------------------------- |
+| **Core Framework**  | High-performance server-side engine and application system |
+| **Widget System**   | Library of strongly-typed UI components (Shadcn/Tailwind)  |
+| **SignalR Hub**     | Real-time state synchronization between C# and React       |
+| **Embedded Assets** | Pre-built frontend bundle embedded in the DLL              |
+| **Auth Interfaces** | extensible framework for security and identity             |
 
 Extend Ivy's functionality with official extension packages for authentication and data management.
 
-| Package | Purpose |
-| :--- | :--- |
-| `Ivy.Auth.Supabase` | Identity management via [Supabase](../03_CLI/04_Authentication/02_Supabase.md) |
-| `Ivy.Auth.Authelia` | Single Sign-On and 2FA via [Authelia](../03_CLI/04_Authentication/02_Authelia.md) |
-| `Ivy.Auth.Entra` | Microsoft [Entra](../03_CLI/04_Authentication/02_MicrosoftEntra.md) ID (Azure AD) integration |
-| `Ivy.Database.Generator.Toolkit` | Utilities for AI-powered schema and code generation |
+| Package                          | Purpose                                                                                       |
+| :------------------------------- | :-------------------------------------------------------------------------------------------- |
+| `Ivy.Auth.Supabase`              | Identity management via [Supabase](../03_CLI/04_Authentication/02_Supabase.md)                |
+| `Ivy.Auth.Authelia`              | Single Sign-On and 2FA via [Authelia](../03_CLI/04_Authentication/02_Authelia.md)             |
+| `Ivy.Auth.Entra`                 | Microsoft [Entra](../03_CLI/04_Authentication/02_MicrosoftEntra.md) ID (Azure AD) integration |
+| `Ivy.Database.Generator.Toolkit` | Utilities for AI-powered schema and code generation                                           |
 
 ```terminal
 >dotnet add package Ivy.Auth.Supabase
@@ -148,12 +148,12 @@ The Ivy package abstracts away several modern technologies to provide its seamle
 
 A standard Ivy project follows a clean, flattened structure designed for clarity.
 
-| File/Folder | Description |
-| :--- | :--- |
-| **`Project.csproj`** | Matches the .NET 10.0 target and contains Ivy references |
-| **`Program.cs`** | The entry point where you configure and run the Ivy server |
-| **`Apps/`** | Where your Views and business logic reside |
-| **`Assets/`** | Optional static files (images, custom CSS) |
+| File/Folder          | Description                                                |
+| :------------------- | :--------------------------------------------------------- |
+| **`Project.csproj`** | Matches the .NET 10.0 target and contains Ivy references   |
+| **`Program.cs`**     | The entry point where you configure and run the Ivy server |
+| **`Apps/`**          | Where your Views and business logic reside                 |
+| **`Assets/`**        | Optional static files (images, custom CSS)                 |
 
 ### Multi-Project Solutions
 
@@ -173,10 +173,22 @@ For detailed server configuration options, including `ServerArgs` properties and
 
 The server automatically optimizes its behavior based on the current environment.
 
-| Feature | Development | Production |
-| :--- | :--- | :--- |
-| **Hot Reload** | Enabled (instant UI updates) | Disabled (optimized performance) |
-| **Error Handling** | Detailed stack traces | Secure, logged exceptions |
-| **Caching** | Disabled for immediate changes | Aggressive ETag & compression |
-| **Logging** | Debug & Information | Warning & Error only |
-| **Port Management** | Conflict detection & auto-shift | Strict port binding |
+| Feature             | Development                     | Production                       |
+| :------------------ | :------------------------------ | :------------------------------- |
+| **Hot Reload**      | Enabled (instant UI updates)    | Disabled (optimized performance) |
+| **Error Handling**  | Detailed stack traces           | Secure, logged exceptions        |
+| **Caching**         | Disabled for immediate changes  | Aggressive ETag & compression    |
+| **Logging**         | Debug & Information             | Warning & Error only             |
+| **Port Management** | Conflict detection & auto-shift | Strict port binding              |
+
+### Troubleshooting "command not found"
+
+If you have installed the tool but receive a `command not found: ivy` error, you likely need to add the .NET global tools directory to your system's PATH.
+
+For macOS (using the default Zsh shell), add the following line to your `~/.zshrc` file:
+
+```bash
+export PATH="$PATH:$HOME/.dotnet/tools"
+```
+
+After adding the line, restart your terminal or run `source ~/.zshrc` to apply the changes.

--- a/src/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/01_CLIOverview.md
+++ b/src/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/01_CLIOverview.md
@@ -95,6 +95,10 @@ See [Program](../02_Concepts/01_Program.md) for the entry point, [Apps](../02_Co
 
 Most Ivy commands require authentication. Use `ivy login` to authenticate with your Ivy account.
 
+<Callout Type="tip">
+On macOS, if you get a `command not found: ivy` error, you likely need to add the .NET tools directory to your PATH by adding `export PATH="$PATH:$HOME/.dotnet/tools"` to your `~/.zshrc`.
+</Callout>
+
 ## Next Steps
 
 1. **Initialize a project**: `ivy init`


### PR DESCRIPTION
## Installation.md

<img width="2076" height="1231" alt="image" src="https://github.com/user-attachments/assets/9fd0933d-5f47-4935-ae28-da633f9304d7" />

## CLIOverview.md

<img width="1971" height="1216" alt="image" src="https://github.com/user-attachments/assets/5a69132b-83cc-42b6-a65e-375bb10b8b1f" />
