### PR TITLE
[01694] Extract useScrollShadow hook from HeaderLayout and DataTable

### DIFF
--- a/src/frontend/src/hooks/use-scroll-shadow.test.ts
+++ b/src/frontend/src/hooks/use-scroll-shadow.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * Tests for the useScrollShadow hook.
+ *
+ * Since @testing-library/react is not available in this project, we verify
+ * the source code contains the expected patterns. Visual behavior is covered
+ * by the IvyFrameworkVerification end-to-end test.
+ */
+describe("useScrollShadow", () => {
+  const hookSource = fs.readFileSync(path.resolve(__dirname, "./use-scroll-shadow.ts"), "utf-8");
+
+  it("should export useScrollShadow function", () => {
+    expect(hookSource).toContain("export function useScrollShadow");
+  });
+
+  it("should use useState for isScrolled state", () => {
+    expect(hookSource).toContain("useState(false)");
+  });
+
+  it("should use useRef for scrollRef", () => {
+    expect(hookSource).toContain("useRef<HTMLDivElement>(null)");
+  });
+
+  it("should default selector to radix scroll area viewport", () => {
+    expect(hookSource).toContain("[data-radix-scroll-area-viewport]");
+  });
+
+  it("should accept a custom selector parameter", () => {
+    expect(hookSource).toMatch(/function useScrollShadow\(\s*selector\s*=/);
+  });
+
+  it("should listen for scroll events and check scrollTop", () => {
+    expect(hookSource).toContain('addEventListener("scroll"');
+    expect(hookSource).toContain("scrollTop > 0");
+  });
+
+  it("should clean up the scroll event listener on unmount", () => {
+    expect(hookSource).toContain('removeEventListener("scroll"');
+  });
+
+  it("should include selector in useEffect dependency array", () => {
+    expect(hookSource).toContain("[selector]");
+  });
+
+  it("should return isScrolled and scrollRef", () => {
+    expect(hookSource).toContain("return { isScrolled, scrollRef }");
+  });
+});
+
+describe("HeaderLayoutWidget uses useScrollShadow hook", () => {
+  const widgetSource = fs.readFileSync(
+    path.resolve(__dirname, "../widgets/layouts/HeaderLayoutWidget.tsx"),
+    "utf-8",
+  );
+
+  it("should import useScrollShadow", () => {
+    expect(widgetSource).toContain('from "@/hooks/use-scroll-shadow"');
+  });
+
+  it("should use the hook instead of inline implementation", () => {
+    expect(widgetSource).toContain("useScrollShadow()");
+    // Should NOT have the inline scroll listener pattern
+    expect(widgetSource).not.toContain('addEventListener("scroll"');
+    expect(widgetSource).not.toContain("setIsScrolled");
+  });
+
+  it("should destructure isScrolled and scrollRef from the hook", () => {
+    expect(widgetSource).toContain("const { isScrolled, scrollRef } = useScrollShadow()");
+  });
+});

--- a/src/frontend/src/hooks/use-scroll-shadow.ts
+++ b/src/frontend/src/hooks/use-scroll-shadow.ts
@@ -1,0 +1,25 @@
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * Hook that tracks scroll position to trigger shadow effects
+ * @param selector - Optional selector for the scroll container (default: "[data-radix-scroll-area-viewport]")
+ * @returns Object containing isScrolled state and scrollRef
+ */
+export function useScrollShadow(selector = "[data-radix-scroll-area-viewport]") {
+  const [isScrolled, setIsScrolled] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const viewport = scrollRef.current?.querySelector(selector);
+    if (!viewport) return;
+
+    const handleScroll = () => {
+      setIsScrolled(viewport.scrollTop > 0);
+    };
+
+    viewport.addEventListener("scroll", handleScroll);
+    return () => viewport.removeEventListener("scroll", handleScroll);
+  }, [selector]);
+
+  return { isScrolled, scrollRef };
+}

--- a/src/frontend/src/widgets/layouts/HeaderLayoutWidget.tsx
+++ b/src/frontend/src/widgets/layouts/HeaderLayoutWidget.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { useScrollShadow } from "@/hooks/use-scroll-shadow";
 import { getWidth } from "@/lib/styles";
 import { cn } from "@/lib/utils";
 
@@ -19,20 +20,7 @@ export const HeaderLayoutWidget: React.FC<HeaderLayoutWidgetProps> = ({
   showHeaderDivider = true,
   contentScroll = "Auto",
 }) => {
-  const [isScrolled, setIsScrolled] = React.useState(false);
-  const scrollRef = React.useRef<HTMLDivElement>(null);
-
-  React.useEffect(() => {
-    const viewport = scrollRef.current?.querySelector("[data-radix-scroll-area-viewport]");
-    if (!viewport) return;
-
-    const handleScroll = () => {
-      setIsScrolled(viewport.scrollTop > 0);
-    };
-
-    viewport.addEventListener("scroll", handleScroll);
-    return () => viewport.removeEventListener("scroll", handleScroll);
-  }, []);
+  const { isScrolled, scrollRef } = useScrollShadow();
 
   if (!slots?.Header || !slots?.Content) {
     return (


### PR DESCRIPTION
# Summary

## Changes

Extracted the scroll-triggered shadow pattern from `HeaderLayoutWidget` into a reusable `useScrollShadow()` hook. The hook encapsulates `useState`, `useRef`, and `useEffect` for tracking scroll position on Radix ScrollArea viewports. HeaderLayoutWidget was refactored to use the hook, replacing 14 lines of inline logic with a single hook call.

DataTable was investigated but does not currently use this scroll shadow pattern, so no changes were needed there.

## API Changes

- **New:** `useScrollShadow(selector?)` hook exported from `@/hooks/use-scroll-shadow`
  - `selector` parameter (default: `"[data-radix-scroll-area-viewport]"`) — CSS selector for the scroll container
  - Returns `{ isScrolled: boolean, scrollRef: React.RefObject<HTMLDivElement> }`

## Files Modified

- **New hook:** `src/frontend/src/hooks/use-scroll-shadow.ts`
- **New tests:** `src/frontend/src/hooks/use-scroll-shadow.test.ts` (12 tests)
- **Refactored:** `src/frontend/src/widgets/layouts/HeaderLayoutWidget.tsx` — replaced inline scroll logic with `useScrollShadow()` hook

## Commits

- 53c4f7d3 [01694] Extract useScrollShadow hook from HeaderLayoutWidget