### PR TITLE
[01789] Add test coverage for ScatterChart widget

### DIFF
--- a/src/Ivy.Tests/Widgets/Charts/ScatterTests.cs
+++ b/src/Ivy.Tests/Widgets/Charts/ScatterTests.cs
@@ -1,0 +1,46 @@
+using Ivy.Core;
+
+namespace Ivy.Tests.Widgets.Charts;
+
+public class ScatterTests
+{
+    [Fact]
+    public void YAxisIndex_WhenSet_SerializesToJson()
+    {
+        var scatter = new Scatter("Value").YAxisIndex(1);
+
+        var chart = new ScatterChart(new object[] { }, scatter);
+        chart.Id = Guid.NewGuid().ToString();
+
+        var result = WidgetSerializer.Serialize(chart);
+        var props = result["props"]!.AsObject();
+        var scatters = props["scatters"]!.AsArray();
+        var firstScatter = scatters[0]!.AsObject();
+
+        Assert.Equal(1, firstScatter["yAxisIndex"]!.GetValue<int>());
+    }
+
+    [Fact]
+    public void YAxisIndex_WhenNull_IsOmittedFromJson()
+    {
+        var scatter = new Scatter("Value");
+
+        var chart = new ScatterChart(new object[] { }, scatter);
+        chart.Id = Guid.NewGuid().ToString();
+
+        var result = WidgetSerializer.Serialize(chart);
+        var props = result["props"]!.AsObject();
+        var scatters = props["scatters"]!.AsArray();
+        var firstScatter = scatters[0]!.AsObject();
+
+        Assert.False(firstScatter.ContainsKey("yAxisIndex"));
+    }
+
+    [Fact]
+    public void YAxisIndex_ExtensionMethod_SetsValue()
+    {
+        var scatter = new Scatter("Value").YAxisIndex(2);
+
+        Assert.Equal(2, scatter.YAxisIndex);
+    }
+}


### PR DESCRIPTION
# Summary

## Changes

Added `ScatterTests.cs` with three unit tests for the `ScatterChart` widget's `YAxisIndex` property, following the established pattern from `BarTests.cs`. Tests cover serialization, null omission, and extension method behavior.

## API Changes

None.

## Files Modified

- **Tests:** `src/Ivy.Tests/Widgets/Charts/ScatterTests.cs` (new file)

## Commits

- 9de53eb6 [01789] Add test coverage for ScatterChart widget