### PR TITLE
[01912] Disable Save button when no changes in General Settings

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Settings/GeneralSettingsView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Settings/GeneralSettingsView.cs
@@ -19,13 +19,16 @@ public class GeneralSettingsView : ViewBase
                 .Language(Languages.Markdown)
                 .Height(Size.Units(40))
                 .WithField().Label("Plan Template")
-            | new Button("Save").Primary().OnClick(() =>
-            {
-                config.Settings.AgentCommand = agentCommand.Value;
-                config.Settings.PlanTemplate = planTemplate.Value;
-                config.SaveSettings();
-                client.Toast("Settings saved successfully", "Saved");
-            });
+            | new Button("Save").Primary()
+                .Disabled(agentCommand.Value == config.Settings.AgentCommand
+                          && planTemplate.Value == config.Settings.PlanTemplate)
+                .OnClick(() =>
+                {
+                    config.Settings.AgentCommand = agentCommand.Value;
+                    config.Settings.PlanTemplate = planTemplate.Value;
+                    config.SaveSettings();
+                    client.Toast("Settings saved successfully", "Saved");
+                });
 
         return form;
     }


### PR DESCRIPTION
# Summary

## Changes

Added `.Disabled()` to the Save button in `GeneralSettingsView` so it is disabled when the current form values match the original configuration values. The button becomes enabled only when the user modifies either the Agent Command or Plan Template field.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Apps/Settings/GeneralSettingsView.cs` — Added `.Disabled()` condition comparing state values to config values

## Commits

- 8e95fa62 [01912] Disable Save button when no changes in General Settings