### PR TITLE
[01874] Add OnSelect handler to Dashboard StackedProgress for project filtering

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/DashboardApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/DashboardApp.cs
@@ -16,6 +16,8 @@ public class DashboardApp : ViewBase
             refreshToken.Refresh();
         }, TimeSpan.FromSeconds(60));
 
+        var selectedProject = UseState<string?>(null);
+
         var plans = planService.GetPlans();
 
         // Statistics cards
@@ -35,6 +37,10 @@ public class DashboardApp : ViewBase
             | BuildStatCard(failedCount, "Failed");
 
         // Daily activity table - last 7 days
+        var filteredPlans = selectedProject.Value != null
+            ? plans.Where(p => p.Project == selectedProject.Value).ToList()
+            : plans;
+
         var today = DateTime.UtcNow.Date;
         var days = Enumerable.Range(0, 7).Select(i => today.AddDays(-i)).ToList();
 
@@ -44,12 +50,12 @@ public class DashboardApp : ViewBase
                 : day == today.AddDays(-1) ? "Yesterday"
                 : day.ToString("MMM dd");
 
-            var createdCount = plans.Count(p => p.Created.Date == day);
-            var dayCompletedCount = plans.Count(p => p.Status == PlanStatus.Completed && p.Updated.Date == day);
-            var prsMerged = plans.Where(p => p.Status == PlanStatus.Completed && p.Updated.Date == day).Sum(p => p.Prs.Count);
-            var dayFailedCount = plans.Count(p => p.Status == PlanStatus.Failed && p.Updated.Date == day);
+            var createdCount = filteredPlans.Count(p => p.Created.Date == day);
+            var dayCompletedCount = filteredPlans.Count(p => p.Status == PlanStatus.Completed && p.Updated.Date == day);
+            var prsMerged = filteredPlans.Where(p => p.Status == PlanStatus.Completed && p.Updated.Date == day).Sum(p => p.Prs.Count);
+            var dayFailedCount = filteredPlans.Count(p => p.Status == PlanStatus.Failed && p.Updated.Date == day);
 
-            var completedOrFailedPlans = plans
+            var completedOrFailedPlans = filteredPlans
                 .Where(p => p.Updated.Date == day && p.Status is PlanStatus.Completed or PlanStatus.Failed or PlanStatus.ReadyForReview)
                 .ToList();
 
@@ -105,10 +111,18 @@ public class DashboardApp : ViewBase
                 Color: configService.GetProjectColor(p.Project),
                 Label: p.Project
             )).ToArray()
-        );
+        )
+        .Selected(selectedProject.Value != null
+            ? Array.FindIndex(projectData, p => p.Project == selectedProject.Value)
+            : null)
+        .OnSelect(async e =>
+        {
+            var clickedProject = projectData[e.Value].Project;
+            selectedProject.Set(selectedProject.Value == clickedProject ? null : clickedProject);
+        });
 
         // Hourly cost & tokens combined bar chart
-        var hourlyBurn = planService.GetHourlyTokenBurn(days: 7);
+        var hourlyBurn = planService.GetHourlyTokenBurn(days: 7, project: selectedProject.Value);
 
         var combinedChart = hourlyBurn.ToBarChart(
                 style: BarChartStyles.Default,

--- a/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
@@ -509,7 +509,7 @@ public class PlanReaderService(ConfigService config)
     /// Correlates <c>costs.csv</c> entries with log file timestamps to determine when tokens were consumed.
     /// Plans without both a costs file and a logs directory are skipped.
     /// </remarks>
-    public List<HourlyTokenBurn> GetHourlyTokenBurn(int days = 7)
+    public List<HourlyTokenBurn> GetHourlyTokenBurn(int days = 7, string? project = null)
     {
         var cutoff = DateTime.UtcNow.AddDays(-days);
         var buckets = new Dictionary<DateTime, (decimal Cost, int Tokens)>();
@@ -520,6 +520,15 @@ public class PlanReaderService(ConfigService config)
         {
             try
             {
+                if (project != null)
+                {
+                    var planYamlPath = Path.Combine(dir, "plan.yaml");
+                    if (!File.Exists(planYamlPath)) continue;
+                    var planYaml = YamlDeserializer.Deserialize<PlanYaml>(FileHelper.ReadAllText(planYamlPath));
+                    if (planYaml == null || !string.Equals(planYaml.Project, project, StringComparison.OrdinalIgnoreCase))
+                        continue;
+                }
+
                 var costsPath = Path.Combine(dir, "costs.csv");
                 var logsDir = Path.Combine(dir, "logs");
                 if (!File.Exists(costsPath) || !Directory.Exists(logsDir)) continue;


### PR DESCRIPTION
# Summary

## Changes

Added interactive project filtering to the Dashboard's StackedProgress widget. Clicking a project segment now filters both the daily activity table and the hourly cost/tokens chart to show only that project's data. Clicking the same segment again deselects it, restoring the full view.

## API Changes

- `PlanReaderService.GetHourlyTokenBurn(int days, string? project)` — added optional `project` parameter to filter hourly burn data by project name (case-insensitive match against plan.yaml)

## Files Modified

- **DashboardApp.cs** — Added `selectedProject` state, `filteredPlans` variable, `.Selected()` and `.OnSelect()` on StackedProgress, project parameter on hourly burn call
- **PlanReaderService.cs** — Added `string? project = null` parameter to `GetHourlyTokenBurn` with plan.yaml project filtering

## Commits

- ebf0f12c [01874] Add OnSelect handler to Dashboard StackedProgress for project filtering