### PR TITLE
[01710] Document polish callback for LineChart and AreaChart

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/06_Charts/01_LineChart.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/06_Charts/01_LineChart.md
@@ -158,3 +158,56 @@ public class BitcoinChart : ViewBase
 
 </Body>
 </Details>
+
+## Customizing with polish
+
+When building charts from queryable data with `ToLineChart()`, use the `polish` callback to customize the scaffolded chart before it renders. The callback receives the fully built `LineChart` with lines from your measures already configured by the selected style.
+
+Common use cases for `polish`:
+- Override line colors, widths, or curve types
+- Add reference lines or areas
+- Replace the default lines array with custom line configurations
+- Add or modify tooltips, legends, or grids
+
+### Example: Custom line styling
+
+```csharp demo-below
+public class PolishLineChartDemo : ViewBase
+{
+    record SalesData(string Month, int Desktop, int Mobile);
+
+    public override object? Build()
+    {
+        var data = new SalesData[]
+        {
+            new("Jan", 186, 100),
+            new("Feb", 305, 200),
+            new("Mar", 237, 300),
+            new("Apr", 186, 100),
+            new("May", 325, 200),
+        };
+
+        return Layout.Vertical()
+            | data.ToLineChart(
+                polish: chart =>
+                {
+                    // Replace the scaffolded lines with custom styling
+                    return chart with
+                    {
+                        Lines =
+                        [
+                            new Line("Desktop").Stroke(Colors.Blue).StrokeWidth(3).CurveType(CurveTypes.Step),
+                            new Line("Mobile").Stroke(Colors.Orange).StrokeWidth(2).StrokeDashArray("5 5")
+                        ]
+                    };
+                }
+            )
+            .Dimension("Month", e => e.Month)
+            .Measure("Desktop", e => e.Sum(f => f.Desktop))
+            .Measure("Mobile", e => e.Sum(f => f.Mobile))
+            .Toolbox();
+    }
+}
+```
+
+> **Note:** The `polish` callback receives the fully scaffolded `LineChart` which already includes lines from the style. Use `chart with { ... }` syntax to replace or modify chart properties while preserving others.

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/06_Charts/03_AreaChart.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/06_Charts/03_AreaChart.md
@@ -152,3 +152,57 @@ public class ImmigrationToEurope : ViewBase
 
 </Body>
 </Details>
+
+## Customizing with polish
+
+When building charts from queryable data with `ToAreaChart()`, use the `polish` callback to customize the scaffolded chart before it renders. The callback receives the fully built `AreaChart` with areas from your measures already configured by the selected style.
+
+Common use cases for `polish`:
+- Override area colors, opacity, or curve types
+- Add reference lines or grids
+- Replace the default areas array with custom area configurations
+- Modify stacking behavior
+- Add or modify tooltips, legends
+
+### Example: Custom area styling
+
+```csharp demo-below
+public class PolishAreaChartDemo : ViewBase
+{
+    record SalesData(string Month, int Desktop, int Mobile);
+
+    public override object? Build()
+    {
+        var data = new SalesData[]
+        {
+            new("Jan", 186, 80),
+            new("Feb", 305, 200),
+            new("Mar", 237, 120),
+            new("Apr", 186, 100),
+            new("May", 325, 180),
+        };
+
+        return Layout.Vertical()
+            | data.ToAreaChart(
+                polish: chart =>
+                {
+                    // Replace the scaffolded areas with custom styling
+                    return chart with
+                    {
+                        Areas =
+                        [
+                            new Area("Desktop", 1).Fill(Colors.Blue).FillOpacity(0.6),
+                            new Area("Mobile", 1).Fill(Colors.Orange).FillOpacity(0.4)
+                        ]
+                    };
+                }
+            )
+            .Dimension("Month", e => e.Month)
+            .Measure("Desktop", e => e.Sum(f => f.Desktop))
+            .Measure("Mobile", e => e.Sum(f => f.Mobile))
+            .Toolbox();
+    }
+}
+```
+
+> **Note:** The `polish` callback receives the fully scaffolded `AreaChart` which already includes areas from the style. Use `chart with { ... }` syntax to replace or modify chart properties while preserving others.


### PR DESCRIPTION
# Summary

## Changes

Added "Customizing with polish" documentation sections to both LineChart (`01_LineChart.md`) and AreaChart (`03_AreaChart.md`) docs. Each section explains the `polish` callback parameter, lists common use cases, and provides a working demo example showing how to replace scaffolded lines/areas with custom styling.

## API Changes

None.

## Files Modified

- **Documentation:**
  - `src/Ivy.Docs.Shared/Docs/02_Widgets/06_Charts/01_LineChart.md` — Added polish section with `PolishLineChartDemo` example
  - `src/Ivy.Docs.Shared/Docs/02_Widgets/06_Charts/03_AreaChart.md` — Added polish section with `PolishAreaChartDemo` example

## Commits

- 26deb258 [01710] Document polish callback for LineChart and AreaChart