### PR TITLE
[01695] Add scroll-triggered drop shadow to FooterLayout footer

### DIFF
--- a/src/frontend/src/widgets/layouts/FooterLayoutWidget.tsx
+++ b/src/frontend/src/widgets/layouts/FooterLayoutWidget.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { cn } from "@/lib/utils";
 
 interface FooterLayoutWidgetProps {
   slots?: {
@@ -9,6 +10,30 @@ interface FooterLayoutWidgetProps {
 }
 
 export const FooterLayoutWidget: React.FC<FooterLayoutWidgetProps> = ({ slots }) => {
+  const [hasMoreContent, setHasMoreContent] = React.useState(false);
+  const scrollRef = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    const viewport = scrollRef.current?.querySelector("[data-radix-scroll-area-viewport]");
+    if (!viewport) return;
+
+    const handleScroll = () => {
+      const { scrollTop, scrollHeight, clientHeight } = viewport;
+      setHasMoreContent(scrollTop < scrollHeight - clientHeight - 1);
+    };
+
+    handleScroll();
+
+    viewport.addEventListener("scroll", handleScroll);
+    const resizeObserver = new ResizeObserver(handleScroll);
+    resizeObserver.observe(viewport);
+
+    return () => {
+      viewport.removeEventListener("scroll", handleScroll);
+      resizeObserver.disconnect();
+    };
+  }, []);
+
   if (!slots?.Footer || !slots?.Content) {
     return (
       <div className="text-red-500">
@@ -19,12 +44,17 @@ export const FooterLayoutWidget: React.FC<FooterLayoutWidgetProps> = ({ slots })
 
   return (
     <div className="h-full flex flex-col relative remove-parent-padding">
-      <div className="flex-1 min-h-0 overflow-hidden">
+      <div ref={scrollRef} className="flex-1 min-h-0 overflow-hidden">
         <ScrollArea className="h-full">
           <div className="p-4">{slots.Content}</div>
         </ScrollArea>
       </div>
-      <div className="flex-none w-full bg-background">
+      <div
+        className={cn(
+          "flex-none w-full bg-background transition-shadow",
+          hasMoreContent && "shadow-[0_-2px_4px_rgba(0,0,0,0.1)]",
+        )}
+      >
         <div className="border-t"></div>
         <div className="p-4">{slots.Footer}</div>
       </div>


### PR DESCRIPTION
# Summary

## Changes

Added scroll-triggered drop shadow to the `FooterLayout` footer. When the content area has more scrollable content below the current viewport, an upward shadow appears on the footer div to visually indicate more content exists. The shadow smoothly fades in/out using CSS transitions and uses a `ResizeObserver` to handle dynamic content height changes.

## API Changes

None.

## Files Modified

- **Frontend:**
  - `src/frontend/src/widgets/layouts/FooterLayoutWidget.tsx` — Added scroll detection state, `ResizeObserver`, and conditional upward shadow class on the footer container

## Commits

- 98c3ed31 [01695] Add scroll-triggered drop shadow to FooterLayout footer