### PR TITLE
[01831] Refine markdown spacing with element-specific CSS

### DIFF
--- a/src/frontend/src/styles/markdown-spacing.css
+++ b/src/frontend/src/styles/markdown-spacing.css
@@ -1,0 +1,24 @@
+/* Element-specific spacing for markdown widget content.
+   Replaces the uniform flex gap with contextual margins based on adjacent elements. */
+
+.markdown-widget > * + * {
+  margin-top: 0.5rem; /* Default spacing between elements */
+}
+
+/* Tighter spacing between consecutive details blocks */
+.markdown-widget > details + details {
+  margin-top: 0.25rem;
+}
+
+/* Larger spacing after headings for visual hierarchy */
+.markdown-widget > h1 + *,
+.markdown-widget > h2 + *,
+.markdown-widget > h3 + * {
+  margin-top: 0.75rem;
+}
+
+/* Tighter spacing around code blocks */
+.markdown-widget > pre + p,
+.markdown-widget > p + pre {
+  margin-top: 0.375rem;
+}

--- a/src/frontend/src/widgets/primitives/MarkdownWidget.tsx
+++ b/src/frontend/src/widgets/primitives/MarkdownWidget.tsx
@@ -4,6 +4,8 @@ import { getWidth, getHeight } from "@/lib/styles";
 import React, { useCallback, useState, useEffect } from "react";
 import { widgetContentOverrides, subscribeToContentOverride } from "@/widgets/widgetRenderer";
 
+import "@/styles/markdown-spacing.css";
+
 import { Densities } from "@/types/density";
 import { TextAlignment } from "@/types/textAlignment";
 
@@ -64,7 +66,6 @@ const MarkdownWidget: React.FC<MarkdownWidgetProps> = ({
   const styles: React.CSSProperties = {
     display: "flex",
     flexDirection: "column",
-    gap: "0.5rem",
     wordBreak: "normal",
     overflowWrap: "break-word",
     ...(textAlignment && {


### PR DESCRIPTION
# Summary

## Changes

Replaced the uniform `gap: 0.5rem` flex container spacing in MarkdownWidget with a dedicated CSS stylesheet (`markdown-spacing.css`) that applies element-specific margins. Consecutive `<details>` blocks now have tighter 0.25rem spacing, content after headings gets 0.75rem for visual hierarchy, and code block adjacency uses 0.375rem. The default 0.5rem spacing is preserved for all other element combinations.

## API Changes

None.

## Files Modified

- **New:** `src/frontend/src/styles/markdown-spacing.css` — Element-specific spacing rules using CSS sibling selectors
- **Modified:** `src/frontend/src/widgets/primitives/MarkdownWidget.tsx` — Removed `gap: "0.5rem"`, added CSS import

## Commits

- e53e7092 [01831] Replace uniform markdown gap with element-specific CSS spacing

## Artifacts

### Screenshots

![code-block-spacing](https://stivytelemetry.blob.core.windows.net/ivy-tendril/code-block-spacing.png?se=2026-05-05&sp=r&spr=https&sv=2026-02-06&sr=c&sig=PNmOT4fVKfNTWLgSyi9JT1L%2BdJqruIOaF3zRhFrCb9E%3D)

![consecutive-details](https://stivytelemetry.blob.core.windows.net/ivy-tendril/consecutive-details.png?se=2026-05-05&sp=r&spr=https&sv=2026-02-06&sr=c&sig=PNmOT4fVKfNTWLgSyi9JT1L%2BdJqruIOaF3zRhFrCb9E%3D)

![edge-cases](https://stivytelemetry.blob.core.windows.net/ivy-tendril/edge-cases.png?se=2026-05-05&sp=r&spr=https&sv=2026-02-06&sr=c&sig=PNmOT4fVKfNTWLgSyi9JT1L%2BdJqruIOaF3zRhFrCb9E%3D)

![heading-spacing](https://stivytelemetry.blob.core.windows.net/ivy-tendril/heading-spacing.png?se=2026-05-05&sp=r&spr=https&sv=2026-02-06&sr=c&sig=PNmOT4fVKfNTWLgSyi9JT1L%2BdJqruIOaF3zRhFrCb9E%3D)

![mixed-content](https://stivytelemetry.blob.core.windows.net/ivy-tendril/mixed-content.png?se=2026-05-05&sp=r&spr=https&sv=2026-02-06&sr=c&sig=PNmOT4fVKfNTWLgSyi9JT1L%2BdJqruIOaF3zRhFrCb9E%3D)