### PR TITLE
[01675] Reduce redundant disk I/O in ComputeCounts

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/PlanReaderServiceComputePlanCountsTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/PlanReaderServiceComputePlanCountsTests.cs
@@ -1,0 +1,112 @@
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Test;
+
+public class PlanReaderServiceComputePlanCountsTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string _plansDir;
+    private readonly PlanReaderService _service;
+
+    public PlanReaderServiceComputePlanCountsTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"tendril-test-{Guid.NewGuid()}");
+        _plansDir = Path.Combine(_tempDir, "Plans");
+        Directory.CreateDirectory(_plansDir);
+
+        var settings = new TendrilSettings();
+        var configService = new ConfigService(settings, _tempDir);
+        _service = new PlanReaderService(configService);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    private void CreatePlan(string folderName, string state)
+    {
+        var dir = Path.Combine(_plansDir, folderName);
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "plan.yaml"),
+            $"state: {state}\nproject: Tendril\ntitle: Test\nrepos: []\ncommits: []\nprs: []\nverifications: []\nrelatedPlans: []\ndependsOn: []\ncreated: 2026-01-01T00:00:00Z\nupdated: 2026-01-01T00:00:00Z\n");
+
+        var revisionsDir = Path.Combine(dir, "revisions");
+        Directory.CreateDirectory(revisionsDir);
+        File.WriteAllText(Path.Combine(revisionsDir, "001.md"), "# Test");
+    }
+
+    private void CreateRecommendations(string folderName, string yaml)
+    {
+        var artifactsDir = Path.Combine(_plansDir, folderName, "artifacts");
+        Directory.CreateDirectory(artifactsDir);
+        File.WriteAllText(Path.Combine(artifactsDir, "recommendations.yaml"), yaml);
+    }
+
+    [Fact]
+    public void ComputePlanCounts_ReturnsZeros_WhenNoPlans()
+    {
+        var snapshot = _service.ComputePlanCounts();
+
+        Assert.Equal(0, snapshot.Drafts);
+        Assert.Equal(0, snapshot.ReadyForReview);
+        Assert.Equal(0, snapshot.Failed);
+        Assert.Equal(0, snapshot.Icebox);
+        Assert.Equal(0, snapshot.PendingRecommendations);
+    }
+
+    [Fact]
+    public void ComputePlanCounts_CountsAllStates()
+    {
+        CreatePlan("01001-Draft1", "Draft");
+        CreatePlan("01002-Draft2", "Draft");
+        CreatePlan("01003-Review1", "ReadyForReview");
+        CreatePlan("01004-Failed1", "Failed");
+        CreatePlan("01005-Icebox1", "Icebox");
+        CreatePlan("01006-Icebox2", "Icebox");
+        CreatePlan("01007-Completed1", "Completed");
+
+        var snapshot = _service.ComputePlanCounts();
+
+        Assert.Equal(2, snapshot.Drafts);
+        Assert.Equal(1, snapshot.ReadyForReview);
+        Assert.Equal(1, snapshot.Failed);
+        Assert.Equal(2, snapshot.Icebox);
+        Assert.Equal(0, snapshot.PendingRecommendations);
+    }
+
+    [Fact]
+    public void ComputePlanCounts_CountsPendingRecommendations()
+    {
+        CreatePlan("01010-WithRecs", "Completed");
+        CreateRecommendations("01010-WithRecs",
+            "- title: Rec1\n  description: desc\n  state: Pending\n- title: Rec2\n  description: desc\n  state: Done\n- title: Rec3\n  description: desc\n  state: Pending\n");
+
+        var snapshot = _service.ComputePlanCounts();
+
+        Assert.Equal(2, snapshot.PendingRecommendations);
+    }
+
+    [Fact]
+    public void ComputePlanCounts_MatchesIndividualMethods()
+    {
+        CreatePlan("01020-Draft", "Draft");
+        CreatePlan("01021-Review", "ReadyForReview");
+        CreatePlan("01022-Failed", "Failed");
+        CreatePlan("01023-Icebox", "Icebox");
+        CreatePlan("01024-Completed", "Completed");
+        CreateRecommendations("01024-Completed",
+            "- title: R1\n  description: d\n  state: Pending\n- title: R2\n  description: d\n  state: Resolved\n");
+
+        var snapshot = _service.ComputePlanCounts();
+        var plans = _service.GetPlans();
+        var pendingRecs = _service.GetPendingRecommendationsCount();
+
+        Assert.Equal(plans.Count(p => p.Status == Apps.Plans.PlanStatus.Draft), snapshot.Drafts);
+        Assert.Equal(plans.Count(p => p.Status == Apps.Plans.PlanStatus.ReadyForReview), snapshot.ReadyForReview);
+        Assert.Equal(plans.Count(p => p.Status == Apps.Plans.PlanStatus.Failed), snapshot.Failed);
+        Assert.Equal(plans.Count(p => p.Status == Apps.Plans.PlanStatus.Icebox), snapshot.Icebox);
+        Assert.Equal(pendingRecs, snapshot.PendingRecommendations);
+    }
+}

