### PR TITLE
[01869] Rename NewPlanFooterButton to NewPlanButton

### DIFF
--- a/src/tendril/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/tendril/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -504,7 +504,7 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
                 sidebarMenu,
                 Layout.Vertical().Gap(2)
                     | settings.Header
-                    | new NewPlanFooterButton()
+                    | new NewPlanButton()
                 ,
                 Layout.Vertical(
                     new SidebarNews("https://ivy.app/news.json"),

--- a/src/tendril/Ivy.Tendril/Views/NewPlanButton.cs
+++ b/src/tendril/Ivy.Tendril/Views/NewPlanButton.cs
@@ -3,7 +3,7 @@ using Ivy.Tendril.Services;
 
 namespace Ivy.Tendril.Views;
 
-public class NewPlanFooterButton : ViewBase
+public class NewPlanButton : ViewBase
 {
     public override object? Build()
     {


### PR DESCRIPTION
# Summary

## Changes

Renamed `NewPlanFooterButton` to `NewPlanButton` to accurately reflect the component's location in the sidebar header, not the footer. The file was renamed and the single usage in `TendrilAppShell.cs` was updated.

## API Changes

- Renamed class: `NewPlanFooterButton` → `NewPlanButton` (in `Ivy.Tendril.Views` namespace)
- Renamed file: `Views/NewPlanFooterButton.cs` → `Views/NewPlanButton.cs`

## Files Modified

- `src/tendril/Ivy.Tendril/Views/NewPlanButton.cs` — renamed from `NewPlanFooterButton.cs`, class name updated
- `src/tendril/Ivy.Tendril/AppShell/TendrilAppShell.cs` — updated instantiation to use `NewPlanButton`

## Commits

- 36d399ad [01869] Rename NewPlanFooterButton to NewPlanButton