### PR TITLE
[01902] Extract IPlanReaderService, IJobService, and IPlanWatcherService interfaces for testability

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/ServiceInterfaceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/ServiceInterfaceTests.cs
@@ -1,0 +1,48 @@
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Test;
+
+public class ServiceInterfaceTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public ServiceInterfaceTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"tendril-test-{Guid.NewGuid()}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    [Fact]
+    public void PlanReaderService_ImplementsIPlanReaderService()
+    {
+        var settings = new TendrilSettings();
+        var config = new ConfigService(settings, _tempDir);
+        var service = new PlanReaderService(config);
+
+        Assert.IsAssignableFrom<IPlanReaderService>(service);
+    }
+
+    [Fact]
+    public void JobService_ImplementsIJobService()
+    {
+        var service = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
+
+        Assert.IsAssignableFrom<IJobService>(service);
+    }
+
+    [Fact]
+    public void PlanWatcherService_ImplementsIPlanWatcherService()
+    {
+        var settings = new TendrilSettings();
+        var config = new ConfigService(settings, _tempDir);
+        using var service = new PlanWatcherService(config);
+
+        Assert.IsAssignableFrom<IPlanWatcherService>(service);
+    }
+}

--- a/src/tendril/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/tendril/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -59,7 +59,7 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
         var countsService = UseService<PlanCountsService>();
         var menuItems = UseState(() => BuildMenuItems(appRepository, countsService.Current));
         var counts = UseState(() => countsService.Current);
-        var jobService = UseService<JobService>();
+        var jobService = UseService<IJobService>();
         var sidebarOpen = UseState(settings.SidebarOpen);
         var args = UseService<AppContext>();
         var serverArgs = UseService<ServerArgs>();

