### PR TITLE
[01909] JobService JobsChanged Event Thread Safety Issue

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/JobServiceThreadSafetyTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/JobServiceThreadSafetyTests.cs
@@ -1,0 +1,133 @@
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Test;
+
+public class JobServiceThreadSafetyTests
+{
+    private static JobService CreateServiceWithQueuedJob(out string jobId)
+    {
+        // Use maxConcurrentJobs=1 and start a fake job that gets queued by filling the slot first
+        var service = new JobService(
+            TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
+            inboxPath: null, maxConcurrentJobs: 1);
+
+        // Start a job that will try to launch (and fail since no script exists).
+        // Use try/catch since process launch may throw in test environment.
+        string id;
+        try
+        {
+            id = service.StartJob("MakePlan", "-Description", "Slot filler");
+        }
+        catch
+        {
+            // Even if the process fails to launch, the job was created
+            id = "job-001";
+        }
+
+        jobId = id;
+        return service;
+    }
+
+    [Fact]
+    public void JobsChanged_FiresOnSyncContext_WhenAvailable()
+    {
+        var testContext = new TestSynchronizationContext();
+        SynchronizationContext.SetSynchronizationContext(testContext);
+        try
+        {
+            var service = new JobService(
+                TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
+                inboxPath: null, maxConcurrentJobs: 1);
+
+            var invoked = false;
+            service.JobsChanged += () => invoked = true;
+
+            // DeleteJob triggers RaiseJobsChanged — safe since no process is involved
+            service.DeleteJob("nonexistent-id");
+
+            // The event should have been posted to the sync context, not invoked directly
+            Assert.False(invoked, "Handler should not be invoked synchronously when sync context is present");
+            Assert.Equal(1, testContext.PostCount);
+
+            // Execute the posted callback
+            testContext.ExecutePending();
+            Assert.True(invoked, "Handler should be invoked after sync context executes the callback");
+        }
+        finally
+        {
+            SynchronizationContext.SetSynchronizationContext(null);
+        }
+    }
+
+    [Fact]
+    public void JobsChanged_FiresSynchronously_WhenNoSyncContext()
+    {
+        SynchronizationContext.SetSynchronizationContext(null);
+
+        var service = new JobService(
+            TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
+            inboxPath: null, maxConcurrentJobs: 1);
+
+        var invoked = false;
+        service.JobsChanged += () => invoked = true;
+
+        // DeleteJob triggers RaiseJobsChanged
+        service.DeleteJob("nonexistent-id");
+
+        Assert.True(invoked, "Handler should be invoked synchronously when no sync context is present");
+    }
+
+    [Fact]
+    public void JobsChanged_MultipleRapidInvocations_AllPostedToSyncContext()
+    {
+        var testContext = new TestSynchronizationContext();
+        SynchronizationContext.SetSynchronizationContext(testContext);
+        try
+        {
+            var service = new JobService(
+                TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
+                inboxPath: null, maxConcurrentJobs: 1);
+
+            var invokeCount = 0;
+            service.JobsChanged += () => Interlocked.Increment(ref invokeCount);
+
+            // Multiple deletes each raise RaiseJobsChanged
+            service.DeleteJob("id-1");
+            service.DeleteJob("id-2");
+            service.DeleteJob("id-3");
+
+            // All should be posted, not invoked yet
+            Assert.Equal(0, invokeCount);
+            Assert.Equal(3, testContext.PostCount);
+
+            // Execute all pending callbacks
+            testContext.ExecutePending();
+            Assert.Equal(3, invokeCount);
+        }
+        finally
+        {
+            SynchronizationContext.SetSynchronizationContext(null);
+        }
+    }
+
+    private class TestSynchronizationContext : SynchronizationContext
+    {
+        private readonly Queue<(SendOrPostCallback Callback, object? State)> _pending = new();
+        public int PostCount { get; private set; }
+
+        public override void Post(SendOrPostCallback d, object? state)
+        {
+            PostCount++;
+            _pending.Enqueue((d, state));
+        }
+
+        public void ExecutePending()
+        {
+            while (_pending.Count > 0)
+            {
+                var (callback, state) = _pending.Dequeue();
+                callback(state);
+            }
+        }
+    }
+}

--- a/src/tendril/Ivy.Tendril/Services/JobService.cs
+++ b/src/tendril/Ivy.Tendril/Services/JobService.cs
@@ -22,6 +22,7 @@ public class JobService
     private readonly SemaphoreSlim _jobSlotSemaphore;
 
     private readonly string? _inboxPath;
+    private readonly SynchronizationContext? _syncContext;
 
     public event Action? JobsChanged;
     public ConcurrentQueue<JobNotification> PendingNotifications { get; } = new();
