### PR TITLE
[01794] Simplify ConfigPath initialization in Utils.ps1

### DIFF
--- a/src/tendril/Ivy.Tendril.TeamIvyConfig/Hooks/CleanupWorktrees.ps1
+++ b/src/tendril/Ivy.Tendril.TeamIvyConfig/Hooks/CleanupWorktrees.ps1
@@ -10,6 +10,11 @@ param(
 
 $ErrorActionPreference = "Continue"
 
+# Set TENDRIL_CONFIG if not already set (for standalone execution)
+if (-not $env:TENDRIL_CONFIG -and $env:TENDRIL_HOME) {
+    $env:TENDRIL_CONFIG = Join-Path $env:TENDRIL_HOME "config.yaml"
+}
+
 # Bootstrap shared utilities (includes Bootstrap-Modules.ps1 and ExtractRepoPathsFromYaml)
 $sharedPath = Join-Path (Split-Path (Split-Path $PSScriptRoot)) "Ivy.Tendril/.promptwares/.shared"
 . (Join-Path $sharedPath "Utils.ps1")

--- a/src/tendril/Ivy.Tendril/.promptwares/.shared/Utils.ps1
+++ b/src/tendril/Ivy.Tendril/.promptwares/.shared/Utils.ps1
@@ -16,11 +16,13 @@ if (-not $env:TENDRIL_HOME) {
     exit 1
 }
 
-$script:ConfigPath = if ($env:TENDRIL_CONFIG) {
-    $env:TENDRIL_CONFIG
-} else {
-    Join-Path $env:TENDRIL_HOME "config.yaml"
+# TENDRIL_CONFIG is required
+if (-not $env:TENDRIL_CONFIG) {
+    Write-Error "TENDRIL_CONFIG environment variable is not set. This variable must be set by JobService before invoking promptware scripts."
+    exit 1
 }
+
+$script:ConfigPath = $env:TENDRIL_CONFIG
 $script:PlansDir = Join-Path $env:TENDRIL_HOME "Plans"
 
 # Bootstrap required PowerShell modules


### PR DESCRIPTION
# Summary

## Changes

Simplified `$script:ConfigPath` initialization in `Utils.ps1` by removing the conditional fallback to `Join-Path $env:TENDRIL_HOME "config.yaml"`. The variable now requires `TENDRIL_CONFIG` to be set (matching the `TENDRIL_HOME` validation pattern) and exits with a clear error if missing. Updated `CleanupWorktrees.ps1` to set `TENDRIL_CONFIG` before sourcing `Utils.ps1` since it runs standalone outside JobService.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/.promptwares/.shared/Utils.ps1` — Replaced conditional ConfigPath initialization with validation + direct assignment
- `src/tendril/Ivy.Tendril.TeamIvyConfig/Hooks/CleanupWorktrees.ps1` — Added TENDRIL_CONFIG fallback for standalone execution

## Commits

- 294ba20c [01794] Simplify ConfigPath initialization in Utils.ps1