### PR TITLE
[01867] Add Empty Inbox State to Plans and Review Apps

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Plans/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Plans/ContentView.cs
@@ -84,6 +84,13 @@ public class ContentView(
 
         if (_selectedPlan is null)
         {
+            if (_allPlans.Count == 0)
+            {
+                return Layout.Vertical().AlignContent(Align.Center).Height(Size.Full()).Gap(2)
+                    | new Icon(Icons.Inbox).Large().Color(Colors.Gray)
+                    | Text.Muted("No draft plans yet");
+            }
+
             return Layout.Vertical().AlignContent(Align.Center).Height(Size.Full())
                 | Text.Muted("Select a plan from the sidebar");
         }

--- a/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -89,6 +89,13 @@ public class ContentView(
 
         if (_selectedPlan is null)
         {
+            if (_allPlans.Count == 0)
+            {
+                return Layout.Vertical().AlignContent(Align.Center).Height(Size.Full()).Gap(2)
+                    | new Icon(Icons.Inbox).Large().Color(Colors.Gray)
+                    | Text.Muted("No plans to review");
+            }
+
             return Layout.Vertical().AlignContent(Align.Center).Height(Size.Full())
                 | Text.Muted("Select a completed plan to review");
         }


### PR DESCRIPTION
# Summary

## Changes

Added empty inbox state to the Plans (Drafts) and Review apps, matching the existing pattern in the Recommendations app. When no items exist in the list, a large gray inbox icon with an appropriate message is shown instead of the generic "select from sidebar" text.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Apps/Plans/ContentView.cs` — Added empty state check when `_allPlans.Count == 0`
- `src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs` — Added empty state check when `_allPlans.Count == 0`

## Commits

- 63bbaf9c [01867] Add empty inbox state to Plans and Review apps