@@ -45,6 +46,7 @@ public class JobService
 
     public JobService(ConfigService configService, ModelPricingService? modelPricingService = null)
     {
+        _syncContext = SynchronizationContext.Current;
         _configService = configService;
         _modelPricingService = modelPricingService;
         _jobTimeout = TimeSpan.FromMinutes(configService.Settings.JobTimeout);
@@ -56,6 +58,7 @@ public class JobService
 
     public JobService(TimeSpan jobTimeout, TimeSpan staleOutputTimeout, string? inboxPath = null, int maxConcurrentJobs = 5)
     {
+        _syncContext = SynchronizationContext.Current;
         _jobTimeout = jobTimeout;
         _staleOutputTimeout = staleOutputTimeout;
         _maxConcurrentJobs = maxConcurrentJobs;
@@ -71,6 +74,18 @@ public class JobService
     public void SetTelemetryService(TelemetryService telemetryService)
     {
         _telemetryService = telemetryService;
+    }
+
+    private void RaiseJobsChanged()
+    {
+        if (_syncContext != null)
+        {
+            _syncContext.Post(_ => JobsChanged?.Invoke(), null);
+        }
+        else
+        {
+            JobsChanged?.Invoke();
+        }
     }
 
     public string StartJob(string type, string[] args, string? inboxFilePath)
@@ -170,7 +185,7 @@ public class JobService
                 ResetPlanStateToBlocked(job);
 
                 PendingNotifications.Enqueue(new JobNotification("Job Blocked", $"{planFile}: {blockReason}", false));
-                JobsChanged?.Invoke();
+                RaiseJobsChanged();
                 return id;
             }
         }
@@ -181,7 +196,7 @@ public class JobService
             job.Status = "Queued";
             job.StatusMessage = $"Waiting (max {_maxConcurrentJobs} concurrent jobs)";
             _jobQueue.Enqueue(id);
-            JobsChanged?.Invoke();
+            RaiseJobsChanged();
             return id;
         }
 
@@ -301,7 +316,7 @@ public class JobService
             _ = RunStaleOutputWatchdog(id, cts);
         }
 
-        JobsChanged?.Invoke();
+        RaiseJobsChanged();
     }
 
     internal void RunHooks(string when, string jobType, string planFolder, string project, JobItem job)
@@ -495,7 +510,7 @@ public class JobService
                         if (_jobs.TryGetValue(jobId, out var j))
                         {
                             j.Cost = (decimal)costCalc.TotalCost;
-                            JobsChanged?.Invoke();
+                            RaiseJobsChanged();
                         }
 
                         if (jobArgs.Length > 0)
@@ -508,7 +523,7 @@ public class JobService
             });
         }
 
-        JobsChanged?.Invoke();
+        RaiseJobsChanged();
 
         // Try to start queued jobs now that a slot is free
         ProcessJobQueue();
@@ -536,7 +551,7 @@ public class JobService
 
         CleanupInboxFile(job);
         ResetPlanState(job);
-        JobsChanged?.Invoke();
+        RaiseJobsChanged();
 
         // Try to start queued jobs now that a slot is free
         if (wasRunning)
@@ -546,7 +561,7 @@ public class JobService
     public void DeleteJob(string id)
     {
         _jobs.TryRemove(id, out _);
-        JobsChanged?.Invoke();
+        RaiseJobsChanged();
     }
 
     public void ClearCompletedJobs()
@@ -558,7 +573,7 @@ public class JobService
         foreach (var id in completedIds)
             _jobs.TryRemove(id, out _);
         if (completedIds.Count > 0)
-            JobsChanged?.Invoke();
+            RaiseJobsChanged();
     }
 
     public void ClearFailedJobs()
@@ -570,7 +585,7 @@ public class JobService
         foreach (var id in failedIds)
             _jobs.TryRemove(id, out _);
         if (failedIds.Count > 0)
-            JobsChanged?.Invoke();
+            RaiseJobsChanged();
     }
 
     public List<JobItem> GetJobs()


### PR DESCRIPTION
# Summary

## Changes

Added thread-safe marshalling of the `JobsChanged` event in `JobService`. The service now captures `SynchronizationContext.Current` during construction and uses `Post()` to marshal all event invocations to the captured context. When no synchronization context is available, invocations fall back to direct synchronous calls.

## API Changes

None. The public `event Action? JobsChanged` signature is unchanged. The marshalling is transparent to subscribers.

## Files Modified

- **src/tendril/Ivy.Tendril/Services/JobService.cs** — Added `_syncContext` field, capture in both constructors, `RaiseJobsChanged()` helper method, replaced all 8 `JobsChanged?.Invoke()` call sites
- **src/tendril/Ivy.Tendril.Test/JobServiceThreadSafetyTests.cs** — New test class with 3 tests verifying sync context marshalling, synchronous fallback, and multiple rapid invocations

## Commits

- [01909] Marshal JobsChanged event to SynchronizationContext for thread safety (7e594628)