### PR TITLE
[01676] Remove redundant state badge from Recommendations ContentView

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Recommendations/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Recommendations/ContentView.cs
@@ -31,17 +31,9 @@ public class ContentView(
 
         var currentIndex = _all.FindIndex(r => r.PlanId == _selected.PlanId && r.Title == _selected.Title);
 
-        var stateBadgeVariant = _selected.State switch
-        {
-            "Accepted" => BadgeVariant.Success,
-            "Declined" => BadgeVariant.Destructive,
-            _ => BadgeVariant.Outline
-        };
-
         // Header
         var header = Layout.Horizontal().Width(Size.Full()).Padding(1).Gap(2)
             | Text.Block(_selected.Title).Bold()
-            | new Badge(_selected.State).Variant(stateBadgeVariant)
             | new Badge($"#{_selected.PlanId}").Variant(BadgeVariant.Outline)
             | new Spacer().Width(Size.Grow())
             | Text.Rich()


### PR DESCRIPTION
# Summary

## Changes

Removed the redundant state badge from the Recommendations ContentView header. Since all visible recommendations are now pending (after plan 01653), the badge always showed "Pending" and added no value. The `stateBadgeVariant` switch expression and the `Badge(_selected.State)` element were removed.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Apps/Recommendations/ContentView.cs` -- Removed state badge variable and badge element from header layout

## Commits

- 597971e8 [01676] Remove redundant state badge from Recommendations ContentView