### PR TITLE
[01910] Add tooltips to LevelsSettings buttons for accessibility

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Settings/LevelsSettingsView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Settings/LevelsSettingsView.cs
@@ -28,13 +28,13 @@ public class LevelsSettingsView : ViewBase
             .Header(t => t.Index, "")
             .Builder(t => t.Index, f => f.Func<LevelRow, int>(idx =>
                 Layout.Horizontal().Gap(1)
-                    | new Button().Icon(Icons.Pencil).Outline().Small().OnClick(() =>
+                    | new Button().Icon(Icons.Pencil).Outline().Small().Tooltip("Edit this level").OnClick(() =>
                     {
                         editIndex.Set(idx);
                         editName.Set(levels[idx].Name);
                         editBadge.Set(levels[idx].Badge);
                     })
-                    | new Button().Icon(Icons.Trash).Outline().Small().OnClick(() =>
+                    | new Button().Icon(Icons.Trash).Outline().Small().Tooltip("Delete this level").OnClick(() =>
                     {
                         var name = levels[idx].Name;
                         levels.RemoveAt(idx);
@@ -43,7 +43,7 @@ public class LevelsSettingsView : ViewBase
                         refreshToken.Refresh();
                     })
                     | (idx > 0
-                        ? (object)new Button().Icon(Icons.ChevronUp).Ghost().Small().OnClick(() =>
+                        ? (object)new Button().Icon(Icons.ChevronUp).Ghost().Small().Tooltip("Move up").OnClick(() =>
                         {
                             (levels[idx], levels[idx - 1]) = (levels[idx - 1], levels[idx]);
                             config.SaveSettings();
@@ -51,7 +51,7 @@ public class LevelsSettingsView : ViewBase
                         })
                         : new Spacer().Width(Size.Units(0)))
                     | (idx < levels.Count - 1
-                        ? (object)new Button().Icon(Icons.ChevronDown).Ghost().Small().OnClick(() =>
+                        ? (object)new Button().Icon(Icons.ChevronDown).Ghost().Small().Tooltip("Move down").OnClick(() =>
                         {
                             (levels[idx], levels[idx + 1]) = (levels[idx + 1], levels[idx]);
                             config.SaveSettings();


### PR DESCRIPTION
# Summary

## Changes

Added `.Tooltip()` calls to all four action buttons in the LevelsSettings table: "Edit this level", "Delete this level", "Move up", and "Move down". This improves accessibility for icon-only buttons (ChevronUp/ChevronDown) and provides consistent hover information across all action buttons.

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/Apps/Settings/LevelsSettingsView.cs** — Added `.Tooltip()` to Edit, Delete, ChevronUp, and ChevronDown buttons

## Commits

- 8692c559 [01910] Add tooltips to LevelsSettings buttons for accessibility