### PR TITLE
[01788] Prevent Category axis types on ScatterChart

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/06_Charts/05_ScatterChart.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/06_Charts/05_ScatterChart.md
@@ -16,6 +16,8 @@ searchHints:
 Visualize correlations and distributions with interactive scatter plots that support bubble charts, multiple series, and customizable point shapes.
 </Ingress>
 
+> **Important:** ScatterChart requires numeric axes for both X and Y. Always use `.Type(AxisTypes.Number)` on axes, or omit the `.Type()` call (YAxis defaults to Number). Do NOT use `AxisTypes.Category` — it will cause "NaN" rendering and data clustering. If you have categorical data (e.g., "Q1", "Q2"), convert it to numeric values before using ScatterChart.
+
 Scatter charts display data points on a two-dimensional coordinate system, making them ideal for showing correlations between two numeric variables. Build chart [views](../../01_Onboarding/02_Concepts/02_Views.md) inside [layouts](../../01_Onboarding/02_Concepts/04_Layout.md) and use [state](../../03_Hooks/02_Core/03_UseState.md) for dynamic data. See [Charts](../../01_Onboarding/02_Concepts/18_Charts.md) for an overview of Ivy chart widgets. The example below renders a basic scatter plot showing the relationship between height and weight.
 
 ```csharp demo-tabs

--- a/src/Ivy.Tests/Widgets/Charts/ScatterChartTests.cs
+++ b/src/Ivy.Tests/Widgets/Charts/ScatterChartTests.cs
@@ -1,0 +1,58 @@
+namespace Ivy.Tests.Widgets.Charts;
+
+public class ScatterChartTests
+{
+    [Fact]
+    public void ScatterChart_WithCategoryXAxis_ThrowsInvalidOperationException()
+    {
+        var data = new[] { new { X = 1, Y = 10 } };
+        var chart = new ScatterChart(data);
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            chart.XAxis(new XAxis("X").Type(AxisTypes.Category)));
+
+        Assert.Contains("requires numeric axes", ex.Message);
+        Assert.Contains("XAxis", ex.Message);
+    }
+
+    [Fact]
+    public void ScatterChart_WithCategoryYAxis_ThrowsInvalidOperationException()
+    {
+        var data = new[] { new { X = 10, Y = 1 } };
+        var chart = new ScatterChart(data);
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            chart.YAxis(new YAxis("Y").Type(AxisTypes.Category)));
+
+        Assert.Contains("requires numeric axes", ex.Message);
+        Assert.Contains("YAxis", ex.Message);
+    }
+
+    [Fact]
+    public void ScatterChart_WithNumericAxes_Succeeds()
+    {
+        var data = new[] { new { X = 1, Y = 10 } };
+        var chart = new ScatterChart(data)
+            .XAxis(new XAxis("X").Type(AxisTypes.Number))
+            .YAxis(new YAxis("Y").Type(AxisTypes.Number));
+
+        Assert.NotEmpty(chart.XAxis);
+        Assert.NotEmpty(chart.YAxis);
+    }
+
+    [Fact]
+    public void ScatterChart_WithDefaultAxisTypes_Succeeds()
+    {
+        var data = new[] { new { X = 1, Y = 10 } };
+
+        // XAxis defaults to Category in Axis.cs, but the string-overload
+        // creates an XAxis without explicitly setting Type — validation
+        // only runs on the XAxis(XAxis) overload.
+        var chart = new ScatterChart(data)
+            .XAxis("X")
+            .YAxis("Y");
+
+        Assert.NotEmpty(chart.XAxis);
+        Assert.NotEmpty(chart.YAxis);
+    }
+}

--- a/src/Ivy/Widgets/Charts/ScatterChart.cs
+++ b/src/Ivy/Widgets/Charts/ScatterChart.cs
@@ -52,6 +52,26 @@ public record ScatterChart : WidgetBase<ScatterChart>
 
 public static partial class ScatterChartExtensions
 {
+    private static void ValidateAxisType(AxisBase<XAxis> axis, string axisName)
+    {
+        if (axis.Type == AxisTypes.Category)
+        {
+            throw new InvalidOperationException(
+                $"ScatterChart requires numeric axes. {axisName} has Type=Category, which causes rendering failures. " +
+                $"Use {axisName}(...).Type(AxisTypes.Number) or omit the Type() call (defaults to Number).");
+        }
+    }
+
+    private static void ValidateAxisType(AxisBase<YAxis> axis, string axisName)
+    {
+        if (axis.Type == AxisTypes.Category)
+        {
+            throw new InvalidOperationException(
+                $"ScatterChart requires numeric axes. {axisName} has Type=Category, which causes rendering failures. " +
+                $"Use {axisName}(...).Type(AxisTypes.Number) or omit the Type() call (defaults to Number).");
+        }
+    }
+
     public static ScatterChart Scatter(this ScatterChart chart, Scatter scatter)
     {
         return chart with { Scatters = [.. chart.Scatters, scatter] };
@@ -79,27 +99,29 @@ public static partial class ScatterChartExtensions
 
     public static ScatterChart XAxis(this ScatterChart chart, XAxis xAxis)
     {
+        ValidateAxisType(xAxis, "XAxis");
         return chart with { XAxis = [.. chart.XAxis, xAxis] };
     }
 
     public static ScatterChart XAxis(this ScatterChart chart, string dataKey)
     {
-        return chart with { XAxis = [.. chart.XAxis, new XAxis(dataKey)] };
+        return chart with { XAxis = [.. chart.XAxis, new XAxis(dataKey) { Type = AxisTypes.Number }] };
     }
 
     public static ScatterChart YAxis(this ScatterChart chart, YAxis yAxis)
     {
+        ValidateAxisType(yAxis, "YAxis");
         return chart with { YAxis = [.. chart.YAxis, yAxis] };
     }
 
     public static ScatterChart YAxis(this ScatterChart chart, string dataKey)
     {
-        return chart with { YAxis = [.. chart.YAxis, new YAxis(dataKey)] };
+        return chart with { YAxis = [.. chart.YAxis, new YAxis(dataKey) { Type = AxisTypes.Number }] };
     }
 
     public static ScatterChart YAxis(this ScatterChart chart)
     {
-        return chart with { YAxis = [.. chart.YAxis, new YAxis()] };
+        return chart with { YAxis = [.. chart.YAxis, new YAxis() { Type = AxisTypes.Number }] };
     }
 
     public static ScatterChart ZAxis(this ScatterChart chart, ZAxis zAxis)


### PR DESCRIPTION
# Summary

## Changes

Added runtime validation to ScatterChart that prevents Category-type axes, which cause "NaN" rendering and data clustering in Recharts. The XAxis/YAxis extension methods now throw `InvalidOperationException` with a helpful message when `AxisTypes.Category` is detected, and string-based overloads default to `AxisTypes.Number`. A documentation warning was added to the ScatterChart docs page.

## API Changes

- `ScatterChartExtensions.XAxis(ScatterChart, XAxis)` — now throws `InvalidOperationException` if axis has `Type=Category`
- `ScatterChartExtensions.YAxis(ScatterChart, YAxis)` — now throws `InvalidOperationException` if axis has `Type=Category`
- `ScatterChartExtensions.XAxis(ScatterChart, string)` — now creates XAxis with `Type=AxisTypes.Number` (was `Category`)
- `ScatterChartExtensions.YAxis(ScatterChart, string)` — now creates YAxis with `Type=AxisTypes.Number` (was `Number`, unchanged)
- `ScatterChartExtensions.YAxis(ScatterChart)` — now creates YAxis with `Type=AxisTypes.Number` (was `Number`, unchanged)

## Files Modified

- **Backend validation:** `src/Ivy/Widgets/Charts/ScatterChart.cs` — Added `ValidateAxisType()` methods and validation in XAxis/YAxis extension methods
- **Documentation:** `src/Ivy.Docs.Shared/Docs/02_Widgets/06_Charts/05_ScatterChart.md` — Added warning callout about numeric axis requirement
- **Tests:** `src/Ivy.Tests/Widgets/Charts/ScatterChartTests.cs` (new) — 4 tests verifying validation behavior

## Commits

- d48267f6 [01788] Prevent Category axis types on ScatterChart