### PR TITLE
[01845] Wrap Playwright tests with timeout guard to kill child processes

### DIFF
--- a/src/tendril/Ivy.Tendril.TeamIvyConfig/Promptwares/IvyFrameworkVerification/Memory/PlaywrightKnowledge.md
+++ b/src/tendril/Ivy.Tendril.TeamIvyConfig/Promptwares/IvyFrameworkVerification/Memory/PlaywrightKnowledge.md
@@ -102,6 +102,18 @@
 - **Toast DOM locator**: Radix Toast renders individual toasts as `<li>` elements with `data-state="open"`. Use `page.locator('li[data-state="open"]')` to find all visible toast elements. Do NOT use `[role="status"]` — that matches the aria-live region, not individual toasts. The toast viewport is an `<ol>` element with `gap-2` for spacing.
 - **`Html` component inline styles don't render as expected** — `new Html(...)` with inline CSS properties like `background-color`, `border`, `color`, `width`, `height` are NOT applied to the actual DOM. Do NOT use `page.locator('div[style*="..."]')` selectors to target Html content. Instead use text-based assertions (`page.content().includes(...)`) or `getByText()` locators. Also do NOT check for hex color codes in `page.content()` — they won't appear in the rendered HTML.
 - **Stale server processes**: The `taskkill` in `afterAll` may not reliably kill all dotnet processes. After multiple test runs, stale `Test.*.exe` processes can lock the EXE and prevent rebuilding. The launcher script (`IvyFrameworkVerification.ps1`) now kills processes with executables in `artifacts/sample/bin/` before starting, but the `afterAll` kill should still be done as best-effort cleanup. Use `taskkill //im <name>.exe //f` as a fallback.
+
+## Process Cleanup (Critical)
+
+- **ALWAYS use `test-utils.ts` process tracking** — raw `afterAll` cleanup is insufficient for test timeouts and crashes
+- Create `test-utils.ts` with `trackProcess()` and `killAllTrackedProcesses()` utilities (see IvyFrameworkVerification/Program.md Section 7)
+- **Call `trackProcess(proc)`** immediately after spawning any dotnet process in `beforeAll`
+- **Set explicit test timeout** with `test.setTimeout(60000)` (60s) to catch hung tests before Playwright's default 30s timeout
+- **Use `killAllTrackedProcesses()`** in `afterAll` instead of manual `proc.kill()` — ensures all tracked processes are killed
+- Process tracking registers global handlers for SIGINT, SIGTERM, uncaughtException, and exit events
+- On Windows, uses `taskkill /F /T` for force-kill with child process termination
+- This is **in addition to** the cleanup-on-next-run approach in IvyFrameworkVerification.ps1 (see plan 01834)
+
 - `state.ToTextareaInput()` renders as a standard `<textarea>` element, locatable via `page.locator("textarea").first()`; disabled output textarea is the `.nth(1)`
 - Clipboard `writeText` fails in headless Chromium with "Write permission denied" — this is expected and not an app bug
 - `state.ToSliderInput()` renders as a Radix UI slider with `role="slider"`, NOT a native `<input type="range">` — use `page.getByRole("slider")` and keyboard interaction (ArrowRight/ArrowLeft to increment/decrement by step, Home/End for min/max)

--- a/src/tendril/Ivy.Tendril.TeamIvyConfig/Promptwares/IvyFrameworkVerification/Program.md
+++ b/src/tendril/Ivy.Tendril.TeamIvyConfig/Promptwares/IvyFrameworkVerification/Program.md
@@ -138,10 +138,75 @@ Create `<ArtifactsDir>/sample/.ivy/tests/` directory with:
 
 **IMPORTANT:** Screenshots must be written to `<ArtifactsDir>/screenshots/` (sibling to `sample/`), not inside `sample/`.
 
+**test-utils.ts** — process tracking utility for cleanup on timeout/crash:
+
+```typescript
+import { ChildProcess } from 'child_process';
+
+const activeProcesses = new Set<ChildProcess>();
+
+/**
+ * Track a spawned process so it can be killed on timeout/crash.
+ */
+export function trackProcess(proc: ChildProcess) {
+  activeProcesses.add(proc);
+  proc.on('exit', () => activeProcesses.delete(proc));
+}
+
+/**
+ * Kill all tracked processes. Called by cleanup handlers.
+ */
+export function killAllTrackedProcesses() {
+  activeProcesses.forEach(proc => {
+    if (!proc.killed) {
+      try {
+        if (process.platform === 'win32') {
+          // Windows: taskkill with /F to force immediate termination
+          require('child_process').execSync(`taskkill /pid ${proc.pid} /F /T`, {
+            stdio: 'ignore',
+          });
+        } else {
+          proc.kill('SIGKILL');
+        }
+      } catch (e) {
+        // Process may have already exited
+      }
+    }
+  });
+  activeProcesses.clear();
+}
+
+// Register global cleanup handlers for abnormal termination
+process.on('SIGINT', () => {
+  console.log('\nTest runner interrupted (SIGINT), cleaning up processes...');
+  killAllTrackedProcesses();
+  process.exit(130);
+});
+
+process.on('SIGTERM', () => {
+  console.log('\nTest runner terminated (SIGTERM), cleaning up processes...');
+  killAllTrackedProcesses();
+  process.exit(143);
+});
+
+process.on('uncaughtException', (err) => {
+  console.error('Uncaught exception:', err);
+  killAllTrackedProcesses();
+  process.exit(1);
+});
+
+// Best-effort cleanup on normal exit (afterAll should have already run)
+process.on('exit', () => {
+  killAllTrackedProcesses();
+});
+```
+
 **One `.spec.ts` per app:**
 
