### PR TITLE
[01798] Fix cost tracking session ID capture

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/JobServiceCostTrackingTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/JobServiceCostTrackingTests.cs
@@ -1,0 +1,41 @@
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Test;
+
+public class JobServiceCostTrackingTests
+{
+    private static JobService CreateService()
+    {
+        return new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
+    }
+
+    [Fact]
+    public void LaunchJob_SetsSessionIdToValidGuid()
+    {
+        var service = CreateService();
+
+        var id = service.StartJob("ExecutePlan", Path.GetTempPath());
+        var job = service.GetJob(id);
+
+        Assert.NotNull(job);
+        Assert.NotNull(job.SessionId);
+        Assert.NotEmpty(job.SessionId);
+        Assert.True(Guid.TryParse(job.SessionId, out _), "SessionId should be a valid GUID");
+    }
+
+    [Fact]
+    public void LaunchJob_SessionIdIsUniquePerJob()
+    {
+        var service = CreateService();
+
+        var id1 = service.StartJob("ExecutePlan", Path.GetTempPath());
+        var id2 = service.StartJob("ExecutePlan", Path.GetTempPath());
+
+        var job1 = service.GetJob(id1);
+        var job2 = service.GetJob(id2);
+
+        Assert.NotNull(job1?.SessionId);
+        Assert.NotNull(job2?.SessionId);
+        Assert.NotEqual(job1.SessionId, job2.SessionId);
+    }
+}

--- a/src/tendril/Ivy.Tendril/.promptwares/ExecutePlan.ps1
+++ b/src/tendril/Ivy.Tendril/.promptwares/ExecutePlan.ps1
@@ -32,7 +32,11 @@ $promptFile = PrepareFirmware $PSScriptRoot $logFile $programFolder @{
 }
 
 $agent = GetAgentCommandFromConfig -Promptware "ExecutePlan"
-$sessionId = [guid]::NewGuid().ToString()
+$sessionId = $env:TENDRIL_SESSION_ID
+if (-not $sessionId) {
+    $sessionId = [guid]::NewGuid().ToString()
+    Write-Warning "TENDRIL_SESSION_ID not set, generated fallback: $sessionId"
+}
 
 Write-Host "Starting Agent in $workDir..."
 SendStatusMessage "Executing Plan"

--- a/src/tendril/Ivy.Tendril/.promptwares/MakePlan.ps1
+++ b/src/tendril/Ivy.Tendril/.promptwares/MakePlan.ps1
@@ -13,7 +13,11 @@ $logFile = GetNextLogFile $programFolder
 $Description | Set-Content $logFile
 Write-Host "Log file: $logFile"
 
-$sessionId = [guid]::NewGuid().ToString()
+$sessionId = $env:TENDRIL_SESSION_ID
+if (-not $sessionId) {
+    $sessionId = [guid]::NewGuid().ToString()
+    Write-Warning "TENDRIL_SESSION_ID not set, generated fallback: $sessionId"
+}
 $planId = AllocatePlanId
 
 $firmwareValues = @{

--- a/src/tendril/Ivy.Tendril/.promptwares/MakePr.ps1
+++ b/src/tendril/Ivy.Tendril/.promptwares/MakePr.ps1
@@ -18,7 +18,11 @@ $promptFile = PrepareFirmware $PSScriptRoot $logFile $programFolder @{
 }
 
 $agent = GetAgentCommandFromConfig -Promptware "MakePr"
-$sessionId = [guid]::NewGuid().ToString()
+$sessionId = $env:TENDRIL_SESSION_ID
+if (-not $sessionId) {
+    $sessionId = [guid]::NewGuid().ToString()
+    Write-Warning "TENDRIL_SESSION_ID not set, generated fallback: $sessionId"
+}
 
 Write-Host "Starting Agent..."
 Push-Location $programFolder

--- a/src/tendril/Ivy.Tendril/Services/JobService.cs
+++ b/src/tendril/Ivy.Tendril/Services/JobService.cs
@@ -222,12 +222,13 @@ public class JobService
             StandardOutputEncoding = System.Text.Encoding.UTF8,
             StandardErrorEncoding = System.Text.Encoding.UTF8,
         };
-        // Capture session ID from environment for cost tracking after job completes
-        job.SessionId = Environment.GetEnvironmentVariable("CLAUDE_SESSION_ID");
+        // Generate session ID for cost tracking — passed to child process so both sides share the same ID
+        job.SessionId = Guid.NewGuid().ToString();
 
         psi.Environment["TENDRIL_JOB_ID"] = id;
         psi.Environment["TENDRIL_URL"] = "http://localhost:5010";
         psi.Environment["TENDRIL_SHARED"] = SharedRoot;
+        psi.Environment["TENDRIL_SESSION_ID"] = job.SessionId;
         if (_configService != null)
             psi.Environment["TENDRIL_CONFIG"] = _configService.ConfigPath;
 


### PR DESCRIPTION
# Summary

## Changes

Fixed cost tracking that completely stopped working after the PowerShell-to-C# migration in plan 01618. The root cause was that `JobService.LaunchJob()` tried to read `CLAUDE_SESSION_ID` from its own environment (always null), instead of generating a session ID and passing it to the child process. Now JobService generates a GUID session ID, passes it to child processes via `TENDRIL_SESSION_ID` environment variable, and all three PowerShell launcher scripts consume it with a backward-compatible fallback.

## API Changes

- `TENDRIL_SESSION_ID` — new environment variable passed from JobService to child processes containing the session ID for cost tracking

## Files Modified

- **Core fix:**
  - `src/tendril/Ivy.Tendril/Services/JobService.cs` — generate session ID with `Guid.NewGuid()` and pass via `TENDRIL_SESSION_ID` env var
- **PowerShell scripts (consume TENDRIL_SESSION_ID):**
  - `src/tendril/Ivy.Tendril/.promptwares/MakePlan.ps1`
  - `src/tendril/Ivy.Tendril/.promptwares/ExecutePlan.ps1`
  - `src/tendril/Ivy.Tendril/.promptwares/MakePr.ps1`
- **Tests:**
  - `src/tendril/Ivy.Tendril.Test/JobServiceCostTrackingTests.cs` — 2 tests verifying session ID generation

## Commits

- 04a18e02 [01798] Fix cost tracking by generating session ID in JobService