### PR TITLE
[01841] Rename RunningJobs to ActiveJobs in PlanCounts

### DIFF
--- a/src/tendril/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/tendril/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -38,7 +38,7 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
         {
             ["plans"] = planCounts.Drafts,
             ["review"] = planCounts.Reviews,
-            ["jobs"] = planCounts.RunningJobs,
+            ["jobs"] = planCounts.ActiveJobs,
             ["icebox"] = planCounts.Icebox,
             ["recommendations"] = planCounts.Recommendations
         };

--- a/src/tendril/Ivy.Tendril/Services/PlanCountsService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanCountsService.cs
@@ -1,6 +1,6 @@
 namespace Ivy.Tendril.Services;
 
-public record PlanCounts(int Drafts, int RunningJobs, int Reviews, int Icebox, int Recommendations);
+public record PlanCounts(int Drafts, int ActiveJobs, int Reviews, int Icebox, int Recommendations);
 
 public class PlanCountsService : IDisposable
 {
@@ -45,7 +45,7 @@ public class PlanCountsService : IDisposable
 
         return new PlanCounts(
             Drafts: snapshot.Drafts,
-            RunningJobs: jobs.Count(j => j.Status == "Running" || j.Status == "Queued"),
+            ActiveJobs: jobs.Count(j => j.Status == "Running" || j.Status == "Queued"),
             Reviews: snapshot.ReadyForReview + snapshot.Failed,
             Icebox: snapshot.Icebox,
             Recommendations: snapshot.PendingRecommendations


### PR DESCRIPTION
# Summary

## Changes

Renamed the `RunningJobs` property to `ActiveJobs` in the `PlanCounts` record and all its usages. This better reflects that the field counts both Running and Queued jobs, not just Running ones.

## API Changes

- `PlanCounts.RunningJobs` renamed to `PlanCounts.ActiveJobs` (record positional parameter)

## Files Modified

- **src/tendril/Ivy.Tendril/Services/PlanCountsService.cs** — Record definition and computation updated
- **src/tendril/Ivy.Tendril/AppShell/TendrilAppShell.cs** — Consumer updated to use `ActiveJobs`

## Commits

- 4973a07d [01841] Rename RunningJobs to ActiveJobs in PlanCounts