### PR TITLE
[01837] Add allowDuplicateTabs to FileApp

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/FileApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/FileApp.cs
@@ -2,7 +2,7 @@ namespace Ivy.Tendril.Apps;
 
 public record FileAppArgs(string Url);
 
-[App(title: "File", icon: Icons.File, isVisible: false)]
+[App(title: "File", icon: Icons.File, isVisible: false, allowDuplicateTabs: true)]
 public class FileApp : ViewBase
 {
     private static readonly HashSet<string> ImageExtensions = new(StringComparer.OrdinalIgnoreCase)


### PR DESCRIPTION
# Summary

## Changes

Added `allowDuplicateTabs: true` to the `[App]` attribute on `FileApp` so that opening different files creates separate tabs instead of reusing a single tab.

## API Changes

- `FileApp` class: `[App]` attribute now includes `allowDuplicateTabs: true` (previously defaulted to `false`)

## Files Modified

- `src/tendril/Ivy.Tendril/Apps/FileApp.cs` — Added `allowDuplicateTabs: true` to `[App]` attribute

---

**Commits:**
- 4e7cc02e [01837] Add allowDuplicateTabs: true to FileApp