### PR TITLE
[01883] Fix double-counting of Failed plans in Drafts badge

### DIFF
--- a/src/tendril/Ivy.Tendril/Services/PlanCountsService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanCountsService.cs
@@ -44,7 +44,7 @@ public class PlanCountsService : IDisposable
         var jobs = _jobService.GetJobs();
 
         return new PlanCounts(
-            Drafts: snapshot.Drafts + snapshot.Failed,
+            Drafts: snapshot.Drafts,
             ActiveJobs: jobs.Count(j => j.Status == "Running" || j.Status == "Queued"),
             Reviews: snapshot.ReadyForReview + snapshot.Failed,
             Icebox: snapshot.Icebox,


### PR DESCRIPTION
# Summary

## Changes

Removed `snapshot.Failed` from the Drafts badge count in `PlanCountsService.ComputeCounts()`. Failed plans were being counted in both the Drafts and Reviews badges, causing inflated totals. Now Failed plans are only counted in Reviews.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Services/PlanCountsService.cs` — Changed Drafts count from `snapshot.Drafts + snapshot.Failed` to `snapshot.Drafts`

## Commits

- cd425ac1 [01883] Remove Failed plans from Drafts badge count to fix double-counting