### PR TITLE
[01716] Automate .npmrc setup for worktrees

### DIFF
--- a/src/tendril/Ivy.Tendril/.promptwares/ExecutePlan/Program.md
+++ b/src/tendril/Ivy.Tendril/.promptwares/ExecutePlan/Program.md
@@ -121,27 +121,17 @@ git worktree add "<PlanFolder>/worktrees/<RepoName>" -b "plan-<PlanId>-<RepoName
 
 **Important:** Always branch from `origin/<default-branch>`, not local HEAD. This ensures the PR only contains the plan's commits, not any unpushed local work.
 
-### 2.5. Configure pnpm for Ivy-Framework Worktrees
+### 2.5. Setup Frontend Dependencies
 
-If the worktree is for the Ivy-Framework repo (contains `src/frontend/` and uses pnpm):
+If any worktree contains a `frontend/` directory with `package.json`, run the frontend setup tool:
 
-1. Create temporary `.npmrc` files with `node-linker=hoisted` in:
-   - `<worktree>/src/frontend/.npmrc`
-   - Each `<worktree>/src/widgets/*/frontend/.npmrc` (if widget frontend directories exist)
+```bash
+pwsh -NoProfile -File "$env:TENDRIL_HOME/.promptwares/ExecutePlan/Tools/Setup-WorktreeFrontend.ps1" -WorktreeRoot "<PlanFolder>/worktrees"
+```
 
-2. Run pnpm install:
-   ```bash
-   cd <worktree>/src/frontend && pnpm install
-   ```
+This creates `.npmrc` files for private package authentication and `node-linker=hoisted` (required for pnpm in worktrees), runs `pnpm install`, and cleans up credentials afterward.
 
-3. For each widget frontend:
-   ```bash
-   cd <worktree>/src/widgets/<widget>/frontend && pnpm install
-   ```
-
-**Important:** These `.npmrc` files must be deleted after verification (Step 8 "Final Clean Check") — they are build workarounds and should not be committed.
-
-**Rationale:** Worktree paths are longer than main repo paths, breaking pnpm's symlink resolution for `@voidzero-dev/vite-plus-core`'s package imports. Hoisted mode avoids this issue. See Memory/dotnet-project-gotchas.md for details.
+**Important:** This step must run after worktrees are created but before any build commands that depend on `node_modules`.
 
 ### 3. Handle Cross-Repo References
 
@@ -338,3 +328,4 @@ You are running in non-interactive mode and CANNOT ask questions. If you are uns
 - Commit messages must reference the plan ID
 - All `file:///` paths in plans should be converted to Windows paths when needed
 - Do NOT commit artifact files (screenshots, images) to the repo. Test artifacts belong in `<PlanFolder>/artifacts/` only — MakePr handles uploading them to persistent storage.
+- Private npm packages (like `@ivy-interactive/ivy-design-system`) require authentication via `.npmrc`. The Setup-WorktreeFrontend.ps1 tool handles this automatically. Credentials come from NPM_TOKEN env var or .NET user secrets (Npm:RegistryToken).

