### PR TITLE
[01857] Remove Make Draft button from Review Recommendations

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -317,16 +317,9 @@ public class ContentView(
         {
             foreach (var rec in recommendations)
             {
-                var recCapture = rec;
                 var card = Layout.Vertical().Gap(1)
                     | Text.Block(rec.Title).Bold()
-                    | new Markdown(rec.Description).DangerouslyAllowLocalFiles()
-                    | new Button("Make Draft").Icon(Icons.Plus).Outline().Small().OnClick(() =>
-                    {
-                        _jobService.StartJob("MakePlan",
-                            "-Description", $"[FORCE] {_selectedPlan.Project}: {recCapture.Title}\n\n{recCapture.Description}",
-                            "-Project", _selectedPlan.Project);
-                    });
+                    | new Markdown(rec.Description).DangerouslyAllowLocalFiles();
                 recommendationsLayout |= card;
                 recommendationsLayout |= new Separator();
             }


### PR DESCRIPTION
# Summary

## Changes

Removed the "+ Make Draft" button from the Review app's Recommendations tab. This button was redundant since the dedicated Recommendations app provides proper Accept/Decline workflow with state management via `UpdateRecommendationState()`.

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs** — Removed the Button and its `_jobService.StartJob("MakePlan", ...)` handler from the recommendations loop (lines 324-329). Also removed the now-unused `recCapture` variable.

## Commits

- 6ec71d48 [01857] Remove Make Draft button from Review Recommendations tab