### PR TITLE
[01745] Refactor repo path extraction to shared function

### DIFF
--- a/src/tendril/Ivy.Tendril/.promptwares/.shared/Utils.ps1
+++ b/src/tendril/Ivy.Tendril/.promptwares/.shared/Utils.ps1
@@ -223,20 +223,37 @@ function ReadPlanProject {
 }
 
 function ExtractRepoPathsFromYaml {
+    <#
+    .SYNOPSIS
+    Extracts and resolves repository paths from YAML repo entries.
+
+    .PARAMETER Repos
+    Array of repo entries from YAML (can be hashtables with .path or plain strings)
+
+    .PARAMETER ValidateExists
+    If true, only returns paths that exist on disk
+
+    .PARAMETER ReturnFirst
+    If true, returns only the first valid path (for GetProjectWorkDir compatibility)
+
+    .EXAMPLE
+    $repoPaths = ExtractRepoPathsFromYaml $planInfo.Yaml.repos -ValidateExists
+    #>
     param(
         [Parameter(Mandatory = $true)]
-        $ReposArray,
-        [switch]$ValidateExists
+        $Repos,
+
+        [switch]$ValidateExists,
+        [switch]$ReturnFirst
     )
 
-    $paths = @()
-
-    if (-not $ReposArray) {
-        return $paths
+    if (-not $Repos) {
+        if ($ReturnFirst) { return $null }
+        return @()
     }
 
-    foreach ($repo in $ReposArray) {
-        # Handle both formats: plain string or object with 'path' property
+    $paths = @()
+    foreach ($repo in $Repos) {
         $p = if ($repo -is [hashtable] -or $repo -is [System.Collections.IDictionary]) {
             $repo.path
         } else {
@@ -244,19 +261,21 @@ function ExtractRepoPathsFromYaml {
         }
 
         if ($p) {
-            # Expand environment variables (e.g. %REPOS_HOME%)
             $p = [Environment]::ExpandEnvironmentVariables($p)
 
             if ($ValidateExists) {
                 if (Test-Path $p) {
                     $paths += $p
+                    if ($ReturnFirst) { return $p }
                 }
             } else {
                 $paths += $p
+                if ($ReturnFirst) { return $p }
             }
         }
     }
 
+    if ($ReturnFirst) { return $null }
     return $paths
 }
 
@@ -267,11 +286,8 @@ function GetProjectWorkDir {
         try {
             $config = Get-Content $script:ConfigPath -Raw | ConvertFrom-Yaml
             $projectEntry = $config.projects | Where-Object { $_.name -eq $Project } | Select-Object -First 1
-            if ($projectEntry -and $projectEntry.repos) {
-                $paths = ExtractRepoPathsFromYaml -ReposArray $projectEntry.repos
-                if ($paths.Count -gt 0) {
-                    return $paths[0]
-                }
+            if ($projectEntry -and $projectEntry.repos -and $projectEntry.repos.Count -gt 0) {
+                return ExtractRepoPathsFromYaml $projectEntry.repos -ReturnFirst
             }
         }
         catch { }

--- a/src/tendril/Ivy.Tendril/.promptwares/CleanupPlan.ps1
+++ b/src/tendril/Ivy.Tendril/.promptwares/CleanupPlan.ps1
@@ -29,7 +29,7 @@ $planFolderName = Split-Path $PlanPath -Leaf
 $planId = if ($planFolderName -match '^(\d+)') { $Matches[1] } else { "" }
 
 # Extract repo paths from plan.yaml
-$repoPaths = ExtractRepoPathsFromYaml -ReposArray $planInfo.Yaml.repos -ValidateExists
+$repoPaths = ExtractRepoPathsFromYaml $planInfo.Yaml.repos -ValidateExists
 
 $worktreeDirs = Get-ChildItem -Path $worktreesDir -Directory -ErrorAction SilentlyContinue
 $cleanedCount = 0


### PR DESCRIPTION
# Summary

## Changes

Added a shared `ExtractRepoPathsFromYaml` function to `.promptwares/.shared/Utils.ps1` that encapsulates repo path extraction from YAML config entries. Refactored `CleanupPlan.ps1` and `GetProjectWorkDir` in `Utils.ps1` to use this shared function, eliminating duplicated logic.

## API Changes

- **New function:** `ExtractRepoPathsFromYaml` in `Utils.ps1` — accepts `$Repos` (array), `-ValidateExists` (switch), `-ReturnFirst` (switch). Returns array of resolved paths, or single path/null with `-ReturnFirst`.

## Files Modified

- `src/tendril/Ivy.Tendril/.promptwares/.shared/Utils.ps1` — Added `ExtractRepoPathsFromYaml` function; refactored `GetProjectWorkDir` to use it
- `src/tendril/Ivy.Tendril/.promptwares/CleanupPlan.ps1` — Replaced inline repo path extraction with call to `ExtractRepoPathsFromYaml`

## Commits

- 24d48f56 [01745] Refactor repo path extraction to shared ExtractRepoPathsFromYaml function