### PR TITLE
[01663] Audit and migrate YAML regex parsing in PowerShell scripts

### DIFF
--- a/src/tendril/Ivy.Tendril.TeamIvyConfig/Hooks/CleanupWorktrees.ps1
+++ b/src/tendril/Ivy.Tendril.TeamIvyConfig/Hooks/CleanupWorktrees.ps1
@@ -10,6 +10,12 @@ param(
 
 $ErrorActionPreference = "Continue"
 
+# Ensure powershell-yaml is available
+if (-not (Get-Module -ListAvailable -Name powershell-yaml)) {
+    Install-Module -Name powershell-yaml -Force -Scope CurrentUser
+}
+Import-Module powershell-yaml
+
 # Resolve plans directory
 $tendrilHome = $env:TENDRIL_HOME
 if (-not $tendrilHome) {
@@ -38,16 +44,15 @@ foreach ($planFolder in $planFolders) {
     if (-not (Test-Path $planYamlPath)) { continue }
 
     $planContent = Get-Content $planYamlPath -Raw
+    $yaml = $planContent | ConvertFrom-Yaml
 
     # Check state
-    $stateMatch = [regex]::Match($planContent, '(?m)^state:\s*(.+)$')
-    $state = if ($stateMatch.Success) { $stateMatch.Groups[1].Value.Trim() } else { "Unknown" }
+    $state = if ($yaml.state) { $yaml.state } else { "Unknown" }
     if ($state -notin $terminalStates) { continue }
 
     # Check age (use updated timestamp)
-    $updatedMatch = [regex]::Match($planContent, '(?m)^updated:\s*(.+)$')
-    if ($updatedMatch.Success) {
-        $updated = [datetime]::Parse($updatedMatch.Groups[1].Value.Trim())
+    if ($yaml.updated) {
+        $updated = [datetime]::Parse("$($yaml.updated)")
         if ($updated -gt $cutoffDate) { continue }
     }
 
@@ -55,12 +60,15 @@ foreach ($planFolder in $planFolders) {
     $planId = if ($planFolder.Name -match '^(\d+)') { $Matches[1] } else { "" }
 
     # Extract repo paths
-    $repoMatches = [regex]::Matches($planContent, '(?m)^\s*-\s*((?:[A-Za-z]:\\|/).+)$')
     $repoPaths = @()
-    foreach ($m in $repoMatches) {
-        $p = $m.Groups[1].Value.Trim()
-        $p = [Environment]::ExpandEnvironmentVariables($p)
-        if (Test-Path $p) { $repoPaths += $p }
+    if ($yaml.repos) {
+        foreach ($repo in $yaml.repos) {
+            $p = if ($repo -is [hashtable] -or $repo -is [System.Collections.IDictionary]) { $repo.path } else { "$repo" }
+            if ($p) {
+                $p = [Environment]::ExpandEnvironmentVariables($p)
+                if (Test-Path $p) { $repoPaths += $p }
+            }
+        }
     }
 
     Write-Host "Cleaning plan $($planFolder.Name) (state: $state)" -ForegroundColor Cyan

--- a/src/tendril/Ivy.Tendril/.promptwares/.shared/Utils.ps1
+++ b/src/tendril/Ivy.Tendril/.promptwares/.shared/Utils.ps1
@@ -19,6 +19,12 @@ if (-not $env:TENDRIL_HOME) {
 $script:ConfigPath = Join-Path $env:TENDRIL_HOME "config.yaml"
 $script:PlansDir = Join-Path $env:TENDRIL_HOME "Plans"
 
+# Ensure powershell-yaml is available
+if (-not (Get-Module -ListAvailable -Name powershell-yaml)) {
+    Install-Module -Name powershell-yaml -Force -Scope CurrentUser
+}
+Import-Module powershell-yaml
+
 function GetProgramFolder {
     param([string]$ScriptPath)
 
@@ -127,9 +133,11 @@ function UpdatePlanState {
 
     $content = Get-Content $planYamlPath -Raw
     $now = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
-    $content = $content -replace '(?m)^state:\s*.*$', "state: $NewState"
-    $content = $content -replace '(?m)^updated:\s*.*$', "updated: $now"
-    Set-Content -Path $planYamlPath -Value $content -Encoding UTF8
+    $yaml = $content | ConvertFrom-Yaml -Ordered
+    $yaml["state"] = $NewState
+    $yaml["updated"] = $now
+    $content = ConvertTo-Yaml $yaml
+    Set-Content -Path $planYamlPath -Value $content -NoNewline -Encoding UTF8
     Write-Host "Plan state updated to: $NewState" -ForegroundColor Cyan
 }
 
@@ -208,9 +216,9 @@ function ReadPlanProject {
     param([string]$PlanYamlPath)
 
     $content = Get-Content $PlanYamlPath -Raw
-    $match = [regex]::Match($content, '(?m)^project:\s*(.+)$')
-    $project = if ($match.Success) { $match.Groups[1].Value.Trim() } else { "[Auto]" }
-    return @{ Content = $content; Project = $project }
+    $yaml = $content | ConvertFrom-Yaml
+    $project = if ($yaml.project) { $yaml.project } else { "[Auto]" }
+    return @{ Content = $content; Project = $project; Yaml = $yaml }
 }
 
 function GetProjectWorkDir {
@@ -218,20 +226,13 @@ function GetProjectWorkDir {
 
     if (Test-Path $script:ConfigPath) {
         try {
-            $yaml = Get-Content $script:ConfigPath -Raw
-            # Match the project block and extract the first repo path
-            $pattern = "(?s)- name:\s*$([regex]::Escape($Project))\s+repos:\s*\n((?:\s+-.+\n?)+)"
-            $match = [regex]::Match($yaml, $pattern)
-            if ($match.Success) {
-                # Try new format: - path: D:\...
-                $pathLine = [regex]::Match($match.Groups[1].Value, '(?m)path:\s*(.+)$')
-                if ($pathLine.Success) {
-                    return $pathLine.Groups[1].Value.Trim()
-                }
-                # Fallback: old format - D:\...
-                $repoLine = [regex]::Match($match.Groups[1].Value, '^\s+-\s*(.+)$', [System.Text.RegularExpressions.RegexOptions]::Multiline)
-                if ($repoLine.Success) {
-                    return $repoLine.Groups[1].Value.Trim()
+            $config = Get-Content $script:ConfigPath -Raw | ConvertFrom-Yaml
+            $projectEntry = $config.projects | Where-Object { $_.name -eq $Project } | Select-Object -First 1
+            if ($projectEntry -and $projectEntry.repos -and $projectEntry.repos.Count -gt 0) {
+                $repo = $projectEntry.repos[0]
+                $path = if ($repo -is [hashtable] -or $repo -is [System.Collections.IDictionary]) { $repo.path } else { "$repo" }
+                if ($path) {
+                    return [Environment]::ExpandEnvironmentVariables($path)
                 }
             }
         }
@@ -373,16 +374,7 @@ function GetAgentCommandFromConfig {
 
     if (Test-Path $configPath) {
         try {
-            $yaml = Get-Content $configPath -Raw
-            # Regex match as first pass or fallback
-            $pattern = "(?m)^agentCommand:\s*(.+)$"
-            $match = [regex]::Match($yaml, $pattern)
-            if ($match.Success) {
-                $raw = $match.Groups[1].Value.Trim()
-            }
-
-            # Parse config with ConvertFrom-Yaml for structured access
-            $config = $yaml | ConvertFrom-Yaml
+            $config = Get-Content $configPath -Raw | ConvertFrom-Yaml
 
             if ($config.agentCommand) {
                 $raw = $config.agentCommand

--- a/src/tendril/Ivy.Tendril/.promptwares/CleanupPlan.ps1
+++ b/src/tendril/Ivy.Tendril/.promptwares/CleanupPlan.ps1
@@ -9,8 +9,7 @@ $planYamlPath = ValidatePlanPath $PlanPath
 $planInfo = ReadPlanProject $planYamlPath
 
 # Check plan state
-$stateMatch = [regex]::Match($planInfo.Content, '(?m)^state:\s*(.+)$')
-$currentState = if ($stateMatch.Success) { $stateMatch.Groups[1].Value.Trim() } else { "Unknown" }
+$currentState = if ($planInfo.Yaml.state) { $planInfo.Yaml.state } else { "Unknown" }
 
 $terminalStates = @("Completed", "Failed", "Skipped", "Icebox")
 if ($currentState -notin $terminalStates) {
@@ -30,13 +29,15 @@ $planFolderName = Split-Path $PlanPath -Leaf
 $planId = if ($planFolderName -match '^(\d+)') { $Matches[1] } else { "" }
 
 # Extract repo paths from plan.yaml
-$repoMatches = [regex]::Matches($planInfo.Content, '(?m)^\s*-\s*((?:[A-Za-z]:\\|/).+)$')
 $repoPaths = @()
-foreach ($m in $repoMatches) {
-    $p = $m.Groups[1].Value.Trim()
-    # Expand %REPOS_HOME% if present
-    $p = [Environment]::ExpandEnvironmentVariables($p)
-    if (Test-Path $p) { $repoPaths += $p }
+if ($planInfo.Yaml.repos) {
+    foreach ($repo in $planInfo.Yaml.repos) {
+        $p = if ($repo -is [hashtable] -or $repo -is [System.Collections.IDictionary]) { $repo.path } else { "$repo" }
+        if ($p) {
+            $p = [Environment]::ExpandEnvironmentVariables($p)
+            if (Test-Path $p) { $repoPaths += $p }
+        }
+    }
 }
 
 $worktreeDirs = Get-ChildItem -Path $worktreesDir -Directory -ErrorAction SilentlyContinue

--- a/src/tendril/Ivy.Tendril/.promptwares/ExecutePlan.ps1
+++ b/src/tendril/Ivy.Tendril/.promptwares/ExecutePlan.ps1
@@ -10,8 +10,7 @@ $planYamlPath = ValidatePlanPath $PlanPath
 $planInfo = ReadPlanProject $planYamlPath
 
 # Verify plan is in Building state
-$stateMatch = [regex]::Match($planInfo.Content, '(?m)^state:\s*(.+)$')
-$currentState = if ($stateMatch.Success) { $stateMatch.Groups[1].Value.Trim() } else { "Unknown" }
+$currentState = if ($planInfo.Yaml.state) { $planInfo.Yaml.state } else { "Unknown" }
 
 if ($currentState -ne "Building") {
     Write-Host "Plan is not in Building state (current: $currentState): $PlanPath" -ForegroundColor Red
@@ -84,9 +83,12 @@ try {
         WritePlanLog $PlanPath "ExecutePlan" $summary
 
         # Check verification statuses before transitioning
-        $planYaml = Get-Content (Join-Path $PlanPath "plan.yaml") -Raw
-        $verificationStatuses = [regex]::Matches($planYaml, '(?m)^\s+status:\s*(.+)$') |
-        ForEach-Object { $_.Groups[1].Value.Trim() }
+        $planYamlContent = Get-Content (Join-Path $PlanPath "plan.yaml") -Raw
+        $planYamlParsed = $planYamlContent | ConvertFrom-Yaml
+        $verificationStatuses = @()
+        if ($planYamlParsed.verifications) {
+            $verificationStatuses = $planYamlParsed.verifications | ForEach-Object { $_.status }
+        }
 
         $hasFailed = $verificationStatuses | Where-Object { $_ -eq "Fail" }
         $hasPending = $verificationStatuses | Where-Object { $_ -eq "Pending" }


### PR DESCRIPTION
# Summary

## Changes

Migrated all remaining PowerShell scripts from brittle regex-based YAML parsing (`(?m)^key:\s*(.+)$`) to proper `ConvertFrom-Yaml` structured parsing via the `powershell-yaml` module. This covers 4 scripts with a total of 10 regex patterns replaced. Added `powershell-yaml` module availability checks and imports.

## API Changes

- `ReadPlanProject` (Utils.ps1) now returns an additional `Yaml` property in its return hashtable containing the parsed YAML object, alongside the existing `Content` and `Project` properties.
- `UpdatePlanState` (Utils.ps1) now uses `ConvertFrom-Yaml`/`ConvertTo-Yaml` roundtrip instead of regex replace, which may produce slightly different YAML formatting.
- `GetProjectWorkDir` (Utils.ps1) now uses `ConvertFrom-Yaml` to parse `config.yaml` and supports `%ENVVAR%` expansion on repo paths.
- `GetAgentCommandFromConfig` (Utils.ps1) removed regex fallback for `agentCommand` — now relies solely on `ConvertFrom-Yaml`.

## Files Modified

- **Utils.ps1** (`src/tendril/Ivy.Tendril/.promptwares/.shared/Utils.ps1`) — Added `powershell-yaml` import; refactored `UpdatePlanState`, `ReadPlanProject`, `GetProjectWorkDir`, and `GetAgentCommandFromConfig`
- **CleanupWorktrees.ps1** (`src/tendril/Ivy.Tendril.TeamIvyConfig/Hooks/CleanupWorktrees.ps1`) — Added module import; replaced state/updated/repos regex parsing
- **CleanupPlan.ps1** (`src/tendril/Ivy.Tendril/.promptwares/CleanupPlan.ps1`) — Replaced state and repos regex parsing with `$planInfo.Yaml` access
- **ExecutePlan.ps1** (`src/tendril/Ivy.Tendril/.promptwares/ExecutePlan.ps1`) — Replaced state regex and verification status regex with `ConvertFrom-Yaml`

## Commits

- bf2360ee [01663] Migrate YAML regex parsing to ConvertFrom-Yaml in PowerShell scripts