### PR TITLE
[01812] Fix duplicate count display in Jobs status labels

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/JobsApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/JobsApp.cs
@@ -59,7 +59,7 @@ public class JobsApp : ViewBase
             .Select(g => new ProgressSegment(
                 Value: g.Count,
                 Color: GetStatusColor(g.Status),
-                Label: $"{g.Status} ({g.Count})"
+                Label: g.Status
             ))
             .ToArray();
 


### PR DESCRIPTION
# Summary

## Changes

Removed the duplicate count from the Jobs app status labels. The `StackedProgress` widget's `.ShowLabels()` already displays each segment's value, so including the count in the label caused it to appear twice (e.g. "Running (6) 6"). The label now contains only the status name (e.g. "Running 6").

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Apps/JobsApp.cs` — Changed label from `$"{g.Status} ({g.Count})"` to `g.Status`

## Commits

- e4aba7b2 [01812] Remove duplicate count from Jobs status labels