### PR TITLE
[01699] Add allowedTools example to example.config.yaml

### DIFF
--- a/src/tendril/Ivy.Tendril/example.config.yaml
+++ b/src/tendril/Ivy.Tendril/example.config.yaml
@@ -7,8 +7,9 @@ staleOutputTimeout: 10
 
 # Variable Expansion Support:
 # - %DotnetUserSecrets:Section:Key% - Read from .NET user secrets (requires .csproj with UserSecretsId)
-# - %TENDRIL_HOME% - Expands to TENDRIL_HOME env var
-# - %ANY_ENV_VAR% - Standard environment variable expansion (e.g., %REPOS_HOME%)
+# - %TENDRIL_HOME% - Expands to TENDRIL_HOME env var (useful in hooks, verification prompts, and allowedTools paths)
+# - %ANY_ENV_VAR% - Standard environment variable expansion (e.g., %REPOS_HOME% for repo paths)
+# Common uses: repo paths, hook script paths, allowedTools file patterns
 # See VARIABLE_EXPANSION.md for details
 
 # Example with user secrets for sensitive data:
@@ -16,6 +17,31 @@ staleOutputTimeout: 10
 #   endpoint: %DotnetUserSecrets:OpenAi:Endpoint%
 #   apiKey: %DotnetUserSecrets:OpenAi:ApiKey%
 #   model: gpt-4o-mini
+
+# Per-promptware tool permissions (allowedTools) provide least-privilege access control.
+# Without allowedTools, promptwares inherit global permissions from agentCommand.
+# Example promptware configuration with per-agent tool permissions:
+# promptwares:
+#   MakePlan:
+#     model: sonnet
+#     allowedTools:
+#       - Read
+#       - Glob
+#       - Grep
+#       - Bash
+#       - Write
+#       - Edit
+#   ExecutePlan:
+#     model: opus
+#     allowedTools:
+#       - Read
+#       - Write
+#       - Edit
+#       - Glob
+#       - Grep
+#       - Bash
+#       - WebFetch
+#       - WebSearch
 
 projects: []
 verifications: []


### PR DESCRIPTION
# Summary

## Changes

Added `allowedTools` examples and expanded variable expansion documentation in `example.config.yaml`. New users can now see how to configure per-promptware tool permissions during onboarding.

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/example.config.yaml** — Added commented promptwares section with allowedTools examples for MakePlan and ExecutePlan, expanded variable expansion comments with usage guidance

## Commits

- 031d771f [01699] Add allowedTools example to example.config.yaml