--- a/src/tendril/Ivy.Tendril/.promptwares/ExecutePlan/Tools/Setup-WorktreeFrontend.ps1
+++ b/src/tendril/Ivy.Tendril/.promptwares/ExecutePlan/Tools/Setup-WorktreeFrontend.ps1
@@ -1,0 +1,115 @@
+<#
+.SYNOPSIS
+Sets up .npmrc authentication and runs pnpm install for worktree frontend directories.
+
+.DESCRIPTION
+Detects frontend directories in worktrees, creates .npmrc files with authentication
+for private @ivy-interactive packages, runs pnpm install, and optionally cleans up.
+
+.PARAMETER WorktreeRoot
+Path to the worktrees directory (e.g., <PlanFolder>/worktrees)
+
+.PARAMETER RegistryToken
+Authentication token for the npm registry. If not provided, attempts to read from
+.NET user secrets (DotnetUserSecrets:Npm:RegistryToken) or NPM_TOKEN environment variable.
+
+.PARAMETER SkipCleanup
+If set, does not delete .npmrc files after install (useful for debugging).
+
+.EXAMPLE
+Setup-WorktreeFrontend.ps1 -WorktreeRoot "D:\Plans\01234-Example\worktrees"
+
+.EXAMPLE
+Setup-WorktreeFrontend.ps1 -WorktreeRoot ".\worktrees" -SkipCleanup
+#>
+param(
+    [Parameter(Mandatory)]
+    [string]$WorktreeRoot,
+
+    [string]$RegistryToken,
+
+    [switch]$SkipCleanup
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+# Resolve token if not provided
+if (-not $RegistryToken) {
+    # Try .NET user secrets first
+    try {
+        $secretsJson = dotnet user-secrets list --json 2>$null | ConvertFrom-Json
+        $RegistryToken = $secretsJson."Npm:RegistryToken"
+    } catch {
+        # Ignore errors
+    }
+
+    # Fallback to environment variable
+    if (-not $RegistryToken) {
+        $RegistryToken = $env:NPM_TOKEN
+    }
+
+    if (-not $RegistryToken) {
+        Write-Error "No registry token provided. Set NPM_TOKEN env var, configure .NET user secrets (Npm:RegistryToken), or pass -RegistryToken"
+        exit 1
+    }
+}
+
+# Find all frontend directories in worktrees
+$frontendDirs = Get-ChildItem -Path $WorktreeRoot -Directory -Recurse -Filter "frontend" |
+    Where-Object { Test-Path (Join-Path $_.FullName "package.json") }
+
+if ($frontendDirs.Count -eq 0) {
+    Write-Host "No frontend directories found in worktrees."
+    exit 0
+}
+
+Write-Host "Found $($frontendDirs.Count) frontend directories:"
+$frontendDirs | ForEach-Object { Write-Host "  - $($_.FullName)" }
+
+$createdFiles = @()
+
+try {
+    foreach ($dir in $frontendDirs) {
+        $npmrcPath = Join-Path $dir.FullName ".npmrc"
+
+        Write-Host "`nSetting up $npmrcPath..."
+
+        # Create .npmrc with registry authentication and node-linker=hoisted
+        # node-linker=hoisted is required for pnpm in worktrees to avoid
+        # ERR_PACKAGE_IMPORT_NOT_DEFINED errors with @voidzero-dev/vite-plus-core
+        $npmrcContent = @"
+node-linker=hoisted
+@ivy-interactive:registry=https://npm.pkg.github.com/
+//npm.pkg.github.com/:_authToken=$RegistryToken
+"@
+
+        Set-Content -Path $npmrcPath -Value $npmrcContent -NoNewline
+        $createdFiles += $npmrcPath
+
+        Write-Host "Running pnpm install in $($dir.FullName)..."
+        Push-Location $dir.FullName
+        try {
+            npx -y pnpm@10.33.0 install --frozen-lockfile
+            if ($LASTEXITCODE -ne 0) {
+                throw "pnpm install failed with exit code $LASTEXITCODE"
+            }
+        } finally {
+            Pop-Location
+        }
+    }
+
+    Write-Host "`nAll frontend directories set up successfully."
+
+} finally {
+    # Cleanup .npmrc files unless -SkipCleanup is set
+    if (-not $SkipCleanup -and $createdFiles.Count -gt 0) {
+        Write-Host "`nCleaning up .npmrc files..."
+        foreach ($file in $createdFiles) {
+            if (Test-Path $file) {
+                Remove-Item $file -Force
+                Write-Host "  Removed $file"
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Summary

## Changes

Added a PowerShell tool `Setup-WorktreeFrontend.ps1` to automate `.npmrc` creation and `pnpm install` for worktree frontend directories. Updated `Program.md` to invoke this tool as Step 2.5 after worktree creation, and added a Rules note about private npm package authentication.

## API Changes

- New PowerShell tool: `ExecutePlan/Tools/Setup-WorktreeFrontend.ps1` with parameters `-WorktreeRoot` (required), `-RegistryToken` (optional), `-SkipCleanup` (switch)
- New execution step `2.5. Setup Frontend Dependencies` in `Program.md`

## Files Modified

- **Tools:**
  - `src/tendril/Ivy.Tendril/.promptwares/ExecutePlan/Tools/Setup-WorktreeFrontend.ps1` — new PowerShell tool
- **Documentation:**
  - `src/tendril/Ivy.Tendril/.promptwares/ExecutePlan/Program.md` — added Step 2.5 and Rules entry

## Commits

- 2c86c55b [01716] Add Setup-WorktreeFrontend.ps1 tool and update Program.md