### PR TITLE
[01850] Narrow cleanup path to current plan folder to avoid killing processes from concurrent plans

### DIFF
--- a/src/tendril/Ivy.Tendril/.promptwares/ExecutePlan/Program.md
+++ b/src/tendril/Ivy.Tendril/.promptwares/ExecutePlan/Program.md
@@ -380,7 +380,7 @@ After all verifications pass:
 
 1. Kill any remaining sample processes from the plan's artifacts directory:
    ```bash
-   powershell.exe -NoProfile -Command "Get-Process -ErrorAction SilentlyContinue | Where-Object { \$_.Path -and \$_.Path -match '\\\\artifacts\\\\sample\\\\bin\\\\' } | ForEach-Object { Write-Host \"Killing zombie process: \$(\$_.ProcessName) (PID \$(\$_.Id))\"; \$_ | Stop-Process -Force -ErrorAction SilentlyContinue }"
+   powershell.exe -NoProfile -Command "\$planFolder = '<PlanFolder>'.Replace('\\', '\\\\'); Get-Process -ErrorAction SilentlyContinue | Where-Object { \$_.Path -and \$_.Path -match [regex]::Escape(\$planFolder) -and \$_.Path -match '\\\\artifacts\\\\sample\\\\bin\\\\' } | ForEach-Object { Write-Host \"Killing zombie process: \$(\$_.ProcessName) (PID \$(\$_.Id))\"; \$_ | Stop-Process -Force -ErrorAction SilentlyContinue }"
    ```
 
 2. Delete temporary `.npmrc` files created in Step 2.5 (if any):


### PR DESCRIPTION
# Summary

## Changes

Narrowed the zombie process cleanup command in ExecutePlan Step 8 to scope the path match to the current plan's folder. Previously, the cleanup killed all processes matching `\artifacts\sample\bin\` across any plan directory, which could interfere with concurrent plan executions.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/.promptwares/ExecutePlan/Program.md` — Updated Step 8 cleanup command to include `[regex]::Escape($planFolder)` match before the artifacts path match.

## Commits

- 85277009 [01850] Narrow zombie process cleanup to current plan folder