### PR TITLE
[01778] Add .gitattributes to widget frontend directories

### DIFF
--- a/src/widgets/Ivy.Widgets.DiffView/frontend/.gitattributes
+++ b/src/widgets/Ivy.Widgets.DiffView/frontend/.gitattributes
@@ -1,0 +1,4 @@
+# Force LF line endings for all frontend source files.
+# The oxfmt formatter (used by vp fmt) normalizes to LF, so files must be
+# checked out with LF to avoid false positives from `vp fmt --check`.
+* text=auto eol=lf

--- a/src/widgets/Ivy.Widgets.Leaflet/frontend/.gitattributes
+++ b/src/widgets/Ivy.Widgets.Leaflet/frontend/.gitattributes
@@ -1,0 +1,4 @@
+# Force LF line endings for all frontend source files.
+# The oxfmt formatter (used by vp fmt) normalizes to LF, so files must be
+# checked out with LF to avoid false positives from `vp fmt --check`.
+* text=auto eol=lf

--- a/src/widgets/Ivy.Widgets.ScreenshotFeedback/frontend/.gitattributes
+++ b/src/widgets/Ivy.Widgets.ScreenshotFeedback/frontend/.gitattributes
@@ -1,0 +1,4 @@
+# Force LF line endings for all frontend source files.
+# The oxfmt formatter (used by vp fmt) normalizes to LF, so files must be
+# checked out with LF to avoid false positives from `vp fmt --check`.
+* text=auto eol=lf

--- a/src/widgets/Ivy.Widgets.Tiptap/frontend/.gitattributes
+++ b/src/widgets/Ivy.Widgets.Tiptap/frontend/.gitattributes
@@ -1,0 +1,4 @@
+# Force LF line endings for all frontend source files.
+# The oxfmt formatter (used by vp fmt) normalizes to LF, so files must be
+# checked out with LF to avoid false positives from `vp fmt --check`.
+* text=auto eol=lf

--- a/src/widgets/Ivy.Widgets.Xterm/frontend/.gitattributes
+++ b/src/widgets/Ivy.Widgets.Xterm/frontend/.gitattributes
@@ -1,0 +1,4 @@
+# Force LF line endings for all frontend source files.
+# The oxfmt formatter (used by vp fmt) normalizes to LF, so files must be
+# checked out with LF to avoid false positives from `vp fmt --check`.
+* text=auto eol=lf


### PR DESCRIPTION
# Summary

## Changes

Added `.gitattributes` files with `* text=auto eol=lf` to all 5 widget frontend directories, matching the existing configuration in `src/frontend/.gitattributes`. This ensures consistent LF line endings and prevents format check failures on Windows.

## API Changes

None.

## Files Modified

- `src/widgets/Ivy.Widgets.DiffView/frontend/.gitattributes` (new)
- `src/widgets/Ivy.Widgets.Leaflet/frontend/.gitattributes` (new)
- `src/widgets/Ivy.Widgets.ScreenshotFeedback/frontend/.gitattributes` (new)
- `src/widgets/Ivy.Widgets.Tiptap/frontend/.gitattributes` (new)
- `src/widgets/Ivy.Widgets.Xterm/frontend/.gitattributes` (new)

## Commits

- 445f350b [01778] Add .gitattributes to widget frontend directories