### PR TITLE
[01816] Change Content tab badges to secondary color and smaller size

### DIFF
--- a/src/frontend/src/widgets/layouts/tabs/components/Variants.tsx
+++ b/src/frontend/src/widgets/layouts/tabs/components/Variants.tsx
@@ -159,7 +159,11 @@ export const ContentVariant: React.FC<ContentVariantProps> = ({
                 <div className="text-sm font-medium leading-4 whitespace-nowrap flex items-center justify-center h-full">
                   {title}
                   {badge && (
-                    <Badge variant="primary" className="ml-2 w-min whitespace-nowrap">
+                    <Badge
+                      variant="secondary"
+                      density="small"
+                      className="ml-2 w-min whitespace-nowrap"
+                    >
                       {badge}
                     </Badge>
                   )}


### PR DESCRIPTION
# Summary

## Changes

Changed the Content variant tab badges in `TabsLayoutWidget` from primary color with medium density to secondary color with small density. This is a single-prop change in the Badge component within `Variants.tsx`.

## API Changes

None.

## Files Modified

- **Frontend:** `src/frontend/src/widgets/layouts/tabs/components/Variants.tsx` — Updated Badge props from `variant="primary"` to `variant="secondary" density="small"`

## Commits

- 153c54ea [01816] Change Content tab badges to secondary color and smaller size

## Artifacts

### Screenshots

![basic-full](https://stivytelemetry.blob.core.windows.net/ivy-tendril/basic-full.png?se=2026-05-05&sp=r&spr=https&sv=2026-02-06&sr=c&sig=PNmOT4fVKfNTWLgSyi9JT1L%2BdJqruIOaF3zRhFrCb9E%3D)

![basic-initial](https://stivytelemetry.blob.core.windows.net/ivy-tendril/basic-initial.png?se=2026-05-05&sp=r&spr=https&sv=2026-02-06&sr=c&sig=PNmOT4fVKfNTWLgSyi9JT1L%2BdJqruIOaF3zRhFrCb9E%3D)

![basic-tab-selected](https://stivytelemetry.blob.core.windows.net/ivy-tendril/basic-tab-selected.png?se=2026-05-05&sp=r&spr=https&sv=2026-02-06&sr=c&sig=PNmOT4fVKfNTWLgSyi9JT1L%2BdJqruIOaF3zRhFrCb9E%3D)

![edge-cases-empty-badges](https://stivytelemetry.blob.core.windows.net/ivy-tendril/edge-cases-empty-badges.png?se=2026-05-05&sp=r&spr=https&sv=2026-02-06&sr=c&sig=PNmOT4fVKfNTWLgSyi9JT1L%2BdJqruIOaF3zRhFrCb9E%3D)

![edge-cases-full](https://stivytelemetry.blob.core.windows.net/ivy-tendril/edge-cases-full.png?se=2026-05-05&sp=r&spr=https&sv=2026-02-06&sr=c&sig=PNmOT4fVKfNTWLgSyi9JT1L%2BdJqruIOaF3zRhFrCb9E%3D)

![edge-cases-long-names](https://stivytelemetry.blob.core.windows.net/ivy-tendril/edge-cases-long-names.png?se=2026-05-05&sp=r&spr=https&sv=2026-02-06&sr=c&sig=PNmOT4fVKfNTWLgSyi9JT1L%2BdJqruIOaF3zRhFrCb9E%3D)

![edge-cases-many-tabs](https://stivytelemetry.blob.core.windows.net/ivy-tendril/edge-cases-many-tabs.png?se=2026-05-05&sp=r&spr=https&sv=2026-02-06&sr=c&sig=PNmOT4fVKfNTWLgSyi9JT1L%2BdJqruIOaF3zRhFrCb9E%3D)

![edge-cases-rapid-clicks](https://stivytelemetry.blob.core.windows.net/ivy-tendril/edge-cases-rapid-clicks.png?se=2026-05-05&sp=r&spr=https&sv=2026-02-06&sr=c&sig=PNmOT4fVKfNTWLgSyi9JT1L%2BdJqruIOaF3zRhFrCb9E%3D)

![events-add-button](https://stivytelemetry.blob.core.windows.net/ivy-tendril/events-add-button.png?se=2026-05-05&sp=r&spr=https&sv=2026-02-06&sr=c&sig=PNmOT4fVKfNTWLgSyi9JT1L%2BdJqruIOaF3zRhFrCb9E%3D)

![events-after-add](https://stivytelemetry.blob.core.windows.net/ivy-tendril/events-after-add.png?se=2026-05-05&sp=r&spr=https&sv=2026-02-06&sr=c&sig=PNmOT4fVKfNTWLgSyi9JT1L%2BdJqruIOaF3zRhFrCb9E%3D)

![events-full](https://stivytelemetry.blob.core.windows.net/ivy-tendril/events-full.png?se=2026-05-05&sp=r&spr=https&sv=2026-02-06&sr=c&sig=PNmOT4fVKfNTWLgSyi9JT1L%2BdJqruIOaF3zRhFrCb9E%3D)

![events-initial](https://stivytelemetry.blob.core.windows.net/ivy-tendril/events-initial.png?se=2026-05-05&sp=r&spr=https&sv=2026-02-06&sr=c&sig=PNmOT4fVKfNTWLgSyi9JT1L%2BdJqruIOaF3zRhFrCb9E%3D)

![events-rendered](https://stivytelemetry.blob.core.windows.net/ivy-tendril/events-rendered.png?se=2026-05-05&sp=r&spr=https&sv=2026-02-06&sr=c&sig=PNmOT4fVKfNTWLgSyi9JT1L%2BdJqruIOaF3zRhFrCb9E%3D)

![events-tabs-no-close](https://stivytelemetry.blob.core.windows.net/ivy-tendril/events-tabs-no-close.png?se=2026-05-05&sp=r&spr=https&sv=2026-02-06&sr=c&sig=PNmOT4fVKfNTWLgSyi9JT1L%2BdJqruIOaF3zRhFrCb9E%3D)

![integration-after-increment](https://stivytelemetry.blob.core.windows.net/ivy-tendril/integration-after-increment.png?se=2026-05-05&sp=r&spr=https&sv=2026-02-06&sr=c&sig=PNmOT4fVKfNTWLgSyi9JT1L%2BdJqruIOaF3zRhFrCb9E%3D)

![integration-full](https://stivytelemetry.blob.core.windows.net/ivy-tendril/integration-full.png?se=2026-05-05&sp=r&spr=https&sv=2026-02-06&sr=c&sig=PNmOT4fVKfNTWLgSyi9JT1L%2BdJqruIOaF3zRhFrCb9E%3D)

![integration-initial](https://stivytelemetry.blob.core.windows.net/ivy-tendril/integration-initial.png?se=2026-05-05&sp=r&spr=https&sv=2026-02-06&sr=c&sig=PNmOT4fVKfNTWLgSyi9JT1L%2BdJqruIOaF3zRhFrCb9E%3D)

![integration-notifications-tab](https://stivytelemetry.blob.core.windows.net/ivy-tendril/integration-notifications-tab.png?se=2026-05-05&sp=r&spr=https&sv=2026-02-06&sr=c&sig=PNmOT4fVKfNTWLgSyi9JT1L%2BdJqruIOaF3zRhFrCb9E%3D)

![props-all-badges](https://stivytelemetry.blob.core.windows.net/ivy-tendril/props-all-badges.png?se=2026-05-05&sp=r&spr=https&sv=2026-02-06&sr=c&sig=PNmOT4fVKfNTWLgSyi9JT1L%2BdJqruIOaF3zRhFrCb9E%3D)

![props-full](https://stivytelemetry.blob.core.windows.net/ivy-tendril/props-full.png?se=2026-05-05&sp=r&spr=https&sv=2026-02-06&sr=c&sig=PNmOT4fVKfNTWLgSyi9JT1L%2BdJqruIOaF3zRhFrCb9E%3D)