### PR TITLE
[01828] Audit GetRecommendations() callers for count-only usage

### DIFF
--- a/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
@@ -514,6 +514,16 @@ public class PlanReaderService(ConfigService config)
             .ToList();
     }
 
+    /// <summary>
+    /// Gets all recommendations from all plans. This method reads and deserializes all
+    /// recommendations.yaml files in the plans directory, which can be expensive.
+    /// </summary>
+    /// <remarks>
+    /// If you only need the count of pending recommendations, use <see cref="GetPendingRecommendationsCount"/>
+    /// instead, which uses an optimized path via <see cref="ComputePlanCounts"/> that counts
+    /// without full deserialization.
+    /// </remarks>
+    /// <returns>List of all recommendations ordered by date (most recent first).</returns>
     public List<Recommendation> GetRecommendations()
     {
         var recommendations = new List<Recommendation>();
@@ -563,6 +573,15 @@ public class PlanReaderService(ConfigService config)
         return recommendations.OrderByDescending(r => r.Date).ToList();
     }
 
+    /// <summary>
+    /// Gets the count of pending recommendations efficiently without deserializing full recommendation objects.
+    /// </summary>
+    /// <remarks>
+    /// This method delegates to <see cref="ComputePlanCounts"/> which only counts pending items
+    /// without building full Recommendation objects, making it much more efficient than calling
+    /// <c>GetRecommendations().Count(r => r.State == "Pending")</c>.
+    /// </remarks>
+    /// <returns>Number of pending recommendations.</returns>
     public int GetPendingRecommendationsCount()
     {
         return ComputePlanCounts().PendingRecommendations;


### PR DESCRIPTION
# Summary

## Changes

Added XML documentation comments to `GetRecommendations()` and `GetPendingRecommendationsCount()` methods in `PlanReaderService.cs`. The documentation warns that `GetRecommendations()` is expensive (reads and deserializes all recommendations.yaml files) and directs developers to use `GetPendingRecommendationsCount()` for count-only needs, which delegates to the optimized `ComputePlanCounts()` path.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Services/PlanReaderService.cs` — Added XML doc comments to `GetRecommendations()` and `GetPendingRecommendationsCount()`

---

## Commits

- 6670d68d [01828] Add XML documentation to GetRecommendations() and GetPendingRecommendationsCount()