### PR TITLE
[01799] Fix draft count mismatch in sidebar badge

### DIFF
--- a/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
@@ -584,6 +584,9 @@ public class PlanReaderService(ConfigService config)
         {
             try
             {
+                var folderName = Path.GetFileName(dir);
+                if (!FolderNameRegex.Match(folderName).Success) continue;
+
                 var planYamlPath = Path.Combine(dir, "plan.yaml");
                 if (File.Exists(planYamlPath))
                 {


### PR DESCRIPTION
# Summary

## Changes

Added folder name pattern validation to `ComputePlanCounts()` in `PlanReaderService.cs`. The method now checks each directory against `FolderNameRegex` (5-digit ID + name pattern) before counting, matching the existing validation in `GetPlans()`. This fixes the sidebar badge showing inflated draft counts from non-plan directories.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Services/PlanReaderService.cs` — Added `FolderNameRegex` validation to `ComputePlanCounts()` loop (3 lines added)

## Commits

- f3cba1ce [01799] Fix draft count mismatch by validating plan folder names