### PR TITLE
[01849] Auto-select first plan in Drafts, Review, Recommendations

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/PlansApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/PlansApp.cs
@@ -33,6 +33,11 @@ public class PlansApp : ViewBase
             .ToList();
         var filteredPlans = PlanFilters.ApplyFilters(plans, projectFilter.Value, levelFilter.Value, textFilter.Value).ToList();
 
+        if (selectedPlanState.Value == null && filteredPlans.Count > 0)
+        {
+            selectedPlanState.Set(filteredPlans[0]);
+        }
+
         if (selectedPlanState.Value is { } selected && !filteredPlans.Any(p => p.FolderName == selected.FolderName))
         {
             var oldIndex = previousPlans.Value.FindIndex(p => p.FolderName == selected.FolderName);

--- a/src/tendril/Ivy.Tendril/Apps/RecommendationsApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/RecommendationsApp.cs
@@ -35,6 +35,11 @@ public class RecommendationsApp : ViewBase
             })
             .ToList();
 
+        if (selectedState.Value == null && filtered.Count > 0)
+        {
+            selectedState.Set(filtered[0]);
+        }
+
         // If selected recommendation is no longer in filtered list, adjust selection
         if (selectedState.Value is { } selected && !filtered.Any(r => r.PlanId == selected.PlanId && r.Title == selected.Title))
         {

--- a/src/tendril/Ivy.Tendril/Apps/ReviewApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/ReviewApp.cs
@@ -32,6 +32,11 @@ public class ReviewApp : ViewBase
             .ToList();
         var filteredPlans = PlanFilters.ApplyFilters(plans, null, null, textFilter.Value).ToList();
 
+        if (selectedPlanState.Value == null && filteredPlans.Count > 0)
+        {
+            selectedPlanState.Set(filteredPlans[0]);
+        }
+
         if (selectedPlanState.Value is { } selected && !filteredPlans.Any(p => p.FolderName == selected.FolderName))
         {
             var oldIndex = previousPlans.Value.FindIndex(p => p.FolderName == selected.FolderName);


### PR DESCRIPTION
# Summary

## Changes

Added auto-selection of the first item when opening Drafts (PlansApp), Review (ReviewApp), and Recommendations (RecommendationsApp) apps. When no item is currently selected and the filtered list has items, the first item is automatically selected.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Apps/PlansApp.cs` — Added auto-select logic after filtering
- `src/tendril/Ivy.Tendril/Apps/ReviewApp.cs` — Added auto-select logic after filtering
- `src/tendril/Ivy.Tendril/Apps/RecommendationsApp.cs` — Added auto-select logic after filtering

## Commits

- 21ae88bd [01849] Auto-select first plan in Drafts, Review, and Recommendations apps