### PR TITLE
[01822] Allow apps to opt out of duplicate prevention

### DIFF
--- a/src/Ivy/AppShell/DefaultSidebarAppShell.cs
+++ b/src/Ivy/AppShell/DefaultSidebarAppShell.cs
@@ -169,30 +169,34 @@ public class DefaultSidebarAppShell(AppShellSettings settings) : ViewBase
                 if (settings.PreventTabDuplicates)
                 {
                     var appId = navigateArgs.AppId;
-                    int existingTabIndex = -1;
-                    for (int i = 0; i < tabs.Value.Length; i++)
+                    var appDescriptor = appRepository.GetApp(appId);
+                    if (appDescriptor?.AllowDuplicateTabs != true)
                     {
-                        if (tabs.Value[i].AppId == appId)
+                        int existingTabIndex = -1;
+                        for (int i = 0; i < tabs.Value.Length; i++)
                         {
-                            existingTabIndex = i;
-                            break;
+                            if (tabs.Value[i].AppId == appId)
+                            {
+                                existingTabIndex = i;
+                                break;
+                            }
                         }
-                    }
 
-                    if (existingTabIndex >= 0)
-                    {
-                        var previousSelectedIndex = selectedIndex.Value;
-                        selectedIndex.Set(existingTabIndex);
-                        tabId = tabs.Value[existingTabIndex].Id;
-
-                        // Set page title
-                        SetAppTitle(appId);
-
-                        if (navigateArgs.HistoryOp is HistoryOp.Push && previousSelectedIndex != existingTabIndex)
+                        if (existingTabIndex >= 0)
                         {
-                            RedirectToAppIfNotError(navigateArgs, replaceHistory, tabId);
+                            var previousSelectedIndex = selectedIndex.Value;
+                            selectedIndex.Set(existingTabIndex);
+                            tabId = tabs.Value[existingTabIndex].Id;
+
+                            // Set page title
+                            SetAppTitle(appId);
+
+                            if (navigateArgs.HistoryOp is HistoryOp.Push && previousSelectedIndex != existingTabIndex)
+                            {
+                                RedirectToAppIfNotError(navigateArgs, replaceHistory, tabId);
+                            }
+                            return;
                         }
-                        return;
                     }
                 }
 

--- a/src/Ivy/Apps/AppAttribute.cs
+++ b/src/Ivy/Apps/AppAttribute.cs
@@ -13,7 +13,8 @@ public class AppAttribute(
     int order = 0,
     bool groupExpanded = false,
     string? documentSource = null,
-    string[]? searchHints = null
+    string[]? searchHints = null,
+    bool allowDuplicateTabs = false
 )
     : Attribute
 {
@@ -36,4 +37,6 @@ public class AppAttribute(
     public string? DocumentSource { get; set; } = documentSource;
 
     public string[]? SearchHints { get; set; } = searchHints;
+
+    public bool AllowDuplicateTabs { get; set; } = allowDuplicateTabs;
 }

--- a/src/Ivy/Core/Apps/AppDescriptor.cs
+++ b/src/Ivy/Core/Apps/AppDescriptor.cs
@@ -59,6 +59,8 @@ public class AppDescriptor : IAppRepositoryNode
 
     public string[]? SearchHints { get; set; }
 
+    public bool AllowDuplicateTabs { get; init; }
+
     public ViewBase CreateApp()
     {
         if (ViewFactory != null)

--- a/src/Ivy/Core/Apps/AppHelpers.cs
+++ b/src/Ivy/Core/Apps/AppHelpers.cs
@@ -67,6 +67,7 @@ public static class AppHelpers
                 GroupExpanded = appAttribute.GroupExpanded,
                 DocumentSource = appAttribute.DocumentSource,
                 SearchHints = appAttribute.SearchHints,
+                AllowDuplicateTabs = appAttribute.AllowDuplicateTabs,
             };
         }
         throw new InvalidOperationException($"Type '{type.FullName}' is missing the [App] attribute.");

