### PR TITLE
[01873] Fix YAML deserialization error for declineReason in Review app

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Plans/Models.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Plans/Models.cs
@@ -44,6 +44,7 @@ public class RecommendationItem
     public string Title { get; set; } = "";
     public string Description { get; set; } = "";
     public string State { get; set; } = "Pending";
+    public string? DeclineReason { get; set; }
 }
 
 public static class PlanFilters


### PR DESCRIPTION
# Summary

## Changes

Added the missing `DeclineReason` property to the `RecommendationItem` class in `Models.cs`. This fixes the `YamlException` that occurred when the Review app tried to deserialize `recommendations.yaml` files containing the `declineReason` field.

## API Changes

- `RecommendationItem` class: Added `public string? DeclineReason { get; set; }` property

## Files Modified

- `src/tendril/Ivy.Tendril/Apps/Plans/Models.cs` — Added `DeclineReason` property to `RecommendationItem`

## Commits

- 20871f87 [01873] Add DeclineReason property to RecommendationItem