### PR TITLE
[01840] Rename RunningJobs to ActiveJobs in PlanCounts

### DIFF
--- a/src/tendril/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/tendril/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -38,7 +38,7 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
         {
             ["plans"] = planCounts.Drafts,
             ["review"] = planCounts.Reviews,
-            ["jobs"] = planCounts.RunningJobs,
+            ["jobs"] = planCounts.ActiveJobs,
             ["icebox"] = planCounts.Icebox,
             ["recommendations"] = planCounts.Recommendations
         };

--- a/src/tendril/Ivy.Tendril/Services/PlanCountsService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanCountsService.cs
@@ -1,6 +1,6 @@
 namespace Ivy.Tendril.Services;
 
-public record PlanCounts(int Drafts, int RunningJobs, int Reviews, int Icebox, int Recommendations);
+public record PlanCounts(int Drafts, int ActiveJobs, int Reviews, int Icebox, int Recommendations);
 
 public class PlanCountsService : IDisposable
 {
@@ -45,7 +45,7 @@ public class PlanCountsService : IDisposable
 
         return new PlanCounts(
             Drafts: snapshot.Drafts,
-            RunningJobs: jobs.Count(j => j.Status == "Running" || j.Status == "Queued"),
+            ActiveJobs: jobs.Count(j => j.Status == "Running" || j.Status == "Queued"),
             Reviews: snapshot.ReadyForReview + snapshot.Failed,
             Icebox: snapshot.Icebox,
             Recommendations: snapshot.PendingRecommendations


### PR DESCRIPTION
# Summary

## Changes

Renamed `RunningJobs` to `ActiveJobs` in the `PlanCounts` record and all its usages. This better reflects that the count includes both Running and Queued jobs.

## API Changes

- `PlanCounts.RunningJobs` renamed to `PlanCounts.ActiveJobs` (property rename)

## Files Modified

- `src/tendril/Ivy.Tendril/Services/PlanCountsService.cs` — record definition and field computation
- `src/tendril/Ivy.Tendril/AppShell/TendrilAppShell.cs` — consumer usage in badge dictionary

## Commits

- 2a399782 [01840] Rename RunningJobs to ActiveJobs in PlanCounts