### PR TITLE
[01817] Delegate GetPendingRecommendationsCount to ComputePlanCounts

### DIFF
--- a/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
@@ -565,8 +565,7 @@ public class PlanReaderService(ConfigService config)
 
     public int GetPendingRecommendationsCount()
     {
-        return GetRecommendations()
-            .Count(r => r.State.Equals("Pending", StringComparison.OrdinalIgnoreCase));
+        return ComputePlanCounts().PendingRecommendations;
     }
 
     public record PlanCountSnapshot(


### PR DESCRIPTION
# Summary

## Changes

Changed `GetPendingRecommendationsCount()` in `PlanReaderService` to delegate to `ComputePlanCounts().PendingRecommendations` instead of calling `GetRecommendations()` and counting manually. This avoids full deserialization of all plan and recommendation YAML files just to get a count.

## API Changes

None. The public method signature `int GetPendingRecommendationsCount()` is unchanged; only the internal implementation was optimized.

## Files Modified

- `src/tendril/Ivy.Tendril/Services/PlanReaderService.cs` — Replaced `GetRecommendations().Count(...)` with `ComputePlanCounts().PendingRecommendations`

## Commits

- c777c7c9 [01817] Delegate GetPendingRecommendationsCount to ComputePlanCounts