### PR TITLE
[01712] Fix PrepareFirmware shared folder path resolution

### DIFF
--- a/src/tendril/Ivy.Tendril/.promptwares/.shared/Utils.ps1
+++ b/src/tendril/Ivy.Tendril/.promptwares/.shared/Utils.ps1
@@ -69,7 +69,11 @@ function PrepareFirmware {
 
     $header = ($Values.GetEnumerator() | Sort-Object Name | ForEach-Object { "$($_.Key): $($_.Value)" }) -join "`n"
 
-    $sharedFolder = Join-Path $ScriptRoot ".shared"
+    $sharedFolder = if ($env:TENDRIL_SHARED) {
+        $env:TENDRIL_SHARED
+    } else {
+        Join-Path $ScriptRoot ".shared"
+    }
     $firmware = Get-Content "$sharedFolder\Firmware.md" -Raw
     $firmware = $firmware.Replace("[HEADER]", $header)
     $firmware = $firmware.Replace("[LOGFILE]", $LogFile)


### PR DESCRIPTION
# Summary

## Changes

Modified the `PrepareFirmware` function in `Utils.ps1` to resolve the shared folder path using `$env:TENDRIL_SHARED` when available, falling back to `Join-Path $ScriptRoot ".shared"`. This fixes null-valued expression errors when user promptwares (like `IvyFrameworkVerification.ps1`) invoke `PrepareFirmware` from a directory that doesn't contain a `.shared` subfolder.

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/.promptwares/.shared/Utils.ps1** — Updated `PrepareFirmware` shared folder path resolution (line 72)

---

## Commits

- 0bad72a1 [01712] Fix PrepareFirmware shared folder path resolution