### PR TITLE
[01882] Refactor YAML deserializer in Review ContentView

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -125,10 +125,7 @@ public class ContentView(
         var recommendations = new List<RecommendationYaml>();
         if (File.Exists(recommendationsPath))
         {
-            var recDeserializer = new DeserializerBuilder()
-                .WithNamingConvention(CamelCaseNamingConvention.Instance)
-                .Build();
-            recommendations = recDeserializer.Deserialize<List<RecommendationYaml>>(
+            recommendations = PlanReaderService.YamlDeserializer.Deserialize<List<RecommendationYaml>>(
                 File.ReadAllText(recommendationsPath)) ?? new();
         }
 

--- a/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
@@ -13,7 +13,7 @@ public class PlanReaderService(ConfigService config)
 
     private static readonly Regex FolderNameRegex = new(@"^(\d{5})-(.+)$", RegexOptions.Compiled);
 
-    private static readonly IDeserializer YamlDeserializer = new DeserializerBuilder()
+    public static readonly IDeserializer YamlDeserializer = new DeserializerBuilder()
         .WithNamingConvention(CamelCaseNamingConvention.Instance)
         .IgnoreUnmatchedProperties()
         .Build();


### PR DESCRIPTION
# Summary

## Changes

Replaced the inline `DeserializerBuilder` in `ContentView.cs` with the shared `PlanReaderService.YamlDeserializer` static field. Changed the field's visibility from `private` to `public` to enable direct access. This eliminates duplicate YAML configuration and ensures consistent deserialization settings (the shared instance includes `IgnoreUnmatchedProperties()` which the inline version lacked).

## API Changes

- `PlanReaderService.YamlDeserializer` — changed from `private static readonly` to `public static readonly`

## Files Modified

- **Services/PlanReaderService.cs** — Made `YamlDeserializer` field public
- **Apps/Review/ContentView.cs** — Replaced inline deserializer with `PlanReaderService.YamlDeserializer`

## Commits

- [01882] Refactor YAML deserializer in Review ContentView to use shared instance (5d4cc165)