### PR TITLE
[01692] Add filtering to RecommendationsApp by project and plan status

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/RecommendationServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/RecommendationServiceTests.cs
@@ -1,3 +1,4 @@
+using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Services;
 
 namespace Ivy.Tendril.Test;
@@ -26,12 +27,12 @@ public class RecommendationServiceTests : IDisposable
             Directory.Delete(_tempDir, recursive: true);
     }
 
-    private string CreatePlanWithRecommendations(string folderName, string recommendationsYaml)
+    private string CreatePlanWithRecommendations(string folderName, string recommendationsYaml, string project = "Tendril", string state = "Completed")
     {
         var dir = Path.Combine(_plansDir, folderName);
         Directory.CreateDirectory(dir);
 
-        var planYaml = "state: Completed\nproject: Tendril\ntitle: Test Plan\nrepos: []\ncommits: []\nprs: []\nverifications: []\nrelatedPlans: []\ndependsOn: []\ncreated: 2026-01-01T00:00:00Z\nupdated: 2026-01-01T00:00:00Z\n";
+        var planYaml = $"state: {state}\nproject: {project}\ntitle: Test Plan\nrepos: []\ncommits: []\nprs: []\nverifications: []\nrelatedPlans: []\ndependsOn: []\ncreated: 2026-01-01T00:00:00Z\nupdated: 2026-01-01T00:00:00Z\n";
         File.WriteAllText(Path.Combine(dir, "plan.yaml"), planYaml);
 
         var revisionsDir = Path.Combine(dir, "revisions");
@@ -150,5 +151,88 @@ public class RecommendationServiceTests : IDisposable
         var count = _service.GetPendingRecommendationsCount();
 
         Assert.Equal(0, count);
+    }
+
+    [Fact]
+    public void GetRecommendations_PopulatesSourcePlanStatus()
+    {
+        var yaml = "- title: Item\n  description: Desc\n  state: Pending\n";
+        CreatePlanWithRecommendations("01620-StatusTest", yaml, project: "Framework", state: "Completed");
+
+        var recommendations = _service.GetRecommendations();
+
+        Assert.Single(recommendations);
+        Assert.Equal(PlanStatus.Completed, recommendations[0].SourcePlanStatus);
+    }
+
+    [Fact]
+    public void GetRecommendations_FilterByProject_ReturnsOnlyMatchingProject()
+    {
+        var yaml = "- title: Rec A\n  description: Desc\n  state: Pending\n";
+        CreatePlanWithRecommendations("01621-Framework", yaml, project: "Framework");
+        CreatePlanWithRecommendations("01622-Tendril", yaml, project: "Tendril");
+        CreatePlanWithRecommendations("01623-Agent", yaml, project: "Agent");
+
+        var recommendations = _service.GetRecommendations();
+        var frameworkOnly = recommendations.Where(r => r.Project == "Framework").ToList();
+
+        Assert.Equal(3, recommendations.Count);
+        Assert.Single(frameworkOnly);
+        Assert.Equal("Framework", frameworkOnly[0].Project);
+    }
+
+    [Fact]
+    public void GetRecommendations_FilterByPlanStatus_ReturnsOnlyMatchingStatus()
+    {
+        var yaml = "- title: Rec\n  description: Desc\n  state: Pending\n";
+        CreatePlanWithRecommendations("01624-Completed", yaml, state: "Completed");
+        CreatePlanWithRecommendations("01625-Failed", yaml, state: "Failed");
+        CreatePlanWithRecommendations("01626-Draft", yaml, state: "Draft");
+
+        var recommendations = _service.GetRecommendations();
+        var completedOnly = recommendations.Where(r => r.SourcePlanStatus == PlanStatus.Completed).ToList();
+
+        Assert.Equal(3, recommendations.Count);
+        Assert.Single(completedOnly);
+        Assert.Equal(PlanStatus.Completed, completedOnly[0].SourcePlanStatus);
+    }
+
+    [Fact]
+    public void GetRecommendations_CombinedFilters_ApplyAndLogic()
+    {
+        var yaml = "- title: Rec\n  description: Desc\n  state: Pending\n";
+        CreatePlanWithRecommendations("01627-FwCompleted", yaml, project: "Framework", state: "Completed");
+        CreatePlanWithRecommendations("01628-FwFailed", yaml, project: "Framework", state: "Failed");
+        CreatePlanWithRecommendations("01629-TdCompleted", yaml, project: "Tendril", state: "Completed");
+
+        var recommendations = _service.GetRecommendations();
+        var filtered = recommendations
+            .Where(r => r.Project == "Framework")
+            .Where(r => r.SourcePlanStatus == PlanStatus.Completed)
+            .ToList();
+
+        Assert.Equal(3, recommendations.Count);
+        Assert.Single(filtered);
+        Assert.Equal("Framework", filtered[0].Project);
+        Assert.Equal(PlanStatus.Completed, filtered[0].SourcePlanStatus);
+    }
+
+    [Fact]
+    public void GetRecommendations_NullFilters_ReturnsAll()
+    {
+        var yaml = "- title: Rec\n  description: Desc\n  state: Pending\n";
+        CreatePlanWithRecommendations("01630-All1", yaml, project: "Framework", state: "Completed");
+        CreatePlanWithRecommendations("01631-All2", yaml, project: "Tendril", state: "Failed");
+
+        var recommendations = _service.GetRecommendations();
+        string? projectFilter = null;
+        string? statusFilter = null;
+
+        var filtered = recommendations
+            .Where(r => projectFilter == null || r.Project == projectFilter)
+            .Where(r => statusFilter == null || r.SourcePlanStatus.ToString() == statusFilter)
+            .ToList();
+
+        Assert.Equal(2, filtered.Count);
     }
 }

