### PR TITLE
[01727] Add barrel export to hooks directory

### DIFF
--- a/src/frontend/src/hooks/index.ts
+++ b/src/frontend/src/hooks/index.ts
@@ -1,8 +1,9 @@
 export * from "./use-auto-scroll";
 export * from "./use-backend";
 export * from "./use-debounce";
-export * from "./use-error-sheet";
+export { useErrorSheet, showError } from "./use-error-sheet";
+export type { ErrorSheetData } from "./use-error-sheet";
 export * from "./use-focus-management";
 export * from "./use-mobile";
 export * from "./use-scroll-shadow";
-export * from "./use-toast";
+export { useToast, toast } from "./use-toast";


### PR DESCRIPTION
# Summary

## Changes

Added a barrel export file (`index.ts`) to the `src/frontend/src/hooks/` directory that re-exports all public APIs from the 8 existing hook files. This enables cleaner imports like `import { useScrollShadow, useDebounce } from "@/hooks"` instead of individual file imports.

## API Changes

- New file: `src/frontend/src/hooks/index.ts` — barrel export re-exporting all named exports from `use-auto-scroll`, `use-backend`, `use-debounce`, `use-error-sheet`, `use-focus-management`, `use-mobile`, `use-scroll-shadow`, and `use-toast`. Uses explicit named exports for `use-error-sheet` and `use-toast` to avoid duplicate `reducer` export conflict.

## Files Modified

- **Added:** `src/frontend/src/hooks/index.ts` — barrel export file

## Commits

- 72676f4e - [01727] Fix duplicate reducer export in barrel file
- b89b4621 - [01727] Add barrel export to hooks directory