### PR TITLE
[01751] Extract Get-SharedFolder helper function to reduce duplication

### DIFF
--- a/src/tendril/Ivy.Tendril.TeamIvyConfig/Promptwares/IvyFrameworkVerification.ps1
+++ b/src/tendril/Ivy.Tendril.TeamIvyConfig/Promptwares/IvyFrameworkVerification.ps1
@@ -3,6 +3,7 @@ param(
     [string]$PlanPath
 )
 
+# Cannot use Get-SharedFolder here since we need this path to dot-source Utils.ps1
 # User-defined promptwares use TENDRIL_SHARED to access built-in shared utilities
 $sharedDir = if ($env:TENDRIL_SHARED) { $env:TENDRIL_SHARED } else { "$PSScriptRoot/.shared" }
 . "$sharedDir/Utils.ps1"

--- a/src/tendril/Ivy.Tendril/.promptwares/.shared/Utils.ps1
+++ b/src/tendril/Ivy.Tendril/.promptwares/.shared/Utils.ps1
@@ -22,6 +22,21 @@ $script:PlansDir = Join-Path $env:TENDRIL_HOME "Plans"
 # Bootstrap required PowerShell modules
 . (Join-Path $PSScriptRoot "Bootstrap-Modules.ps1")
 
+# Resolves the shared folder path. Uses $env:TENDRIL_SHARED if set, otherwise
+# falls back to the ".shared" directory relative to the given script root.
+# Note: Scripts that need to dot-source Utils.ps1 itself cannot use this helper
+# (they need the path before Utils.ps1 is loaded). Those scripts must use the
+# inline pattern instead — see IvyFrameworkVerification.ps1 for an example.
+function Get-SharedFolder {
+    param([string]$ScriptRoot)
+
+    if ($env:TENDRIL_SHARED) {
+        return $env:TENDRIL_SHARED
+    } else {
+        return Join-Path $ScriptRoot ".shared"
+    }
+}
+
 function GetProgramFolder {
     param([string]$ScriptPath)
 
@@ -69,11 +84,7 @@ function PrepareFirmware {
 
     $header = ($Values.GetEnumerator() | Sort-Object Name | ForEach-Object { "$($_.Key): $($_.Value)" }) -join "`n"
 
-    $sharedFolder = if ($env:TENDRIL_SHARED) {
-        $env:TENDRIL_SHARED
-    } else {
-        Join-Path $ScriptRoot ".shared"
-    }
+    $sharedFolder = Get-SharedFolder $ScriptRoot
     $firmware = Get-Content "$sharedFolder\Firmware.md" -Raw
     $firmware = $firmware.Replace("[HEADER]", $header)
     $firmware = $firmware.Replace("[LOGFILE]", $LogFile)


### PR DESCRIPTION
# Summary

## Changes

Extracted a reusable `Get-SharedFolder` helper function in Utils.ps1 that encapsulates the `$env:TENDRIL_SHARED` fallback pattern. Updated `PrepareFirmware` to use the new helper. Added an explanatory comment to IvyFrameworkVerification.ps1 documenting why it must keep the inline pattern (it needs the shared folder path before Utils.ps1 is loaded).

## API Changes

- New function `Get-SharedFolder` in Utils.ps1 — accepts a `$ScriptRoot` parameter, returns the shared folder path (from `$env:TENDRIL_SHARED` or `Join-Path $ScriptRoot ".shared"`).

## Files Modified

- `src/tendril/Ivy.Tendril/.promptwares/.shared/Utils.ps1` — added `Get-SharedFolder` function, updated `PrepareFirmware` to use it
- `src/tendril/Ivy.Tendril.TeamIvyConfig/Promptwares/IvyFrameworkVerification.ps1` — added explanatory comment about inline pattern

## Commits

- c08102de [01751] Extract Get-SharedFolder helper to reduce duplication