### PR TITLE
[Tabs]: fix tab flicker on refresh by syncing tab order synchronously during render

### DIFF
--- a/src/frontend/src/widgets/layouts/tabs/hooks/useTabManagement.ts
+++ b/src/frontend/src/widgets/layouts/tabs/hooks/useTabManagement.ts
@@ -102,19 +102,30 @@ export function useTabManagement(
     eventHandlerRef.current = eventHandler;
   }, [eventHandler]);
 
-  // Sync tab order on add/remove
-  React.useEffect(() => {
-    const prev = tabOrderRef.current;
-    const currentTabIds = tabWidgets
-      .map((tab) => getTabProps(tab)?.id)
-      .filter((id): id is string => id !== undefined);
-    const added = currentTabIds.filter((id) => !prev.includes(id));
-    const removed = prev.filter((id) => !currentTabIds.includes(id));
+  const currentTabIds = React.useMemo(
+    () =>
+      tabWidgets.map((tab) => getTabProps(tab)?.id).filter((id): id is string => id !== undefined),
+    [tabWidgets],
+  );
 
-    if (added.length || removed.length) {
-      setTabOrder(currentTabIds);
+  const added = currentTabIds.filter((id) => !tabOrder.includes(id));
+  const removed = tabOrder.filter((id) => !currentTabIds.includes(id));
+
+  if (added.length || removed.length) {
+    if (activeTabId && removed.includes(activeTabId)) {
+      const oldIndex = tabOrder.indexOf(activeTabId);
+      const newIdAtSamePos = currentTabIds[oldIndex];
+      if (newIdAtSamePos && added.includes(newIdAtSamePos)) {
+        setActiveTabId(newIdAtSamePos);
+        setLoadedTabs((prev) => {
+          const newSet = new Set(prev);
+          newSet.add(newIdAtSamePos);
+          return newSet;
+        });
+      }
     }
-  }, [tabWidgets, tabOrderRef, setTabOrder]);
+    setTabOrder(currentTabIds);
+  }
 
   // Sync activeTabId with selectedIndex prop from backend (only when not user-initiated)
   React.useEffect(() => {


### PR DESCRIPTION
## Problem

When clicking the refresh button (🔄) on an active tab, the tab to the right would briefly flash as selected before the correct tab re-selected itself. This happened consistently with every tab — refreshing the leftmost tab would briefly select the middle one, refreshing the middle would briefly select the rightmost, etc.

## Root Cause

When a tab is refreshed, the backend generates a new `RefreshToken`, which changes the tab's `Key`, which in turn changes its serialized widget `id` in the tree. The frontend receives the updated children with the new id and treats it as "one tab removed + one tab added."

The old code used a `useEffect` to synchronize the `tabOrder` state with the incoming tab widgets. Since `useEffect` runs **after** rendering, there was one rendered frame where:

1. `tabWidgets` (props) already had the **new** tab id
2. `tabOrder` (state) still had the **old** tab id
3. `orderedTabWidgets` couldn't match the refreshed tab → it disappeared from render
4. The `<Tabs>` component lost its active value → visually selected the next available tab

This single intermediate frame was visible as a brief flicker.

## Fix

Replaced the `useEffect`-based tab order sync with a **synchronous state update during render** (React 18 pattern for derived state). When React encounters `setState` during render, it immediately abandons the current render and re-renders with the correct state — no intermediate frame reaches the DOM.

Additionally, the fix detects when the active tab's id was replaced (refresh scenario) and atomically updates `activeTabId` to point to the new id at the same position.

### Changed file

- `src/frontend/src/widgets/layouts/tabs/hooks/useTabManagement.ts`

https://github.com/user-attachments/assets/00830bf2-16ad-41df-be0f-dd2875082069

