### PR TITLE
[01922] PendingNotifications Queue Thread Safety and Delivery

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/JobServiceNotificationTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/JobServiceNotificationTests.cs
@@ -1,3 +1,4 @@
+#pragma warning disable CS0618 // PendingNotifications is obsolete — these tests verify backward compatibility
 using Ivy.Tendril.Services;
 
 namespace Ivy.Tendril.Test;

--- a/src/tendril/Ivy.Tendril.Test/JobServiceNotificationThreadSafetyTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/JobServiceNotificationThreadSafetyTests.cs
@@ -1,0 +1,136 @@
+using System.Collections.Concurrent;
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Test;
+
+public class JobServiceNotificationThreadSafetyTests
+{
+    [Fact]
+    public void NotificationReady_FiresOnSyncContext_WhenAvailable()
+    {
+        var testContext = new TestSynchronizationContext();
+        SynchronizationContext.SetSynchronizationContext(testContext);
+        try
+        {
+            var service = new JobService(
+                TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
+                inboxPath: null, maxConcurrentJobs: 1);
+
+            JobNotification? received = null;
+            service.NotificationReady += n => received = n;
+
+            // Start a job and complete it to trigger notification
+            var id = service.StartJob("MakePr", Path.GetTempPath());
+            service.CompleteJob(id, exitCode: 0);
+
+            // The notification should have been posted to the sync context, not invoked directly
+            Assert.Null(received);
+            Assert.True(testContext.PostCount > 0, "Expected at least one Post to sync context");
+
+            // Execute the posted callbacks
+            testContext.ExecutePending();
+            Assert.NotNull(received);
+            Assert.Equal("MakePr Completed", received.Title);
+            Assert.True(received.IsSuccess);
+        }
+        finally
+        {
+            SynchronizationContext.SetSynchronizationContext(null);
+        }
+    }
+
+    [Fact]
+    public void NotificationReady_FiresSynchronously_WhenNoSyncContext()
+    {
+        SynchronizationContext.SetSynchronizationContext(null);
+
+        var service = new JobService(
+            TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
+            inboxPath: null, maxConcurrentJobs: 1);
+
+        JobNotification? received = null;
+        service.NotificationReady += n => received = n;
+
+        var id = service.StartJob("MakePr", Path.GetTempPath());
+        service.CompleteJob(id, exitCode: 0);
+
+        Assert.NotNull(received);
+        Assert.Equal("MakePr Completed", received.Title);
+        Assert.True(received.IsSuccess);
+    }
+
+    [Fact]
+    public void NotificationReady_MultipleRapidNotifications_PreserveOrder()
+    {
+        SynchronizationContext.SetSynchronizationContext(null);
+
+        var service = new JobService(
+            TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
+            inboxPath: null, maxConcurrentJobs: 10);
+
+        var notifications = new ConcurrentQueue<JobNotification>();
+        service.NotificationReady += n => notifications.Enqueue(n);
+
+        // Complete multiple jobs rapidly
+        var ids = new List<string>();
+        for (var i = 0; i < 5; i++)
+        {
+            ids.Add(service.StartJob("MakePr", Path.GetTempPath()));
+        }
+
+        foreach (var id in ids)
+        {
+            service.CompleteJob(id, exitCode: 0);
+        }
+
+        Assert.Equal(5, notifications.Count);
+
+        // All should be "MakePr Completed"
+        while (notifications.TryDequeue(out var n))
+        {
+            Assert.Equal("MakePr Completed", n.Title);
+            Assert.True(n.IsSuccess);
+        }
+    }
+
+    [Fact]
+    public void NotificationReady_FailedJob_DeliversFailureNotification()
+    {
+        SynchronizationContext.SetSynchronizationContext(null);
+
+        var service = new JobService(
+            TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
+            inboxPath: null, maxConcurrentJobs: 1);
+
+        JobNotification? received = null;
+        service.NotificationReady += n => received = n;
+
+        var id = service.StartJob("ExecutePlan", Path.GetTempPath());
+        service.CompleteJob(id, exitCode: 1);
+
+        Assert.NotNull(received);
+        Assert.Equal("ExecutePlan Failed", received.Title);
+        Assert.False(received.IsSuccess);
+    }
+
+    private class TestSynchronizationContext : SynchronizationContext
+    {
+        private readonly Queue<(SendOrPostCallback Callback, object? State)> _pending = new();
+        public int PostCount { get; private set; }
+
+        public override void Post(SendOrPostCallback d, object? state)
+        {
+            PostCount++;
+            _pending.Enqueue((d, state));
+        }
+
+        public void ExecutePending()
+        {
+            while (_pending.Count > 0)
+            {
+                var (callback, state) = _pending.Dequeue();
+                callback(state);
+            }
+        }
+    }
+}

--- a/src/tendril/Ivy.Tendril.Test/JobServiceTimeoutTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/JobServiceTimeoutTests.cs
@@ -1,3 +1,4 @@
+#pragma warning disable CS0618 // PendingNotifications is obsolete — these tests verify backward compatibility
 using Ivy.Tendril.Services;
 
 namespace Ivy.Tendril.Test;

--- a/src/tendril/Ivy.Tendril/Apps/JobsApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/JobsApp.cs
@@ -1,3 +1,4 @@
+using System.Reactive.Disposables;
 using System.Text.RegularExpressions;
 using Ivy.Tendril.Apps.Jobs;
 using Ivy.Tendril.Apps.Plans;
@@ -19,17 +20,19 @@ public class JobsApp : ViewBase
         var showPlan = UseState<string?>(null);
         var openFile = UseState<string?>(null);
         var config = UseService<IConfigService>();
