### PR TITLE
[01824] Reduce spacing between markdown details elements

### DIFF
--- a/src/frontend/src/widgets/primitives/MarkdownWidget.tsx
+++ b/src/frontend/src/widgets/primitives/MarkdownWidget.tsx
@@ -64,7 +64,7 @@ const MarkdownWidget: React.FC<MarkdownWidgetProps> = ({
   const styles: React.CSSProperties = {
     display: "flex",
     flexDirection: "column",
-    gap: "1rem",
+    gap: "0.5rem",
     wordBreak: "normal",
     overflowWrap: "break-word",
     ...(textAlignment && {


### PR DESCRIPTION
# Summary

## Changes

Reduced the CSS gap in the markdown widget container from `1rem` (16px) to `0.5rem` (8px), making consecutive `<details>` elements and other markdown blocks more compact and easier to scan.

## API Changes

None.

## Files Modified

- **Frontend:** `src/frontend/src/widgets/primitives/MarkdownWidget.tsx` — changed `gap` style property from `"1rem"` to `"0.5rem"`

## Commits

- f2b9460a [01824] Reduce markdown container gap from 1rem to 0.5rem