### PR TITLE
[01864] Update IvyFrameworkVerification to use split PlaywrightKnowledge files

### DIFF
--- a/src/tendril/Ivy.Tendril.TeamIvyConfig/Promptwares/IvyFrameworkVerification/Program.md
+++ b/src/tendril/Ivy.Tendril.TeamIvyConfig/Promptwares/IvyFrameworkVerification/Program.md
@@ -25,7 +25,16 @@ If the changes are non-visual (docs, analyzers, refactoring, code-only fixes), w
 ### 2. Research
 
 - Read `Memory/IvyFrameworkGotchas.md` for known API issues and workarounds
-- Read `Memory/PlaywrightKnowledge.md` for Ivy testing patterns and locator strategies
+- Read `Memory/PlaywrightKnowledge-Index.md` for an overview of the split knowledge files
+- Always read the critical files:
+  - `Memory/PlaywrightKnowledge-Process.md` — mandatory for all tests
+  - `Memory/PlaywrightKnowledge-Gotchas.md` — avoid known crash patterns
+- Read additional files based on the feature being verified (identified in Step 1):
+  - For new test projects or framework setup: `Memory/PlaywrightKnowledge-Framework.md`
+  - For widget testing: `Memory/PlaywrightKnowledge-Widgets.md`
+  - For locator/assertion work: `Memory/PlaywrightKnowledge-Locators.md`
+  - For DOM/rendering issues: `Memory/PlaywrightKnowledge-DOM.md`
+  - For test structure guidance: `Memory/PlaywrightKnowledge-Testing.md`
 - Read the Ivy Framework AGENTS.md: `~/git/ivy/Ivy-Framework/AGENTS.md`
 - Read relevant source code for the changed feature from `~/git/ivy/Ivy-Framework/src/`
 - Read existing samples: `~/git/ivy/Ivy-Framework/src/Ivy.Samples.Shared/Apps/`
@@ -221,7 +230,7 @@ process.on('exit', () => {
 5. No console errors or warnings
 6. No backend errors or exceptions
 
-**Code patterns (from PlaywrightKnowledge.md):**
+**Code patterns (refer to PlaywrightKnowledge-Index.md for specific files):**
 
 - Use `getByText()`, `getByRole()` locators
 - Use `.first()` when multiple matches possible


### PR DESCRIPTION
# Summary

## Changes

Updated the IvyFrameworkVerification Program.md to reference the new split PlaywrightKnowledge files instead of the monolithic `PlaywrightKnowledge.md`. The Research step now loads `PlaywrightKnowledge-Index.md` plus critical files (Process, Gotchas) unconditionally, with additional files loaded conditionally based on feature type. The code patterns reference in Step 7 was updated to point to the Index file.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril.TeamIvyConfig/Promptwares/IvyFrameworkVerification/Program.md` — Updated PlaywrightKnowledge references from monolithic to split files

## Commits

- e7e4a768 [01864] Update IvyFrameworkVerification to use split PlaywrightKnowledge files