### PR TITLE
[01834] Fix IvyFrameworkVerification leaving zombie sample processes running

### DIFF
--- a/src/tendril/Ivy.Tendril.TeamIvyConfig/Promptwares/IvyFrameworkVerification.ps1
+++ b/src/tendril/Ivy.Tendril.TeamIvyConfig/Promptwares/IvyFrameworkVerification.ps1
@@ -25,17 +25,26 @@ foreach ($dir in @($verificationDir, "$artifactsDir\tests", "$artifactsDir\scree
     }
 }
 
-# Kill any leftover sample processes that may lock DLLs
-$sampleBinDir = Join-Path $artifactsDir "sample" "bin"
-if (Test-Path $sampleBinDir) {
-    Get-Process | Where-Object {
-        $_.Path -and $_.Path.StartsWith($sampleBinDir, [StringComparison]::OrdinalIgnoreCase)
-    } | ForEach-Object {
-        Write-Host "Killing leftover process: $($_.ProcessName) ($($_.Id))" -ForegroundColor Yellow
-        $_ | Stop-Process -Force -ErrorAction SilentlyContinue
+# Kill ALL sample processes from any plan's artifacts directory (not just current plan)
+# to prevent accumulated zombie processes from blocking builds
+Write-Host "Cleaning up any leftover sample processes..." -ForegroundColor Yellow
+$killed = 0
+Get-Process -ErrorAction SilentlyContinue | Where-Object {
+    $_.Path -and $_.Path -match '\\artifacts\\sample\\bin\\'
+} | ForEach-Object {
+    Write-Host "  Killing: $($_.ProcessName) (PID $($_.Id)) from $($_.Path)" -ForegroundColor Yellow
+    try {
+        $_ | Stop-Process -Force -ErrorAction Stop
+        $killed++
+    } catch {
+        Write-Warning "  Failed to kill PID $($_.Id): $_"
     }
-    # Brief wait for file handles to release
-    Start-Sleep -Milliseconds 500
+}
+if ($killed -gt 0) {
+    Write-Host "  Killed $killed process(es). Waiting for file handles to release..." -ForegroundColor Yellow
+    Start-Sleep -Milliseconds 2000
+} else {
+    Write-Host "  No leftover processes found." -ForegroundColor Green
 }
 
 # Set ARTIFACTS_DIR so Playwright tests can write directly to plan artifacts

--- a/src/tendril/Ivy.Tendril.TeamIvyConfig/Promptwares/IvyFrameworkVerification/Program.md
+++ b/src/tendril/Ivy.Tendril.TeamIvyConfig/Promptwares/IvyFrameworkVerification/Program.md
@@ -118,7 +118,7 @@ From `<ArtifactsDir>/sample/`:
 Before building, kill any leftover processes from previous runs that may lock DLLs:
 
 ```bash
-powershell.exe -NoProfile -Command "Get-Process | Where-Object { $_.Path -and $_.Path -like '*artifacts*sample*bin*' } | Stop-Process -Force -ErrorAction SilentlyContinue"
+powershell.exe -NoProfile -Command "Get-Process -ErrorAction SilentlyContinue | Where-Object { \$_.Path -and \$_.Path -match '\\\\artifacts\\\\sample\\\\bin\\\\' } | ForEach-Object { Write-Host \"Killing \$(\$_.ProcessName) (PID \$(\$_.Id))\"; \$_ | Stop-Process -Force -ErrorAction Stop } ; Start-Sleep -Milliseconds 2000"
 ```
 
 ```bash
@@ -173,6 +173,14 @@ cd <ArtifactsDir>/sample/.ivy/tests
 vp install
 npx playwright install chromium
 vp run test
+```
+
+### 8.5. Post-Test Cleanup
+
+Even if tests pass, kill all sample processes to ensure clean state:
+
+```bash
+powershell.exe -NoProfile -Command "Get-Process -ErrorAction SilentlyContinue | Where-Object { \$_.Path -and \$_.Path -match '\\\\artifacts\\\\sample\\\\bin\\\\' } | Stop-Process -Force -ErrorAction SilentlyContinue"
 ```
 
 ### 9. Fix Loop (up to 10 rounds)


### PR DESCRIPTION
# Summary

## Changes

Replaced the narrow process cleanup in `IvyFrameworkVerification.ps1` (which only killed processes from the current plan's artifact directory) with a broad regex-based cleanup that kills sample processes from ANY plan's artifacts directory. Added a post-test cleanup step to `Program.md` to prevent zombie processes even after successful test runs.

## API Changes

None.

## Files Modified

- **Promptwares/IvyFrameworkVerification.ps1** — Replaced lines 28-39 with broader regex-based process cleanup, try/catch error handling, and increased wait time (500ms -> 2000ms)
- **Promptwares/IvyFrameworkVerification/Program.md** — Updated pre-build cleanup command (section 6) and added new post-test cleanup section (8.5)

## Commits

- 55cbad28 [01834] Fix zombie process cleanup in IvyFrameworkVerification