### PR TITLE
[01900] Fix cost display in Jobs table

### DIFF
--- a/src/tendril/Ivy.Tendril/Services/JobService.cs
+++ b/src/tendril/Ivy.Tendril/Services/JobService.cs
@@ -480,6 +480,7 @@ public class JobService
             var sessionId = job.SessionId;
             var jobArgs = job.Args;
             var jobType = job.Type;
+            var jobId = job.Id;
 
             _ = Task.Run(async () =>
             {
@@ -489,9 +490,18 @@ public class JobService
                 try
                 {
                     var costCalc = _modelPricingService.CalculateSessionCost(sessionId);
-                    if (costCalc.TotalCost > 0 && jobArgs.Length > 0)
+                    if (costCalc.TotalCost > 0)
                     {
-                        LogCostToCsv(jobArgs[0], jobType, costCalc.TotalTokens, costCalc.TotalCost);
+                        if (_jobs.TryGetValue(jobId, out var j))
+                        {
+                            j.Cost = (decimal)costCalc.TotalCost;
+                            JobsChanged?.Invoke();
+                        }
+
+                        if (jobArgs.Length > 0)
+                        {
+                            LogCostToCsv(jobArgs[0], jobType, costCalc.TotalTokens, costCalc.TotalCost);
+                        }
                     }
                 }
                 catch { /* Best-effort cost tracking */ }


### PR DESCRIPTION
# Summary

## Changes

Updated the async cost calculation in `JobService.CompleteJob()` to assign the computed cost back to `JobItem.Cost` and invoke `JobsChanged` to refresh the UI. Previously, costs were calculated and logged to CSV but never stored on the job item, leaving the Jobs table Cost column empty.

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/Services/JobService.cs** — Added cost assignment to `JobItem.Cost` after `CalculateSessionCost()`, plus `JobsChanged` invocation for UI refresh

## Commits

- 27903466 [01900] Fix cost display in Jobs table