### PR TITLE
[01723] Extract duplicated YAML repo path extraction logic to shared function

### DIFF
--- a/src/tendril/Ivy.Tendril.TeamIvyConfig/Hooks/CleanupWorktrees.ps1
+++ b/src/tendril/Ivy.Tendril.TeamIvyConfig/Hooks/CleanupWorktrees.ps1
@@ -10,18 +10,11 @@ param(
 
 $ErrorActionPreference = "Continue"
 
-# Bootstrap required PowerShell modules
+# Bootstrap shared utilities (includes Bootstrap-Modules.ps1 and ExtractRepoPathsFromYaml)
 $sharedPath = Join-Path (Split-Path (Split-Path $PSScriptRoot)) "Ivy.Tendril/.promptwares/.shared"
-. (Join-Path $sharedPath "Bootstrap-Modules.ps1")
+. (Join-Path $sharedPath "Utils.ps1")
 
-# Resolve plans directory
-$tendrilHome = $env:TENDRIL_HOME
-if (-not $tendrilHome) {
-    Write-Error "TENDRIL_HOME environment variable is not set."
-    exit 1
-}
-
-$plansDir = Join-Path $tendrilHome "Plans"
+$plansDir = Join-Path $env:TENDRIL_HOME "Plans"
 if (-not (Test-Path $plansDir)) {
     Write-Host "Plans directory not found: $plansDir" -ForegroundColor Yellow
     exit 0
@@ -58,16 +51,7 @@ foreach ($planFolder in $planFolders) {
     $planId = if ($planFolder.Name -match '^(\d+)') { $Matches[1] } else { "" }
 
     # Extract repo paths
-    $repoPaths = @()
-    if ($yaml.repos) {
-        foreach ($repo in $yaml.repos) {
-            $p = if ($repo -is [hashtable] -or $repo -is [System.Collections.IDictionary]) { $repo.path } else { "$repo" }
-            if ($p) {
-                $p = [Environment]::ExpandEnvironmentVariables($p)
-                if (Test-Path $p) { $repoPaths += $p }
-            }
-        }
-    }
+    $repoPaths = ExtractRepoPathsFromYaml -ReposArray $yaml.repos -ValidateExists
 
     Write-Host "Cleaning plan $($planFolder.Name) (state: $state)" -ForegroundColor Cyan
 

--- a/src/tendril/Ivy.Tendril/.promptwares/.shared/Utils.ps1
+++ b/src/tendril/Ivy.Tendril/.promptwares/.shared/Utils.ps1
@@ -218,6 +218,44 @@ function ReadPlanProject {
     return @{ Content = $content; Project = $project; Yaml = $yaml }
 }
 
+function ExtractRepoPathsFromYaml {
+    param(
+        [Parameter(Mandatory = $true)]
+        $ReposArray,
+        [switch]$ValidateExists
+    )
+
+    $paths = @()
+
+    if (-not $ReposArray) {
+        return $paths
+    }
+
+    foreach ($repo in $ReposArray) {
+        # Handle both formats: plain string or object with 'path' property
+        $p = if ($repo -is [hashtable] -or $repo -is [System.Collections.IDictionary]) {
+            $repo.path
+        } else {
+            "$repo"
+        }
+
+        if ($p) {
+            # Expand environment variables (e.g. %REPOS_HOME%)
+            $p = [Environment]::ExpandEnvironmentVariables($p)
+
+            if ($ValidateExists) {
+                if (Test-Path $p) {
+                    $paths += $p
+                }
+            } else {
+                $paths += $p
+            }
+        }
+    }
+
+    return $paths
+}
+
 function GetProjectWorkDir {
     param([string]$Project)
 
@@ -225,11 +263,10 @@ function GetProjectWorkDir {
         try {
             $config = Get-Content $script:ConfigPath -Raw | ConvertFrom-Yaml
             $projectEntry = $config.projects | Where-Object { $_.name -eq $Project } | Select-Object -First 1
-            if ($projectEntry -and $projectEntry.repos -and $projectEntry.repos.Count -gt 0) {
-                $repo = $projectEntry.repos[0]
-                $path = if ($repo -is [hashtable] -or $repo -is [System.Collections.IDictionary]) { $repo.path } else { "$repo" }
-                if ($path) {
-                    return [Environment]::ExpandEnvironmentVariables($path)
+            if ($projectEntry -and $projectEntry.repos) {
+                $paths = ExtractRepoPathsFromYaml -ReposArray $projectEntry.repos
+                if ($paths.Count -gt 0) {
+                    return $paths[0]
                 }
             }
         }

--- a/src/tendril/Ivy.Tendril/.promptwares/CleanupPlan.ps1
+++ b/src/tendril/Ivy.Tendril/.promptwares/CleanupPlan.ps1
@@ -29,16 +29,7 @@ $planFolderName = Split-Path $PlanPath -Leaf
 $planId = if ($planFolderName -match '^(\d+)') { $Matches[1] } else { "" }
 
 # Extract repo paths from plan.yaml
-$repoPaths = @()
-if ($planInfo.Yaml.repos) {
-    foreach ($repo in $planInfo.Yaml.repos) {
-        $p = if ($repo -is [hashtable] -or $repo -is [System.Collections.IDictionary]) { $repo.path } else { "$repo" }
-        if ($p) {
-            $p = [Environment]::ExpandEnvironmentVariables($p)
-            if (Test-Path $p) { $repoPaths += $p }
-        }
-    }
-}
+$repoPaths = ExtractRepoPathsFromYaml -ReposArray $planInfo.Yaml.repos -ValidateExists
 
 $worktreeDirs = Get-ChildItem -Path $worktreesDir -Directory -ErrorAction SilentlyContinue
 $cleanedCount = 0


### PR DESCRIPTION
# Summary

## Changes

Extracted the duplicated YAML repo path extraction logic into a new shared `ExtractRepoPathsFromYaml` function in `Utils.ps1`. Updated `CleanupPlan.ps1`, `CleanupWorktrees.ps1`, and `GetProjectWorkDir` to use the new function, eliminating code duplication across three files.

## API Changes

- **New function:** `ExtractRepoPathsFromYaml -ReposArray <array> [-ValidateExists]` in `Utils.ps1` — extracts and expands repo paths from YAML arrays supporting both string and object formats.
- `CleanupWorktrees.ps1` now sources `Utils.ps1` instead of just `Bootstrap-Modules.ps1`.

## Files Modified

- `src/tendril/Ivy.Tendril/.promptwares/.shared/Utils.ps1` — Added `ExtractRepoPathsFromYaml` function; refactored `GetProjectWorkDir` to use it
- `src/tendril/Ivy.Tendril/.promptwares/CleanupPlan.ps1` — Replaced inline repo extraction with function call
- `src/tendril/Ivy.Tendril.TeamIvyConfig/Hooks/CleanupWorktrees.ps1` — Replaced inline repo extraction with function call; sourced Utils.ps1

## Commits

- dd1afabc [01723] Extract duplicated YAML repo path extraction to shared ExtractRepoPathsFromYaml function