### PR TITLE
[01899] In the dashboard table add a cost per plan

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/DashboardApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/DashboardApp.cs
@@ -61,6 +61,9 @@ public class DashboardApp : ViewBase
 
             var dayCost = completedOrFailedPlans.Sum(p => planService.GetPlanTotalCost(p.FolderPath));
             var dayTokens = completedOrFailedPlans.Sum(p => planService.GetPlanTotalTokens(p.FolderPath));
+            var costPerPlan = dayCompletedCount > 0 && dayCost > 0
+                ? $"${dayCost / dayCompletedCount:F2}"
+                : "";
 
             return new DashboardDayRow
             {
@@ -71,6 +74,7 @@ public class DashboardApp : ViewBase
                 PrsMerged = prsMerged,
                 Failed = dayFailedCount,
                 Cost = dayCost > 0 ? $"${dayCost:F2}" : "",
+                CostPerPlan = costPerPlan,
                 Tokens = dayTokens > 0 ? FormatTokens(dayTokens) : ""
             };
         }).ToList();
@@ -86,6 +90,7 @@ public class DashboardApp : ViewBase
             .Header(t => t.PrsMerged, "PRs Merged")
             .Header(t => t.Failed, "Failed")
             .Header(t => t.Cost, "Cost")
+            .Header(t => t.CostPerPlan, "Cost/Plan")
             .Header(t => t.Tokens, "Tokens")
             .Hidden(t => t.SortDate)
             .Config(c =>
@@ -198,5 +203,6 @@ public class DashboardDayRow
     public int PrsMerged { get; set; }
     public int Failed { get; set; }
     public string Cost { get; set; } = "";
+    public string CostPerPlan { get; set; } = "";
     public string Tokens { get; set; } = "";
 }


### PR DESCRIPTION
# Summary

## Changes

Added a "Cost/Plan" column to the dashboard table that displays the average cost per completed plan for each day. The calculation divides the total day cost by the number of completed plans, displaying the result as a dollar amount (e.g., "$1.25").

## API Changes

- `DashboardDayRow.CostPerPlan` — new `string` property added to the dashboard row model

## Files Modified

- **src/tendril/Ivy.Tendril/Apps/DashboardApp.cs** — Added `CostPerPlan` property to `DashboardDayRow`, cost-per-plan calculation in the row builder, and "Cost/Plan" column header to the DataTable

---

## Commits

- e1449be4 [01899] Add Cost/Plan column to dashboard table