### PR TITLE
[01846] Change New Draft button to New Plan

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Plans/Dialogs/CreatePlanDialog.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Plans/Dialogs/CreatePlanDialog.cs
@@ -17,11 +17,11 @@ public class CreatePlanDialog(List<string> projectNames, Action<string, string> 
 
         return new Dialog(
             _ => _onClose(),
-            new DialogHeader("Create New Draft"),
+            new DialogHeader("Create New Plan"),
             new DialogBody(
                 Layout.Vertical()
                     | selectedProject.ToSelectInput(options).Variant(SelectInputVariant.Toggle).WithLabel("Select project")
-                    | createPlanText.ToTextareaInput("Enter task description...").Rows(6).AutoFocus().WithField().Label("Describe the task for the new draft")
+                    | createPlanText.ToTextareaInput("Enter task description...").Rows(6).AutoFocus().WithField().Label("Describe the task for the new plan")
             ),
             new DialogFooter(
                 new Button("Cancel").Outline().OnClick(() => _onClose()),

--- a/src/tendril/Ivy.Tendril/Views/NewPlanFooterButton.cs
+++ b/src/tendril/Ivy.Tendril/Views/NewPlanFooterButton.cs
@@ -16,12 +16,12 @@ public class NewPlanFooterButton : ViewBase
 
         var elements = new List<object>
         {
-            new Button("New Draft")
+            new Button("New Plan")
                 .Icon(Icons.Plus)
                 .Width(Size.Full())
                 .Variant(ButtonVariant.Primary)
                 .OnClick(() => dialogOpen.Set(true))
-                .ShortcutKey("CTRL+ALT+D")
+                .ShortcutKey("CTRL+ALT+N")
         };
 
         if (dialogOpen.Value)


### PR DESCRIPTION
# Summary

## Changes

Renamed the "New Draft" button to "New Plan" in the Tendril Plans app footer, changed its keyboard shortcut from CTRL+ALT+D to CTRL+ALT+N, and updated the dialog header and label text from "Create New Draft" to "Create New Plan". This re-execution addresses the feedback from revision 002 to use CTRL+ALT+N instead of CTRL+N.

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/Views/NewPlanFooterButton.cs** — Button text and shortcut key
- **src/tendril/Ivy.Tendril/Apps/Plans/Dialogs/CreatePlanDialog.cs** — Dialog header and textarea label

## Commits

- b79ab828 [01846] Change New Draft button to New Plan with CTRL+ALT+N shortcut