### PR TITLE
[01747] Make promptware tools shareable across machines

### DIFF
--- a/src/tendril/Ivy.Tendril/.promptwares/.gitignore
+++ b/src/tendril/Ivy.Tendril/.promptwares/.gitignore
@@ -1,3 +1,2 @@
 **/Logs/
 **/Memory/
-**/Tools/

--- a/src/tendril/Ivy.Tendril/.promptwares/ExpandPlan/Tools/Analyze-ErrorAccumulation.ps1
+++ b/src/tendril/Ivy.Tendril/.promptwares/ExpandPlan/Tools/Analyze-ErrorAccumulation.ps1
@@ -1,0 +1,52 @@
+param(
+    [string]$BuildErrorsFile
+)
+
+# Analyze error accumulation pattern in langfuse-build-errors.md
+$content = Get-Content $BuildErrorsFile -Raw
+
+# Extract each build section
+$builds = @()
+$buildMatches = [regex]::Matches($content, '## Build #(\d+).*?(?=## Build #|\z)', [System.Text.RegularExpressions.RegexOptions]::Singleline)
+
+foreach ($match in $buildMatches) {
+    $buildNum = [int]$match.Groups[1].Value
+    $buildContent = $match.Value
+
+    # Count errors in this build
+    $errorCount = ([regex]::Matches($buildContent, '- `CS\d+')).Count
+
+    # Count files affected
+    $fileMatches = [regex]::Matches($buildContent, '### ([^\r\n]+)')
+    $fileCount = $fileMatches.Count
+
+    # Calculate content size (indicator of context size)
+    $contentSize = $buildContent.Length
+
+    $builds += [PSCustomObject]@{
+        BuildNumber = $buildNum
+        ErrorCount = $errorCount
+        FilesAffected = $fileCount
+        ContentSize = $contentSize
+        Status = if ($buildContent -match '✅ OK') { 'SUCCESS' } else { 'FAILED' }
+    }
+}
+
+Write-Output "`nError Accumulation Analysis:"
+Write-Output "="*60
+$builds | Format-Table -AutoSize
+
+# Calculate accumulation
+Write-Output "`nAccumulation Pattern:"
+Write-Output "="*60
+Write-Output "Total context at each build (cumulative sum of errors shown):"
+
+$cumulative = 0
+foreach ($build in $builds) {
+    if ($build.Status -eq 'FAILED') {
+        $cumulative += $build.ErrorCount
+    }
+    Write-Output "Build #$($build.BuildNumber): $cumulative total errors in history"
+}
+
+return $builds

--- a/src/tendril/Ivy.Tendril/.promptwares/ExpandPlan/Tools/Extract-TokenData.ps1
+++ b/src/tendril/Ivy.Tendril/.promptwares/ExpandPlan/Tools/Extract-TokenData.ps1
@@ -1,0 +1,22 @@
+param(
+    [string]$SessionFile
+)
+
+# Read session.ldjson and extract token usage at generation boundaries
+$generations = @()
+
+Get-Content $SessionFile | ForEach-Object {
+    $event = $_ | ConvertFrom-Json
+
+    if ($event.eventName -eq "UITokenUsageMessage") {
+        $generations += [PSCustomObject]@{
+            GenerationNumber = $event.generationNumber
+            InputTokens = $event.inputTokens
+            OutputTokens = $event.outputTokens
+            TotalTokens = $event.inputTokens + $event.outputTokens
+            Timestamp = $event.timestamp
+        }
+    }
+}
+
+return $generations | Format-Table -AutoSize

--- a/src/tendril/Ivy.Tendril/.promptwares/ExpandPlan/Tools/Find-SimilarPatterns.ps1
+++ b/src/tendril/Ivy.Tendril/.promptwares/ExpandPlan/Tools/Find-SimilarPatterns.ps1
@@ -1,0 +1,57 @@
+# Find Similar Implementation Patterns in Codebase
+# Usage: .\Find-SimilarPatterns.ps1 -Pattern "StateHasChanged" -Context "Dialog"
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$Pattern,
+
+    [string]$Context = "",
+
+    [string]$SearchPath = "D:\Repos\_Ivy\Ivy-Framework\src",
+
+    [int]$ContextLines = 3
+)
+
+Write-Host "Searching for pattern: $Pattern" -ForegroundColor Cyan
+if ($Context) {
+    Write-Host "With context: $Context" -ForegroundColor Cyan
+}
+
+$results = @()
+
+# Search for the pattern using ripgrep
+$rgArgs = @(
+    $Pattern,
+    $SearchPath,
+    "--type", "cs",
+    "--type", "tsx",
+    "--type", "ts",
+    "--line-number",
+    "--context", $ContextLines,
+    "--heading",
+    "--color", "never"
+)
+
+if ($Context) {
+    # If context provided, filter results
+    $allMatches = rg @rgArgs
+    $results = $allMatches | Select-String -Pattern $Context -Context ($ContextLines * 2)
+} else {
+    $results = rg @rgArgs
+}
+
+if ($results) {
+    Write-Host "`nFound $($results.Count) matches:" -ForegroundColor Green
+    $results | ForEach-Object {
+        Write-Host $_ -ForegroundColor Gray
+    }
+} else {
+    Write-Host "`nNo matches found" -ForegroundColor Yellow
+}
+
+# Group by file for summary
+$fileGroups = $results | Group-Object { ($_ -split ':')[0] } | Select-Object -First 10
+
+Write-Host "`n=== Top Files with Pattern ===" -ForegroundColor Cyan
+$fileGroups | ForEach-Object {
+    Write-Host "$($_.Count) matches: $($_.Name)" -ForegroundColor White
+}

