### PR TITLE
[01752] Add keyboard shortcut help to Review app

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -588,7 +588,7 @@ public class ContentView(
                 new DialogHeader("Keyboard Shortcuts"),
                 new DialogBody(
                     Layout.Vertical().Gap(2)
-                        | Text.Block("Navigate through plans and actions using these shortcuts:").Padding(0, 0, 2, 0)
+                        | Text.Muted("Navigate through plans and actions using these shortcuts:")
                         | (Layout.Horizontal().Gap(2)
                             | new Badge("p").Variant(BadgeVariant.Outline)
                             | Text.Block("Previous plan"))


### PR DESCRIPTION
# Summary

## Changes

Added a keyboard shortcut help dialog to the Review app's ContentView. The dialog is triggered by pressing "?" or clicking the help button (CircleQuestionMark icon) in the action bar, and displays all available keyboard shortcuts: p (Previous plan), n (Next plan), d (Suggest changes), and ? (Show help).

## API Changes

None.

## Files Modified

- **Review app UI:**
  - `src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs` — Added `helpDialogOpen` state, help Dialog with shortcut descriptions, and help Button with `ShortcutKey("?")` in the action bar

## Commits

- 6f306bf4 [01752] Fix TextBuilder.Padding compile error in help dialog
- 38faa6db [01752] Add keyboard shortcut help dialog to Review app