### PR TITLE
[01826] Add HelpApp for Tendril Documentation

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/HelpApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/HelpApp.cs
@@ -1,0 +1,21 @@
+namespace Ivy.Tendril.Apps;
+
+[App(title: "Help", icon: Icons.CircleQuestionMark, group: new[] { "Tools" }, order: 50)]
+public class HelpApp : ViewBase
+{
+    public override object? Build()
+    {
+        var client = UseService<IClientProvider>();
+
+        return Layout.TopCenter()
+            | (Layout.Vertical().Margin(0, 20).Width(150).Gap(3)
+                | Text.H1("Help & Documentation")
+                | Text.Muted("View Tendril documentation and guides at tendril.ivy.app.")
+                | new Button("Open Documentation")
+                    .Primary()
+                    .Large()
+                    .Icon(Icons.ExternalLink, Align.Right)
+                    .OnClick(() => client.OpenUrl("https://tendril.ivy.app"))
+            );
+    }
+}


### PR DESCRIPTION
# Summary

## Changes

Added a HelpApp to Tendril that opens the documentation website (https://tendril.ivy.app) in the user's default browser. The app appears in the "Tools" group in the sidebar with a question mark icon.

## API Changes

- **New class:** `Ivy.Tendril.Apps.HelpApp` — `ViewBase` subclass with `[App]` attribute for automatic discovery. No public API surface beyond the standard Ivy app pattern.

## Files Modified

- **New:** `src/tendril/Ivy.Tendril/Apps/HelpApp.cs` — Simple help app with a button to open documentation URL

## Commits

- ba8791d1 [01826] Add HelpApp for Tendril documentation