--- a/src/tendril/Ivy.Tendril/.promptwares/MakePlan/Tools/Verify-IvyApi.ps1
+++ b/src/tendril/Ivy.Tendril/.promptwares/MakePlan/Tools/Verify-IvyApi.ps1
@@ -1,0 +1,39 @@
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$ClassName,
+
+    [Parameter(Mandatory=$true)]
+    [string]$MethodName
+)
+
+$repoPath = "D:\Repos\_Ivy\Ivy-Framework\src\Ivy"
+
+# Search for class definition
+$classFiles = Get-ChildItem -Path $repoPath -Filter "$ClassName.cs" -Recurse
+
+if ($classFiles.Count -eq 0) {
+    Write-Host "Class $ClassName not found"
+    exit 1
+}
+
+$classFile = $classFiles[0].FullName
+$content = Get-Content $classFile -Raw
+
+# Search for method
+if ($content -match "public\s+\w+\s+$MethodName\s*\(") {
+    Write-Host "Found: $ClassName.$MethodName"
+    Write-Host "File: $classFile"
+
+    # Extract method signature
+    $lines = $content -split "`n"
+    for ($i = 0; $i -lt $lines.Length; $i++) {
+        if ($lines[$i] -match "public\s+\w+\s+$MethodName\s*\(") {
+            Write-Host "Signature: $($lines[$i].Trim())"
+            break
+        }
+    }
+    exit 0
+} else {
+    Write-Host "Method $MethodName not found on $ClassName"
+    exit 1
+}

--- a/src/tendril/Ivy.Tendril/.promptwares/MakePr/Tools/Upload-Artifacts.ps1
+++ b/src/tendril/Ivy.Tendril/.promptwares/MakePr/Tools/Upload-Artifacts.ps1
@@ -1,0 +1,40 @@
+param(
+    [Parameter(Mandatory)]
+    [string]$PlanFolder
+)
+
+$env:NO_COLOR = "1"
+$screenshotsDir = Join-Path $PlanFolder "artifacts/screenshots"
+
+$screenshotFiles = @()
+
+if (Test-Path $screenshotsDir) {
+    $screenshotFiles = Get-ChildItem -Path $screenshotsDir -Filter "*.png" -File | Sort-Object Name
+}
+
+if ($screenshotFiles.Count -eq 0) {
+    return ""
+}
+
+$markdown = @()
+
+if ($screenshotFiles.Count -gt 0) {
+    $markdown += "### Screenshots"
+    $markdown += ""
+    foreach ($file in $screenshotFiles) {
+        $raw = & storage upload ivy-tendril $file.FullName 2>&1 | Out-String
+        # Strip ANSI codes and collapse whitespace to reconstruct wrapped URLs
+        $clean = $raw -replace "\x1B\[[0-9;]*m", ""
+        $noWs = $clean -replace "\s+", ""
+        if ($noWs -match "(https://stivytelemetry\.blob\.core\.windows\.net/[^""]+)") {
+            $url = $Matches[1].Trim()
+        } else {
+            continue
+        }
+        $name = [System.IO.Path]::GetFileNameWithoutExtension($file.Name)
+        $markdown += "![${name}](${url})"
+        $markdown += ""
+    }
+}
+
+return ($markdown -join "`n")


### PR DESCRIPTION
# Summary

## Changes

Removed `**/Tools/` from `.promptwares/.gitignore` to allow promptware tool scripts to be tracked in git. Added the 5 previously-untracked PowerShell tools from ExpandPlan, MakePlan, and MakePr promptwares so they are shared across machines.

## API Changes

None.

## Files Modified

- **Configuration:**
  - `src/tendril/Ivy.Tendril/.promptwares/.gitignore` — removed `**/Tools/` ignore rule

- **New tracked tools (previously untracked):**
  - `src/tendril/Ivy.Tendril/.promptwares/ExpandPlan/Tools/Analyze-ErrorAccumulation.ps1`
  - `src/tendril/Ivy.Tendril/.promptwares/ExpandPlan/Tools/Extract-TokenData.ps1`
  - `src/tendril/Ivy.Tendril/.promptwares/ExpandPlan/Tools/Find-SimilarPatterns.ps1`
  - `src/tendril/Ivy.Tendril/.promptwares/MakePlan/Tools/Verify-IvyApi.ps1`
  - `src/tendril/Ivy.Tendril/.promptwares/MakePr/Tools/Upload-Artifacts.ps1`

---

**Commits:**
- 376d20e1 [01747] Make promptware tools shareable across machines