### PR TITLE
[01709] Add YAxisIndex support to Line and Area charts

### DIFF
--- a/src/Ivy/Widgets/Charts/Shared/Area.cs
+++ b/src/Ivy/Widgets/Charts/Shared/Area.cs
@@ -42,6 +42,8 @@ public record Area
     public Label? Label { get; set; } = null;
 
     public string? StackId { get; set; }
+
+    public int? YAxisIndex { get; set; } = null;
 }
 
 public static class AreaExtensions
@@ -109,6 +111,11 @@ public static class AreaExtensions
     public static Area FillOpacity(this Area area, double fillOpacity)
     {
         return area with { FillOpacity = fillOpacity };
+    }
+
+    public static Area YAxisIndex(this Area area, int yAxisIndex)
+    {
+        return area with { YAxisIndex = yAxisIndex };
     }
 }
 

--- a/src/Ivy/Widgets/Charts/Shared/Line.cs
+++ b/src/Ivy/Widgets/Charts/Shared/Line.cs
@@ -37,6 +37,8 @@ public record Line
     public bool Animated { get; set; } = false;
 
     public Label? Label { get; set; } = null;
+
+    public int? YAxisIndex { get; set; } = null;
 }
 
 public static class LineExtensions
@@ -94,6 +96,11 @@ public static class LineExtensions
     public static Line Scale(this Line line, Scales scale)
     {
         return line with { Scale = scale };
+    }
+
+    public static Line YAxisIndex(this Line line, int yAxisIndex)
+    {
+        return line with { YAxisIndex = yAxisIndex };
     }
 }
 


### PR DESCRIPTION
# Summary

## Changes

Added `YAxisIndex` property and fluent extension method to `Line` and `Area` record types, matching the existing pattern in `Bar`. This enables dual-axis chart patterns for LineChart and AreaChart visualizations.

## API Changes

- `Line.YAxisIndex` — new `int?` property (default `null`)
- `LineExtensions.YAxisIndex(this Line, int)` — new fluent extension method
- `Area.YAxisIndex` — new `int?` property (default `null`)
- `AreaExtensions.YAxisIndex(this Area, int)` — new fluent extension method

## Files Modified

- `src/Ivy/Widgets/Charts/Shared/Line.cs` — added YAxisIndex property and extension method
- `src/Ivy/Widgets/Charts/Shared/Area.cs` — added YAxisIndex property and extension method

## Commits

- 05f52afd [01709] Add YAxisIndex property to Line and Area chart types