### PR TITLE
[01904] Add time-based cache to GetRecommendations for polling views

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/RecommendationServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/RecommendationServiceTests.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+
 using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Services;
 
@@ -298,5 +300,55 @@ public class RecommendationServiceTests : IDisposable
             .ToList();
 
         Assert.Equal(2, filtered.Count);
+    }
+
+    [Fact]
+    public void GetRecommendations_CachesResultForTwoMinutes()
+    {
+        var yaml = "- title: Cached Item\n  description: Desc\n  state: Pending\n";
+        CreatePlanWithRecommendations("01650-CacheTest", yaml);
+
+        // First call computes and caches
+        var result1 = _service.GetRecommendations();
+        Assert.Single(result1);
+
+        // Add a new recommendation file on disk
+        var yaml2 = "- title: New Item\n  description: Desc2\n  state: Pending\n";
+        CreatePlanWithRecommendations("01651-CacheTest2", yaml2);
+
+        // Second call within cache window returns cached value (still 1 item)
+        var result2 = _service.GetRecommendations();
+        Assert.Single(result2);
+        Assert.Same(result1, result2);
+
+        // Simulate cache expiration by setting _recommendationsCacheTime to 3 minutes ago
+        var cacheTimeField = typeof(PlanReaderService).GetField("_recommendationsCacheTime", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        cacheTimeField.SetValue(_service, DateTime.UtcNow.AddMinutes(-3));
+
+        // Third call after expiration recomputes (now sees both items)
+        var result3 = _service.GetRecommendations();
+        Assert.Equal(2, result3.Count);
+        Assert.NotSame(result1, result3);
+    }
+
+    [Fact]
+    public void UpdateRecommendationState_InvalidatesCache()
+    {
+        var yaml = "- title: Fix bug\n  description: Found a bug\n  state: Pending\n";
+        CreatePlanWithRecommendations("01652-CacheInvalidate", yaml);
+
+        // Prime the cache
+        var result1 = _service.GetRecommendations();
+        Assert.Single(result1);
+        Assert.Equal("Pending", result1[0].State);
+
+        // Update state (should invalidate cache)
+        _service.UpdateRecommendationState("01652-CacheInvalidate", "Fix bug", "Accepted");
+
+        // Next call should recompute and reflect the updated state
+        var result2 = _service.GetRecommendations();
+        Assert.Single(result2);
+        Assert.Equal("Accepted", result2[0].State);
+        Assert.NotSame(result1, result2);
     }
 }

--- a/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
@@ -13,6 +13,11 @@ public class PlanReaderService(ConfigService config)
 
     private static readonly Regex FolderNameRegex = new(@"^(\d{5})-(.+)$", RegexOptions.Compiled);
 
+    // Cache for GetRecommendations results
+    private List<Recommendation>? _recommendationsCache;
+    private DateTime? _recommendationsCacheTime;
+    private static readonly TimeSpan RecommendationsCacheExpiration = TimeSpan.FromMinutes(2);
+
     public static readonly IDeserializer YamlDeserializer = new DeserializerBuilder()
         .WithNamingConvention(CamelCaseNamingConvention.Instance)
         .IgnoreUnmatchedProperties()
@@ -619,6 +624,23 @@ public class PlanReaderService(ConfigService config)
     /// <returns>List of all recommendations ordered by date (most recent first).</returns>
     public List<Recommendation> GetRecommendations()
     {
+        if (_recommendationsCache != null &&
+            _recommendationsCacheTime != null &&
+            DateTime.UtcNow - _recommendationsCacheTime.Value < RecommendationsCacheExpiration)
+        {
+            return _recommendationsCache;
+        }
+
+        var result = ComputeRecommendations();
+
+        _recommendationsCache = result;
+        _recommendationsCacheTime = DateTime.UtcNow;
+
+        return result;
+    }
+
+    private List<Recommendation> ComputeRecommendations()
+    {
         var recommendations = new List<Recommendation>();
 
         foreach (var (folderPath, folderName, planYamlPath) in EnumerateValidPlanFolders())
@@ -766,6 +788,10 @@ public class PlanReaderService(ConfigService config)
             item.DeclineReason = declineReason;
         }
         FileHelper.WriteAllText(recommendationsPath, YamlSerializer.Serialize(items));
+
+        // Invalidate cache after state change
+        _recommendationsCache = null;
+        _recommendationsCacheTime = null;
     }
 
     private static DateTime? ExtractCompletedTimestamp(string logFilePath)


### PR DESCRIPTION
# Summary

## Changes

Added a 2-minute time-based cache to `GetRecommendations()` in `PlanReaderService` to reduce repeated directory-wide I/O during polling. The cache is automatically invalidated when `UpdateRecommendationState()` modifies recommendation data.

## API Changes

- `GetRecommendations()` — now returns cached results within a 2-minute window (public signature unchanged)
- Added private `ComputeRecommendations()` — extracted original implementation

## Files Modified

- **Services:**
  - `src/tendril/Ivy.Tendril/Services/PlanReaderService.cs` — added cache fields, wrapped `GetRecommendations()` with cache logic, extracted `ComputeRecommendations()`, added cache invalidation in `UpdateRecommendationState()`
- **Tests:**
  - `src/tendril/Ivy.Tendril.Test/RecommendationServiceTests.cs` — added `GetRecommendations_CachesResultForTwoMinutes` and `UpdateRecommendationState_InvalidatesCache` tests

## Commits

- 6008f62d [01904] Add time-based cache to GetRecommendations for polling views