### PR TITLE
[01711] Remove workaround sort from DashboardApp after ToDataTable fix

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/DashboardApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/DashboardApp.cs
@@ -68,7 +68,7 @@ public class DashboardApp : ViewBase
                 Cost = dayCost > 0 ? $"${dayCost:F2}" : "",
                 Tokens = dayTokens > 0 ? FormatTokens(dayTokens) : ""
             };
-        }).OrderByDescending(r => r.SortDate).ToList();
+        }).ToList();
 
         var dataTable = rows.AsQueryable()
             .ToDataTable(idSelector: t => t.SortDate)


### PR DESCRIPTION
# Summary

## Changes

Removed the redundant `.OrderByDescending(r => r.SortDate)` call from `DashboardApp.cs`. This explicit sort was a workaround added in plan [01652] that became unnecessary after plan [01666] fixed the root cause in `QueryProcessor` to preserve source order when `AllowSorting = false`.

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/Apps/DashboardApp.cs** — Removed `.OrderByDescending(r => r.SortDate)` from the row creation LINQ chain (line 71)

## Commits

- 10b57813 [01711] Remove workaround OrderByDescending from DashboardApp