### PR TITLE
[01847] Make sure all Tendril projects share the same version

### DIFF
--- a/src/tendril/Directory.Build.props
+++ b/src/tendril/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <Version>1.0.1</Version>
+  </PropertyGroup>
+</Project>

--- a/src/tendril/Ivy.Tendril/Ivy.Tendril.csproj
+++ b/src/tendril/Ivy.Tendril/Ivy.Tendril.csproj
@@ -5,7 +5,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <NoWarn>CS8618;CS8603;CS8602;CS8604;CS9113</NoWarn>
-    <Version>1.0.1</Version>
     <RootNamespace>Ivy.Tendril</RootNamespace>
     <UserSecretsId>a8f3c2e1-4b7d-4e9f-a1c3-8d6e2f5b9a7c</UserSecretsId>
   </PropertyGroup>


### PR DESCRIPTION
# Summary

## Changes

Created a shared `Directory.Build.props` at `src/tendril/` to centralize the version number (1.0.1) for all Tendril projects. Removed the duplicate `<Version>` property from `Ivy.Tendril.csproj` so all four Tendril projects now inherit the same version from a single source of truth.

## API Changes

None.

## Files Modified

- **New:** `src/tendril/Directory.Build.props` — shared version property file
- **Modified:** `src/tendril/Ivy.Tendril/Ivy.Tendril.csproj` — removed `<Version>1.0.1</Version>` line

## Commits

- 526f366d [01847] Centralize Tendril version in Directory.Build.props