### PR TITLE
[01811] Adjust Logo and Version Display in Tendril Header

### DIFF
--- a/src/tendril/Ivy.Tendril/Program.cs
+++ b/src/tendril/Ivy.Tendril/Program.cs
@@ -94,13 +94,17 @@ server.UseWebApplication(app =>
 });
 server.AddAppsFromAssembly();
 server.AddConnectionsFromAssembly();
-var version = typeof(TendrilAppShell).Assembly.GetName().Version!.ToString();
+var version = typeof(TendrilAppShell).Assembly.GetName().Version!;
+var versionString = version.ToString(3);
 var appShellSettings = new AppShellSettings()
     .Header(
         Layout.Horizontal(
-            new Image("/tendril/assets/Tendril.svg").Width(Size.Units(21)).Height(Size.Auto()),
-            Text.Muted($"v{version}")
-        ).Gap(2).Padding(2).AlignContent(Align.Left)
+            new Image("/tendril/assets/Tendril.svg").Width(Size.Units(15)).Height(Size.Auto()),
+            Layout.Vertical(
+                Text.Muted("Ivy Tendril").Small(),
+                Text.Muted($"v{versionString}")
+            )
+        ).Gap(2).Padding(2).AlignContent(Align.BottomLeft)
     )
     .DefaultAppId("dashboard")
     .UseTabs(preventDuplicates: false);


### PR DESCRIPTION
# Summary

## Changes

Adjusted the Tendril header to make the logo 30% smaller (width from 21 to 15 units), added an "Ivy Tendril" label above the version number, trimmed the trailing ".0" from the version display, and bottom-aligned the text block relative to the logo.

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/Program.cs** — Updated header layout: smaller logo, vertical text layout with "Ivy Tendril" label + trimmed version, bottom-left alignment

## Commits

- 81c814f3 [01811] Adjust logo and version display in Tendril header