### PR TITLE
[01890] Consolidate DeserializerBuilder Instances

### DIFF
--- a/src/tendril/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/tendril/Ivy.Tendril/Services/ConfigService.cs
@@ -108,6 +108,11 @@ public class TendrilSettings
 
 public class ConfigService
 {
+    private static readonly IDeserializer CamelCaseDeserializer = new DeserializerBuilder()
+        .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        .IgnoreUnmatchedProperties()
+        .Build();
+
     private TendrilSettings _settings;
     private string _configPath;
     private string _tendrilHome;
@@ -151,11 +156,7 @@ public class ConfigService
             try
             {
                 var yaml = File.ReadAllText(_configPath);
-                var deserializer = new DeserializerBuilder()
-                    .WithNamingConvention(CamelCaseNamingConvention.Instance)
-                    .IgnoreUnmatchedProperties()
-                    .Build();
-                _settings = deserializer.Deserialize<TendrilSettings>(yaml) ?? new TendrilSettings();
+                _settings = CamelCaseDeserializer.Deserialize<TendrilSettings>(yaml) ?? new TendrilSettings();
                 NeedsOnboarding = false;
             }
             catch (Exception)
@@ -252,10 +253,7 @@ public class ConfigService
         if (File.Exists(_configPath))
         {
             var yaml = File.ReadAllText(_configPath);
-            var deserializer = new DeserializerBuilder()
-                .WithNamingConvention(CamelCaseNamingConvention.Instance)
-                .Build();
-            var loadedSettings = deserializer.Deserialize<TendrilSettings>(yaml);
+            var loadedSettings = CamelCaseDeserializer.Deserialize<TendrilSettings>(yaml);
             if (loadedSettings != null)
             {
                 _settings = loadedSettings;

--- a/src/tendril/Ivy.Tendril/Services/ModelPricingService.cs
+++ b/src/tendril/Ivy.Tendril/Services/ModelPricingService.cs
@@ -19,6 +19,8 @@ public record CostCalculation
 
 public class ModelPricingService
 {
+    private static readonly IDeserializer DefaultDeserializer = new DeserializerBuilder().Build();
+
     private readonly Dictionary<string, ModelPricing> _pricing;
 
     public ModelPricingService()
@@ -42,8 +44,7 @@ public class ModelPricingService
         using var reader = new StreamReader(stream);
         var yaml = reader.ReadToEnd();
 
-        var deserializer = new DeserializerBuilder().Build();
-        var config = deserializer.Deserialize<Dictionary<string, object>>(yaml);
+        var config = DefaultDeserializer.Deserialize<Dictionary<string, object>>(yaml);
 
         var result = new Dictionary<string, ModelPricing>();
         if (config.TryGetValue("models", out var modelsObj) && modelsObj is Dictionary<object, object> models)


### PR DESCRIPTION
# Summary

## Changes

Consolidated inline `DeserializerBuilder` calls into shared static readonly fields. `ConfigService` now uses a single `CamelCaseDeserializer` field (replacing two inline builders), and `ModelPricingService` uses a `DefaultDeserializer` field (replacing one inline builder).

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/Services/ConfigService.cs** — Added `CamelCaseDeserializer` static field, replaced two inline `new DeserializerBuilder()` calls
- **src/tendril/Ivy.Tendril/Services/ModelPricingService.cs** — Added `DefaultDeserializer` static field, replaced one inline `new DeserializerBuilder()` call

## Commits

- 69fde098 [01890] Consolidate DeserializerBuilder instances into shared static fields