### PR TITLE
[01891] Refactor ContentView to use shared YamlSerializer

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -4,8 +4,6 @@ using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Apps.Review.Dialogs;
 using Ivy.Tendril.Services;
 using Ivy.Widgets.DiffView;
-using YamlDotNet.Serialization;
-using YamlDotNet.Serialization.NamingConventions;
 
 namespace Ivy.Tendril.Apps.Review;
 
@@ -495,11 +493,8 @@ public class ContentView(
                             ["assignee"] = customPrAssignee.Value ?? "",
                             ["comment"] = customPrComment.Value
                         };
-                        var serializer = new SerializerBuilder()
-                            .WithNamingConvention(CamelCaseNamingConvention.Instance)
-                            .Build();
                         var optionsPath = Path.Combine(_selectedPlan.FolderPath, ".custom-pr-options.yaml");
-                        File.WriteAllText(optionsPath, serializer.Serialize(options));
+                        File.WriteAllText(optionsPath, PlanReaderService.YamlSerializer.Serialize(options));
                         _jobService.StartJob("MakePr", _selectedPlan.FolderPath);
                         _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Building);
                         _refreshPlans();

--- a/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
@@ -18,7 +18,7 @@ public class PlanReaderService(ConfigService config)
         .IgnoreUnmatchedProperties()
         .Build();
 
-    private static readonly ISerializer YamlSerializer = new SerializerBuilder()
+    public static readonly ISerializer YamlSerializer = new SerializerBuilder()
         .WithNamingConvention(CamelCaseNamingConvention.Instance)
         .Build();
 


### PR DESCRIPTION
# Summary

## Changes

Made `PlanReaderService.YamlSerializer` public and replaced the inline `SerializerBuilder` in `ContentView.cs` with a reference to the shared instance. Removed unused YamlDotNet using directives from ContentView.

## API Changes

- `PlanReaderService.YamlSerializer` — changed from `private` to `public static readonly`

## Files Modified

- **Services/PlanReaderService.cs** — visibility change on YamlSerializer field
- **Apps/Review/ContentView.cs** — removed inline serializer, removed unused usings

## Commits

- 61e77c5c [01891] Refactor ContentView to use shared YamlSerializer from PlanReaderService