### PR TITLE
[01783] Fix frontend format:check issues in multiselect.tsx and SelectInputWidget.tsx

### DIFF
--- a/src/frontend/src/components/ui/multiselect.tsx
+++ b/src/frontend/src/components/ui/multiselect.tsx
@@ -266,8 +266,9 @@ const MultipleSelector = React.forwardRef<
       return defaultOptions.filter((o) => set.has(o.value) && !o.disable);
     }, [defaultOptions, filteredForBulk]);
 
-    const bulkSelectAllDisabled =
-      visibleEnabledForBulk.every((o) => selectedValueStrings.includes(o.value));
+    const bulkSelectAllDisabled = visibleEnabledForBulk.every((o) =>
+      selectedValueStrings.includes(o.value),
+    );
 
     const bulkClearAllDisabled = selectedValueStrings.length <= (minSelections ?? 0);
 

--- a/src/frontend/src/widgets/inputs/SelectInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/SelectInputWidget.tsx
@@ -280,8 +280,7 @@ const ToggleVariant: React.FC<SelectInputWidgetProps> = ({
   );
 
   const bulkSelectAllDisabled =
-    !selectMany ||
-    visibleEnabledForBulk.every((o) => selectedValues.includes(o.value));
+    !selectMany || visibleEnabledForBulk.every((o) => selectedValues.includes(o.value));
 
   const bulkClearAllDisabled = !selectMany || selectedValues.length <= (minSelections ?? 0);
 
@@ -760,8 +759,9 @@ const CheckboxVariant: React.FC<SelectInputWidgetProps> = ({
     [filteredOptions, disabled, loading],
   );
 
-  const bulkSelectAllDisabledList =
-    visibleEnabledForBulkList.every((o) => selectedValues.includes(o.value));
+  const bulkSelectAllDisabledList = visibleEnabledForBulkList.every((o) =>
+    selectedValues.includes(o.value),
+  );
 
   const bulkClearAllDisabledList = selectedValues.length <= (minSelections ?? 0);
 


### PR DESCRIPTION
# Summary

## Changes

Applied oxfmt formatting fixes to `multiselect.tsx` and `SelectInputWidget.tsx` to resolve `format:check` failures. The formatter adjusted line-wrapping in `.every()` method calls to use consistent arrow function breaking style.

## API Changes

None.

## Files Modified

- `src/frontend/src/components/ui/multiselect.tsx` — reformatted `.every()` call (lines 269-271)
- `src/frontend/src/widgets/inputs/SelectInputWidget.tsx` — reformatted two `.every()` calls (lines 282-283, 762-764)

## Commits

- fd0adf01 [01783] Fix frontend format:check issues in multiselect.tsx and SelectInputWidget.tsx