### PR TITLE
[01726] Extend useScrollShadow hook with direction parameter for FooterLayoutWidget

### DIFF
--- a/src/frontend/src/hooks/use-scroll-shadow.test.ts
+++ b/src/frontend/src/hooks/use-scroll-shadow.test.ts
@@ -41,12 +41,46 @@ describe("useScrollShadow", () => {
     expect(hookSource).toContain('removeEventListener("scroll"');
   });
 
-  it("should include selector in useEffect dependency array", () => {
-    expect(hookSource).toContain("[selector]");
+  it("should include selector and direction in useEffect dependency array", () => {
+    expect(hookSource).toContain("[selector, direction]");
   });
 
   it("should return isScrolled and scrollRef", () => {
     expect(hookSource).toContain("return { isScrolled, scrollRef }");
+  });
+});
+
+describe("useScrollShadow direction parameter", () => {
+  const hookSource = fs.readFileSync(path.resolve(__dirname, "./use-scroll-shadow.ts"), "utf-8");
+
+  it("should export ScrollShadowDirection type", () => {
+    expect(hookSource).toContain("export type ScrollShadowDirection");
+  });
+
+  it("should accept a direction parameter defaulting to bottom", () => {
+    expect(hookSource).toMatch(/direction:\s*ScrollShadowDirection\s*=\s*"bottom"/);
+  });
+
+  it("should check scrollTop > 0 for bottom direction", () => {
+    expect(hookSource).toContain('direction === "bottom"');
+    expect(hookSource).toContain("scrollTop > 0");
+  });
+
+  it("should check not-at-bottom for top direction", () => {
+    expect(hookSource).toContain("scrollTop < scrollHeight - clientHeight - 1");
+  });
+
+  it("should use ResizeObserver for top direction", () => {
+    expect(hookSource).toContain("new ResizeObserver(handleScroll)");
+    expect(hookSource).toContain('direction === "top"');
+  });
+
+  it("should call handleScroll on initial mount to set state", () => {
+    expect(hookSource).toMatch(/handleScroll\(\);\s*\n\s*viewport\.addEventListener/);
+  });
+
+  it("should disconnect ResizeObserver on cleanup", () => {
+    expect(hookSource).toContain("resizeObserver?.disconnect()");
   });
 });
 
@@ -69,5 +103,29 @@ describe("HeaderLayoutWidget uses useScrollShadow hook", () => {
 
   it("should destructure isScrolled and scrollRef from the hook", () => {
     expect(widgetSource).toContain("const { isScrolled, scrollRef } = useScrollShadow()");
+  });
+});
+
+describe("FooterLayoutWidget uses useScrollShadow hook with top direction", () => {
+  const widgetSource = fs.readFileSync(
+    path.resolve(__dirname, "../widgets/layouts/FooterLayoutWidget.tsx"),
+    "utf-8",
+  );
+
+  it("should import useScrollShadow", () => {
+    expect(widgetSource).toContain('from "@/hooks/use-scroll-shadow"');
+  });
+
+  it("should use the hook with top direction instead of inline implementation", () => {
+    expect(widgetSource).toContain('"top"');
+    // Should NOT have the inline scroll listener pattern
+    expect(widgetSource).not.toContain('addEventListener("scroll"');
+    expect(widgetSource).not.toContain("setHasMoreContent");
+    expect(widgetSource).not.toContain("ResizeObserver");
+  });
+
+  it("should destructure isScrolled as hasMoreContent from the hook", () => {
+    expect(widgetSource).toContain("isScrolled: hasMoreContent");
+    expect(widgetSource).toContain("scrollRef");
   });
 });

--- a/src/frontend/src/hooks/use-scroll-shadow.ts
+++ b/src/frontend/src/hooks/use-scroll-shadow.ts
@@ -1,11 +1,17 @@
 import { useEffect, useRef, useState } from "react";
 
+export type ScrollShadowDirection = "top" | "bottom";
+
 /**
  * Hook that tracks scroll position to trigger shadow effects
  * @param selector - Optional selector for the scroll container (default: "[data-radix-scroll-area-viewport]")
+ * @param direction - Shadow direction: "bottom" shows shadow when scrolled down from top, "top" shows shadow when not at bottom (default: "bottom")
  * @returns Object containing isScrolled state and scrollRef
  */