--- a/src/tendril/Ivy.Tendril/Services/PlanCountsService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanCountsService.cs
@@ -1,5 +1,3 @@
-using Ivy.Tendril.Apps.Plans;
-
 namespace Ivy.Tendril.Services;
 
 public record PlanCounts(int Drafts, int RunningJobs, int Reviews, int Icebox, int Recommendations);
@@ -42,14 +40,15 @@ public class PlanCountsService : IDisposable
 
     private PlanCounts ComputeCounts()
     {
-        var plans = _planReaderService.GetPlans();
+        var snapshot = _planReaderService.ComputePlanCounts();
         var jobs = _jobService.GetJobs();
+
         return new PlanCounts(
-            Drafts: plans.Count(p => p.Status == PlanStatus.Draft),
+            Drafts: snapshot.Drafts,
             RunningJobs: jobs.Count(j => j.Status == "Running"),
-            Reviews: plans.Count(p => p.Status is PlanStatus.ReadyForReview or PlanStatus.Failed),
-            Icebox: plans.Count(p => p.Status == PlanStatus.Icebox),
-            Recommendations: _planReaderService.GetPendingRecommendationsCount()
+            Reviews: snapshot.ReadyForReview + snapshot.Failed,
+            Icebox: snapshot.Icebox,
+            Recommendations: snapshot.PendingRecommendations
         );
     }
 

--- a/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
@@ -573,6 +573,68 @@ public class PlanReaderService(ConfigService config)
         return count;
     }
 
+    public record PlanCountSnapshot(
+        int Drafts,
+        int ReadyForReview,
+        int Failed,
+        int Icebox,
+        int PendingRecommendations
+    );
+
+    public PlanCountSnapshot ComputePlanCounts()
+    {
+        int drafts = 0, reviews = 0, failed = 0, icebox = 0, pendingRecs = 0;
+
+        if (!Directory.Exists(PlansDirectory))
+            return new PlanCountSnapshot(0, 0, 0, 0, 0);
+
+        foreach (var dir in Directory.GetDirectories(PlansDirectory))
+        {
+            try
+            {
+                var planYamlPath = Path.Combine(dir, "plan.yaml");
+                if (File.Exists(planYamlPath))
+                {
+                    var yaml = File.ReadAllText(planYamlPath);
+                    var stateMatch = Regex.Match(yaml, @"(?m)^state:\s*(.+)$");
+                    if (stateMatch.Success)
+                    {
+                        var state = stateMatch.Groups[1].Value.Trim();
+                        switch (state.ToLowerInvariant())
+                        {
+                            case "draft": drafts++; break;
+                            case "readyforreview": reviews++; break;
+                            case "failed": failed++; break;
+                            case "icebox": icebox++; break;
+                        }
+                    }
+                }
+
+                var recommendationsPath = Path.Combine(dir, "artifacts", "recommendations.yaml");
+                if (File.Exists(recommendationsPath))
+                {
+                    var yaml = File.ReadAllText(recommendationsPath);
+                    var items = YamlDeserializer.Deserialize<List<RecommendationYaml>>(yaml);
+                    if (items != null)
+                    {
+                        foreach (var item in items)
+                        {
+                            var state = string.IsNullOrWhiteSpace(item.State) ? "Pending" : item.State;
+                            if (state.Equals("Pending", StringComparison.OrdinalIgnoreCase))
+                                pendingRecs++;
+                        }
+                    }
+                }
+            }
+            catch
+            {
+                // Skip malformed plans
+            }
+        }
+
+        return new PlanCountSnapshot(drafts, reviews, failed, icebox, pendingRecs);
+    }
+
     public void UpdateRecommendationState(string planFolderName, string recommendationTitle, string newState)
     {
         var recommendationsPath = Path.Combine(PlansDirectory, planFolderName, "artifacts", "recommendations.yaml");


### PR DESCRIPTION
# Summary

## Changes

Added a single-pass `ComputePlanCounts()` method to `PlanReaderService` that computes all plan state counts (Draft, ReadyForReview, Failed, Icebox) and pending recommendations count in one directory iteration. Updated `PlanCountsService.ComputeCounts()` to use this method instead of the previous two-pass approach (`GetPlans()` + `GetPendingRecommendationsCount()`).

## API Changes

- **New record:** `PlanReaderService.PlanCountSnapshot(int Drafts, int ReadyForReview, int Failed, int Icebox, int PendingRecommendations)`
- **New method:** `PlanReaderService.ComputePlanCounts()` — returns a `PlanCountSnapshot` computed in a single directory pass
- **Removed import:** `using Ivy.Tendril.Apps.Plans` from `PlanCountsService.cs` (no longer needed)

## Files Modified

- **PlanReaderService.cs** — added `PlanCountSnapshot` record and `ComputePlanCounts()` method
- **PlanCountsService.cs** — replaced `ComputeCounts()` implementation to use single-pass method
- **PlanReaderServiceComputePlanCountsTests.cs** (new) — 4 test methods verifying correctness

## Commits

- 5960510b [01675] Reduce redundant disk I/O in ComputeCounts