### PR TITLE
[01724] Add code validation to MakePlan at plan creation time

### DIFF
--- a/src/tendril/Ivy.Tendril/.promptwares/MakePlan/Program.md
+++ b/src/tendril/Ivy.Tendril/.promptwares/MakePlan/Program.md
@@ -68,7 +68,7 @@ The plan ID is pre-allocated by the launcher script and provided in the firmware
 
   - **Verify the fix commit exists on main**: Read the existing plan's `commits` list and run `git log --oneline <hash>` to confirm the commit is on the main branch. If the commit is not on main, do NOT trash — create the plan.
   - **Check commit date vs observation time**: If the inbox item describes an issue observed at a specific time, compare against the fix commit date (`git log -1 --format=%ci <hash>`). If the observation is **after** the fix was committed, the fix may not have worked — create the plan instead of trashing.
-  - **Verify in code**: For code fixes, grep the actual source to confirm the fix is still present.
+  - **Verify in code**: For code fixes, use `Tools/Validate-CodeAssertion.ps1` or grep the actual source to confirm the fix is still present.
 
   #### Step 4: Regression detection (for Completed plans)
 
@@ -113,6 +113,30 @@ The plan ID is pre-allocated by the launcher script and provided in the firmware
   gh search issues "<keyword>" --repo <owner>/<repo> --json title,url,number,state
   ```
   Derive the repo owner/name from the repos in `config.yaml`. If an issue already covers the task, reference it in the plan and avoid creating workaround plans.
+
+### 3.5. Validate Code State
+
+Before creating the plan, scan the task description (args) for code state assertions — statements about what the code currently does or how it currently looks.
+
+**Patterns to detect:**
+- "currently does/has/is/returns"
+- "the code at [location]" or "[file]:[lines]"
+- Code blocks (` ```language ... ``` `) with descriptive context
+- "existing implementation" or "current behavior"
+
+For each assertion found:
+1. Extract the referenced file path and optional line range
+2. Use `Tools/Validate-CodeAssertion.ps1` to check if the described code actually exists
+3. If validation fails, investigate:
+   - Check `git log --oneline -10 --all -- <file>` for recent changes
+   - Check `git blame <file>` to find who/when the code changed
+   - Look for plan IDs in commit messages (e.g., `[01234]`)
+
+**Decision:**
+- **All validations pass** → Proceed to Step 4, include validated code blocks in plan with `**Current implementation**` headers
+- **Any validation fails** → Write trash file to `$env:TENDRIL_HOME/Trash/<PlanId>-<SafeTitle>.md` explaining the validation failure, then exit without creating a plan
+
+This catches stale plans before they enter the review queue, reducing wasted review time.
 
 ### 4. Create Plan
 

--- a/src/tendril/Ivy.Tendril/.promptwares/MakePlan/Tools/Validate-CodeAssertion.ps1
+++ b/src/tendril/Ivy.Tendril/.promptwares/MakePlan/Tools/Validate-CodeAssertion.ps1
@@ -1,0 +1,62 @@
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$FilePath,
+
+    [Parameter(Mandatory=$false)]
+    [string]$ExpectedCode,
+
+    [Parameter(Mandatory=$false)]
+    [string]$Description,
+
+    [Parameter(Mandatory=$false)]
+    [int]$LineStart,
+
+    [Parameter(Mandatory=$false)]
+    [int]$LineEnd
+)
+
+# Read file content
+if (-not (Test-Path $FilePath)) {
+    Write-Host "FAIL: File not found at $FilePath"
+    exit 1
+}
+
+$content = Get-Content $FilePath -Raw
+
+# If specific line range given, extract those lines
+if ($LineStart -and $LineEnd) {
+    $lines = Get-Content $FilePath
+    $content = ($lines[($LineStart-1)..($LineEnd-1)] -join "`n")
+}
+
+# Validate against expected code (exact match, normalized whitespace)
+if ($ExpectedCode) {
+    $normalizedExpected = $ExpectedCode -replace '\s+', ' ' -replace '^\s+|\s+$', ''
+    $normalizedActual = $content -replace '\s+', ' ' -replace '^\s+|\s+$', ''
+
+    if ($normalizedActual -like "*$normalizedExpected*") {
+        Write-Host "PASS: Code matches expected"
+        exit 0
+    } else {
+        Write-Host "FAIL: Code does not match"
+        Write-Host "Expected: $normalizedExpected"
+        Write-Host "Actual: $normalizedActual"
+        exit 1
+    }
+}
+
+# Validate against description (pattern matching)
+if ($Description) {
+    if ($content -match $Description) {
+        Write-Host "PASS: Code matches description"
+        exit 0
+    } else {
+        Write-Host "FAIL: Code does not match description"
+        Write-Host "Description: $Description"
+        Write-Host "Content: $($content.Substring(0, [Math]::Min(200, $content.Length)))..."
+        exit 1
+    }
+}
+
+Write-Host "FAIL: No validation criteria provided"
+exit 1


### PR DESCRIPTION
# Summary

## Changes

Added code validation to MakePlan that detects stale code state assertions at plan creation time, before plans enter the review queue. This includes a new PowerShell tool (`Validate-CodeAssertion.ps1`) and a new Step 3.5 in MakePlan's Program.md.

## API Changes

None. Changes are to promptware instructions and tooling only.

## Files Modified

- **src/tendril/Ivy.Tendril/.promptwares/MakePlan/Program.md** — Added Step 3.5 (Validate Code State) and updated Step 3 to reference the new validation tool
- **src/tendril/Ivy.Tendril/.promptwares/MakePlan/Tools/Validate-CodeAssertion.ps1** — New PowerShell tool for validating code assertions against the current codebase

## Commits

- 8455ef18 [01724] Add code validation to MakePlan at plan creation time