### PR TITLE
[01898] Move edit/delete to end of table and use icons

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Settings/LevelsSettingsView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Settings/LevelsSettingsView.cs
@@ -20,16 +20,21 @@ public class LevelsSettingsView : ViewBase
         var rows = levels.Select((level, i) => new LevelRow(i, level.Name, level.Badge)).ToList();
 
         var table = new TableBuilder<LevelRow>(rows)
-            .Header(t => t.Index, "Actions")
+            .Builder(t => t.Badge, f => f.Func<LevelRow, string>(badge =>
+                new Badge(badge).Variant(
+                    Enum.TryParse<BadgeVariant>(badge, out var v) ? v : BadgeVariant.Outline
+                )
+            ))
+            .Header(t => t.Index, "")
             .Builder(t => t.Index, f => f.Func<LevelRow, int>(idx =>
                 Layout.Horizontal().Gap(1)
-                    | new Button("Edit").Outline().Small().OnClick(() =>
+                    | new Button().Icon(Icons.Pencil).Outline().Small().OnClick(() =>
                     {
                         editIndex.Set(idx);
                         editName.Set(levels[idx].Name);
                         editBadge.Set(levels[idx].Badge);
                     })
-                    | new Button("Delete").Outline().Small().OnClick(() =>
+                    | new Button().Icon(Icons.Trash).Outline().Small().OnClick(() =>
                     {
                         var name = levels[idx].Name;
                         levels.RemoveAt(idx);
@@ -53,11 +58,6 @@ public class LevelsSettingsView : ViewBase
                             refreshToken.Refresh();
                         })
                         : new Spacer().Width(Size.Units(0)))
-            ))
-            .Builder(t => t.Badge, f => f.Func<LevelRow, string>(badge =>
-                new Badge(badge).Variant(
-                    Enum.TryParse<BadgeVariant>(badge, out var v) ? v : BadgeVariant.Outline
-                )
             ));
 
         var content = Layout.Vertical().Gap(4).Padding(4).Width(Size.Auto().Max(Size.Units(120)))


### PR DESCRIPTION
# Summary

## Changes

Moved the Actions column (Edit/Delete/Move buttons) from the first column to the last column in the Priority Levels settings table. Replaced text labels on the Edit and Delete buttons with `Icons.Pencil` and `Icons.Trash` icons respectively.

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/Apps/Settings/LevelsSettingsView.cs** — Reordered table column builders (Badge before Actions) and changed Edit/Delete buttons from text to icon-only.

## Commits

- 0c85777e [01898] Move edit/delete to end of table and use icons