### PR TITLE
[01861] Clicking on Plan Ids tries to open an app - we want to show plans in a sheet like we did before

### DIFF
--- a/src/frontend/src/widgets/dataTables/hooks/useCellInteractions.ts
+++ b/src/frontend/src/widgets/dataTables/hooks/useCellInteractions.ts
@@ -72,10 +72,11 @@ export const useCellInteractions = ({
         ]);
       }
 
-      // Handle click on custom link cells
+      // Handle click on custom link cells (only if no OnCellClick handler is configured)
       if (
         cellContent.kind === GridCellKind.Custom &&
-        (cellContent.data as { kind?: string })?.kind === "link-cell"
+        (cellContent.data as { kind?: string })?.kind === "link-cell" &&
+        !(enableCellClickEvents ?? false)
       ) {
         const url = (cellContent.data as { url?: string })?.url;
 


### PR DESCRIPTION
# Summary

## Changes

Added a guard condition to the link-cell click handler in `useCellInteractions.ts` to skip URL navigation when `enableCellClickEvents` is true. This prevents Plan ID cells (which use `LinkDisplayRenderer` for styling) from triggering navigation when they already have an `OnCellClick` handler configured to open the plan in a sheet.

## API Changes

None.

## Files Modified

- **Frontend:**
  - `src/frontend/src/widgets/dataTables/hooks/useCellInteractions.ts` — Added `!(enableCellClickEvents ?? false)` condition to link-cell click handler

## Commits

- d7964fc3 [01861] Fix link-cell click navigating when OnCellClick is configured