### PR TITLE
[01808] Write session IDs to plan log files

### DIFF
--- a/src/tendril/Ivy.Tendril/Ivy.Tendril.Test/JobServiceLogTests.cs
+++ b/src/tendril/Ivy.Tendril/Ivy.Tendril.Test/JobServiceLogTests.cs
@@ -1,0 +1,87 @@
+using Ivy.Tendril.Apps.Jobs;
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Test;
+
+public class JobServiceLogTests
+{
+    [Fact]
+    public void WriteJobLog_IncludesSessionId()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"tendril-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var configService = new ConfigService(new TendrilSettings(), tempDir);
+            var planReaderService = new PlanReaderService(configService);
+            var jobService = new JobService(TimeSpan.FromMinutes(5), TimeSpan.FromMinutes(1));
+            jobService.SetPlanReaderService(planReaderService);
+
+            var sessionId = Guid.NewGuid().ToString();
+            var job = new JobItem
+            {
+                Id = "1",
+                Type = "ExecutePlan",
+                PlanFile = "00001-TestPlan",
+                Status = "Completed",
+                StartedAt = DateTime.UtcNow.AddMinutes(-2),
+                CompletedAt = DateTime.UtcNow,
+                DurationSeconds = 120,
+                SessionId = sessionId
+            };
+
+            jobService.WriteJobLog(job);
+
+            var logsDir = Path.Combine(tempDir, "Plans", "00001-TestPlan", "logs");
+            var logFiles = Directory.GetFiles(logsDir, "*.md");
+            Assert.Single(logFiles);
+
+            var logContent = File.ReadAllText(logFiles[0]);
+            Assert.Contains("**SessionId:**", logContent);
+            Assert.Contains(sessionId, logContent);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void WriteJobLog_OmitsSessionIdWhenNull()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"tendril-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var configService = new ConfigService(new TendrilSettings(), tempDir);
+            var planReaderService = new PlanReaderService(configService);
+            var jobService = new JobService(TimeSpan.FromMinutes(5), TimeSpan.FromMinutes(1));
+            jobService.SetPlanReaderService(planReaderService);
+
+            var job = new JobItem
+            {
+                Id = "2",
+                Type = "ExecutePlan",
+                PlanFile = "00002-TestPlan",
+                Status = "Completed",
+                StartedAt = DateTime.UtcNow.AddMinutes(-1),
+                CompletedAt = DateTime.UtcNow,
+                DurationSeconds = 60,
+                SessionId = null
+            };
+
+            jobService.WriteJobLog(job);
+
+            var logsDir = Path.Combine(tempDir, "Plans", "00002-TestPlan", "logs");
+            var logFiles = Directory.GetFiles(logsDir, "*.md");
+            Assert.Single(logFiles);
+
+            var logContent = File.ReadAllText(logFiles[0]);
+            Assert.DoesNotContain("**SessionId:**", logContent);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+}

--- a/src/tendril/Ivy.Tendril/Services/JobService.cs
+++ b/src/tendril/Ivy.Tendril/Services/JobService.cs
@@ -914,7 +914,7 @@ public class JobService
         File.AppendAllText(csvPath, line);
     }
 
-    private void WriteJobLog(JobItem job)
+    internal void WriteJobLog(JobItem job)
     {
         if (_planReaderService == null || string.IsNullOrEmpty(job.PlanFile))
             return;
@@ -932,6 +932,9 @@ public class JobService
                 $"- **Started:** {job.StartedAt:u}\n" +
                 $"- **Completed:** {job.CompletedAt:u}\n" +
                 $"- **Duration:** {duration}\n";
+
+            if (!string.IsNullOrEmpty(job.SessionId))
+                logContent += $"- **SessionId:** {job.SessionId}\n";
 
             if (job.Status == "Timeout" && job.StatusMessage != null)
                 logContent += $"- **Timeout Reason:** {job.StatusMessage}\n";


### PR DESCRIPTION
# Summary

## Changes

Added session ID persistence to plan log files. When `WriteJobLog` writes a log entry after job completion, it now includes a `- **SessionId:** <guid>` line if the job has a session ID set. This enables future cost backfill scripts to look up Claude sessions directly by ID instead of relying on timestamp matching.

## API Changes

- `JobService.WriteJobLog()` changed from `private` to `internal` to enable direct unit testing via `InternalsVisibleTo`.

## Files Modified

- **src/tendril/Ivy.Tendril/Services/JobService.cs** — Added session ID output to `WriteJobLog`, changed visibility to `internal`
- **src/tendril/Ivy.Tendril/Ivy.Tendril.Test/JobServiceLogTests.cs** — New test class with two tests verifying session ID inclusion/omission in logs

## Commits

- a1aeec33 [01808] Write session IDs to plan log files