### PR TITLE
[01829] Move Recommendations filterBar to SidebarView for consistency

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Recommendations/SidebarView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Recommendations/SidebarView.cs
@@ -5,25 +5,62 @@ namespace Ivy.Tendril.Apps.Recommendations;
 public class SidebarView(
     List<Recommendation> recommendations,
     IState<Recommendation?> selectedState,
+    IState<string?> projectFilter,
+    IState<string?> planStatusFilter,
     int totalCount,
     bool hasActiveFilters,
     IState<string?> textFilter) : ViewBase
 {
     private readonly List<Recommendation> _recommendations = recommendations;
     private readonly IState<Recommendation?> _selectedState = selectedState;
+    private readonly IState<string?> _projectFilter = projectFilter;
+    private readonly IState<string?> _planStatusFilter = planStatusFilter;
     private readonly int _totalCount = totalCount;
     private readonly bool _hasActiveFilters = hasActiveFilters;
     private readonly IState<string?> _textFilter = textFilter;
 
     public object BuildHeader()
     {
+        var projectOptions = _recommendations
+            .GroupBy(r => r.Project)
+            .OrderByDescending(g => g.Count())
+            .Select(g => new Option<string>($"{g.Key} ({g.Count()})", g.Key))
+            .ToArray<IAnyOption>();
+
+        var statusOptions = _recommendations
+            .Select(r => r.SourcePlanStatus)
+            .Distinct()
+            .OrderBy(s => s)
+            .Select(s => new Option<string>(s.ToString(), s.ToString()))
+            .ToArray<IAnyOption>();
+
         return Layout.Vertical()
-            | _textFilter.ToSearchInput().Placeholder("Search recommendations...");
+            | _textFilter.ToSearchInput().Placeholder("Search recommendations...")
+            | new Expandable(
+                header: "Filters",
+                content: Layout.Vertical()
+                    | _projectFilter.ToSelectInput(projectOptions).Placeholder("All Projects").Nullable().WithField().Label("Project")
+                    | _planStatusFilter.ToSelectInput(statusOptions).Placeholder("All Statuses").Nullable().WithField().Label("Plan Status")
+            ).Open(false).Ghost();
     }
 
     public object BuildContent()
     {
-        if (_recommendations.Count == 0 && _hasActiveFilters && _totalCount > 0)
+        var filtered = _recommendations
+            .Where(r => _projectFilter.Value == null || r.Project == _projectFilter.Value)
+            .Where(r => _planStatusFilter.Value == null || r.SourcePlanStatus.ToString() == _planStatusFilter.Value)
+            .Where(r =>
+            {
+                if (string.IsNullOrWhiteSpace(_textFilter.Value)) return true;
+                var search = _textFilter.Value.ToLowerInvariant();
+                return r.Title.ToLowerInvariant().Contains(search) ||
+                       r.Description.ToLowerInvariant().Contains(search) ||
+                       r.PlanId.Contains(search) ||
+                       r.PlanTitle.ToLowerInvariant().Contains(search);
+            })
+            .ToList();
+
+        if (filtered.Count == 0 && _hasActiveFilters && _totalCount > 0)
         {
             return Layout.Vertical().AlignContent(Align.Center).Gap(2).Padding(4)
                 | new Icon(Icons.ListFilterPlus).Size(Size.Units(6)).Color(Colors.Gray)
@@ -31,7 +68,7 @@ public class SidebarView(
                 | Text.Muted("Try adjusting your filters").Small();
         }
 
-        return new List(_recommendations.Select(rec =>
+        return new List(filtered.Select(rec =>
         {
             var clickableRec = rec;
 

--- a/src/tendril/Ivy.Tendril/Apps/RecommendationsApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/RecommendationsApp.cs
@@ -19,8 +19,9 @@ public class RecommendationsApp : ViewBase
 
         var recommendations = planService.GetRecommendations();
 
-        var filtered = recommendations
-            .Where(r => r.State == "Pending")
+        var allPending = recommendations.Where(r => r.State == "Pending").ToList();
+
+        var filtered = allPending
             .Where(r => projectFilter.Value == null || r.Project == projectFilter.Value)
             .Where(r => planStatusFilter.Value == null || r.SourcePlanStatus.ToString() == planStatusFilter.Value)
             .Where(r =>
@@ -42,38 +43,22 @@ public class RecommendationsApp : ViewBase
 
         void Refresh() => refreshToken.Refresh();
 
-        var projectOptions = recommendations
-            .Where(r => r.State == "Pending")
-            .GroupBy(r => r.Project)
-            .OrderByDescending(g => g.Count())
-            .Select(g => new Option<string>($"{g.Key} ({g.Count()})", g.Key))
-            .ToArray<IAnyOption>();
-
-        var statusOptions = recommendations
-            .Where(r => r.State == "Pending")
-            .Select(r => r.SourcePlanStatus)
-            .Distinct()
-            .OrderBy(s => s)
-            .Select(s => new Option<string>(s.ToString(), s.ToString()))
-            .ToArray<IAnyOption>();
-
-        var filterBar = new Expandable(
-            header: "Filters",
-            content: Layout.Vertical()
-                | projectFilter.ToSelectInput(projectOptions).Placeholder("All Projects").Nullable().WithField().Label("Project")
-                | planStatusFilter.ToSelectInput(statusOptions).Placeholder("All Statuses").Nullable().WithField().Label("Plan Status")
-        ).Open(false).Ghost();
-
-        var totalPendingCount = recommendations.Count(r => r.State == "Pending");
+        var totalPendingCount = allPending.Count;
         var hasActiveFilters = projectFilter.Value != null || planStatusFilter.Value != null || !string.IsNullOrWhiteSpace(textFilter.Value);
 
-        var sidebar = new Recommendations.SidebarView(filtered, selectedState, totalPendingCount, hasActiveFilters, textFilter);
+        var sidebar = new Recommendations.SidebarView(
+            allPending,
+            selectedState,
+            projectFilter,
+            planStatusFilter,
+            totalPendingCount,
+            hasActiveFilters,
+            textFilter
+        );
 
         return new SidebarLayout(
             mainContent: new Recommendations.ContentView(selectedState.Value, filtered, selectedState, planService, jobService, Refresh),
-            sidebarContent: Layout.Vertical()
-                | filterBar
-                | sidebar.BuildContent(),
+            sidebarContent: sidebar,
             sidebarHeader: sidebar.BuildHeader()
         );
     }


### PR DESCRIPTION
# Summary

## Changes

Moved the project and status filter bar (Expandable widget) from RecommendationsApp into Recommendations.SidebarView.BuildHeader(), making the Recommendations app consistent with Plans, Icebox, and Review apps. SidebarView now receives all pending recommendations and filter states, computing filter options and applying filters internally.

## API Changes

- `Recommendations.SidebarView` constructor: added `IState<string?> projectFilter` and `IState<string?> planStatusFilter` parameters; now receives all pending recommendations instead of pre-filtered list
- `RecommendationsApp.Build()`: simplified SidebarLayout to use `sidebarContent: sidebar` (was `Layout.Vertical() | filterBar | sidebar.BuildContent()`)

## Files Modified

- **src/tendril/Ivy.Tendril/Apps/Recommendations/SidebarView.cs** — Added filter state parameters, moved filter bar into BuildHeader(), added internal filtering in BuildContent()
- **src/tendril/Ivy.Tendril/Apps/RecommendationsApp.cs** — Removed filter options computation and filterBar creation, updated SidebarView instantiation and SidebarLayout usage

## Commits

- 1dac3e74 [01829] Move Recommendations filterBar to SidebarView for consistency