-- `beforeAll`: find free port, spawn `dotnet run -- --port <port>`, wait for HTTP 200
-- `afterAll`: kill process
+- Import `trackProcess` and `killAllTrackedProcesses` from `./test-utils`
+- `beforeAll`: find free port, spawn `dotnet run -- --port <port>`, **call `trackProcess(proc)`**, wait for HTTP 200
+- `afterAll`: kill process with `killAllTrackedProcesses()` (also kills any other tracked processes)
+- Set `test.setTimeout(60000)` (60s) to catch hung tests before Playwright's default timeout
 - Test each app at `http://localhost:<port>/<app-id>?shell=false`
 - Take screenshots directly to `<ArtifactsDir>/screenshots/` with descriptive names. **Before taking each screenshot, check if the page has meaningful content (visible text > 20 chars or > 5 visible elements). Skip screenshots of empty/blank pages** — these add no verification value. Use a `takeScreenshotIfNotEmpty()` helper (see PlaywrightKnowledge.md)
 - Capture browser console logs → `<ArtifactsDir>/tests/console.log`
@@ -165,6 +230,61 @@ Create `<ArtifactsDir>/sample/.ivy/tests/` directory with:
 - Resolve project root: `process.cwd().replace(/[/\\]\.ivy[/\\]tests$/, "")`
 - Wait for server ready by polling HTTP, not just stdout
 - Use `takeScreenshotIfNotEmpty()` instead of raw `page.screenshot()` — skips blank pages
+
+**Process management pattern:**
+
+```typescript
+import { test, expect } from '@playwright/test';
+import { spawn, ChildProcess } from 'child_process';
+import http from 'http';
+import net from 'net';
+import path from 'path';
+import { trackProcess, killAllTrackedProcesses } from './test-utils';
+
+test.describe('Feature Tests', () => {
+  let serverProcess: ChildProcess;
+  let port: number;
+  const projectRoot = process.cwd().replace(/[/\\]\.ivy[/\\]tests$/, '');
+
+  test.setTimeout(60000); // 60s timeout per test
+
+  test.beforeAll(async () => {
+    // Find free port
+    port = await new Promise<number>((resolve) => {
+      const server = net.createServer();
+      server.listen(0, () => {
+        const addr = server.address();
+        const port = typeof addr === 'string' ? 0 : addr?.port ?? 0;
+        server.close(() => resolve(port));
+      });
+    });
+
+    // Spawn dotnet process
+    serverProcess = spawn(
+      'dotnet',
+      ['run', '--no-build', '--', '--port', port.toString()],
+      {
+        cwd: projectRoot,
+        shell: true,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }
+    );
+
+    // Track for cleanup on timeout/crash
+    trackProcess(serverProcess);
+
+    // Wait for server ready
+    await waitForServer(`http://localhost:${port}`, 30000);
+  });
+
+  test.afterAll(() => {
+    // Kill this process and any other tracked processes
+    killAllTrackedProcesses();
+  });
+
+  // ... tests ...
+});
+```
 
 ### 8. Install & Run Tests
 


### PR DESCRIPTION
# Summary

## Changes

Updated IvyFrameworkVerification's Program.md to include a `test-utils.ts` process tracking utility pattern and updated the test generation instructions to use tracked processes with global signal handlers (SIGINT/SIGTERM/uncaughtException/exit). Added a "Process Cleanup (Critical)" section to PlaywrightKnowledge.md memory to reinforce the pattern for future verification runs.

## API Changes

None.

## Files Modified

- **Promptwares/IvyFrameworkVerification/Program.md** — Added `test-utils.ts` code template, updated beforeAll/afterAll pattern, added full process management example
- **Promptwares/IvyFrameworkVerification/Memory/PlaywrightKnowledge.md** — Added "Process Cleanup (Critical)" section with usage guidelines

## Commits

- d2c48898 [01845] Add process timeout guard pattern to Playwright test instructions