### PR TITLE
[01678] Prevent API Hallucination in MakePlan

### DIFF
--- a/src/tendril/Ivy.Tendril/.promptwares/MakePlan/Program.md
+++ b/src/tendril/Ivy.Tendril/.promptwares/MakePlan/Program.md
@@ -152,6 +152,24 @@ The `## Tests` section MUST include two parts:
    
    Never leave test scope unspecified — this causes the full suite to run unnecessarily.
 
+### 4.7. API Validation
+
+When suggesting Ivy Framework code in plan revisions:
+
+1. **Read Memory** — Check `Memory/ivy-framework-api-reference.md` for known patterns
+2. **Verify APIs** — Before suggesting any Ivy API (widgets, layouts, properties):
+   - Use `Grep` to find actual usage in `D:\Repos\_Ivy\Ivy-Framework\src\Ivy`
+   - Read the source file to confirm method signatures
+   - Check AGENTS.md for documented patterns
+3. **Never Guess** — If you can't verify an API, either:
+   - Use a verified alternative from memory/AGENTS.md
+   - Suggest the user verify the API (in ## Questions section)
+   - Omit the specific API and describe behavior instead
+
+**Example violation**: Writing `AlignItems(Alignment.Center)` without verifying it exists.
+
+**Correct approach**: Grep for `AlignContent` → Read `LayoutView.cs` → Confirm `AlignContent(Align align)` exists → Suggest verified API.
+
 ### 5. Verification Checklist
 
 In the `## Verification` section of the plan revision, generate a checklist from the project's `verifications` in `config.yaml`.


### PR DESCRIPTION
# Summary

## Changes

Added an API validation step (4.7) to MakePlan's Program.md that requires verifying Ivy Framework APIs before suggesting them in plan revisions. Created a local API reference memory file (`ivy-framework-api-reference.md`) with verified layout alignment patterns and a PowerShell verification tool (`Verify-IvyApi.ps1`) for checking class/method existence.

## API Changes

None.

## Files Modified

- **MakePlan Program.md** — Added section 4.7 "API Validation" with verification workflow instructions
- **MakePlan Memory/ivy-framework-api-reference.md** — New local memory file with verified Ivy Framework API patterns (gitignored)
- **MakePlan Tools/Verify-IvyApi.ps1** — New PowerShell tool for verifying class/method existence in Ivy Framework (gitignored)

## Commits

- 454fe021 [01678] Add API validation step to MakePlan Program.md