### PR TITLE
[01830] Include queued jobs in job count

### DIFF
--- a/src/tendril/Ivy.Tendril/Services/PlanCountsService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanCountsService.cs
@@ -45,7 +45,7 @@ public class PlanCountsService : IDisposable
 
         return new PlanCounts(
             Drafts: snapshot.Drafts,
-            RunningJobs: jobs.Count(j => j.Status == "Running"),
+            RunningJobs: jobs.Count(j => j.Status == "Running" || j.Status == "Queued"),
             Reviews: snapshot.ReadyForReview + snapshot.Failed,
             Icebox: snapshot.Icebox,
             Recommendations: snapshot.PendingRecommendations


### PR DESCRIPTION
# Summary

## Changes

Updated `PlanCountsService.ComputeCounts()` to include jobs with status "Queued" in the `RunningJobs` count, alongside "Running" jobs. This ensures the Jobs navigation badge accurately reflects all active jobs.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Services/PlanCountsService.cs` — Updated job count filter to include "Queued" status

## Commits

- 2356c5f7 [01830] Include queued jobs in job count