### PR TITLE
[01703] Support multiple virtual columns from same root property in TableBuilder

### DIFF
--- a/src/Ivy.Test/Helpers/TypeHelperTests.cs
+++ b/src/Ivy.Test/Helpers/TypeHelperTests.cs
@@ -210,6 +210,30 @@ public class TypeHelperTests
         Assert.True(TypeHelper.IsComplexExpression(expr.Body));
     }
 
+    [Fact]
+    public void GetFullPathFromMemberExpression_SimpleProperty_ReturnsName()
+    {
+        Expression<Func<TestModel, object>> expr = m => m.Name;
+        var name = TypeHelper.GetFullPathFromMemberExpression(expr.Body);
+        Assert.Equal("Name", name);
+    }
+
+    [Fact]
+    public void GetFullPathFromMemberExpression_NavigationProperty_ReturnsFullPath()
+    {
+        Expression<Func<TestModel, object>> expr = m => m.Owner!.Name;
+        var name = TypeHelper.GetFullPathFromMemberExpression(expr.Body);
+        Assert.Equal("Owner.Name", name);
+    }
+
+    [Fact]
+    public void GetFullPathFromMemberExpression_DeepNavigation_ReturnsFullPath()
+    {
+        Expression<Func<TestModel, object>> expr = m => m.Owner!.Address!.City;
+        var name = TypeHelper.GetFullPathFromMemberExpression(expr.Body);
+        Assert.Equal("Owner.Address.City", name);
+    }
+
     private class TestModel
     {
         public string Name { get; set; } = "";

--- a/src/Ivy.Test/TableBuilderTests.cs
+++ b/src/Ivy.Test/TableBuilderTests.cs
@@ -13,6 +13,81 @@ public class TableBuilderTests
         public bool IsActive { get; set; }
     }
 
