### PR TITLE
[01673] Restore file-link handling to inline Sheets in JobsApp and PullRequestApp

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/JobsApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/JobsApp.cs
@@ -17,6 +17,8 @@ public class JobsApp : ViewBase
         var showCommand = UseState<string?>(null);
         var showOutput = UseState<string?>(null);
         var showPlan = UseState<string?>(null);
+        var openFile = UseState<string?>(null);
+        var config = UseService<ConfigService>();
         UseInterval(() =>
         {
             while (jobService.PendingNotifications.TryDequeue(out var notification))
@@ -228,7 +230,77 @@ public class JobsApp : ViewBase
             var sheetContent = string.IsNullOrEmpty(content)
                 ? Text.P("Plan not found or empty.")
                 : (object)new Markdown(MarkdownHelper.AnnotateBrokenFileLinks(content))
-                    .DangerouslyAllowLocalFiles();
+                    .DangerouslyAllowLocalFiles()
+                    .OnLinkClick(url =>
+                    {
+                        if (url.StartsWith("file:///", StringComparison.OrdinalIgnoreCase))
+                        {
+                            var filePath = url.Substring("file:///".Length);
+                            openFile.Set(filePath);
+                        }
+                    });
+
+            if (openFile.Value is { } filePath2)
+            {
+                var ext = Path.GetExtension(filePath2);
+                var imageExts = new[] { ".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp" };
+                object fileSheetContent;
+                if (imageExts.Contains(ext, StringComparer.OrdinalIgnoreCase))
+                {
+                    var imageUrl = $"/ivy/local-file?path={Uri.EscapeDataString(filePath2)}";
+                    fileSheetContent = new Image(imageUrl) { ObjectFit = ImageFit.Contain, Alt = Path.GetFileName(filePath2) };
+                }
+                else
+                {
+                    if (File.Exists(filePath2))
+                    {
+                        var fileContent = File.ReadAllText(filePath2);
+                        var language = FileApp.GetLanguage(ext);
+                        fileSheetContent = new Markdown($"```{language.ToString().ToLowerInvariant()}\n{fileContent}\n```");
+                    }
+                    else
+                    {
+                        var fileName = Path.GetFileName(filePath2);
+                        var repoPaths = (plan?.Repos?.Count ?? 0) > 0
+                            ? plan!.Repos
+                            : config.GetProject(plan?.Project ?? "")?.RepoPaths ?? [];
+                        var suggestions = MarkdownHelper.FindFilesInRepos(repoPaths, fileName);
+                        var notFoundContent = suggestions.Count > 0
+                            ? $"File not found.\n\nDid you mean:\n{string.Join("\n", suggestions.Select(s => $"- `{s}`"))}"
+                            : "File not found.";
+                        fileSheetContent = new Markdown(notFoundContent);
+                    }
+                }
+
+                var finalContent = File.Exists(filePath2)
+                    ? (object)new HeaderLayout(
+                        header: new Button("Open in VS Code").Icon(Icons.ExternalLink).Outline().OnClick(() =>
+                        {
+                            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+                            {
+                                FileName = "code",
+                                Arguments = $"\"{filePath2}\"",
+                                UseShellExecute = true
+                            });
+                        }),
+                        content: fileSheetContent
+                    )
+                    : fileSheetContent;
+
+                return layout | new Fragment(
+                    dataTable,
+                    new Sheet(
+                        onClose: () => showPlan.Set(null),
+                        content: sheetContent,
+                        title: plan?.Title ?? folderName
+                    ).Width(Size.Half()).Resizable(),
+                    new Sheet(
+                        onClose: () => openFile.Set(null),
+                        content: finalContent,
+                        title: Path.GetFileName(filePath2)
+                    ).Width(Size.Half()).Resizable()
+                );
+            }
 
             return layout | new Fragment(
                 dataTable,

--- a/src/tendril/Ivy.Tendril/Apps/PullRequestApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/PullRequestApp.cs
@@ -13,6 +13,8 @@ public class PullRequestApp : ViewBase
         var refreshToken = UseRefreshToken();
         var nav = this.UseNavigation();
         var showPlan = UseState<string?>(null);
+        var openFile = UseState<string?>(null);
+        var config = UseService<ConfigService>();
 
         var plans = planService.GetPlans()
             .Where(p => p.Prs.Count > 0)
@@ -98,7 +100,77 @@ public class PullRequestApp : ViewBase
             var sheetContent = string.IsNullOrEmpty(content)
                 ? Text.P("Plan not found or empty.")
                 : (object)new Markdown(MarkdownHelper.AnnotateBrokenFileLinks(content))
-                    .DangerouslyAllowLocalFiles();
+                    .DangerouslyAllowLocalFiles()
+                    .OnLinkClick(url =>
+                    {
+                        if (url.StartsWith("file:///", StringComparison.OrdinalIgnoreCase))
+                        {
+                            var filePath = url.Substring("file:///".Length);
+                            openFile.Set(filePath);
+                        }
+                    });
+
+            if (openFile.Value is { } filePath2)
+            {
+                var ext = Path.GetExtension(filePath2);
+                var imageExts = new[] { ".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp" };
+                object fileSheetContent;
+                if (imageExts.Contains(ext, StringComparer.OrdinalIgnoreCase))
+                {
+                    var imageUrl = $"/ivy/local-file?path={Uri.EscapeDataString(filePath2)}";
+                    fileSheetContent = new Image(imageUrl) { ObjectFit = ImageFit.Contain, Alt = Path.GetFileName(filePath2) };
+                }
+                else
+                {
+                    if (File.Exists(filePath2))
+                    {
+                        var fileContent = File.ReadAllText(filePath2);
+                        var language = FileApp.GetLanguage(ext);
+                        fileSheetContent = new Markdown($"```{language.ToString().ToLowerInvariant()}\n{fileContent}\n```");
+                    }
+                    else
+                    {
+                        var fileName = Path.GetFileName(filePath2);
+                        var repoPaths = (plan?.Repos?.Count ?? 0) > 0
+                            ? plan!.Repos
+                            : config.GetProject(plan?.Project ?? "")?.RepoPaths ?? [];
+                        var suggestions = MarkdownHelper.FindFilesInRepos(repoPaths, fileName);
+                        var notFoundContent = suggestions.Count > 0
+                            ? $"File not found.\n\nDid you mean:\n{string.Join("\n", suggestions.Select(s => $"- `{s}`"))}"
+                            : "File not found.";
+                        fileSheetContent = new Markdown(notFoundContent);
+                    }
+                }
+
+                var finalContent = File.Exists(filePath2)
+                    ? (object)new HeaderLayout(
+                        header: new Button("Open in VS Code").Icon(Icons.ExternalLink).Outline().OnClick(() =>
+                        {
+                            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+                            {
+                                FileName = "code",
+                                Arguments = $"\"{filePath2}\"",
+                                UseShellExecute = true
+                            });
+                        }),
+                        content: fileSheetContent
+                    )
+                    : fileSheetContent;
+
+                return Layout.Vertical().Height(Size.Full()) | new Fragment(
+                    dataTable,
+                    new Sheet(
+                        onClose: () => showPlan.Set(null),
+                        content: sheetContent,
+                        title: plan?.Title ?? folderName
+                    ).Width(Size.Half()).Resizable(),
+                    new Sheet(
+                        onClose: () => openFile.Set(null),
+                        content: finalContent,
+                        title: Path.GetFileName(filePath2)
+                    ).Width(Size.Half()).Resizable()
+                );
+            }
 
             return Layout.Vertical().Height(Size.Full()) | new Fragment(
                 dataTable,


### PR DESCRIPTION
# Summary

## Changes

Added rich file-link click handling to the inline Sheet displays in JobsApp and PullRequestApp. When users click `file:///` links in plan markdown, a nested Sheet now opens showing the file content with syntax highlighting (for code files), image display (for image files), or "File not found" with suggestions (for missing files). An "Open in VS Code" button is included for existing files. This restores the functionality that was lost when PlanViewerApp was replaced with inline Sheets in plan 01661.

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/Apps/JobsApp.cs** - Added `openFile` state, `ConfigService` dependency, `.OnLinkClick()` handler on Markdown widget, and nested Sheet rendering for file preview
- **src/tendril/Ivy.Tendril/Apps/PullRequestApp.cs** - Added `openFile` state, `ConfigService` dependency, `.OnLinkClick()` handler on Markdown widget, and nested Sheet rendering for file preview

## Commits

- 72f75235 [01673] Restore file-link handling to inline Sheets in JobsApp and PullRequestApp