### PR TITLE
[Docs]: improve compound widget documentation

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/05_Details.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/05_Details.md
@@ -141,3 +141,4 @@ Use `.Builder(x => x.Field, b => ...)` to customize how a value is *rendered*, n
 </Details>
 
 <WidgetDocs Type="Ivy.Details" ExtensionTypes="Ivy.DetailsBuilderExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Views/Builders/DetailsBuilder.cs"/>
+<WidgetDocs Type="Ivy.Detail" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Details/Detail.cs"/>

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/07_List.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/07_List.md
@@ -42,14 +42,22 @@ public class BasicListDemo : ViewBase
 
 ## ListItem Configuration
 
-`ListItem`s are highly customizable, supporting titles, subtitles, [icons](../01_Primitives/02_Icon.md), [badges](02_Badge.md), custom content, and interactive states.
+`ListItem` is a flexible building block for the `List` widget. Each item supports text labels, [icons](../01_Primitives/02_Icon.md), [badges](02_Badge.md), custom widget content, click handlers, and disabled states.
 
-- **Title & Subtitle** - Primary and secondary text labels.
-- **Icon** - Visual indicator using the [Icons](../../04_ApiReference/Ivy/Icons.md) enum.
-- **Badge** - Small status indicator or counter.
-- **Tag** - Hidden object reference (e.g., a database entity) used to identify the item in click handlers.
-- **Disabled** - Disables interactions and applies a muted visual style.
-- **Content** - Custom widget content injected into the item (e.g., a switch, input, or complex layout).
+### ListItem Properties
+
+| Method | Description |
+|--------|-------------|
+| `.Title(string)` | Primary text label displayed on the item |
+| `.Subtitle(string)` | Secondary text label displayed below the title |
+| `.Icon(Icons)` | Visual indicator using the [Icons](../../04_ApiReference/Ivy/Icons.md) enum |
+| `.Badge(string)` | Small status indicator or counter displayed on the right side |
+| `.Tag(object)` | Hidden object reference (e.g., a database entity) used to identify the item in click handlers |
+| `.Content(object)` | Custom widget content injected into the item (e.g., a switch, input, or complex layout) |
+| `.Disabled(bool)` | Disables interactions and applies a muted visual style |
+| `.OnClick(...)` | Click event handler — supports multiple overloads (see [OnClick Overloads](#onclick-overloads) below) |
+
+All properties can be set either via constructor parameters or through fluent extension methods.
 
 ```csharp demo-tabs
 public class ListConfigDemo : ViewBase
@@ -95,6 +103,54 @@ public class ListConfigDemo : ViewBase
     }
 }
 ```
+
+## Item Identification with Tag
+
+Use the `.Tag()` method to attach a data object (e.g., a database entity) to a `ListItem`. When the item is clicked, retrieve the tag from `e.Sender.Tag` to identify which item was selected. This pattern is essential for building master-detail interfaces with [blades](12_Blades.md).
+
+```csharp demo-tabs
+public class TagIdentificationDemo : ViewBase
+{
+    record User(int Id, string Name, string Email, int Age);
+
+    public override object? Build()
+    {
+        var selectedUser = UseState<User?>(null);
+
+        var users = new[]
+        {
+            new User(1, "Alice Johnson", "alice@example.com", 28),
+            new User(2, "Bob Smith", "bob@example.com", 35),
+            new User(3, "Charlie Brown", "charlie@example.com", 42)
+        };
+
+        var onItemClick = new Action<Event<ListItem>>(e =>
+        {
+            var user = (User)e.Sender.Tag!;
+            selectedUser.Set(user);
+        });
+
+        var listItems = users.Select(user =>
+            new ListItem(user.Name)
+                .Subtitle(user.Email)
+                .Icon(Icons.User)
+                .Badge(user.Age.ToString())
+                .Tag(user)
+                .OnClick(onItemClick)
+        );
+
+        return Layout.Horizontal().Gap(6)
+            | new List(listItems)
+            | (selectedUser.Value != null
+                ? selectedUser.Value.ToDetails()
+                : Text.Muted("Select a user from the list"));
+    }
+}
+```
+
+<Callout Type="tip">
+The <code>Tag</code> property is not rendered in the UI — it is only accessible in event handlers via <code>e.Sender.Tag</code>. Use it to pass entity objects, IDs, or any reference data needed for handling clicks.
+</Callout>
 
 ## Interactive Lists
 
@@ -191,6 +247,34 @@ public class SearchableListDemo : ViewBase
             | new List(listItems);
     }
 }