-        UseInterval(() =>
+        UseEffect(() =>
         {
-            while (jobService.PendingNotifications.TryDequeue(out var notification))
+            void OnNotification(JobNotification notification)
             {
                 if (notification.IsSuccess)
                     client.Toast(notification.Message, notification.Title);
                 else
                     client.Toast(notification.Message, notification.Title).Destructive();
             }
-            refreshToken.Refresh();
-        }, TimeSpan.FromSeconds(5));
+
+            jobService.NotificationReady += OnNotification;
+            return Disposable.Create(() => jobService.NotificationReady -= OnNotification);
+        });
 
         var jobs = jobService.GetJobs();
         var rows = jobs.Select(j => new JobItemRow

--- a/src/tendril/Ivy.Tendril/Services/IJobService.cs
+++ b/src/tendril/Ivy.Tendril/Services/IJobService.cs
@@ -6,6 +6,9 @@ namespace Ivy.Tendril.Services;
 public interface IJobService
 {
     event Action? JobsChanged;
+    event Action<JobNotification>? NotificationReady;
+
+    [Obsolete("Use NotificationReady event instead. Will be removed in a future version.")]
     ConcurrentQueue<JobNotification> PendingNotifications { get; }
 
     void SetPlanReaderService(PlanReaderService planReaderService);

--- a/src/tendril/Ivy.Tendril/Services/JobService.cs
+++ b/src/tendril/Ivy.Tendril/Services/JobService.cs
@@ -25,6 +25,9 @@ public class JobService : IJobService
     private readonly SynchronizationContext? _syncContext;
 
     public event Action? JobsChanged;
+    public event Action<JobNotification>? NotificationReady;
+
+    [Obsolete("Use NotificationReady event instead. Will be removed in a future version.")]
     public ConcurrentQueue<JobNotification> PendingNotifications { get; } = new();
 
     private static readonly string PromptsRoot =
@@ -85,6 +88,18 @@ public class JobService : IJobService
         else
         {
             JobsChanged?.Invoke();
+        }
+    }
+
+    private void RaiseNotification(JobNotification notification)
+    {
+        if (_syncContext != null)
+        {
+            _syncContext.Post(_ => NotificationReady?.Invoke(notification), null);
+        }
+        else
+        {
+            NotificationReady?.Invoke(notification);
         }
     }
 
@@ -184,7 +199,11 @@ public class JobService : IJobService
                 // Reset plan state back to Draft since we can't execute
                 ResetPlanStateToBlocked(job);
 
-                PendingNotifications.Enqueue(new JobNotification("Job Blocked", $"{planFile}: {blockReason}", false));
+                var blockedNotification = new JobNotification("Job Blocked", $"{planFile}: {blockReason}", false);
+#pragma warning disable CS0618 // Obsolete PendingNotifications kept for backward compatibility
+                PendingNotifications.Enqueue(blockedNotification);
+#pragma warning restore CS0618
+                RaiseNotification(blockedNotification);
                 RaiseJobsChanged();
                 return id;
             }
@@ -466,7 +485,11 @@ public class JobService : IJobService
         var message = job.PlanFile ?? job.Type;
         if (!isSuccess && job.StatusMessage != null)
             message += $": {job.StatusMessage}";
-        PendingNotifications.Enqueue(new JobNotification(title, message, isSuccess));
+        var completionNotification = new JobNotification(title, message, isSuccess);
+#pragma warning disable CS0618 // Obsolete PendingNotifications kept for backward compatibility
+        PendingNotifications.Enqueue(completionNotification);
+#pragma warning restore CS0618
+        RaiseNotification(completionNotification);
 
         if (job.Status is "Failed" or "Timeout")
             ResetPlanState(job);


### PR DESCRIPTION
# Summary

## Changes

Replaced the 5-second polling pattern for job notifications in JobsApp with an event-based `NotificationReady` event on `IJobService`/`JobService`. The event is marshalled through `SynchronizationContext` for thread safety, matching the pattern already used by `JobsChanged`. The old `PendingNotifications` queue is marked `[Obsolete]` but kept for backward compatibility (hybrid approach).

## API Changes

- `IJobService.NotificationReady` — new `event Action<JobNotification>?` for immediate notification delivery
- `IJobService.PendingNotifications` — marked `[Obsolete("Use NotificationReady event instead")]`
- `JobService.RaiseNotification(JobNotification)` — new private method for sync-context-aware event raising
- `CustomPrDialog` constructor — changed parameters from concrete `JobService`/`PlanReaderService` to `IJobService`/`IPlanReaderService` (pre-existing bug fix)

## Files Modified

- **Core changes:**
  - `src/tendril/Ivy.Tendril/Services/IJobService.cs` — added `NotificationReady` event, `[Obsolete]` on `PendingNotifications`
  - `src/tendril/Ivy.Tendril/Services/JobService.cs` — added `NotificationReady` event, `RaiseNotification()`, hybrid enqueue+raise pattern
  - `src/tendril/Ivy.Tendril/Apps/JobsApp.cs` — replaced `UseInterval` polling with `UseEffect` event subscription

- **Bug fix:**
  - `src/tendril/Ivy.Tendril/Apps/Review/Dialogs/CustomPrDialog.cs` — interface types instead of concrete types

- **Tests:**
  - `src/tendril/Ivy.Tendril.Test/JobServiceNotificationThreadSafetyTests.cs` — new test class (4 tests)
  - `src/tendril/Ivy.Tendril.Test/JobServiceNotificationTests.cs` — added obsolete pragma
  - `src/tendril/Ivy.Tendril.Test/JobServiceTimeoutTests.cs` — added obsolete pragma

## Commits

- 7ae9c166f [01922] Replace notification polling with event-based delivery