### PR TITLE
[01708] Pin powershell-yaml version in Bootstrap-Modules.ps1

### DIFF
--- a/src/tendril/Ivy.Tendril/.promptwares/.shared/Bootstrap-Modules.ps1
+++ b/src/tendril/Ivy.Tendril/.promptwares/.shared/Bootstrap-Modules.ps1
@@ -5,7 +5,7 @@
 # Ensure powershell-yaml is available
 if (-not (Get-Module -ListAvailable -Name powershell-yaml)) {
     Write-Host "Installing powershell-yaml module..." -ForegroundColor Yellow
-    Install-Module -Name powershell-yaml -Force -Scope CurrentUser
+    Install-Module -Name powershell-yaml -RequiredVersion 0.4.12 -Force -Scope CurrentUser
 }
 
 # Import the module


### PR DESCRIPTION
# Summary

## Changes

Pinned the `powershell-yaml` module to version `0.4.12` in `Bootstrap-Modules.ps1`. The `Install-Module` call now uses `-RequiredVersion 0.4.12` instead of installing the latest version, preventing unexpected breaking changes across all promptware scripts that source this bootstrap file.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/.promptwares/.shared/Bootstrap-Modules.ps1` — Added `-RequiredVersion 0.4.12` to the `Install-Module` command

## Commits

- 1d5a8d44 [01708] Pin powershell-yaml to version 0.4.12 in Bootstrap-Modules.ps1