### PR TITLE
[01664] Migrate regex YAML parsing to ConvertFrom-Yaml in hook scripts

### DIFF
--- a/src/tendril/Ivy.Tendril.TeamIvyConfig/Hooks/CleanupWorktrees.ps1
+++ b/src/tendril/Ivy.Tendril.TeamIvyConfig/Hooks/CleanupWorktrees.ps1
@@ -38,16 +38,15 @@ foreach ($planFolder in $planFolders) {
     if (-not (Test-Path $planYamlPath)) { continue }
 
     $planContent = Get-Content $planYamlPath -Raw
+    $plan = $planContent | ConvertFrom-Yaml
 
     # Check state
-    $stateMatch = [regex]::Match($planContent, '(?m)^state:\s*(.+)$')
-    $state = if ($stateMatch.Success) { $stateMatch.Groups[1].Value.Trim() } else { "Unknown" }
+    $state = if ($plan.state) { $plan.state } else { "Unknown" }
     if ($state -notin $terminalStates) { continue }
 
     # Check age (use updated timestamp)
-    $updatedMatch = [regex]::Match($planContent, '(?m)^updated:\s*(.+)$')
-    if ($updatedMatch.Success) {
-        $updated = [datetime]::Parse($updatedMatch.Groups[1].Value.Trim())
+    if ($plan.updated) {
+        $updated = [datetime]::Parse($plan.updated)
         if ($updated -gt $cutoffDate) { continue }
     }
 
@@ -55,11 +54,9 @@ foreach ($planFolder in $planFolders) {
     $planId = if ($planFolder.Name -match '^(\d+)') { $Matches[1] } else { "" }
 
     # Extract repo paths
-    $repoMatches = [regex]::Matches($planContent, '(?m)^\s*-\s*((?:[A-Za-z]:\\|/).+)$')
     $repoPaths = @()
-    foreach ($m in $repoMatches) {
-        $p = $m.Groups[1].Value.Trim()
-        $p = [Environment]::ExpandEnvironmentVariables($p)
+    foreach ($repo in $plan.repos) {
+        $p = [Environment]::ExpandEnvironmentVariables($repo)
         if (Test-Path $p) { $repoPaths += $p }
     }
 

--- a/src/tendril/Ivy.Tendril/.promptwares/.shared/Utils.ps1
+++ b/src/tendril/Ivy.Tendril/.promptwares/.shared/Utils.ps1
@@ -208,8 +208,8 @@ function ReadPlanProject {
     param([string]$PlanYamlPath)
 
     $content = Get-Content $PlanYamlPath -Raw
-    $match = [regex]::Match($content, '(?m)^project:\s*(.+)$')
-    $project = if ($match.Success) { $match.Groups[1].Value.Trim() } else { "[Auto]" }
+    $plan = $content | ConvertFrom-Yaml
+    $project = if ($plan.project) { $plan.project } else { "[Auto]" }
     return @{ Content = $content; Project = $project }
 }
 
@@ -374,13 +374,6 @@ function GetAgentCommandFromConfig {
     if (Test-Path $configPath) {
         try {
             $yaml = Get-Content $configPath -Raw
-            # Regex match as first pass or fallback
-            $pattern = "(?m)^agentCommand:\s*(.+)$"
-            $match = [regex]::Match($yaml, $pattern)
-            if ($match.Success) {
-                $raw = $match.Groups[1].Value.Trim()
-            }
-
             # Parse config with ConvertFrom-Yaml for structured access
             $config = $yaml | ConvertFrom-Yaml
 

--- a/src/tendril/Ivy.Tendril/.promptwares/CleanupPlan.ps1
+++ b/src/tendril/Ivy.Tendril/.promptwares/CleanupPlan.ps1
@@ -9,8 +9,8 @@ $planYamlPath = ValidatePlanPath $PlanPath
 $planInfo = ReadPlanProject $planYamlPath
 
 # Check plan state
-$stateMatch = [regex]::Match($planInfo.Content, '(?m)^state:\s*(.+)$')
-$currentState = if ($stateMatch.Success) { $stateMatch.Groups[1].Value.Trim() } else { "Unknown" }
+$plan = $planInfo.Content | ConvertFrom-Yaml
+$currentState = if ($plan.state) { $plan.state } else { "Unknown" }
 
 $terminalStates = @("Completed", "Failed", "Skipped", "Icebox")
 if ($currentState -notin $terminalStates) {
@@ -30,12 +30,9 @@ $planFolderName = Split-Path $PlanPath -Leaf
 $planId = if ($planFolderName -match '^(\d+)') { $Matches[1] } else { "" }
 
 # Extract repo paths from plan.yaml
-$repoMatches = [regex]::Matches($planInfo.Content, '(?m)^\s*-\s*((?:[A-Za-z]:\\|/).+)$')
 $repoPaths = @()
-foreach ($m in $repoMatches) {
-    $p = $m.Groups[1].Value.Trim()
-    # Expand %REPOS_HOME% if present
-    $p = [Environment]::ExpandEnvironmentVariables($p)
+foreach ($repo in $plan.repos) {
+    $p = [Environment]::ExpandEnvironmentVariables($repo)
     if (Test-Path $p) { $repoPaths += $p }
 }
 

--- a/src/tendril/Ivy.Tendril/.promptwares/ExecutePlan.ps1
+++ b/src/tendril/Ivy.Tendril/.promptwares/ExecutePlan.ps1
@@ -10,8 +10,8 @@ $planYamlPath = ValidatePlanPath $PlanPath
 $planInfo = ReadPlanProject $planYamlPath
 
 # Verify plan is in Building state
-$stateMatch = [regex]::Match($planInfo.Content, '(?m)^state:\s*(.+)$')
-$currentState = if ($stateMatch.Success) { $stateMatch.Groups[1].Value.Trim() } else { "Unknown" }
+$plan = $planInfo.Content | ConvertFrom-Yaml
+$currentState = if ($plan.state) { $plan.state } else { "Unknown" }
 
 if ($currentState -ne "Building") {
     Write-Host "Plan is not in Building state (current: $currentState): $PlanPath" -ForegroundColor Red
@@ -85,8 +85,8 @@ try {
 
         # Check verification statuses before transitioning
         $planYaml = Get-Content (Join-Path $PlanPath "plan.yaml") -Raw
-        $verificationStatuses = [regex]::Matches($planYaml, '(?m)^\s+status:\s*(.+)$') |
-        ForEach-Object { $_.Groups[1].Value.Trim() }
+        $planData = $planYaml | ConvertFrom-Yaml
+        $verificationStatuses = $planData.verifications | ForEach-Object { $_.status }
 
         $hasFailed = $verificationStatuses | Where-Object { $_ -eq "Fail" }
         $hasPending = $verificationStatuses | Where-Object { $_ -eq "Pending" }


### PR DESCRIPTION
# Summary

## Changes

Replaced regex-based YAML field extraction (`[regex]::Match` / `[regex]::Matches`) with proper `ConvertFrom-Yaml` cmdlet usage across 4 PowerShell scripts. Regex-based `-replace` for in-place YAML text updates (UpdatePlanState) and non-YAML pattern matching (UpdatePlan.ps1 `>>` marker) were correctly preserved.

## API Changes

None.

## Files Modified

- **Hooks/CleanupWorktrees.ps1** — Replaced 3 regex instances (state, updated, repos extraction) with `ConvertFrom-Yaml` property access
- **.promptwares/CleanupPlan.ps1** — Replaced 2 regex instances (state, repos extraction)
- **.promptwares/.shared/Utils.ps1** — Replaced `ReadPlanProject` regex with `ConvertFrom-Yaml`; removed redundant regex fallback in `GetAgentCommandFromConfig`
- **.promptwares/ExecutePlan.ps1** — Replaced state check regex and verification status extraction regex

## Commits

- eb4ad1d7 [01664] Replace regex YAML parsing with ConvertFrom-Yaml in hook scripts