### PR TITLE
[01810] Extract plan ID badge to content area in Plans and Review apps

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Recommendations/SidebarView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Recommendations/SidebarView.cs
@@ -31,10 +31,7 @@ public class SidebarView(
                 ? rec.Description[..120] + "…"
                 : rec.Description;
 
-            return new ListItem(rec.Title, subtitle: preview)
-                .Content(Layout.Horizontal().Gap(1)
-                    | new Badge($"#{rec.PlanId}").Variant(BadgeVariant.Outline).Small()
-                )
+            return new ListItem($"#{rec.PlanId} {rec.Title}", subtitle: preview)
                 .OnClick(() => _selectedState.Set(clickableRec));
         }));
     }


### PR DESCRIPTION
# Summary

## Changes

Moved the plan ID from a separate `Badge` widget in the content area to the `ListItem` title string in the Recommendations sidebar view. This standardizes the display pattern across Plans, Review, and Recommendations apps — all now show `"#{planId} {title}"` in the list item title.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Apps/Recommendations/SidebarView.cs` — Replaced `ListItem(rec.Title)` + Badge content with `ListItem($"#{rec.PlanId} {rec.Title}")`, removed the `.Content()` call entirely.

## Commits

- bf26ee40 [01810] Move plan ID from badge to title in Recommendations sidebar