### PR TITLE
[01825] Restore OnboardingApp visibility in Debug mode

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/OnboardingApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/OnboardingApp.cs
@@ -3,7 +3,11 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Ivy.Tendril.Apps;
 
+#if DEBUG
+[App(title: "Onboarding", icon: Icons.Rocket, group: new[] { "Debug" }, isVisible: true, order: 100)]
+#else
 [App(icon: Icons.Rocket, isVisible: false, order: 100)]
+#endif
 public class OnboardingApp : ViewBase
 {
     private StepperItem[] GetSteps(int selectedIndex) =>


### PR DESCRIPTION
# Summary

## Changes

Restored the `#if DEBUG` conditional on `OnboardingApp` that was removed in PR #3047. In Debug builds, the app now appears in the "Debug" menu group with the title "Onboarding". In Release builds, it remains hidden.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Apps/OnboardingApp.cs` — Added `#if DEBUG` / `#else` / `#endif` preprocessor directives around the `[App]` attribute

## Commits

**[01825] Restore OnboardingApp visibility in Debug mode**

Re-add #if DEBUG conditional to make OnboardingApp visible in the Debug
menu group during development, while keeping it hidden in Release builds.