### PR TITLE
[01697] Add TENDRIL_CONFIG_PATH environment variable to JobService hooks

### DIFF
--- a/src/tendril/Ivy.Tendril.TeamIvyConfig/Hooks/NotifySlack.ps1
+++ b/src/tendril/Ivy.Tendril.TeamIvyConfig/Hooks/NotifySlack.ps1
@@ -36,10 +36,10 @@ if ($prs.Count -eq 0) {
 }
 
 # Read config.yaml to find slackEmoji for the project
-$configPath = Join-Path (Split-Path (Split-Path $planFolder -Parent) -Parent) "config.yaml"
-# Try standard config location; fall back to repo path
-if (-not (Test-Path $configPath)) {
-    $configPath = "D:\Repos\_Ivy\Ivy-Tendril\config.yaml"
+$configPath = $env:TENDRIL_CONFIG
+if (-not $configPath -or -not (Test-Path $configPath)) {
+    Write-Error "TENDRIL_CONFIG not set or config.yaml not found at $configPath"
+    exit 1
 }
 
 $slackEmoji = ""

--- a/src/tendril/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/tendril/Ivy.Tendril/Services/ConfigService.cs
@@ -206,6 +206,7 @@ public class ConfigService
 
     public TendrilSettings Settings => _settings;
     public string TendrilHome => _tendrilHome;
+    public string ConfigPath => _configPath;
     public string PlanFolder => string.IsNullOrEmpty(_tendrilHome) ? "" : Path.Combine(_tendrilHome, "Plans");
     public List<ProjectConfig> Projects => _settings.Projects;
     public List<LevelConfig> Levels => _settings.Levels;

--- a/src/tendril/Ivy.Tendril/Services/JobService.cs
+++ b/src/tendril/Ivy.Tendril/Services/JobService.cs
@@ -330,6 +330,7 @@ public class JobService
                 actionPsi.Environment["TENDRIL_JOB_TYPE"] = jobType;
                 actionPsi.Environment["TENDRIL_JOB_STATUS"] = job.Status;
                 actionPsi.Environment["TENDRIL_PLAN_FOLDER"] = planFolder;
+                actionPsi.Environment["TENDRIL_CONFIG"] = _configService.ConfigPath;
 
                 var actionProc = System.Diagnostics.Process.Start(actionPsi);
                 var output = actionProc?.StandardOutput.ReadToEnd().Trim() ?? "";


### PR DESCRIPTION
# Summary

## Changes

Added `TENDRIL_CONFIG` environment variable to JobService hook execution, exposing the config.yaml path to hook scripts. Updated `NotifySlack.ps1` to use this env var instead of fragile relative path guessing.

## API Changes

- `ConfigService.ConfigPath` — new public property exposing the resolved config.yaml file path
- `TENDRIL_CONFIG` — new environment variable set in `JobService.RunHooks()` for all hook processes

## Files Modified

- **src/tendril/Ivy.Tendril/Services/ConfigService.cs** — Added `ConfigPath` public property
- **src/tendril/Ivy.Tendril/Services/JobService.cs** — Set `TENDRIL_CONFIG` env var in `RunHooks()`
- **src/tendril/Ivy.Tendril.TeamIvyConfig/Hooks/NotifySlack.ps1** — Replaced path guessing with `$env:TENDRIL_CONFIG` usage

## Commits

- 7cafd28f [01697] Add TENDRIL_CONFIG environment variable to JobService hooks