### PR TITLE
[01757] Fix vite.config.mjs line endings in worktrees

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,35 @@
+# Normalize line endings for text files
+* text=auto
+
+# Force LF for source code files
+*.js text eol=lf
+*.mjs text eol=lf
+*.ts text eol=lf
+*.tsx text eol=lf
+*.jsx text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+
+# Force LF for C# files
+*.cs text eol=lf
+*.csproj text eol=lf
+*.sln text eol=lf
+*.slnx text eol=lf
+
+# Force CRLF for Windows-specific files
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf
+
+# Binary files
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.eot binary


### PR DESCRIPTION
# Summary

## Changes

Added a `.gitattributes` file at the repo root to enforce consistent line endings across all environments. This ensures `vite.config.mjs` (and all other JS/TS files) are checked out with LF endings even when `core.autocrlf=true`, fixing the `npm run format:check` failure in worktrees.

## API Changes

None.

## Files Modified

- **`.gitattributes`** (new) — Line ending rules: LF for source code (JS, TS, C#, JSON, YAML, MD), CRLF for Windows scripts (.ps1, .bat, .cmd), binary for images/fonts

## Commits

- 3d05ab1b [01757] Add .gitattributes to enforce consistent line endings