### PR TITLE
[01754] Fix IvyFrameworkVerification promptware invocation from ExecutePlan

### DIFF
--- a/src/tendril/Ivy.Tendril.TeamIvyConfig/config.yaml
+++ b/src/tendril/Ivy.Tendril.TeamIvyConfig/config.yaml
@@ -313,7 +313,7 @@ verifications:
   - name: FrontendLint
     prompt: "Run `cd src/frontend && npm run lint && npm run format:check` and verify no errors."
   - name: IvyFrameworkVerification
-    prompt: "Run the IvyFrameworkVerification promptware to visually verify UI changes. Execute: `pwsh -NoProfile -File %TENDRIL_HOME%/Promptwares/IvyFrameworkVerification.ps1 -PlanPath <PlanFolder>`. Creates a temp project with demo apps, runs Playwright tests, and copies artifacts to <PlanFolder>/artifacts/. Write the verification report to <PlanFolder>/verification/IvyFrameworkVerification.md."
+    prompt: "Run the IvyFrameworkVerification promptware to visually verify UI changes. Execute: `pwsh -NoProfile -File \"$TENDRIL_HOME/Promptwares/IvyFrameworkVerification.ps1\" -PlanPath \"<PlanFolder>\"`. Creates a temp project with demo apps, runs Playwright tests, and copies artifacts to <PlanFolder>/artifacts/. Write the verification report to <PlanFolder>/verification/IvyFrameworkVerification.md."
   - name: CheckResult
     prompt: |
       Verify the implementation matches what was requested in the plan.


### PR DESCRIPTION
# Summary

## Changes

Changed the IvyFrameworkVerification prompt in config.yaml to use Bash-compatible environment variable syntax (`$TENDRIL_HOME`) instead of Windows CMD syntax (`%TENDRIL_HOME%`). Added quotes around the file path and `<PlanFolder>` placeholder to handle paths with spaces.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril.TeamIvyConfig/config.yaml` — Fixed environment variable syntax in IvyFrameworkVerification verification prompt (line 316)

## Commits

- 93c384fb [01754] Fix IvyFrameworkVerification promptware invocation from ExecutePlan