### PR TITLE
[01827] Add empty state feedback to TrashApp sidebar

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/TrashApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/TrashApp.cs
@@ -46,15 +46,26 @@ public class TrashApp : ViewBase
         // Sidebar content - search input + file list
         var sidebarHeader = searchFilter.ToSearchInput().Placeholder("Search trash...");
 
-        var sidebarList = new List(filteredList.Select(f =>
+        object sidebarList;
+        if (filteredList.Count == 0)
         {
-            var item = f;
-            return new ListItem(item.FileName.Replace(".md", ""))
-                .Content(Layout.Horizontal().Gap(1)
-                    | new Badge(item.Project).Variant(BadgeVariant.Outline).Small()
-                    | Text.Muted(item.Date.ToString("yyyy-MM-dd")).Small())
-                .OnClick(() => selectedFile.Set(item.FilePath));
-        }));
+            sidebarList = Layout.Vertical().AlignContent(Align.Center).Gap(2).Padding(4)
+                | new Icon(Icons.Trash2).Size(Size.Units(6)).Color(Colors.Gray)
+                | Text.Muted("No trash items")
+                | Text.Muted("Duplicate plans will appear here").Small();
+        }
+        else
+        {
+            sidebarList = new List(filteredList.Select(f =>
+            {
+                var item = f;
+                return new ListItem(item.FileName.Replace(".md", ""))
+                    .Content(Layout.Horizontal().Gap(1)
+                        | new Badge(item.Project).Variant(BadgeVariant.Outline).Small()
+                        | Text.Muted(item.Date.ToString("yyyy-MM-dd")).Small())
+                    .OnClick(() => selectedFile.Set(item.FilePath));
+            }));
+        }
 
         // Main content
         object mainContent;


### PR DESCRIPTION
# Summary

## Changes

Added conditional empty state rendering to the TrashApp sidebar. When the filtered file list is empty, the sidebar now displays a centered layout with a trash icon, "No trash items" primary text, and "Duplicate plans will appear here" subtitle, following the same pattern used in the Recommendations SidebarView.

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/Apps/TrashApp.cs** — Added empty state conditional around sidebar list rendering

## Commits

- 6d47984a [01827] Add empty state feedback to TrashApp sidebar