+```
+
+## OnClick Overloads
+
+`ListItem` supports multiple `.OnClick()` overloads to match different handler patterns:
+
+| Overload | Description |
+|----------|-------------|
+| `.OnClick(Action)` | Simple callback with no parameters |
+| `.OnClick(Action<Event<ListItem>>)` | Callback with access to the event sender (use `e.Sender.Tag` to identify the item) |
+| `.OnClick(Func<Event<ListItem>, ValueTask>)` | Async callback for operations that need `await` |
+| `.OnClick(EventHandler<Event<ListItem>>)` | Full event handler delegate |
+
+The same overloads are available via the constructor's `onClick` parameter:
+
+```csharp
+// Constructor with Action<Event<ListItem>>
+new ListItem("Click me", onClick: e => Console.WriteLine(e.Sender.Title))
+
+// Constructor with simple Action
+new ListItem("Click me", onClick: () => Console.WriteLine("Clicked!"))
+
+// Extension method
+new ListItem("Click me").OnClick(async e =>
+{
+    await Task.Delay(100);
+    Console.WriteLine($"Async click: {e.Sender.Tag}");
+})
 ```
 
 <WidgetDocs Type="Ivy.List" ExtensionTypes="Ivy.WidgetBaseExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Lists/List.cs"/>

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/08_Table.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/08_Table.md
@@ -306,6 +306,29 @@ public class ManualTableDemo : ViewBase
 }
 ```
 
+#### TableRow Properties
+
+| Method | Description |
+|--------|-------------|
+| `.IsHeader(bool)` | Marks the entire row as a header row |
+
+`TableRow` accepts `TableCell` elements as children. Use the `|` operator to pipe cells into a row:
+
+```csharp
+var row = new TableRow()
+    | new TableCell("Name")
+    | new TableCell("Email");
+```
+
+#### TableCell Properties
+
+| Method | Description |
+|--------|-------------|
+| `.IsHeader(bool)` | Marks the cell as a header cell (renders with bold/emphasis) |
+| `.IsFooter(bool)` | Marks the cell as a footer cell |
+| `.AlignContent(Align)` | Controls text alignment within the cell (`Align.Left`, `Align.Center`, `Align.Right`) |
+| `.Multiline(bool)` | Enables multi-line text wrapping instead of truncation with ellipsis |
+
 ### Builder Factory Methods
 
 The `Builder()` method allows you to specify how different data types should be rendered. Use the builder factory methods to create appropriate renderers for your data.
@@ -511,3 +534,5 @@ See [DataTable](../07_Advanced/01_DataTable.md) for full grid capabilities.
 </Details>
 
 <WidgetDocs Type="Ivy.Table" ExtensionTypes="Ivy.TableExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Tables/Table.cs"/>
