### PR TITLE
[01748] Create Cleanup-WorktreeFrontend.ps1 tool for .npmrc cleanup

### DIFF
--- a/src/tendril/Ivy.Tendril/.promptwares/ExecutePlan/Program.md
+++ b/src/tendril/Ivy.Tendril/.promptwares/ExecutePlan/Program.md
@@ -137,6 +137,16 @@ git worktree add "<PlanFolder>/worktrees/<RepoName>" -b "plan-<PlanId>-<RepoName
 
 **!CRITICAL: Frontend builds in worktrees have known issues with `@linaria/core` and `echarts` module resolution that cause 15-25 minute timeouts. Follow this workaround to avoid them.**
 
+#### Cleanup Leftover Files
+
+Before setting up frontend dependencies, clean up any `.npmrc` files left from previous crashed runs:
+
+```bash
+pwsh -NoProfile -File "$env:TENDRIL_HOME/.promptwares/ExecutePlan/Tools/Cleanup-WorktreeFrontend.ps1" -WorktreeRoot "<PlanFolder>/worktrees"
+```
+
+This prevents stale `.npmrc` files with auth tokens from accumulating across multiple plan executions.
+
 #### Default Path (Most Plans)
 
 If the plan does **NOT** modify frontend code (`.tsx`, `.ts`, `.css` files in `src/frontend/` or `src/widgets/*/frontend/`):


### PR DESCRIPTION
# Summary

## Changes

Created a standalone `Cleanup-WorktreeFrontend.ps1` PowerShell tool that scans worktree frontend directories for leftover `.npmrc` files and removes them. Updated `Program.md` Step 2.5 to invoke this cleanup tool before setting up frontend dependencies, preventing auth token accumulation from crashed runs.

## API Changes

None.

## Files Modified

- **New tool:** `src/tendril/Ivy.Tendril/.promptwares/ExecutePlan/Tools/Cleanup-WorktreeFrontend.ps1` (gitignored, local-only)
- **Updated:** `src/tendril/Ivy.Tendril/.promptwares/ExecutePlan/Program.md` — added cleanup substep at start of Step 2.5

## Commits

- [01748] Add Cleanup-WorktreeFrontend.ps1 integration to Program.md (4eaf2997)