--- a/src/tendril/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/tendril/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -214,28 +214,32 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
                     if (settings.PreventTabDuplicates)
                     {
                         var appId = navigateArgs.AppId;
-                        int existingTabIndex = -1;
-                        for (int i = 0; i < tabs.Value.Length; i++)
+                        var appDescriptor = appRepository.GetApp(appId);
+                        if (appDescriptor?.AllowDuplicateTabs != true)
                         {
-                            if (tabs.Value[i].AppId == appId)
+                            int existingTabIndex = -1;
+                            for (int i = 0; i < tabs.Value.Length; i++)
                             {
-                                existingTabIndex = i;
-                                break;
+                                if (tabs.Value[i].AppId == appId)
+                                {
+                                    existingTabIndex = i;
+                                    break;
+                                }
                             }
-                        }
 
-                        if (existingTabIndex >= 0)
-                        {
-                            var previousSelectedIndex = selectedIndex.Value;
-                            selectedIndex.Set(existingTabIndex);
-                            tabId = tabs.Value[existingTabIndex].Id;
-                            SetAppTitle(appId);
-
-                            if (navigateArgs.HistoryOp is HistoryOp.Push && previousSelectedIndex != existingTabIndex)
+                            if (existingTabIndex >= 0)
                             {
-                                RedirectToAppIfNotError(navigateArgs, replaceHistory, tabId);
+                                var previousSelectedIndex = selectedIndex.Value;
+                                selectedIndex.Set(existingTabIndex);
+                                tabId = tabs.Value[existingTabIndex].Id;
+                                SetAppTitle(appId);
+
+                                if (navigateArgs.HistoryOp is HistoryOp.Push && previousSelectedIndex != existingTabIndex)
+                                {
+                                    RedirectToAppIfNotError(navigateArgs, replaceHistory, tabId);
+                                }
+                                return;
                             }
-                            return;
                         }
                     }
 

--- a/src/tendril/Ivy.Tendril/Apps/ReviewApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/ReviewApp.cs
@@ -4,7 +4,7 @@ using Ivy.Tendril.Services;
 
 namespace Ivy.Tendril.Apps;
 
-[App(title: "Review", icon: Icons.ThumbsUp, group: new[] { "Tools" }, order: 25)]
+[App(title: "Review", icon: Icons.ThumbsUp, group: new[] { "Tools" }, order: 25, allowDuplicateTabs: true)]
 public class ReviewApp : ViewBase
 {
     public override object? Build()


### PR DESCRIPTION
# Summary

## Changes

Added per-app opt-out from duplicate tab prevention. A new `AllowDuplicateTabs` property on `AppDescriptor` (with corresponding `allowDuplicateTabs` parameter on `[App]` attribute) lets individual apps bypass the global `PreventTabDuplicates` setting. Both `DefaultSidebarAppShell` and `TendrilAppShell` now check this flag before deduplicating tabs. `ReviewApp` is marked with `allowDuplicateTabs: true` so users can open multiple review tabs side-by-side.

## API Changes

- `AppDescriptor.AllowDuplicateTabs` (new `bool` property, default `false`) - when `true`, the app shell skips duplicate tab prevention for this app
- `AppAttribute` constructor: new optional parameter `allowDuplicateTabs` (default `false`)
- `AppAttribute.AllowDuplicateTabs` (new `bool` property)

## Files Modified

- **Framework core:**
  - `src/Ivy/Core/Apps/AppDescriptor.cs` - added `AllowDuplicateTabs` property
  - `src/Ivy/Apps/AppAttribute.cs` - added `allowDuplicateTabs` constructor parameter and property
  - `src/Ivy/Core/Apps/AppHelpers.cs` - mapped attribute to descriptor
- **App shell logic:**
  - `src/Ivy/AppShell/DefaultSidebarAppShell.cs` - updated duplicate detection to check per-app flag
  - `src/tendril/Ivy.Tendril/AppShell/TendrilAppShell.cs` - same update for Tendril's app shell
- **Tendril app:**
  - `src/tendril/Ivy.Tendril/Apps/ReviewApp.cs` - set `allowDuplicateTabs: true`

---

**Commits:**
- c266f395 [01822] Allow apps to opt out of duplicate tab prevention