### PR TITLE
[01813] Make Plan ID in DataTables styled as links

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/JobsApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/JobsApp.cs
@@ -89,7 +89,7 @@ public class JobsApp : ViewBase
             .Width(t => t.Cost, Size.Px(80))
             .Width(t => t.StatusMessage, Size.Auto())
             .Renderer(t => t.Status, new LabelsDisplayRenderer())
-            .Renderer(t => t.PlanId, new ButtonDisplayRenderer())
+            .Renderer(t => t.PlanId, new LinkDisplayRenderer())
             .Hidden(t => t.Id)
             .Hidden(t => t.LastOutputTimestamp)
             .Filterable(t => t.Timer, false)

--- a/src/tendril/Ivy.Tendril/Apps/PullRequestApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/PullRequestApp.cs
@@ -40,7 +40,7 @@ public class PullRequestApp : ViewBase
             .Header(t => t.Repository, "Repository")
             .Header(t => t.Pr, "PR")
             .Header(t => t.Plan, "Plan")
-            .Renderer(t => t.PlanId, new ButtonDisplayRenderer())
+            .Renderer(t => t.PlanId, new LinkDisplayRenderer())
             .Renderer(t => t.Pr, new LinkDisplayRenderer())
             .SortDirection(t => t.PlanId, SortDirection.Descending)
             .Hidden(t => t.Id)


### PR DESCRIPTION
# Summary

## Changes

Replaced `ButtonDisplayRenderer` with `LinkDisplayRenderer` for the Plan ID column in both the Jobs and Pull Requests DataTables. This makes plan IDs render as styled links instead of buttons, matching web UX patterns for navigation elements.

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/Apps/JobsApp.cs** — Changed PlanId renderer from `ButtonDisplayRenderer` to `LinkDisplayRenderer`
- **src/tendril/Ivy.Tendril/Apps/PullRequestApp.cs** — Changed PlanId renderer from `ButtonDisplayRenderer` to `LinkDisplayRenderer`

---

**Commits:**
- 89b86a81 [01813] Style Plan ID columns as links instead of buttons