### PR TITLE
[01767] Remove Redundant Empty Array Checks in Frontend Lint Warnings

### DIFF
--- a/src/frontend/src/components/ui/multiselect.tsx
+++ b/src/frontend/src/components/ui/multiselect.tsx
@@ -267,7 +267,6 @@ const MultipleSelector = React.forwardRef<
     }, [defaultOptions, filteredForBulk]);
 
     const bulkSelectAllDisabled =
-      visibleEnabledForBulk.length === 0 ||
       visibleEnabledForBulk.every((o) => selectedValueStrings.includes(o.value));
 
     const bulkClearAllDisabled = selectedValueStrings.length <= (minSelections ?? 0);

--- a/src/frontend/src/widgets/inputs/SelectInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/SelectInputWidget.tsx
@@ -281,7 +281,6 @@ const ToggleVariant: React.FC<SelectInputWidgetProps> = ({
 
   const bulkSelectAllDisabled =
     !selectMany ||
-    visibleEnabledForBulk.length === 0 ||
     visibleEnabledForBulk.every((o) => selectedValues.includes(o.value));
 
   const bulkClearAllDisabled = !selectMany || selectedValues.length <= (minSelections ?? 0);
@@ -762,7 +761,6 @@ const CheckboxVariant: React.FC<SelectInputWidgetProps> = ({
   );
 
   const bulkSelectAllDisabledList =
-    visibleEnabledForBulkList.length === 0 ||
     visibleEnabledForBulkList.every((o) => selectedValues.includes(o.value));
 
   const bulkClearAllDisabledList = selectedValues.length <= (minSelections ?? 0);


### PR DESCRIPTION
# Summary

## Changes

Removed 3 redundant `array.length === 0 ||` checks that preceded `Array#every()` calls in the multiselect and SelectInput widget components. Since `Array#every()` returns `true` for empty arrays (vacuous truth), the length checks were unnecessary and triggered lint warnings.

## API Changes

None.

## Files Modified

- **Frontend components:**
  - `src/frontend/src/components/ui/multiselect.tsx` — removed redundant empty check on `bulkSelectAllDisabled`
  - `src/frontend/src/widgets/inputs/SelectInputWidget.tsx` — removed redundant empty checks on `bulkSelectAllDisabled` (ToggleVariant) and `bulkSelectAllDisabledList` (CheckboxVariant)

## Commits

- f3ab72c8 [01767] Remove redundant empty array checks before Array#every()