+    private class CustomerModel
+    {
+        public string Name { get; set; } = string.Empty;
+        public AddressModel Address { get; set; } = new();
+    }
+
+    private class AddressModel
+    {
+        public string City { get; set; } = string.Empty;
+        public string Region { get; set; } = string.Empty;
+    }
+
+    [Fact]
+    public void SubProperty_MultipleHeaderCalls_CreatesSeparateColumns()
+    {
+        var data = new[]
+        {
+            new CustomerModel { Name = "Alice", Address = new AddressModel { City = "NYC", Region = "NY" } }
+        };
+
+        var builder = new TableBuilder<CustomerModel>(data);
+        builder.Header(c => c.Address.City, "City");
+        builder.Header(c => c.Address.Region, "Region");
+
+        var columnsField = typeof(TableBuilder<CustomerModel>)
+            .GetField("_columns", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var columns = (System.Collections.IDictionary)columnsField!.GetValue(builder)!;
+
+        Assert.True(columns.Contains("Address.City"));
+        Assert.True(columns.Contains("Address.Region"));
+    }
+
+    [Fact]
+    public void SubProperty_DifferentAccessors_BothWork()
+    {
+        var data = new[]
+        {
+            new CustomerModel { Name = "Alice", Address = new AddressModel { City = "NYC", Region = "NY" } }
+        };
+
+        var builder = new TableBuilder<CustomerModel>(data);
+        builder.Header(c => c.Address.City, "City");
+        builder.Header(c => c.Address.Region, "Region");
+
+        var columnsField = typeof(TableBuilder<CustomerModel>)
+            .GetField("_columns", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var columns = (System.Collections.IDictionary)columnsField!.GetValue(builder)!;
+
+        var cityColumn = columns["Address.City"]!;
+        var regionColumn = columns["Address.Region"]!;
+
+        var getValueMethod = cityColumn.GetType().GetMethod("GetValue");
+        Assert.Equal("NYC", getValueMethod!.Invoke(cityColumn, new object[] { data[0] }));
+        Assert.Equal("NY", getValueMethod!.Invoke(regionColumn, new object[] { data[0] }));
+    }
+
+    [Fact]
+    public void SimpleProperty_BackwardCompatibility_UsesSimpleName()
+    {
+        var data = new[]
+        {
+            new CustomerModel { Name = "Alice", Address = new AddressModel { City = "NYC", Region = "NY" } }
+        };
+
+        var builder = new TableBuilder<CustomerModel>(data);
+
+        var columnsField = typeof(TableBuilder<CustomerModel>)
+            .GetField("_columns", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var columns = (System.Collections.IDictionary)columnsField!.GetValue(builder)!;
+
+        // Scaffolded columns should use simple property names
+        Assert.True(columns.Contains("Name"));
+        Assert.True(columns.Contains("Address"));
+    }
+
     [Fact]
     public void Reset_ShouldRestoreInitialState()
     {

--- a/src/Ivy/Helpers/TypeHelper.cs
+++ b/src/Ivy/Helpers/TypeHelper.cs
@@ -245,6 +245,33 @@ public static class TypeHelper
         }
     }
 
+    public static string GetFullPathFromMemberExpression(Expression expression)
+    {
+        while (expression is UnaryExpression unary)
+            expression = unary.Operand;
+
+        if (expression is MethodCallExpression methodCall
+            && methodCall.Method.Name == "get_Item"
+            && methodCall.Arguments.Count == 1
+            && methodCall.Arguments[0] is ConstantExpression constant)
+        {
+            return constant.Value?.ToString() ?? throw new ArgumentException("Invalid expression.");
+        }
+
+        var parts = new List<string>();
+        while (expression is MemberExpression member)
+        {
+            parts.Add(member.Member.Name);
+            expression = member.Expression!;
+        }
+
+        if (parts.Count == 0)
+            throw new ArgumentException("Invalid expression.");
+
+        parts.Reverse();
+        return string.Join(".", parts);
+    }
+
     internal static bool IsComplexExpression(Expression expression)
     {
         // Unwrap Convert/ConvertChecked

--- a/src/Ivy/Views/Tables/TableBuilder.cs
+++ b/src/Ivy/Views/Tables/TableBuilder.cs
@@ -45,6 +45,7 @@ public class TableBuilder<TModel> : ViewBase, IStateless
         public Align AlignContent { get; set; } = alignContent;
         public Size? Width { get; set; }
         public Func<IEnumerable<TModel>, object>? FooterAggregate { get; set; }
+        public Func<TModel, object>? ExpressionAccessor { get; set; }
 
         public object? GetValue(TModel obj)
         {
@@ -52,6 +53,11 @@ public class TableBuilder<TModel> : ViewBase, IStateless
 
             try
             {
+                if (ExpressionAccessor != null)
+                {
+                    return ExpressionAccessor(obj);
+                }
+
                 if (FieldInfo != null)
                 {
                     return FieldInfo.GetValue(obj);
@@ -246,12 +252,13 @@ public class TableBuilder<TModel> : ViewBase, IStateless
 
     private TableBuilderColumn GetField(Expression<Func<TModel, object>> field)
     {
-        var name = TypeHelper.GetNameFromMemberExpression(field.Body);
+        var name = TypeHelper.GetFullPathFromMemberExpression(field.Body);
         if (!_columns.TryGetValue(name, out var column))
         {
             var order = _columns.Count;
             var builder = _builderFactory.Default();
             column = new TableBuilderColumn(name, order, builder, Ivy.Align.Left, null!, null, false, builder, false, Ivy.Align.Left);
+            column.ExpressionAccessor = field.Compile();
             column.Width = CalculateSmartDefaultWidth(column);
             _columns[name] = column;
         }
@@ -311,7 +318,7 @@ public class TableBuilder<TModel> : ViewBase, IStateless
     {
         foreach (var field in fields)
         {
-            var name = TypeHelper.GetNameFromMemberExpression(field.Body);
+            var name = TypeHelper.GetFullPathFromMemberExpression(field.Body);
             if (!_columns.TryGetValue(name, out var hint)) continue;
             hint.Removed = true;
         }


### PR DESCRIPTION
# Summary

## Changes

Added support for multiple virtual columns derived from the same root navigation property in `TableBuilder<T>`. Previously, expressions like `e => e.Address.City` and `e => e.Address.Region` both resolved to the same column key `"Address"`, causing the second call to overwrite the first. Now each sub-property gets its own column keyed by the full property path (e.g., `"Address.City"`, `"Address.Region"`).

## API Changes

- **New:** `TypeHelper.GetFullPathFromMemberExpression(Expression)` — returns the complete dot-separated property path from a member expression (e.g., `"Address.City"` instead of `"Address"`).
- **Changed:** `TableBuilder<T>.GetField()` now uses `GetFullPathFromMemberExpression` instead of `GetNameFromMemberExpression` for column keying. Simple property expressions (e.g., `e => e.Name`) still resolve to `"Name"` (backward compatible).
- **New:** `TableBuilderColumn.ExpressionAccessor` property — compiled expression accessor used for dynamically created sub-property columns.

## Files Modified

- `src/Ivy/Helpers/TypeHelper.cs` — Added `GetFullPathFromMemberExpression` method
- `src/Ivy/Views/Tables/TableBuilder.cs` — Updated `GetField()` and `Remove()` to use full paths; added `ExpressionAccessor` to `TableBuilderColumn`
- `src/Ivy.Test/Helpers/TypeHelperTests.cs` — Added 3 tests for `GetFullPathFromMemberExpression`
- `src/Ivy.Test/TableBuilderTests.cs` — Added 3 tests for sub-property column support and backward compatibility

## Commits

- 162d8e3e [01703] Support multiple virtual columns from same root property