### PR TITLE
[01669] Create shared PowerShell module bootstrap script

### DIFF
--- a/src/tendril/Ivy.Tendril.TeamIvyConfig/Hooks/CleanupWorktrees.ps1
+++ b/src/tendril/Ivy.Tendril.TeamIvyConfig/Hooks/CleanupWorktrees.ps1
@@ -10,11 +10,9 @@ param(
 
 $ErrorActionPreference = "Continue"
 
-# Ensure powershell-yaml is available
-if (-not (Get-Module -ListAvailable -Name powershell-yaml)) {
-    Install-Module -Name powershell-yaml -Force -Scope CurrentUser
-}
-Import-Module powershell-yaml
+# Bootstrap required PowerShell modules
+$sharedPath = Join-Path (Split-Path (Split-Path $PSScriptRoot)) "Ivy.Tendril/.promptwares/.shared"
+. (Join-Path $sharedPath "Bootstrap-Modules.ps1")
 
 # Resolve plans directory
 $tendrilHome = $env:TENDRIL_HOME

--- a/src/tendril/Ivy.Tendril.TeamIvyConfig/Hooks/NotifySlack.ps1
+++ b/src/tendril/Ivy.Tendril.TeamIvyConfig/Hooks/NotifySlack.ps1
@@ -19,11 +19,9 @@ if (-not (Test-Path $planYamlPath)) {
     exit 1
 }
 
-# Ensure powershell-yaml is available
-if (-not (Get-Module -ListAvailable -Name powershell-yaml)) {
-    Install-Module -Name powershell-yaml -Force -Scope CurrentUser
-}
-Import-Module powershell-yaml
+# Bootstrap required PowerShell modules
+$sharedPath = Join-Path (Split-Path (Split-Path $PSScriptRoot)) "Ivy.Tendril/.promptwares/.shared"
+. (Join-Path $sharedPath "Bootstrap-Modules.ps1")
 
 $planContent = Get-Content $planYamlPath -Raw
 $plan = ConvertFrom-Yaml $planContent

--- a/src/tendril/Ivy.Tendril/.promptwares/.shared/Bootstrap-Modules.ps1
+++ b/src/tendril/Ivy.Tendril/.promptwares/.shared/Bootstrap-Modules.ps1
@@ -1,0 +1,12 @@
+# Bootstrap-Modules.ps1 — Shared module installation and import
+# Source this file from any PowerShell script that needs the powershell-yaml module:
+#   . (Join-Path (Split-Path $PSScriptRoot) ".shared/Bootstrap-Modules.ps1")
+
+# Ensure powershell-yaml is available
+if (-not (Get-Module -ListAvailable -Name powershell-yaml)) {
+    Write-Host "Installing powershell-yaml module..." -ForegroundColor Yellow
+    Install-Module -Name powershell-yaml -Force -Scope CurrentUser
+}
+
+# Import the module
+Import-Module powershell-yaml -ErrorAction Stop

--- a/src/tendril/Ivy.Tendril/.promptwares/.shared/Utils.ps1
+++ b/src/tendril/Ivy.Tendril/.promptwares/.shared/Utils.ps1
@@ -19,11 +19,8 @@ if (-not $env:TENDRIL_HOME) {
 $script:ConfigPath = Join-Path $env:TENDRIL_HOME "config.yaml"
 $script:PlansDir = Join-Path $env:TENDRIL_HOME "Plans"
 
-# Ensure powershell-yaml is available
-if (-not (Get-Module -ListAvailable -Name powershell-yaml)) {
-    Install-Module -Name powershell-yaml -Force -Scope CurrentUser
-}
-Import-Module powershell-yaml
+# Bootstrap required PowerShell modules
+. (Join-Path $PSScriptRoot "Bootstrap-Modules.ps1")
 
 function GetProgramFolder {
     param([string]$ScriptPath)


### PR DESCRIPTION
# Summary

## Changes

Created a shared `Bootstrap-Modules.ps1` script in `.promptwares/.shared/` that centralizes the `powershell-yaml` module installation and import logic. Replaced duplicate Install-Module/Import-Module blocks in `Utils.ps1`, `CleanupWorktrees.ps1`, and `NotifySlack.ps1` with dot-source calls to the new bootstrap script.

## API Changes

None.

## Files Modified

- **New:** `src/tendril/Ivy.Tendril/.promptwares/.shared/Bootstrap-Modules.ps1` — shared module bootstrap script
- **Modified:** `src/tendril/Ivy.Tendril/.promptwares/.shared/Utils.ps1` — replaced inline module loading with bootstrap source call
- **Modified:** `src/tendril/Ivy.Tendril.TeamIvyConfig/Hooks/CleanupWorktrees.ps1` — replaced inline module loading with bootstrap source call
- **Modified:** `src/tendril/Ivy.Tendril.TeamIvyConfig/Hooks/NotifySlack.ps1` — replaced inline module loading with bootstrap source call

## Commits

- 0ce53ff9 [01669] Create shared Bootstrap-Modules.ps1 and refactor module loading