### PR TITLE
[01818] Change back to AppShell prevent Duplications = true

### DIFF
--- a/src/tendril/Ivy.Tendril/Program.cs
+++ b/src/tendril/Ivy.Tendril/Program.cs
@@ -103,6 +103,6 @@ var appShellSettings = new AppShellSettings()
         ).Gap(2).Padding(2).AlignContent(Align.Left)
     )
     .DefaultAppId("dashboard")
-    .UseTabs(preventDuplicates: false);
+    .UseTabs(preventDuplicates: true);
 server.UseAppShell(() => new TendrilAppShell(appShellSettings));
 await server.RunAsync();


### PR DESCRIPTION
# Summary

## Changes

Changed the `preventDuplicates` parameter from `false` back to `true` in the Tendril AppShell tab configuration. This restores the behavior where clicking an already-open app focuses the existing tab instead of creating a duplicate.

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/Program.cs** — Changed `.UseTabs(preventDuplicates: false)` to `.UseTabs(preventDuplicates: true)`

## Commits

- 922ea445 [01818] Change AppShell preventDuplicates back to true