### PR TITLE
[01901] Add Cost column to Pull Request Table

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/PullRequest/Models.cs
+++ b/src/tendril/Ivy.Tendril/Apps/PullRequest/Models.cs
@@ -7,5 +7,6 @@ public record PrRow
     public string Repository { get; init; } = "";
     public string Pr { get; init; } = "";
     public string Plan { get; init; } = "";
+    public string Cost { get; init; } = "";
     public string PlanFolderPath { get; init; } = "";
 }

--- a/src/tendril/Ivy.Tendril/Apps/PullRequestApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/PullRequestApp.cs
@@ -21,15 +21,21 @@ public class PullRequestApp : ViewBase
             .OrderByDescending(p => p.Id)
             .ToList();
 
-        var rows = plans.SelectMany(plan => plan.Prs.Select((pr, i) => new PrRow
+        var rows = plans.SelectMany(plan =>
         {
-            Id = $"{plan.Id}-{i}",
-            PlanId = $"{plan.Id:D5}",
-            Repository = ExtractRepo(pr),
-            Pr = pr,
-            Plan = $"#{plan.Id:D5} {plan.Title}",
-            PlanFolderPath = plan.FolderPath
-        })).ToList();
+            var costValue = planService.GetPlanTotalCost(plan.FolderPath);
+            var cost = costValue > 0 ? $"${costValue:F2}" : "";
+            return plan.Prs.Select((pr, i) => new PrRow
+            {
+                Id = $"{plan.Id}-{i}",
+                PlanId = $"{plan.Id:D5}",
+                Repository = ExtractRepo(pr),
+                Pr = pr,
+                Plan = $"#{plan.Id:D5} {plan.Title}",
+                Cost = cost,
+                PlanFolderPath = plan.FolderPath
+            });
+        }).ToList();
 
         var dataTable = rows.AsQueryable()
             .ToDataTable(idSelector: t => t.Id)
@@ -38,8 +44,10 @@ public class PullRequestApp : ViewBase
             .Height(Size.Full())
             .Header(t => t.PlanId, "Plan ID")
             .Header(t => t.Repository, "Repository")
+            .Header(t => t.Cost, "Cost")
             .Header(t => t.Pr, "PR")
             .Header(t => t.Plan, "Plan")
+            .Width(t => t.Cost, Size.Px(80))
             .Renderer(t => t.PlanId, new LinkDisplayRenderer())
             .Renderer(t => t.Pr, new LinkDisplayRenderer())
             .SortDirection(t => t.PlanId, SortDirection.Descending)


### PR DESCRIPTION
# Summary

## Changes

Added a Cost column to the Pull Request Table in PullRequestApp. The column displays the total cost for each plan using the existing `PlanReaderService.GetPlanTotalCost()` method, formatted as `$X.XX`. The column is placed between Repository and PR columns with an 80px width.

## API Changes

None.

## Files Modified

- **Model**: `src/tendril/Ivy.Tendril/Apps/PullRequest/Models.cs` - Added `Cost` property to `PrRow` record
- **UI**: `src/tendril/Ivy.Tendril/Apps/PullRequestApp.cs` - Calculate and display cost per plan, added Cost header and column width

## Commits

- 5cfb23ad [01901] Add Cost column to Pull Request Table