### PR TITLE
[01725] Add YAxisIndex to Scatter chart

### DIFF
--- a/src/Ivy/Widgets/Charts/Shared/Scatter.cs
+++ b/src/Ivy/Widgets/Charts/Shared/Scatter.cs
@@ -39,6 +39,8 @@ public record Scatter
     public ScatterLineType LineType { get; set; } = ScatterLineType.Joint;
 
     public double? FillOpacity { get; set; } = null;
+
+    public int? YAxisIndex { get; set; } = null;
 }
 
 public static class ScatterExtensions
@@ -101,5 +103,10 @@ public static class ScatterExtensions
     public static Scatter FillOpacity(this Scatter scatter, double fillOpacity)
     {
         return scatter with { FillOpacity = fillOpacity };
+    }
+
+    public static Scatter YAxisIndex(this Scatter scatter, int yAxisIndex)
+    {
+        return scatter with { YAxisIndex = yAxisIndex };
     }
 }

--- a/src/frontend/src/widgets/charts/ScatterChartWidget.tsx
+++ b/src/frontend/src/widgets/charts/ScatterChartWidget.tsx
@@ -286,6 +286,7 @@ const generateScatterSeries = (
         data: scatterData,
         symbol: customPath || symbol,
         symbolSize,
+        yAxisIndex: scatter.yAxisIndex ?? 0,
         itemStyle: {
           color: scatter.fill || undefined,
           opacity: scatter.fillOpacity !== null ? scatter.fillOpacity : 0.8,

--- a/src/frontend/src/widgets/charts/chartTypes.ts
+++ b/src/frontend/src/widgets/charts/chartTypes.ts
@@ -349,6 +349,7 @@ export interface ScatterProps {
   strokeDashArray?: string | null;
   strokeWidth?: number;
   unit?: string | null;
+  yAxisIndex?: number | null;
 }
 
 export interface ScatterChartWidgetProps {


### PR DESCRIPTION
# Summary

## Changes

Added `YAxisIndex` property to the `Scatter` record and its corresponding extension method, plus updated the frontend `ScatterProps` interface and `generateScatterSeries` function to pass `yAxisIndex` to ECharts. This completes dual-axis support across all cartesian chart series types (Line, Area, Bar, and now Scatter).

## API Changes

- Added `Scatter.YAxisIndex` property (`int?`, default `null`) in `Ivy` namespace
- Added `ScatterExtensions.YAxisIndex(this Scatter, int)` extension method
- Added `yAxisIndex` field to `ScatterProps` TypeScript interface

## Files Modified

- `src/Ivy/Widgets/Charts/Shared/Scatter.cs` — added property and extension method
- `src/frontend/src/widgets/charts/chartTypes.ts` — added `yAxisIndex` to `ScatterProps`
- `src/frontend/src/widgets/charts/ScatterChartWidget.tsx` — added `yAxisIndex` to scatter series config

## Commits

- 33494364 [01725] Add YAxisIndex to Scatter chart

## Artifacts

### Screenshots

![basic-dual-axis](https://stivytelemetry.blob.core.windows.net/ivy-tendril/basic-dual-axis.png?se=2026-05-04&sp=r&spr=https&sv=2026-02-06&sr=c&sig=RuPyoFIJ75szpHjIRnM1qai1N2mLwMeLLiVQd80yL%2B8%3D)

![edge-cases-multiple-series](https://stivytelemetry.blob.core.windows.net/ivy-tendril/edge-cases-multiple-series.png?se=2026-05-04&sp=r&spr=https&sv=2026-02-06&sr=c&sig=RuPyoFIJ75szpHjIRnM1qai1N2mLwMeLLiVQd80yL%2B8%3D)

![integration-reference-lines](https://stivytelemetry.blob.core.windows.net/ivy-tendril/integration-reference-lines.png?se=2026-05-04&sp=r&spr=https&sv=2026-02-06&sr=c&sig=RuPyoFIJ75szpHjIRnM1qai1N2mLwMeLLiVQd80yL%2B8%3D)

![props-temperature-humidity](https://stivytelemetry.blob.core.windows.net/ivy-tendril/props-temperature-humidity.png?se=2026-05-04&sp=r&spr=https&sv=2026-02-06&sr=c&sig=RuPyoFIJ75szpHjIRnM1qai1N2mLwMeLLiVQd80yL%2B8%3D)