### PR TITLE
[01839] In dashboard hide these labels/axis columns

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/DashboardApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/DashboardApp.cs
@@ -105,7 +105,7 @@ public class DashboardApp : ViewBase
                 Color: configService.GetProjectColor(p.Project),
                 Label: p.Project
             )).ToArray()
-        ).ShowLabels();
+        );
 
         // Hourly cost & tokens combined bar chart
         var hourlyBurn = planService.GetHourlyTokenBurn(days: 7);
@@ -119,6 +119,10 @@ public class DashboardApp : ViewBase
                     [
                         new Bar("Cost ($)").Radius(4).FillOpacity(0.8).YAxisIndex(0),
                         new Bar("Tokens").Radius(4).FillOpacity(0.8).YAxisIndex(1),
+                    ],
+                    XAxis =
+                    [
+                        new XAxis().Hide()
                     ],
                     YAxis =
                     [


### PR DESCRIPTION
# Summary

## Changes

Hid the X-axis labels on the hourly cost/tokens bar chart and removed the project name labels from the stacked progress bar in the Tendril dashboard. This cleans up the dashboard UI by removing visual clutter.

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/Apps/DashboardApp.cs** — Removed `.ShowLabels()` from `StackedProgress`, added `XAxis = [new XAxis().Hide()]` to bar chart configuration

---

## Commits

- [01839] Hide dashboard labels and axis columns (5acb5f2b)