### PR TITLE
[01719] Add empty state message for filtered recommendations

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Recommendations/SidebarView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Recommendations/SidebarView.cs
@@ -5,13 +5,25 @@ namespace Ivy.Tendril.Apps.Recommendations;
 
 public class SidebarView(
     List<Recommendation> recommendations,
-    IState<Recommendation?> selectedState) : ViewBase
+    IState<Recommendation?> selectedState,
+    int totalCount,
+    bool hasActiveFilters) : ViewBase
 {
     private readonly List<Recommendation> _recommendations = recommendations;
     private readonly IState<Recommendation?> _selectedState = selectedState;
+    private readonly int _totalCount = totalCount;
+    private readonly bool _hasActiveFilters = hasActiveFilters;
 
     public override object Build()
     {
+        if (_recommendations.Count == 0 && _hasActiveFilters && _totalCount > 0)
+        {
+            return Layout.Vertical().AlignContent(Align.Center).Gap(2).Padding(4)
+                | new Icon(Icons.ListFilterPlus).Size(Size.Units(6)).Color(Colors.Gray)
+                | Text.Muted("No matching recommendations")
+                | Text.Muted("Try adjusting your filters").Small();
+        }
+
         return new List(_recommendations.Select(rec =>
         {
             var clickableRec = rec;

--- a/src/tendril/Ivy.Tendril/Apps/RecommendationsApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/RecommendationsApp.cs
@@ -57,7 +57,10 @@ public class RecommendationsApp : ViewBase
                 | planStatusFilter.ToSelectInput(statusOptions).Placeholder("All Statuses").Nullable().WithField().Label("Plan Status")
         ).Open(false).Ghost();
 
-        var sidebar = new Recommendations.SidebarView(filtered, selectedState);
+        var totalPendingCount = recommendations.Count(r => r.State == "Pending");
+        var hasActiveFilters = projectFilter.Value != null || planStatusFilter.Value != null;
+
+        var sidebar = new Recommendations.SidebarView(filtered, selectedState, totalPendingCount, hasActiveFilters);
 
         return new SidebarLayout(
             mainContent: new Recommendations.ContentView(selectedState.Value, filtered, selectedState, planService, jobService, Refresh),


### PR DESCRIPTION
# Summary

## Changes

Added an empty state message to the recommendations sidebar that appears when active filters produce zero results. The message displays a filter icon, "No matching recommendations" text, and a hint to adjust filters — distinguishing this from the existing "No recommendations yet" state (which shows when there are no recommendations at all).

## API Changes

- `SidebarView` constructor now accepts two additional parameters: `int totalCount` (total pending recommendations before filtering) and `bool hasActiveFilters` (whether any filter is currently set).

## Files Modified

- **src/tendril/Ivy.Tendril/Apps/Recommendations/SidebarView.cs** — Added `totalCount` and `hasActiveFilters` parameters; added empty state rendering when filters produce no results.
- **src/tendril/Ivy.Tendril/Apps/RecommendationsApp.cs** — Computed `totalPendingCount` and `hasActiveFilters` and passed them to `SidebarView`.

---

## Commits

- b01885ca [01719] Add empty state message for filtered recommendations