-export function useScrollShadow(selector = "[data-radix-scroll-area-viewport]") {
+export function useScrollShadow(
+  selector = "[data-radix-scroll-area-viewport]",
+  direction: ScrollShadowDirection = "bottom",
+) {
   const [isScrolled, setIsScrolled] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
 
@@ -14,12 +20,28 @@ export function useScrollShadow(selector = "[data-radix-scroll-area-viewport]") 
     if (!viewport) return;
 
     const handleScroll = () => {
-      setIsScrolled(viewport.scrollTop > 0);
+      if (direction === "bottom") {
+        setIsScrolled(viewport.scrollTop > 0);
+      } else {
+        const { scrollTop, scrollHeight, clientHeight } = viewport;
+        setIsScrolled(scrollTop < scrollHeight - clientHeight - 1);
+      }
     };
 
+    handleScroll();
+
     viewport.addEventListener("scroll", handleScroll);
-    return () => viewport.removeEventListener("scroll", handleScroll);
-  }, [selector]);
+
+    const resizeObserver = direction === "top" ? new ResizeObserver(handleScroll) : null;
+    if (resizeObserver) {
+      resizeObserver.observe(viewport);
+    }
+
+    return () => {
+      viewport.removeEventListener("scroll", handleScroll);
+      resizeObserver?.disconnect();
+    };
+  }, [selector, direction]);
 
   return { isScrolled, scrollRef };
 }

--- a/src/frontend/src/widgets/layouts/FooterLayoutWidget.tsx
+++ b/src/frontend/src/widgets/layouts/FooterLayoutWidget.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
+import { useScrollShadow } from "@/hooks/use-scroll-shadow";
 
 interface FooterLayoutWidgetProps {
   slots?: {
@@ -10,29 +11,10 @@ interface FooterLayoutWidgetProps {
 }
 
 export const FooterLayoutWidget: React.FC<FooterLayoutWidgetProps> = ({ slots }) => {
-  const [hasMoreContent, setHasMoreContent] = React.useState(false);
-  const scrollRef = React.useRef<HTMLDivElement>(null);
-
-  React.useEffect(() => {
-    const viewport = scrollRef.current?.querySelector("[data-radix-scroll-area-viewport]");
-    if (!viewport) return;
-
-    const handleScroll = () => {
-      const { scrollTop, scrollHeight, clientHeight } = viewport;
-      setHasMoreContent(scrollTop < scrollHeight - clientHeight - 1);
-    };
-
-    handleScroll();
-
-    viewport.addEventListener("scroll", handleScroll);
-    const resizeObserver = new ResizeObserver(handleScroll);
-    resizeObserver.observe(viewport);
-
-    return () => {
-      viewport.removeEventListener("scroll", handleScroll);
-      resizeObserver.disconnect();
-    };
-  }, []);
+  const { isScrolled: hasMoreContent, scrollRef } = useScrollShadow(
+    "[data-radix-scroll-area-viewport]",
+    "top",
+  );
 
   if (!slots?.Footer || !slots?.Content) {
     return (


### PR DESCRIPTION
# Summary

## Changes

Extended the `useScrollShadow` hook with a `direction` parameter (`"top" | "bottom"`) to support both header-style shadows (show when scrolled down) and footer-style shadows (show when more content below). Refactored `FooterLayoutWidget` to use the enhanced hook, eliminating 22 lines of duplicated inline scroll detection logic.

## API Changes

- `useScrollShadow(selector?, direction?)` — added optional second parameter `direction: ScrollShadowDirection` (default: `"bottom"`)
- New exported type `ScrollShadowDirection = "top" | "bottom"`
- `direction: "bottom"` — existing behavior (shadow when `scrollTop > 0`)
- `direction: "top"` — inverse behavior (shadow when not at bottom), includes ResizeObserver for content height changes

## Files Modified

- **Hook:** `src/frontend/src/hooks/use-scroll-shadow.ts` — added direction parameter, conditional scroll logic, and ResizeObserver for top direction
- **Widget:** `src/frontend/src/widgets/layouts/FooterLayoutWidget.tsx` — replaced inline scroll detection with `useScrollShadow("[data-radix-scroll-area-viewport]", "top")`
- **Tests:** `src/frontend/src/hooks/use-scroll-shadow.test.ts` — added 10 new tests (7 for direction parameter, 3 for FooterLayoutWidget hook usage)

## Commits

- 60898056 [01726] Extend useScrollShadow hook with direction parameter