### PR TITLE
[01923] Fix JobService SemaphoreSlim ArgumentOutOfRangeException when maxConcurrentJobs=0

### DIFF
--- a/src/tendril/Ivy.Tendril/Services/JobService.cs
+++ b/src/tendril/Ivy.Tendril/Services/JobService.cs
@@ -52,7 +52,7 @@ public class JobService : IJobService
         _jobTimeout = TimeSpan.FromMinutes(configService.Settings.JobTimeout);
         _staleOutputTimeout = TimeSpan.FromMinutes(configService.Settings.StaleOutputTimeout);
         _maxConcurrentJobs = configService.Settings.MaxConcurrentJobs;
-        _jobSlotSemaphore = new SemaphoreSlim(_maxConcurrentJobs, Math.Max(1, _maxConcurrentJobs));
+        _jobSlotSemaphore = new SemaphoreSlim(Math.Max(1, _maxConcurrentJobs), Math.Max(1, _maxConcurrentJobs));
         _inboxPath = Path.Combine(configService.TendrilHome, "Inbox");
     }
 
@@ -62,7 +62,7 @@ public class JobService : IJobService
         _jobTimeout = jobTimeout;
         _staleOutputTimeout = staleOutputTimeout;
         _maxConcurrentJobs = maxConcurrentJobs;
-        _jobSlotSemaphore = new SemaphoreSlim(maxConcurrentJobs, Math.Max(1, maxConcurrentJobs));
+        _jobSlotSemaphore = new SemaphoreSlim(Math.Max(1, maxConcurrentJobs), Math.Max(1, maxConcurrentJobs));
         _inboxPath = inboxPath;
     }
 


### PR DESCRIPTION
# Summary

## Changes

Clamped `SemaphoreSlim` constructor arguments to a minimum of 1 using `Math.Max(1, maxConcurrentJobs)` in both `JobService` constructors. This fixes `ArgumentOutOfRangeException` when `maxConcurrentJobs=0` while preserving the original value in `_maxConcurrentJobs` for queue logic.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Services/JobService.cs` — Updated both constructors to clamp semaphore count
- `src/tendril/Ivy.Tendril/Apps/Review/Dialogs/CustomPrDialog.cs` — Fixed pre-existing build error: changed concrete types to interfaces

## Commits

- bf4544acd [01923] Fix SemaphoreSlim ArgumentOutOfRangeException when maxConcurrentJobs=0
- 02dde46d9 [01923] Fix CustomPrDialog to use IJobService/IPlanReaderService interfaces