### PR TITLE
[01691] Show full recommendation descriptions

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Recommendations/SidebarView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Recommendations/SidebarView.cs
@@ -16,7 +16,11 @@ public class SidebarView(
         {
             var clickableRec = rec;
 
-            return new ListItem(rec.Title)
+            var preview = rec.Description.Length > 120
+                ? rec.Description[..120] + "…"
+                : rec.Description;
+
+            return new ListItem(rec.Title, subtitle: preview)
                 .Content(Layout.Horizontal().Gap(1)
                     | new Badge($"#{rec.PlanId}").Variant(BadgeVariant.Outline).Small()
                 )


### PR DESCRIPTION
# Summary

## Changes

Added a description preview (first 120 characters) as a subtitle on each recommendation in the sidebar list. The full description was already visible in the detail view (ContentView) after a prior refactor (commit 21b8d746); this change surfaces a preview directly in the sidebar so users can scan recommendations without clicking into each one.

## API Changes

None.

## Files Modified

- **Sidebar UI**: `src/tendril/Ivy.Tendril/Apps/Recommendations/SidebarView.cs` — added `subtitle` parameter to `ListItem` with truncated description preview

## Commits

- 9763e383 [01691] Add description preview to recommendations sidebar