### PR TITLE
[01879] Consolidate duplicate RecommendationItem and RecommendationYaml models

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Plans/Models.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Plans/Models.cs
@@ -39,7 +39,7 @@ public record PlanFile(
     public string FolderName => Path.GetFileName(FolderPath);
 }
 
-public class RecommendationItem
+public class RecommendationYaml
 {
     public string Title { get; set; } = "";
     public string Description { get; set; } = "";

--- a/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -122,13 +122,13 @@ public class ContentView(
 
         // Recommendations
         var recommendationsPath = Path.Combine(_selectedPlan.FolderPath, "artifacts", "recommendations.yaml");
-        var recommendations = new List<RecommendationItem>();
+        var recommendations = new List<RecommendationYaml>();
         if (File.Exists(recommendationsPath))
         {
             var recDeserializer = new DeserializerBuilder()
                 .WithNamingConvention(CamelCaseNamingConvention.Instance)
                 .Build();
-            recommendations = recDeserializer.Deserialize<List<RecommendationItem>>(
+            recommendations = recDeserializer.Deserialize<List<RecommendationYaml>>(
                 File.ReadAllText(recommendationsPath)) ?? new();
         }
 

--- a/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
@@ -808,11 +808,3 @@ public record Recommendation(
     PlanStatus SourcePlanStatus,
     string? DeclineReason = null
 );
-
-public class RecommendationYaml
-{
-    public string Title { get; set; } = "";
-    public string Description { get; set; } = "";
-    public string State { get; set; } = "Pending";
-    public string? DeclineReason { get; set; }
-}


### PR DESCRIPTION
# Summary

## Changes

Consolidated the duplicate `RecommendationItem` (Models.cs) and `RecommendationYaml` (PlanReaderService.cs) classes into a single `RecommendationYaml` class in Models.cs. Removed the duplicate from PlanReaderService.cs and updated all references in ContentView.cs.

## API Changes

- Renamed `RecommendationItem` → `RecommendationYaml` in `Ivy.Tendril.Apps.Plans` namespace
- Removed duplicate `RecommendationYaml` class from bottom of `PlanReaderService.cs` (was in global/file scope)

## Files Modified

- `src/tendril/Ivy.Tendril/Apps/Plans/Models.cs` — Renamed class from `RecommendationItem` to `RecommendationYaml`
- `src/tendril/Ivy.Tendril/Services/PlanReaderService.cs` — Removed duplicate `RecommendationYaml` class definition
- `src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs` — Updated references from `RecommendationItem` to `RecommendationYaml`

## Commits

- 98cbcb4a [01879] Consolidate duplicate RecommendationItem and RecommendationYaml models