### PR TITLE
[01843] Show distinct empty state in TrashApp main content area

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/TrashApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/TrashApp.cs
@@ -69,7 +69,14 @@ public class TrashApp : ViewBase
 
         // Main content
         object mainContent;
-        if (selected is null)
+        if (files.Count == 0)
+        {
+            mainContent = Layout.Vertical().AlignContent(Align.Center).Height(Size.Full())
+                | new Icon(Icons.Trash2).Size(Size.Units(8)).Color(Colors.Gray)
+                | Text.Muted("No trash files yet")
+                | Text.Muted("Duplicate plans will appear here").Small();
+        }
+        else if (selected is null)
         {
             mainContent = Layout.Vertical().AlignContent(Align.Center).Height(Size.Full())
                 | Text.Muted("Select a file from the sidebar");


### PR DESCRIPTION
# Summary

## Changes

Added a distinct empty state to the TrashApp main content area. When the trash directory has zero files (`files.Count == 0`), the main content now shows a trash icon, "No trash files yet", and "Duplicate plans will appear here" — instead of the misleading "Select a file from the sidebar" message.

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/Apps/TrashApp.cs** — Added `files.Count == 0` check before the `selected is null` check in the main content rendering logic

## Commits

- 9ff21ef6 [01843] Show distinct empty state in TrashApp main content area