### PR TITLE
[01770] Simplify promptwares by using TENDRIL_CONFIG environment variable

### DIFF
--- a/src/tendril/Ivy.Tendril/.promptwares/.shared/Utils.ps1
+++ b/src/tendril/Ivy.Tendril/.promptwares/.shared/Utils.ps1
@@ -82,10 +82,6 @@ function PrepareFirmware {
     if (-not $Values.ContainsKey("CurrentTime")) {
         $Values["CurrentTime"] = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
     }
-    if (-not $Values.ContainsKey("ConfigPath")) {
-        $Values["ConfigPath"] = $script:ConfigPath
-    }
-
     $header = ($Values.GetEnumerator() | Sort-Object Name | ForEach-Object { "$($_.Key): $($_.Value)" }) -join "`n"
 
     $sharedFolder = Get-SharedFolder $ScriptRoot

--- a/src/tendril/Ivy.Tendril/.promptwares/CreateIssue/Program.md
+++ b/src/tendril/Ivy.Tendril/.promptwares/CreateIssue/Program.md
@@ -6,7 +6,6 @@ Create a GitHub issue from a plan.
 
 The firmware header contains:
 - **PlanFolder** — path to the plan folder
-- **ConfigPath** — absolute path to config.yaml
 - **CurrentTime** — current UTC timestamp
 - **Repo** — target repository path (local path)
 - **Assignee** — GitHub username to assign (optional, may be empty)

--- a/src/tendril/Ivy.Tendril/.promptwares/ExecutePlan/Program.md
+++ b/src/tendril/Ivy.Tendril/.promptwares/ExecutePlan/Program.md
@@ -7,11 +7,10 @@ Execute an approved plan in isolated git worktrees.
 The firmware header contains:
 
 - **Args** / **PlanFolder** — path to the plan folder
-- **ConfigPath** — absolute path to config.yaml
 - **CurrentTime** — current UTC timestamp
 
 Read the plan structure in `../.shared/Plans.md`.
-Read `config.yaml` (from `ConfigPath`) for project repos and context.
+Read `config.yaml` from the `TENDRIL_CONFIG` environment variable (absolute path to config.yaml) for project repos and context.
 
 The launcher script sets the working directory to the project's primary repo.
 

--- a/src/tendril/Ivy.Tendril/.promptwares/ExpandPlan/Program.md
+++ b/src/tendril/Ivy.Tendril/.promptwares/ExpandPlan/Program.md
@@ -6,10 +6,10 @@ Transform investigation-heavy plans into concrete implementation plans.
 
 The firmware header contains:
 - **Args** / **PlanFolder** — path to the plan folder
-- **ConfigPath** — absolute path to config.yaml
 - **CurrentTime** — current UTC timestamp
 
 Read the plan structure in `../.shared/Plans.md`.
+Read `config.yaml` from the `TENDRIL_CONFIG` environment variable (absolute path to config.yaml).
 
 ## Execution Steps
 

--- a/src/tendril/Ivy.Tendril/.promptwares/MakePlan/Program.md
+++ b/src/tendril/Ivy.Tendril/.promptwares/MakePlan/Program.md
@@ -9,12 +9,11 @@ Create an implementation plan for a task described in args.
 The firmware header contains these key values:
 - **PlanId** — pre-allocated 5-digit plan ID (e.g. `01127`). Use this — do NOT read `.counter`.
 - **PlansDirectory** — where plan folders are created
-- **ConfigPath** — absolute path to config.yaml (projects, repos, context)
 - **Project** — selected project name, or `[Auto]` if not specified
 - **SourcePath** (optional) — absolute path to the source that generated this plan (e.g. test working directory)
 
 Read the plan folder structure in `../.shared/Plans.md`.
-Read the project configuration from the `ConfigPath` in the firmware header.
+Read the project configuration from the `TENDRIL_CONFIG` environment variable (absolute path to config.yaml).
 
 ## Execution Steps
 
@@ -28,7 +27,7 @@ Args contains the user's task description. If it references related plans with `
 
 ### 1.5. Load Project Context
 
-Read `config.yaml` (at the path from the firmware header) to understand all available projects, their repos, and context.
+Read `config.yaml` (at the path from `TENDRIL_CONFIG` environment variable) to understand all available projects, their repos, and context.
 
 **If `Project` is set to a specific project name** (not `[Auto]`):
 - Find that project in `config.yaml` and use its repos and context to scope your research

--- a/src/tendril/Ivy.Tendril/.promptwares/MakePr/Program.md
+++ b/src/tendril/Ivy.Tendril/.promptwares/MakePr/Program.md
@@ -8,11 +8,10 @@ Create GitHub pull requests and apply PR rules.
 
 The firmware header contains:
 - **PlanFolder** — path to the plan folder
-- **ConfigPath** — absolute path to config.yaml
 - **CurrentTime** — current UTC timestamp
 
 Read the plan structure in `../.shared/Plans.md`.
-Read `config.yaml` (from `ConfigPath`) for project repos and their `prRule` setting.
+Read `config.yaml` from the `TENDRIL_CONFIG` environment variable (absolute path to config.yaml) for project repos and their `prRule` setting.
 
 ## PR Rules (from config.yaml per repo)
 

--- a/src/tendril/Ivy.Tendril/.promptwares/SplitPlan/Program.md
+++ b/src/tendril/Ivy.Tendril/.promptwares/SplitPlan/Program.md
@@ -6,11 +6,10 @@ Split a multi-issue plan into separate, self-contained plans.
 
 The firmware header contains:
 - **Args** / **PlanFolder** — path to the plan folder to split
-- **ConfigPath** — absolute path to config.yaml
 - **CurrentTime** — current UTC timestamp
 
 Read the plan structure in `../.shared/Plans.md`.
-Read `config.yaml` (from `ConfigPath`) for available projects and their repos.
+Read `config.yaml` from the `TENDRIL_CONFIG` environment variable (absolute path to config.yaml) for available projects and their repos.
 
 The plans directory path can be derived from the plan folder's parent directory.
 

--- a/src/tendril/Ivy.Tendril/.promptwares/UpdatePlan/Program.md
+++ b/src/tendril/Ivy.Tendril/.promptwares/UpdatePlan/Program.md
@@ -6,10 +6,10 @@ Update an existing plan by applying user comments (lines prefixed with `>>`).
 
 The firmware header contains:
 - **Args** / **PlanFolder** — path to the plan folder
-- **ConfigPath** — absolute path to config.yaml
 - **CurrentTime** — current UTC timestamp
 
 Read the plan structure in `../.shared/Plans.md`.
+Read `config.yaml` from the `TENDRIL_CONFIG` environment variable (absolute path to config.yaml).
 
 ## Execution Steps
 
@@ -43,7 +43,7 @@ If no `>>` lines exist, report "No comments found" and stop.
 
 For each question in the `>>` lines:
 1. Read relevant source files to find the answer
-2. Read `config.yaml` (from `ConfigPath` in header) for project context if needed
+2. Read `config.yaml` (from `TENDRIL_CONFIG` environment variable) for project context if needed
 
 ### 3.5. Resolve Answered Questions
 


### PR DESCRIPTION
# Summary

## Changes

Removed the `ConfigPath` firmware header auto-injection from `Utils.ps1` `PrepareFirmware` function and updated all 7 promptware `Program.md` files to instruct agents to read config.yaml from the `TENDRIL_CONFIG` environment variable instead.

## API Changes

- **Removed**: `ConfigPath` is no longer auto-injected into firmware headers by `PrepareFirmware` in `Utils.ps1`
- **Environment variable**: All promptwares now read config path from `$env:TENDRIL_CONFIG` (set by `JobService.cs`)

## Files Modified

- **Utils.ps1** — Removed ConfigPath auto-injection (lines 85-87)
- **MakePlan/Program.md** — Removed ConfigPath from header list, updated config reference
- **ExecutePlan/Program.md** — Removed ConfigPath from header list, updated config reference
- **UpdatePlan/Program.md** — Removed ConfigPath from header list, updated config reference
- **SplitPlan/Program.md** — Removed ConfigPath from header list, updated config reference
- **ExpandPlan/Program.md** — Removed ConfigPath from header list, updated config reference
- **MakePr/Program.md** — Removed ConfigPath from header list, updated config reference
- **CreateIssue/Program.md** — Removed ConfigPath from header list

## Commits

- [01770] Remove ConfigPath firmware header, use TENDRIL_CONFIG env var (e71f703b)