### PR TITLE
[01814] Remove badges from Review header

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -99,8 +99,6 @@ public class ContentView(
         // Header
         var header = Layout.Horizontal().Width(Size.Full()).Padding(1).Gap(2)
             | Text.Block($"#{_selectedPlan.Id} {_selectedPlan.Title}").Bold()
-            | new Badge(_selectedPlan.Project).Variant(BadgeVariant.Outline).WithProjectColor(_config, _selectedPlan.Project)
-            | new Badge(_selectedPlan.Level).Variant(_config.GetBadgeVariant(_selectedPlan.Level))
             | new Spacer().Width(Size.Grow())
             | Text.Rich()
                 .Bold($"{currentIndex + 1}/{_allPlans.Count}", word: true)


### PR DESCRIPTION
# Summary

## Changes

Removed the Project and Level badge components from the Review app header in ContentView.cs. The header now shows only the plan ID/title on the left, with the plan count indicator and Make PR button on the right.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs` — Removed two badge lines from the header layout

## Commits

- 4af71856 [01814] Remove project and level badges from Review header