### PR TITLE
[01681] Add notification title assertions to JobServiceTimeoutTests

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/JobServiceTimeoutTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/JobServiceTimeoutTests.cs
@@ -30,6 +30,10 @@ public class JobServiceTimeoutTests
         Assert.Contains("30 minute timeout", job.StatusMessage);
         Assert.NotNull(job.CompletedAt);
         Assert.NotNull(job.DurationSeconds);
+
+        var notification = service.PendingNotifications.TryDequeue(out var result) ? result : null;
+        Assert.NotNull(notification);
+        Assert.Equal("ExecutePlan Timed Out", notification.Title);
     }
 
     [Fact]
@@ -46,6 +50,10 @@ public class JobServiceTimeoutTests
         Assert.NotNull(job);
         Assert.Equal("Timeout", job.Status);
         Assert.Contains("No output for 10 minutes", job.StatusMessage);
+
+        var notification = service.PendingNotifications.TryDequeue(out var result) ? result : null;
+        Assert.NotNull(notification);
+        Assert.Equal("ExecutePlan Timed Out", notification.Title);
     }
 
     [Fact]
@@ -61,6 +69,10 @@ public class JobServiceTimeoutTests
         Assert.NotNull(job);
         Assert.Equal("Completed", job.Status);
         Assert.Null(job.StatusMessage);
+
+        var notification = service.PendingNotifications.TryDequeue(out var result) ? result : null;
+        Assert.NotNull(notification);
+        Assert.Equal("ExecutePlan Completed", notification.Title);
     }
 
     [Fact]
@@ -75,6 +87,10 @@ public class JobServiceTimeoutTests
         var job = service.GetJob(id);
         Assert.NotNull(job);
         Assert.Equal("Failed", job.Status);
+
+        var notification = service.PendingNotifications.TryDequeue(out var result) ? result : null;
+        Assert.NotNull(notification);
+        Assert.Equal("ExecutePlan Failed", notification.Title);
     }
 
     [Fact]


### PR DESCRIPTION
# Summary

## Changes

Added notification title assertions to four existing test methods in `JobServiceTimeoutTests.cs`. Each test now verifies that `PendingNotifications` contains a `JobNotification` with the correct title (`"ExecutePlan Timed Out"`, `"ExecutePlan Completed"`, or `"ExecutePlan Failed"`) matching the job-type-based notification titles introduced in plan 01619.

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril.Test/JobServiceTimeoutTests.cs** — Added 4 notification title assertion blocks (3 lines each) to `CompleteJob_WithTimeout_SetsTimeoutStatus`, `CompleteJob_WithStaleOutput_SetsTimeoutStatusWithStaleReason`, `CompleteJob_WithSuccessExitCode_SetsCompletedStatus`, and `CompleteJob_WithNonZeroExitCode_SetsFailedStatus`.

## Commits

- b0655c63 [01681] Add notification title assertions to JobServiceTimeoutTests