### PR TITLE
[01683] Update Sidebar Footer Menu Icons

### DIFF
--- a/src/tendril/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/tendril/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -407,7 +407,7 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
         {
             MenuItem.Default("Setup")
                 .Tag("$setup")
-                .Icon(Icons.Settings)
+                .Icon(Icons.Construction)
                 .OnSelect(() => navigator.Navigate<SetupApp>()),
             MenuItem.Default("Trash")
                 .Tag("$trash")
@@ -472,7 +472,7 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
             var trigger = new Button("Settings")
                 .Content(
                     Layout.Horizontal().AlignContent(Align.Left)
-                        | Icons.Construction.ToIcon()
+                        | Icons.Settings.ToIcon()
                         | Text.P("Settings").Small().Muted()
                     )
                     .Variant(ButtonVariant.Ghost).Width(Size.Full());


### PR DESCRIPTION
# Summary

## Changes

Swapped the sidebar footer menu icons in `TendrilAppShell.cs` for better semantic consistency. The "Setup" menu item now uses `Icons.Construction` (representing configuration/building), and the footer trigger button now uses `Icons.Settings` (representing general settings).

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/AppShell/TendrilAppShell.cs` — swapped `Icons.Settings` and `Icons.Construction` between the Setup menu item (line 410) and the footer trigger button (line 475)

## Commits

- 1a2b493d [01683] Swap sidebar footer menu icons for semantic consistency