### PR TITLE
[01838] Investigate lint-staged modifying unrelated files in pre-commit

### DIFF
--- a/src/frontend/.husky/pre-commit
+++ b/src/frontend/.husky/pre-commit
@@ -1,5 +1,12 @@
 #!/bin/sh
 
-echo "Running Vite+ linter and formatter..."
-cd src/frontend
-vp exec lint-staged -- --relative
+# Check if any frontend files are staged
+FRONTEND_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep "^src/frontend/" || true)
+
+if [ -n "$FRONTEND_FILES" ]; then
+  echo "Running Vite+ linter and formatter on staged frontend files..."
+  cd src/frontend
+  vp exec lint-staged -- --relative
+else
+  echo "No frontend files staged, skipping lint-staged."
+fi


### PR DESCRIPTION
# Summary

## Changes

Scoped the husky pre-commit hook to only run lint-staged when frontend files (`src/frontend/`) are actually staged. Previously, the hook ran on every commit regardless of what was staged, causing unintended formatting changes to frontend files during backend-only commits.

## API Changes

None.

## Files Modified

- **src/frontend/.husky/pre-commit** — Added guard to check for staged frontend files before running `vp exec lint-staged`

## Commits

- 79b4fe93 [01838] Scope pre-commit hook to only run on frontend files