### PR TITLE
[01761] Investigate vite.config.mjs formatting issue

### DIFF
--- a/src/frontend/.gitattributes
+++ b/src/frontend/.gitattributes
@@ -1,0 +1,4 @@
+# Force LF line endings for all frontend source files.
+# The oxfmt formatter (used by vp fmt) normalizes to LF, so files must be
+# checked out with LF to avoid false positives from `vp fmt --check`.
+* text=auto eol=lf


### PR DESCRIPTION
# Summary

## Changes

Added a `.gitattributes` file to `src/frontend/` that forces LF line endings for all frontend source files. This fixes a false positive from `vp fmt --check` on Windows where `core.autocrlf=true` converts stored LF to CRLF on checkout, but the oxfmt formatter normalizes back to LF.

## API Changes

None.

## Files Modified

- **src/frontend/.gitattributes** (new) — Forces `eol=lf` for all files in the frontend directory

---

## Commits

- 66106cf0 [01761] Add .gitattributes to force LF line endings in frontend