### PR TITLE
[01760] Add MutationObserver to useScrollShadow hook for dynamic content changes

### DIFF
--- a/src/frontend/src/hooks/use-scroll-shadow.test.ts
+++ b/src/frontend/src/hooks/use-scroll-shadow.test.ts
@@ -84,6 +84,24 @@ describe("useScrollShadow direction parameter", () => {
   });
 });
 
+describe("useScrollShadow MutationObserver for dynamic content", () => {
+  const hookSource = fs.readFileSync(path.resolve(__dirname, "./use-scroll-shadow.ts"), "utf-8");
+
+  it("should create a MutationObserver when direction is top", () => {
+    expect(hookSource).toContain("new MutationObserver(handleScroll)");
+    expect(hookSource).toMatch(/direction === "top" \? new MutationObserver/);
+  });
+
+  it("should observe viewport with childList and subtree options", () => {
+    expect(hookSource).toContain("childList: true");
+    expect(hookSource).toContain("subtree: true");
+  });
+
+  it("should disconnect the MutationObserver on cleanup", () => {
+    expect(hookSource).toContain("mutationObserver?.disconnect()");
+  });
+});
+
 describe("HeaderLayoutWidget uses useScrollShadow hook", () => {
   const widgetSource = fs.readFileSync(
     path.resolve(__dirname, "../widgets/layouts/HeaderLayoutWidget.tsx"),

--- a/src/frontend/src/hooks/use-scroll-shadow.ts
+++ b/src/frontend/src/hooks/use-scroll-shadow.ts
@@ -33,13 +33,23 @@ export function useScrollShadow(
     viewport.addEventListener("scroll", handleScroll);
 
     const resizeObserver = direction === "top" ? new ResizeObserver(handleScroll) : null;
+    const mutationObserver = direction === "top" ? new MutationObserver(handleScroll) : null;
+
     if (resizeObserver) {
       resizeObserver.observe(viewport);
+    }
+
+    if (mutationObserver) {
+      mutationObserver.observe(viewport, {
+        childList: true,
+        subtree: true,
+      });
     }
 
     return () => {
       viewport.removeEventListener("scroll", handleScroll);
       resizeObserver?.disconnect();
+      mutationObserver?.disconnect();
     };
   }, [selector, direction]);
 


### PR DESCRIPTION
# Summary

## Changes

Added a `MutationObserver` to the `useScrollShadow` hook's "top" direction to detect dynamic content changes (child elements added/removed). This complements the existing `ResizeObserver` which only fires on viewport resize, not on DOM mutations within the viewport. Three new tests were added to verify the MutationObserver creation, configuration, and cleanup.

## API Changes

None.

## Files Modified

- **Hook:** `src/frontend/src/hooks/use-scroll-shadow.ts` — Added `MutationObserver` creation, observation with `childList: true, subtree: true`, and cleanup disconnect
- **Tests:** `src/frontend/src/hooks/use-scroll-shadow.test.ts` — Added `useScrollShadow MutationObserver for dynamic content` test describe block with 3 tests

## Commits

- 81a6b1a4 [01760] Add MutationObserver to useScrollShadow for dynamic content detection

## Artifacts

### Screenshots

![basic-after-adding-items](https://stivytelemetry.blob.core.windows.net/ivy-tendril/basic-after-adding-items.png?se=2026-05-05&sp=r&spr=https&sv=2026-02-06&sr=c&sig=PNmOT4fVKfNTWLgSyi9JT1L%2BdJqruIOaF3zRhFrCb9E%3D)

![basic-after-removing](https://stivytelemetry.blob.core.windows.net/ivy-tendril/basic-after-removing.png?se=2026-05-05&sp=r&spr=https&sv=2026-02-06&sr=c&sig=PNmOT4fVKfNTWLgSyi9JT1L%2BdJqruIOaF3zRhFrCb9E%3D)

![basic-before-removing](https://stivytelemetry.blob.core.windows.net/ivy-tendril/basic-before-removing.png?se=2026-05-05&sp=r&spr=https&sv=2026-02-06&sr=c&sig=PNmOT4fVKfNTWLgSyi9JT1L%2BdJqruIOaF3zRhFrCb9E%3D)

![basic-cleared](https://stivytelemetry.blob.core.windows.net/ivy-tendril/basic-cleared.png?se=2026-05-05&sp=r&spr=https&sv=2026-02-06&sr=c&sig=PNmOT4fVKfNTWLgSyi9JT1L%2BdJqruIOaF3zRhFrCb9E%3D)

![basic-initial](https://stivytelemetry.blob.core.windows.net/ivy-tendril/basic-initial.png?se=2026-05-05&sp=r&spr=https&sv=2026-02-06&sr=c&sig=PNmOT4fVKfNTWLgSyi9JT1L%2BdJqruIOaF3zRhFrCb9E%3D)

![edge-custom-add](https://stivytelemetry.blob.core.windows.net/ivy-tendril/edge-custom-add.png?se=2026-05-05&sp=r&spr=https&sv=2026-02-06&sr=c&sig=PNmOT4fVKfNTWLgSyi9JT1L%2BdJqruIOaF3zRhFrCb9E%3D)

![edge-custom-clear](https://stivytelemetry.blob.core.windows.net/ivy-tendril/edge-custom-clear.png?se=2026-05-05&sp=r&spr=https&sv=2026-02-06&sr=c&sig=PNmOT4fVKfNTWLgSyi9JT1L%2BdJqruIOaF3zRhFrCb9E%3D)

![edge-empty](https://stivytelemetry.blob.core.windows.net/ivy-tendril/edge-empty.png?se=2026-05-05&sp=r&spr=https&sv=2026-02-06&sr=c&sig=PNmOT4fVKfNTWLgSyi9JT1L%2BdJqruIOaF3zRhFrCb9E%3D)

![edge-large](https://stivytelemetry.blob.core.windows.net/ivy-tendril/edge-large.png?se=2026-05-05&sp=r&spr=https&sv=2026-02-06&sr=c&sig=PNmOT4fVKfNTWLgSyi9JT1L%2BdJqruIOaF3zRhFrCb9E%3D)

![edge-single](https://stivytelemetry.blob.core.windows.net/ivy-tendril/edge-single.png?se=2026-05-05&sp=r&spr=https&sv=2026-02-06&sr=c&sig=PNmOT4fVKfNTWLgSyi9JT1L%2BdJqruIOaF3zRhFrCb9E%3D)

![edge-tall](https://stivytelemetry.blob.core.windows.net/ivy-tendril/edge-tall.png?se=2026-05-05&sp=r&spr=https&sv=2026-02-06&sr=c&sig=PNmOT4fVKfNTWLgSyi9JT1L%2BdJqruIOaF3zRhFrCb9E%3D)

![header-initial](https://stivytelemetry.blob.core.windows.net/ivy-tendril/header-initial.png?se=2026-05-05&sp=r&spr=https&sv=2026-02-06&sr=c&sig=PNmOT4fVKfNTWLgSyi9JT1L%2BdJqruIOaF3zRhFrCb9E%3D)

![header-more-items](https://stivytelemetry.blob.core.windows.net/ivy-tendril/header-more-items.png?se=2026-05-05&sp=r&spr=https&sv=2026-02-06&sr=c&sig=PNmOT4fVKfNTWLgSyi9JT1L%2BdJqruIOaF3zRhFrCb9E%3D)

![header-removed-items](https://stivytelemetry.blob.core.windows.net/ivy-tendril/header-removed-items.png?se=2026-05-05&sp=r&spr=https&sv=2026-02-06&sr=c&sig=PNmOT4fVKfNTWLgSyi9JT1L%2BdJqruIOaF3zRhFrCb9E%3D)

![header-scrolled](https://stivytelemetry.blob.core.windows.net/ivy-tendril/header-scrolled.png?se=2026-05-05&sp=r&spr=https&sv=2026-02-06&sr=c&sig=PNmOT4fVKfNTWLgSyi9JT1L%2BdJqruIOaF3zRhFrCb9E%3D)

![lazyload-after-first-load](https://stivytelemetry.blob.core.windows.net/ivy-tendril/lazyload-after-first-load.png?se=2026-05-05&sp=r&spr=https&sv=2026-02-06&sr=c&sig=PNmOT4fVKfNTWLgSyi9JT1L%2BdJqruIOaF3zRhFrCb9E%3D)

![lazyload-after-second-load](https://stivytelemetry.blob.core.windows.net/ivy-tendril/lazyload-after-second-load.png?se=2026-05-05&sp=r&spr=https&sv=2026-02-06&sr=c&sig=PNmOT4fVKfNTWLgSyi9JT1L%2BdJqruIOaF3zRhFrCb9E%3D)

![lazyload-all-loaded](https://stivytelemetry.blob.core.windows.net/ivy-tendril/lazyload-all-loaded.png?se=2026-05-05&sp=r&spr=https&sv=2026-02-06&sr=c&sig=PNmOT4fVKfNTWLgSyi9JT1L%2BdJqruIOaF3zRhFrCb9E%3D)

![lazyload-initial](https://stivytelemetry.blob.core.windows.net/ivy-tendril/lazyload-initial.png?se=2026-05-05&sp=r&spr=https&sv=2026-02-06&sr=c&sig=PNmOT4fVKfNTWLgSyi9JT1L%2BdJqruIOaF3zRhFrCb9E%3D)

![rapid-completed](https://stivytelemetry.blob.core.windows.net/ivy-tendril/rapid-completed.png?se=2026-05-05&sp=r&spr=https&sv=2026-02-06&sr=c&sig=PNmOT4fVKfNTWLgSyi9JT1L%2BdJqruIOaF3zRhFrCb9E%3D)

![rapid-initial](https://stivytelemetry.blob.core.windows.net/ivy-tendril/rapid-initial.png?se=2026-05-05&sp=r&spr=https&sv=2026-02-06&sr=c&sig=PNmOT4fVKfNTWLgSyi9JT1L%2BdJqruIOaF3zRhFrCb9E%3D)

![rapid-running](https://stivytelemetry.blob.core.windows.net/ivy-tendril/rapid-running.png?se=2026-05-05&sp=r&spr=https&sv=2026-02-06&sr=c&sig=PNmOT4fVKfNTWLgSyi9JT1L%2BdJqruIOaF3zRhFrCb9E%3D)

![rapid-stopped](https://stivytelemetry.blob.core.windows.net/ivy-tendril/rapid-stopped.png?se=2026-05-05&sp=r&spr=https&sv=2026-02-06&sr=c&sig=PNmOT4fVKfNTWLgSyi9JT1L%2BdJqruIOaF3zRhFrCb9E%3D)