### PR TITLE
[01722] Document ScatterChart polish callback

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/06_Charts/05_ScatterChart.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/06_Charts/05_ScatterChart.md
@@ -181,6 +181,61 @@ public class ZAxisRangeDemo : ViewBase
 }
 ```
 
+## Customizing with polish
+
+When building charts from queryable data with `ToScatterChart()`, use the `polish` callback to customize the scaffolded chart before it renders. The callback receives the fully built `ScatterChart` with scatter series already configured by the selected style.
+
+Common use cases for `polish`:
+- Override scatter point colors, shapes, or fill opacity
+- Add reference lines or grid customization
+- Replace the default scatters array with custom configurations
+- Add or modify tooltips, legends, or grids
+
+### Example: Custom scatter styling
+
+```csharp demo-below
+public class PolishScatterChartDemo : ViewBase
+{
+    record CityData(string City, int Population, int Area, int GreenSpace);
+
+    public override object? Build()
+    {
+        var data = new CityData[]
+        {
+            new("Oslo", 700, 480, 68),
+            new("Berlin", 3600, 892, 44),
+            new("Paris", 2100, 105, 21),
+            new("London", 8900, 1572, 33),
+            new("Rome", 2800, 1285, 52),
+        };
+
+        return Layout.Vertical()
+            | data.ToScatterChart(
+                polish: chart =>
+                {
+                    // Replace the scaffolded scatters with custom styling
+                    return chart with
+                    {
+                        Scatters = chart.Scatters.Select(s =>
+                            s with
+                            {
+                                Shape = ScatterShape.Diamond,
+                                Fill = Colors.Teal,
+                                FillOpacity = 0.7
+                            }
+                        ).ToArray()
+                    };
+                }
+            )
+            .Dimension("City", e => e.City)
+            .Measure("Population", e => e.Population)
+            .Size("Area", e => e.Area);
+    }
+}
+```
+
+> **Note:** The `polish` callback receives the fully scaffolded `ScatterChart` which already includes scatters from the style. Use `chart with { ... }` syntax to replace or modify chart properties while preserving others.
+
 <WidgetDocs Type="Ivy.ScatterChart" ExtensionTypes="Ivy.ScatterChartExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Charts/ScatterChart.cs"/>
 
 ## Example


### PR DESCRIPTION
# Summary

## Changes

Added a "Customizing with polish" section to the ScatterChart documentation (`05_ScatterChart.md`), documenting the existing `polish` callback parameter in `ToScatterChart()`. The section follows the same pattern established by LineChart and AreaChart documentation, including a description, common use cases, a demo example, and a note about the scaffolded chart.

## API Changes

None.

## Files Modified

- **Documentation:** `src/Ivy.Docs.Shared/Docs/02_Widgets/06_Charts/05_ScatterChart.md` — Added 55 lines with polish callback documentation and `PolishScatterChartDemo` example

## Commits

- c1f3e3c1 [01722] Add polish callback documentation to ScatterChart