### PR TITLE
[01690] RecommendationsApp empty state message

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Recommendations/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Recommendations/ContentView.cs
@@ -25,6 +25,13 @@ public class ContentView(
 
         if (_selected is null)
         {
+            if (_all.Count == 0)
+            {
+                return Layout.Vertical().AlignContent(Align.Center).Height(Size.Full()).Gap(2)
+                    | new Icon(Icons.Inbox).Large().Color(Colors.Gray)
+                    | Text.Muted("No recommendations yet");
+            }
+
             return Layout.Vertical().AlignContent(Align.Center).Height(Size.Full())
                 | Text.Muted("Select a recommendation from the sidebar");
         }


### PR DESCRIPTION
# Summary

## Changes

Added an empty state to the RecommendationsApp ContentView. When no pending recommendations exist, the app now displays a large inbox icon with "No recommendations yet" text instead of the misleading "Select a recommendation from the sidebar" message.

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/Apps/Recommendations/ContentView.cs** — Added empty list check before the null-selection fallback message

## Commits

- 1b09b470 [01690] Add empty state message to RecommendationsApp ContentView