### PR TITLE
[01855] Fix Drafts menu count to include Failed plans

### DIFF
--- a/src/tendril/Ivy.Tendril/Services/PlanCountsService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanCountsService.cs
@@ -44,7 +44,7 @@ public class PlanCountsService : IDisposable
         var jobs = _jobService.GetJobs();
 
         return new PlanCounts(
-            Drafts: snapshot.Drafts,
+            Drafts: snapshot.Drafts + snapshot.Failed,
             ActiveJobs: jobs.Count(j => j.Status == "Running" || j.Status == "Queued"),
             Reviews: snapshot.ReadyForReview + snapshot.Failed,
             Icebox: snapshot.Icebox,


### PR DESCRIPTION
# Summary

## Changes

Added `snapshot.Failed` to the Drafts badge count in `PlanCountsService.ComputeCounts()`. This makes the Drafts menu badge accurately reflect the number of plans shown in the Drafts view, which displays both Draft and Failed plans.

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/Services/PlanCountsService.cs** — Changed `Drafts: snapshot.Drafts` to `Drafts: snapshot.Drafts + snapshot.Failed` (line 47)

## Commits

- [01855] Include Failed plans in Drafts menu badge count (9b83312e)