--- a/src/tendril/Ivy.Tendril/Apps/RecommendationsApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/RecommendationsApp.cs
@@ -1,4 +1,5 @@
 using Ivy;
+using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Apps.Recommendations;
 using Ivy.Tendril.Services;
 
@@ -13,12 +14,18 @@ public class RecommendationsApp : ViewBase
         var jobService = UseService<JobService>();
         var refreshToken = UseRefreshToken();
         var selectedState = UseState<Recommendation?>(null);
+        var projectFilter = UseState<string?>(null);
+        var planStatusFilter = UseState<string?>(null);
 
         UseInterval(() => refreshToken.Refresh(), TimeSpan.FromMinutes(1));
 
         var recommendations = planService.GetRecommendations();
 
-        var filtered = recommendations.Where(r => r.State == "Pending").ToList();
+        var filtered = recommendations
+            .Where(r => r.State == "Pending")
+            .Where(r => projectFilter.Value == null || r.Project == projectFilter.Value)
+            .Where(r => planStatusFilter.Value == null || r.SourcePlanStatus.ToString() == planStatusFilter.Value)
+            .ToList();
 
         // If selected recommendation is no longer in filtered list, adjust selection
         if (selectedState.Value is { } selected && !filtered.Any(r => r.PlanId == selected.PlanId && r.Title == selected.Title))
@@ -28,11 +35,35 @@ public class RecommendationsApp : ViewBase
 
         void Refresh() => refreshToken.Refresh();
 
+        var projectOptions = recommendations
+            .Where(r => r.State == "Pending")
+            .GroupBy(r => r.Project)
+            .OrderByDescending(g => g.Count())
+            .Select(g => new Option<string>($"{g.Key} ({g.Count()})", g.Key))
+            .ToArray<IAnyOption>();
+
+        var statusOptions = recommendations
+            .Where(r => r.State == "Pending")
+            .Select(r => r.SourcePlanStatus)
+            .Distinct()
+            .OrderBy(s => s)
+            .Select(s => new Option<string>(s.ToString(), s.ToString()))
+            .ToArray<IAnyOption>();
+
+        var filterBar = new Expandable(
+            header: "Filters",
+            content: Layout.Vertical()
+                | projectFilter.ToSelectInput(projectOptions).Placeholder("All Projects").Nullable().WithField().Label("Project")
+                | planStatusFilter.ToSelectInput(statusOptions).Placeholder("All Statuses").Nullable().WithField().Label("Plan Status")
+        ).Open(false).Ghost();
+
         var sidebar = new Recommendations.SidebarView(filtered, selectedState);
 
         return new SidebarLayout(
             mainContent: new Recommendations.ContentView(selectedState.Value, filtered, selectedState, planService, jobService, Refresh),
-            sidebarContent: sidebar
+            sidebarContent: Layout.Vertical()
+                | filterBar
+                | sidebar
         );
     }
 }

--- a/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
@@ -527,7 +527,8 @@ public class PlanReaderService(ConfigService config)
                         PlanTitle: plan.Title,
                         PlanFolderName: plan.FolderName,
                         Project: plan.Project,
-                        Date: plan.Updated
+                        Date: plan.Updated,
+                        SourcePlanStatus: plan.Status
                     ));
                 }
             }
@@ -636,7 +637,8 @@ public record Recommendation(
     string PlanTitle,
     string PlanFolderName,
     string Project,
-    DateTime Date
+    DateTime Date,
+    PlanStatus SourcePlanStatus
 );
 
 public class RecommendationYaml


### PR DESCRIPTION
# Summary

## Changes

Added project and plan status filtering to the RecommendationsApp. Extended the `Recommendation` record with a `SourcePlanStatus` field populated from plan metadata, and added two filter dropdowns (project and plan status) in a collapsible filter bar above the sidebar list.

## API Changes

- `Recommendation` record: added `PlanStatus SourcePlanStatus` parameter (positional record, so this is a breaking change for any code constructing `Recommendation` directly)
- `PlanReaderService.GetRecommendations()`: now populates the `SourcePlanStatus` field from `plan.Status`

## Files Modified

- **Service layer:**
  - `src/tendril/Ivy.Tendril/Services/PlanReaderService.cs` - Extended `Recommendation` record, updated `GetRecommendations()` to populate `SourcePlanStatus`
- **UI:**
  - `src/tendril/Ivy.Tendril/Apps/RecommendationsApp.cs` - Added filter state variables, filter logic, filter UI dropdowns in expandable panel
- **Tests:**
  - `src/tendril/Ivy.Tendril.Test/RecommendationServiceTests.cs` - Added 5 new tests for `SourcePlanStatus` population and filtering behavior

---

## Commits

- [01692] Add filtering to RecommendationsApp by project and plan status (b08979d0)