--- a/src/tendril/Ivy.Tendril/Apps/DashboardApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/DashboardApp.cs
@@ -8,7 +8,7 @@ public class DashboardApp : ViewBase
 {
     public override object? Build()
     {
-        var planService = UseService<PlanReaderService>();
+        var planService = UseService<IPlanReaderService>();
         var configService = UseService<ConfigService>();
         var refreshToken = UseRefreshToken();
         UseInterval(() =>

--- a/src/tendril/Ivy.Tendril/Apps/Icebox/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Icebox/ContentView.cs
@@ -9,16 +9,16 @@ public class ContentView(
     PlanFile? selectedPlan,
     List<PlanFile> allPlans,
     IState<PlanFile?> selectedPlanState,
-    PlanReaderService planService,
-    JobService jobService,
+    IPlanReaderService planService,
+    IJobService jobService,
     Action refreshPlans,
     ConfigService config) : ViewBase
 {
     private readonly PlanFile? _selectedPlan = selectedPlan;
     private readonly List<PlanFile> _allPlans = allPlans;
     private readonly IState<PlanFile?> _selectedPlanState = selectedPlanState;
-    private readonly PlanReaderService _planService = planService;
-    private readonly JobService _jobService = jobService;
+    private readonly IPlanReaderService _planService = planService;
+    private readonly IJobService _jobService = jobService;
     private readonly Action _refreshPlans = refreshPlans;
     private readonly ConfigService _config = config;
 

--- a/src/tendril/Ivy.Tendril/Apps/Icebox/Dialogs/DeletePlanDialog.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Icebox/Dialogs/DeletePlanDialog.cs
@@ -6,12 +6,12 @@ namespace Ivy.Tendril.Apps.Icebox.Dialogs;
 public class DeletePlanDialog(
     IState<bool> dialogOpen,
     PlanFile selectedPlan,
-    PlanReaderService planService,
+    IPlanReaderService planService,
     Action refreshPlans) : ViewBase
 {
     private readonly IState<bool> _dialogOpen = dialogOpen;
     private readonly PlanFile _selectedPlan = selectedPlan;
-    private readonly PlanReaderService _planService = planService;
+    private readonly IPlanReaderService _planService = planService;
     private readonly Action _refreshPlans = refreshPlans;
 
     public override object? Build()

--- a/src/tendril/Ivy.Tendril/Apps/IceboxApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/IceboxApp.cs
@@ -9,10 +9,10 @@ public class IceboxApp : ViewBase
 {
     public override object? Build()
     {
-        var planService = UseService<PlanReaderService>();
-        var jobService = UseService<JobService>();
+        var planService = UseService<IPlanReaderService>();
+        var jobService = UseService<IJobService>();
         var configService = UseService<ConfigService>();
-        var planWatcher = UseService<PlanWatcherService>();
+        var planWatcher = UseService<IPlanWatcherService>();
         var selectedPlanState = UseState<PlanFile?>(null);
         var projectFilter = UseState<string?>(null);
         var levelFilter = UseState<string?>(null);

--- a/src/tendril/Ivy.Tendril/Apps/JobsApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/JobsApp.cs
@@ -10,8 +10,8 @@ public class JobsApp : ViewBase
 {
     public override object? Build()
     {
-        var jobService = UseService<JobService>();
-        var planService = UseService<PlanReaderService>();
+        var jobService = UseService<IJobService>();
+        var planService = UseService<IPlanReaderService>();
         var client = UseService<IClientProvider>();
         var refreshToken = UseRefreshToken();
         var showCommand = UseState<string?>(null);

--- a/src/tendril/Ivy.Tendril/Apps/Plans/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Plans/ContentView.cs
@@ -9,16 +9,16 @@ public class ContentView(
     PlanFile? selectedPlan,
     List<PlanFile> allPlans,
     IState<PlanFile?> selectedPlanState,
-    PlanReaderService planService,
-    JobService jobService,
+    IPlanReaderService planService,
+    IJobService jobService,
     Action refreshPlans,
     ConfigService config) : ViewBase
 {
     private readonly PlanFile? _selectedPlan = selectedPlan;
     private readonly List<PlanFile> _allPlans = allPlans;
     private readonly IState<PlanFile?> _selectedPlanState = selectedPlanState;
-    private readonly PlanReaderService _planService = planService;
-    private readonly JobService _jobService = jobService;
+    private readonly IPlanReaderService _planService = planService;
+    private readonly IJobService _jobService = jobService;
     private readonly Action _refreshPlans = refreshPlans;
     private readonly ConfigService _config = config;
 

--- a/src/tendril/Ivy.Tendril/Apps/Plans/Dialogs/CreateIssueDialog.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Plans/Dialogs/CreateIssueDialog.cs
@@ -9,7 +9,7 @@ public class CreateIssueDialog(
     IState<string[]> issueLabelsState,
     IState<string> issueCommentState,
     PlanFile selectedPlan,
-    JobService jobService) : ViewBase
+    IJobService jobService) : ViewBase
 {
     private readonly IState<bool> _dialogOpen = dialogOpen;
     private readonly IState<string?> _selectedRepoState = selectedRepoState;
@@ -17,7 +17,7 @@ public class CreateIssueDialog(
     private readonly IState<string[]> _issueLabelsState = issueLabelsState;
     private readonly IState<string> _issueCommentState = issueCommentState;
     private readonly PlanFile _selectedPlan = selectedPlan;
-    private readonly JobService _jobService = jobService;
+    private readonly IJobService _jobService = jobService;
 
     public override object? Build()
     {

--- a/src/tendril/Ivy.Tendril/Apps/Plans/Dialogs/DeletePlanDialog.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Plans/Dialogs/DeletePlanDialog.cs
@@ -5,12 +5,12 @@ namespace Ivy.Tendril.Apps.Plans.Dialogs;
 public class DeletePlanDialog(
     IState<bool> dialogOpen,
     PlanFile selectedPlan,
-    PlanReaderService planService,
+    IPlanReaderService planService,
     Action refreshPlans) : ViewBase
 {
     private readonly IState<bool> _dialogOpen = dialogOpen;
     private readonly PlanFile _selectedPlan = selectedPlan;
-    private readonly PlanReaderService _planService = planService;
+    private readonly IPlanReaderService _planService = planService;
     private readonly Action _refreshPlans = refreshPlans;
 
     public override object? Build()

--- a/src/tendril/Ivy.Tendril/Apps/Plans/Dialogs/UpdatePlanDialog.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Plans/Dialogs/UpdatePlanDialog.cs
@@ -6,15 +6,15 @@ public class UpdatePlanDialog(
     IState<bool> dialogOpen,
     IState<string> updateText,
     PlanFile selectedPlan,
-    JobService jobService,
-    PlanReaderService planService,
+    IJobService jobService,
+    IPlanReaderService planService,
     Action refreshPlans) : ViewBase
 {
     private readonly IState<bool> _dialogOpen = dialogOpen;
     private readonly IState<string> _updateText = updateText;
     private readonly PlanFile _selectedPlan = selectedPlan;
-    private readonly JobService _jobService = jobService;
-    private readonly PlanReaderService _planService = planService;
+    private readonly IJobService _jobService = jobService;
+    private readonly IPlanReaderService _planService = planService;
     private readonly Action _refreshPlans = refreshPlans;
 
     public override object? Build()

--- a/src/tendril/Ivy.Tendril/Apps/PlansApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/PlansApp.cs
@@ -9,10 +9,10 @@ public class PlansApp : ViewBase
 {
     public override object? Build()
     {
-        var planService = UseService<PlanReaderService>();
-        var jobService = UseService<JobService>();
+        var planService = UseService<IPlanReaderService>();
+        var jobService = UseService<IJobService>();
         var configService = UseService<ConfigService>();
-        var planWatcher = UseService<PlanWatcherService>();
+        var planWatcher = UseService<IPlanWatcherService>();
         var selectedPlanState = UseState<PlanFile?>(null);
         var projectFilter = UseState<string?>(null);
         var levelFilter = UseState<string?>(null);

--- a/src/tendril/Ivy.Tendril/Apps/PullRequestApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/PullRequestApp.cs
@@ -9,7 +9,7 @@ public class PullRequestApp : ViewBase
 {
     public override object? Build()
     {
-        var planService = UseService<PlanReaderService>();
+        var planService = UseService<IPlanReaderService>();
         var refreshToken = UseRefreshToken();
         var nav = this.UseNavigation();
         var showPlan = UseState<string?>(null);

--- a/src/tendril/Ivy.Tendril/Apps/Recommendations/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Recommendations/ContentView.cs
@@ -7,15 +7,15 @@ public class ContentView(
     Recommendation? selectedRecommendation,
     List<Recommendation> allRecommendations,
     IState<Recommendation?> selectedState,
-    PlanReaderService planService,
-    JobService jobService,
+    IPlanReaderService planService,
+    IJobService jobService,
     Action refresh) : ViewBase
 {
     private readonly Recommendation? _selected = selectedRecommendation;
     private readonly List<Recommendation> _all = allRecommendations;
     private readonly IState<Recommendation?> _selectedState = selectedState;
-    private readonly PlanReaderService _planService = planService;
-    private readonly JobService _jobService = jobService;
+    private readonly IPlanReaderService _planService = planService;
+    private readonly IJobService _jobService = jobService;
     private readonly Action _refresh = refresh;
 
     public override object? Build()

--- a/src/tendril/Ivy.Tendril/Apps/RecommendationsApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/RecommendationsApp.cs
@@ -7,8 +7,8 @@ public class RecommendationsApp : ViewBase
 {
     public override object? Build()
     {
-        var planService = UseService<PlanReaderService>();
-        var jobService = UseService<JobService>();
+        var planService = UseService<IPlanReaderService>();
+        var jobService = UseService<IJobService>();
         var refreshToken = UseRefreshToken();
         var selectedState = UseState<Recommendation?>(null);
         var projectFilter = UseState<string?>(null);

--- a/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -13,8 +13,8 @@ public class ContentView(
     PlanFile? selectedPlan,
     List<PlanFile> allPlans,
     IState<PlanFile?> selectedPlanState,
-    PlanReaderService planService,
-    JobService jobService,
+    IPlanReaderService planService,
+    IJobService jobService,
     Action refreshPlans,
     ConfigService config,
     GitService gitService) : ViewBase
@@ -22,8 +22,8 @@ public class ContentView(
     private readonly PlanFile? _selectedPlan = selectedPlan;
     private readonly List<PlanFile> _allPlans = allPlans;
     private readonly IState<PlanFile?> _selectedPlanState = selectedPlanState;
-    private readonly PlanReaderService _planService = planService;
-    private readonly JobService _jobService = jobService;
+    private readonly IPlanReaderService _planService = planService;
+    private readonly IJobService _jobService = jobService;
     private readonly Action _refreshPlans = refreshPlans;
     private readonly ConfigService _config = config;
     private readonly GitService _gitService = gitService;

--- a/src/tendril/Ivy.Tendril/Apps/Review/Dialogs/DiscardPlanDialog.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Review/Dialogs/DiscardPlanDialog.cs
@@ -6,12 +6,12 @@ namespace Ivy.Tendril.Apps.Review.Dialogs;
 public class DiscardPlanDialog(
     IState<bool> dialogOpen,
     PlanFile selectedPlan,
-    PlanReaderService planService,
+    IPlanReaderService planService,
     Action refreshPlans) : ViewBase
 {
     private readonly IState<bool> _dialogOpen = dialogOpen;
     private readonly PlanFile _selectedPlan = selectedPlan;
-    private readonly PlanReaderService _planService = planService;
+    private readonly IPlanReaderService _planService = planService;
     private readonly Action _refreshPlans = refreshPlans;
 
     public override object? Build()

--- a/src/tendril/Ivy.Tendril/Apps/ReviewApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/ReviewApp.cs
@@ -9,11 +9,11 @@ public class ReviewApp : ViewBase
 {
     public override object? Build()
     {
-        var planService = UseService<PlanReaderService>();
-        var jobService = UseService<JobService>();
+        var planService = UseService<IPlanReaderService>();
+        var jobService = UseService<IJobService>();
         var configService = UseService<ConfigService>();
         var gitService = UseService<GitService>();
-        var planWatcher = UseService<PlanWatcherService>();
+        var planWatcher = UseService<IPlanWatcherService>();
         var selectedPlanState = UseState<PlanFile?>(null);
         var textFilter = UseState<string?>("");
         var refreshToken = UseRefreshToken();

--- a/src/tendril/Ivy.Tendril/Apps/TrashApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/TrashApp.cs
@@ -10,7 +10,7 @@ public class TrashApp : ViewBase
     public override object? Build()
     {
         var configService = UseService<ConfigService>();
-        var jobService = UseService<JobService>();
+        var jobService = UseService<IJobService>();
         var client = UseService<IClientProvider>();
         var refreshToken = UseRefreshToken();
         var selectedFile = UseState<string?>(null);

--- a/src/tendril/Ivy.Tendril/Program.cs
+++ b/src/tendril/Ivy.Tendril/Program.cs
@@ -54,6 +54,7 @@ server.Services.AddSingleton<PlanReaderService>(sp =>
     planService.RecoverStuckPlans();
     return planService;
 });
+server.Services.AddSingleton<IPlanReaderService>(sp => sp.GetRequiredService<PlanReaderService>());
 server.Services.AddSingleton<TelemetryService>(sp =>
 {
     var config = sp.GetRequiredService<ConfigService>();
@@ -66,22 +67,24 @@ server.Services.AddSingleton<JobService>(sp =>
     jobService.SetTelemetryService(sp.GetRequiredService<TelemetryService>());
     return jobService;
 });
+server.Services.AddSingleton<IJobService>(sp => sp.GetRequiredService<JobService>());
 server.Services.AddSingleton<PlanWatcherService>(sp =>
 {
     var config = sp.GetRequiredService<ConfigService>();
     return new PlanWatcherService(config);
 });
+server.Services.AddSingleton<IPlanWatcherService>(sp => sp.GetRequiredService<PlanWatcherService>());
 server.Services.AddSingleton<PlanCountsService>(sp =>
 {
-    var planReader = sp.GetRequiredService<PlanReaderService>();
-    var jobService = sp.GetRequiredService<JobService>();
-    var planWatcher = sp.GetRequiredService<PlanWatcherService>();
+    var planReader = sp.GetRequiredService<IPlanReaderService>();
+    var jobService = sp.GetRequiredService<IJobService>();
+    var planWatcher = sp.GetRequiredService<IPlanWatcherService>();
     return new PlanCountsService(planReader, jobService, planWatcher);
 });
 server.Services.AddSingleton<InboxWatcherService>(sp =>
 {
     var config = sp.GetRequiredService<ConfigService>();
-    var jobService = sp.GetRequiredService<JobService>();
+    var jobService = sp.GetRequiredService<IJobService>();
     return new InboxWatcherService(config, jobService);
 });
 server.UseWebApplication(app =>

--- a/src/tendril/Ivy.Tendril/Services/IJobService.cs
+++ b/src/tendril/Ivy.Tendril/Services/IJobService.cs
@@ -1,0 +1,23 @@
+using System.Collections.Concurrent;
+using Ivy.Tendril.Apps.Jobs;
+
+namespace Ivy.Tendril.Services;
+
+public interface IJobService
+{
+    event Action? JobsChanged;
+    ConcurrentQueue<JobNotification> PendingNotifications { get; }
+
+    void SetPlanReaderService(PlanReaderService planReaderService);
+    void SetTelemetryService(TelemetryService telemetryService);
+    string StartJob(string type, string[] args, string? inboxFilePath);
+    string StartJob(string type, params string[] args);
+    void CompleteJob(string id, int? exitCode, bool timedOut = false, bool staleOutput = false);
+    void StopJob(string id);
+    void DeleteJob(string id);
+    void ClearCompletedJobs();
+    void ClearFailedJobs();
+    List<JobItem> GetJobs();
+    JobItem? GetJob(string id);
+    bool IsInboxFileTracked(string filePath);
+}

--- a/src/tendril/Ivy.Tendril/Services/IPlanReaderService.cs
+++ b/src/tendril/Ivy.Tendril/Services/IPlanReaderService.cs
@@ -1,0 +1,30 @@
+using Ivy.Tendril.Apps.Plans;
+
+namespace Ivy.Tendril.Services;
+
+public interface IPlanReaderService
+{
+    string PlansDirectory { get; }
+
+    void RecoverStuckPlans();
+    void RepairPlans();
+    List<PlanFile> GetPlans(PlanStatus? statusFilter = null);
+    PlanFile? GetPlanByFolder(string folderPath);
+    List<PlanFile> GetIceboxPlans();
+    void TransitionState(string folderName, PlanStatus newState);
+    void SaveRevision(string folderName, string content);
+    string ReadLatestRevision(string folderName);
+    List<(int Number, string Content, DateTime Modified)> GetRevisions(string folderName);
+    void AddLog(string folderName, string action, string content);
+    void DeletePlan(string folderName);
+    string ReadRawPlan(string folderName);
+    void SavePlan(string folderName, string fullContent);
+    void UpdateLatestRevision(string folderName, string content);
+    decimal GetPlanTotalCost(string folderPath);
+    int GetPlanTotalTokens(string folderPath);
+    List<HourlyTokenBurn> GetHourlyTokenBurn(int days = 7);
+    List<Recommendation> GetRecommendations();
+    int GetPendingRecommendationsCount();
+    PlanReaderService.PlanCountSnapshot ComputePlanCounts();
+    void UpdateRecommendationState(string planFolderName, string recommendationTitle, string newState, string? declineReason = null);
+}

--- a/src/tendril/Ivy.Tendril/Services/IPlanWatcherService.cs
+++ b/src/tendril/Ivy.Tendril/Services/IPlanWatcherService.cs
@@ -1,0 +1,6 @@
+namespace Ivy.Tendril.Services;
+
+public interface IPlanWatcherService : IDisposable
+{
+    event Action? PlansChanged;
+}

--- a/src/tendril/Ivy.Tendril/Services/InboxWatcherService.cs
+++ b/src/tendril/Ivy.Tendril/Services/InboxWatcherService.cs
@@ -4,13 +4,13 @@ namespace Ivy.Tendril.Services;
 
 public class InboxWatcherService : IDisposable
 {
-    private readonly JobService _jobService;
+    private readonly IJobService _jobService;
     private readonly FileSystemWatcher? _watcher;
     private readonly string _inboxPath;
     private readonly Timer _pollTimer;
     private readonly ConcurrentDictionary<string, byte> _processing = new();
 
-    public InboxWatcherService(ConfigService config, JobService jobService)
+    public InboxWatcherService(ConfigService config, IJobService jobService)
     {
         _jobService = jobService;
         _inboxPath = Path.Combine(config.TendrilHome, "Inbox");

--- a/src/tendril/Ivy.Tendril/Services/JobService.cs
+++ b/src/tendril/Ivy.Tendril/Services/JobService.cs
@@ -7,7 +7,7 @@ namespace Ivy.Tendril.Services;
 
 public record JobNotification(string Title, string Message, bool IsSuccess);
 
-public class JobService
+public class JobService : IJobService
 {
     private readonly ConcurrentDictionary<string, JobItem> _jobs = new();
     private readonly ConcurrentQueue<string> _jobQueue = new();

--- a/src/tendril/Ivy.Tendril/Services/PlanCountsService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanCountsService.cs
@@ -4,16 +4,16 @@ public record PlanCounts(int Drafts, int ActiveJobs, int Reviews, int Icebox, in
 
 public class PlanCountsService : IDisposable
 {
-    private readonly PlanReaderService _planReaderService;
-    private readonly JobService _jobService;
-    private readonly PlanWatcherService _planWatcher;
+    private readonly IPlanReaderService _planReaderService;
+    private readonly IJobService _jobService;
+    private readonly IPlanWatcherService _planWatcher;
     private PlanCounts _current;
 
     public event Action? CountsChanged;
 
     public PlanCounts Current => _current;
 
-    public PlanCountsService(PlanReaderService planReaderService, JobService jobService, PlanWatcherService planWatcher)
+    public PlanCountsService(IPlanReaderService planReaderService, IJobService jobService, IPlanWatcherService planWatcher)
     {
         _planReaderService = planReaderService;
         _jobService = jobService;

--- a/src/tendril/Ivy.Tendril/Services/PlanDownloadHelper.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanDownloadHelper.cs
@@ -4,7 +4,7 @@ namespace Ivy.Tendril.Services;
 
 public static class PlanDownloadHelper
 {
-    public static IState<string?> UsePlanDownload(IViewContext context, PlanReaderService planService, PlanFile? plan)
+    public static IState<string?> UsePlanDownload(IViewContext context, IPlanReaderService planService, PlanFile? plan)
     {
         var pdfService = new PlanPdfService();
         var planRef = context.UseRef<PlanFile?>(plan);

--- a/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
@@ -7,7 +7,7 @@ using YamlDotNet.Serialization.NamingConventions;
 
 namespace Ivy.Tendril.Services;
 
-public class PlanReaderService(ConfigService config)
+public class PlanReaderService(ConfigService config) : IPlanReaderService
 {
     private readonly ConfigService _config = config;
 

--- a/src/tendril/Ivy.Tendril/Services/PlanWatcherService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanWatcherService.cs
@@ -1,6 +1,6 @@
 namespace Ivy.Tendril.Services;
 
-public class PlanWatcherService : IDisposable
+public class PlanWatcherService : IPlanWatcherService, IDisposable
 {
     private readonly FileSystemWatcher? _watcher;
     private readonly System.Timers.Timer _debounceTimer;

--- a/src/tendril/Ivy.Tendril/Views/NewPlanButton.cs
+++ b/src/tendril/Ivy.Tendril/Views/NewPlanButton.cs
@@ -7,7 +7,7 @@ public class NewPlanButton : ViewBase
 {
     public override object? Build()
     {
-        var jobService = UseService<JobService>();
+        var jobService = UseService<IJobService>();
         var configService = UseService<ConfigService>();
         var dialogOpen = UseState(false);
         var lastSelectedProject = UseState("[Auto]");


### PR DESCRIPTION
# Summary

## Changes

Extracted `IPlanReaderService`, `IJobService`, and `IPlanWatcherService` interfaces from the concrete service classes. Updated all 26 consumer files (apps, dialogs, views, services) to depend on interfaces instead of concrete types. Registered interface-to-concrete mappings in the DI container. Added `ServiceInterfaceTests` verifying all three classes implement their interfaces.

## API Changes

- New `IPlanReaderService` interface — mirrors all public methods of `PlanReaderService`
- New `IJobService` interface — mirrors all public methods of `JobService`
- New `IPlanWatcherService` interface — extends `IDisposable`, exposes `PlansChanged` event
- `PlanReaderService` now implements `IPlanReaderService`
- `JobService` now implements `IJobService`
- `PlanWatcherService` now implements `IPlanWatcherService`
- `PlanCountsService` constructor changed from `(PlanReaderService, JobService, PlanWatcherService)` to `(IPlanReaderService, IJobService, IPlanWatcherService)`
- `InboxWatcherService` constructor changed from `(ConfigService, JobService)` to `(ConfigService, IJobService)`
- `PlanDownloadHelper.UsePlanDownload` parameter changed from `PlanReaderService` to `IPlanReaderService`

## Files Modified

- **New interfaces:** `Services/IPlanReaderService.cs`, `Services/IJobService.cs`, `Services/IPlanWatcherService.cs`
- **Concrete classes:** `Services/PlanReaderService.cs`, `Services/JobService.cs`, `Services/PlanWatcherService.cs`
- **DI registration:** `Program.cs`
- **Services:** `PlanCountsService.cs`, `InboxWatcherService.cs`, `PlanDownloadHelper.cs`
- **Apps:** `PlansApp.cs`, `JobsApp.cs`, `ReviewApp.cs`, `RecommendationsApp.cs`, `TrashApp.cs`, `IceboxApp.cs`, `PullRequestApp.cs`, `DashboardApp.cs`
- **Views/Shell:** `TendrilAppShell.cs`, `NewPlanButton.cs`
- **ContentViews:** `Plans/ContentView.cs`, `Review/ContentView.cs`, `Recommendations/ContentView.cs`, `Icebox/ContentView.cs`
- **Dialogs:** `UpdatePlanDialog.cs`, `CreateIssueDialog.cs`, `DeletePlanDialog.cs` (Plans + Icebox), `DiscardPlanDialog.cs`
- **Tests:** `ServiceInterfaceTests.cs` (new)

## Commits

- 3fa0e534 [01902] Extract IPlanReaderService, IJobService, and IPlanWatcherService interfaces