### PR TITLE
[01907] Reorder Menu Recommendation Before Drafts

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/PlansApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/PlansApp.cs
@@ -4,7 +4,7 @@ using Ivy.Tendril.Services;
 
 namespace Ivy.Tendril.Apps;
 
-[App(title: "Drafts", icon: Icons.Feather, group: new[] { "Tools" }, order: 10)]
+[App(title: "Drafts", icon: Icons.Feather, group: new[] { "Tools" }, order: 15)]
 public class PlansApp : ViewBase
 {
     public override object? Build()

--- a/src/tendril/Ivy.Tendril/Apps/RecommendationsApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/RecommendationsApp.cs
@@ -2,7 +2,7 @@ using Ivy.Tendril.Services;
 
 namespace Ivy.Tendril.Apps;
 
-[App(title: "Recommendations", icon: Icons.Lightbulb, group: new[] { "Tools" }, order: 15)]
+[App(title: "Recommendations", icon: Icons.Lightbulb, group: new[] { "Tools" }, order: 10)]
 public class RecommendationsApp : ViewBase
 {
     public override object? Build()


### PR DESCRIPTION
# Summary

## Changes

Swapped the `order` values on the `[App]` attributes of `PlansApp` (Drafts) and `RecommendationsApp` so that Recommendations (order: 10) appears before Drafts (order: 15) in the Tendril sidebar menu.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Apps/PlansApp.cs` — changed order from 10 to 15
- `src/tendril/Ivy.Tendril/Apps/RecommendationsApp.cs` — changed order from 15 to 10

## Commits

- 1856329d [01907] Reorder menu: Recommendations before Drafts