### PR TITLE
[01809] Fix dotnet format issues in test files

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/ContentViewTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/ContentViewTests.cs
@@ -1,4 +1,3 @@
-using Ivy;
 using Ivy.Tendril.Apps.Plans;
 
 namespace Ivy.Tendril.Test;

--- a/src/tendril/Ivy.Tendril.Test/PlanDownloadHelperTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/PlanDownloadHelperTests.cs
@@ -1,4 +1,3 @@
-using Ivy;
 using Ivy.Core;
 using Ivy.Core.Exceptions;
 using Ivy.Core.Hooks;

--- a/src/tendril/Ivy.Tendril.Test/Services/FileLinkHelperTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/Services/FileLinkHelperTests.cs
@@ -1,4 +1,3 @@
-using Ivy;
 using Ivy.Tendril.Services;
 
 namespace Ivy.Tendril.Test.Services;


### PR DESCRIPTION
# Summary

## Changes

Removed unnecessary `using Ivy;` directives from three test files in Ivy.Tendril.Test that were flagged by `dotnet format` (IDE0005).

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril.Test/ContentViewTests.cs` — removed unused `using Ivy;`
- `src/tendril/Ivy.Tendril.Test/PlanDownloadHelperTests.cs` — removed unused `using Ivy;`
- `src/tendril/Ivy.Tendril.Test/Services/FileLinkHelperTests.cs` — removed unused `using Ivy;`

## Commits

- [01809] Remove unnecessary using Ivy directives from test files (f7de56f5)