+<WidgetDocs Type="Ivy.TableRow" ExtensionTypes="Ivy.TableRowExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Tables/TableRow.cs"/>
+<WidgetDocs Type="Ivy.TableCell" ExtensionTypes="Ivy.TableCellExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Tables/TableCell.cs"/>

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/15_Dialog.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/15_Dialog.md
@@ -114,4 +114,24 @@ public class FormDialogExample : ViewBase
 }
 ```
 
-<WidgetDocs Type="Ivy.Dialog" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Dialogs/Dialog.cs"/>
+## Dialog Component Properties
+
+### DialogHeader
+
+| Property | Description |
+|----------|-------------|
+| `title` (constructor) | The title text displayed at the top of the dialog |
+| `.HideCloseButton` | When set to `true`, hides the default close button in the header |
+
+### DialogBody
+
+Container for the main content of the dialog. Accepts any widgets or [views](../../01_Onboarding/02_Concepts/02_Views.md) as children via the constructor.
+
+### DialogFooter
+
+Container for action buttons at the bottom of the dialog. Typically contains Cancel and Confirm/Save [buttons](01_Button.md).
+
+<WidgetDocs Type="Ivy.Dialog" ExtensionTypes="Ivy.DialogExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Dialogs/Dialog.cs"/>
+<WidgetDocs Type="Ivy.DialogHeader" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Dialogs/DialogHeader.cs"/>
+<WidgetDocs Type="Ivy.DialogBody" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Dialogs/DialogBody.cs"/>
+<WidgetDocs Type="Ivy.DialogFooter" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Dialogs/DialogFooter.cs"/>

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/07_Advanced/03_Kanban.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/07_Advanced/03_Kanban.md
@@ -411,3 +411,4 @@ public class SimpleStatusBoard : ViewBase
 </Details>
 
 <WidgetDocs Type="Ivy.Kanban" ExtensionTypes="Ivy.KanbanColumnExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Kanban/Kanban.cs"/>
+<WidgetDocs Type="Ivy.KanbanCard" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Kanban/KanbanCard.cs"/>


### PR DESCRIPTION
## Summary

Addresses #2569 by improving `ListItem` documentation and standardizing the API reference pattern across all compound widgets (parent + child widget pairs).

## Motivation

The `ListItem` documentation was fragmented — properties were listed as bullet points without a proper API table, the `Tag` + `OnClick` identification pattern was undocumented, and constructor/method overloads were not described. Additionally, several other compound widgets (`TableRow`, `TableCell`, `KanbanCard`, `DialogHeader/Body/Footer`, `Detail`) were missing `<WidgetDocs>` references entirely.

## Changes

### List → ListItem (primary fix)
- Replaced bullet-point property list with a structured **API reference table** (8 methods)
- Added **"Item Identification with Tag"** section with a full interactive demo showing the `Tag` + `OnClick` pattern for master-detail selection
- Added **"OnClick Overloads"** reference table documenting all 4 overload signatures with code examples
- Follows the `Calendar → CalendarEvent` documentation pattern as the established standard
<img width="1103" height="861" alt="image" src="https://github.com/user-attachments/assets/a05412c8-b93e-4d41-bf51-043465ec5827" />
<img width="994" height="664" alt="image" src="https://github.com/user-attachments/assets/9a20cc93-1e22-4e9f-9adf-9032c7a83862" />
<img width="1073" height="815" alt="image" src="https://github.com/user-attachments/assets/97eeb987-44b3-4fa3-a189-a204b5a9f493" />


### Table → TableRow, TableCell
- Added **TableRow Properties** table (`IsHeader`) with pipe operator usage example
- Added **TableCell Properties** table (`IsHeader`, `IsFooter`, `AlignContent`, `Multiline`)
- Added `<WidgetDocs>` tags for both `Ivy.TableRow` and `Ivy.TableCell`
<img width="1186" height="702" alt="image" src="https://github.com/user-attachments/assets/47eb1391-8865-4933-bb89-5610f201113b" />



### Kanban → KanbanCard
- Added `<WidgetDocs>` tag for `Ivy.KanbanCard`

### Dialog → DialogHeader, DialogBody, DialogFooter
- Added **"Dialog Component Properties"** section with property tables for `DialogHeader`
- Added `<WidgetDocs>` tags for all three child components
- Added `ExtensionTypes="Ivy.DialogExtensions"` to the existing Dialog `<WidgetDocs>`

<img width="1294" height="656" alt="image" src="https://github.com/user-attachments/assets/730f5ac4-8dd4-4c5d-9d3b-19394e6c1318" />

### Details → Detail
- Added `<WidgetDocs>` tag for `Ivy.Detail`

## Files Changed

| File | Change |
|------|--------|
| `src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/07_List.md` | ListItem API table, Tag demo, OnClick overloads |
| `src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/08_Table.md` | TableRow/TableCell properties + WidgetDocs |
| `src/Ivy.Docs.Shared/Docs/02_Widgets/07_Advanced/03_Kanban.md` | KanbanCard WidgetDocs |
| `src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/15_Dialog.md` | Dialog child properties + WidgetDocs |
| `src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/05_Details.md` | Detail WidgetDocs |
