### PR TITLE
[01927] Extract IGithubService and IGitService interfaces

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Plans/Dialogs/CreateIssueDialog.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Plans/Dialogs/CreateIssueDialog.cs
@@ -21,7 +21,7 @@ public class CreateIssueDialog(
 
     public override object? Build()
     {
-        var githubService = UseService<GithubService>();
+        var githubService = UseService<IGithubService>();
         var assigneesQuery = UseQuery<string[], string>(
             _selectedRepoState.Value ?? "",
             async (repoName, ct) =>

--- a/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -16,7 +16,7 @@ public class ContentView(
     IJobService jobService,
     Action refreshPlans,
     IConfigService config,
-    GitService gitService) : ViewBase
+    IGitService gitService) : ViewBase
 {
     private readonly PlanFile? _selectedPlan = selectedPlan;
     private readonly List<PlanFile> _allPlans = allPlans;
@@ -25,7 +25,7 @@ public class ContentView(
     private readonly IJobService _jobService = jobService;
     private readonly Action _refreshPlans = refreshPlans;
     private readonly IConfigService _config = config;
-    private readonly GitService _gitService = gitService;
+    private readonly IGitService _gitService = gitService;
 
     public override object? Build()
     {
@@ -40,7 +40,7 @@ public class ContentView(
         var suggestChangesText = UseState("");
         var customPrOpen = UseState(false);
 
-        var githubService = UseService<GithubService>();
+        var githubService = UseService<IGithubService>();
         var assigneesQuery = UseQuery<string[], string>(
             _selectedPlan?.Project ?? "",
             async (_, ct) =>

--- a/src/tendril/Ivy.Tendril/Apps/ReviewApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/ReviewApp.cs
@@ -12,7 +12,7 @@ public class ReviewApp : ViewBase
         var planService = UseService<IPlanReaderService>();
         var jobService = UseService<IJobService>();
         var configService = UseService<IConfigService>();
-        var gitService = UseService<GitService>();
+        var gitService = UseService<IGitService>();
         var planWatcher = UseService<IPlanWatcherService>();
         var selectedPlanState = UseState<PlanFile?>(null);
         var textFilter = UseState<string?>("");

--- a/src/tendril/Ivy.Tendril/Program.cs
+++ b/src/tendril/Ivy.Tendril/Program.cs
@@ -47,7 +47,9 @@ if (configService.Settings.Llm is { } llmConfig && !string.IsNullOrEmpty(llmConf
 }
 
 server.Services.AddSingleton<GithubService>();
+server.Services.AddSingleton<IGithubService>(sp => sp.GetRequiredService<GithubService>());
 server.Services.AddSingleton<GitService>();
+server.Services.AddSingleton<IGitService>(sp => sp.GetRequiredService<GitService>());
 server.Services.AddSingleton<PlanReaderService>(sp =>
 {
     var planService = new PlanReaderService(sp.GetRequiredService<IConfigService>());

--- a/src/tendril/Ivy.Tendril/Services/GitService.cs
+++ b/src/tendril/Ivy.Tendril/Services/GitService.cs
@@ -2,7 +2,7 @@ using System.Diagnostics;
 
 namespace Ivy.Tendril.Services;
 
-public class GitService
+public class GitService : IGitService
 {
     public string? GetCommitTitle(string repoPath, string commitHash)
     {

--- a/src/tendril/Ivy.Tendril/Services/GithubService.cs
+++ b/src/tendril/Ivy.Tendril/Services/GithubService.cs
@@ -3,7 +3,7 @@ using System.Text.RegularExpressions;
 
 namespace Ivy.Tendril.Services;
 
-public class GithubService(IConfigService config)
+public class GithubService(IConfigService config) : IGithubService
 {
     private readonly IConfigService _config = config;
     private readonly Dictionary<string, List<string>> _assigneeCache = new();

--- a/src/tendril/Ivy.Tendril/Services/IGitService.cs
+++ b/src/tendril/Ivy.Tendril/Services/IGitService.cs
@@ -1,0 +1,8 @@
+namespace Ivy.Tendril.Services;
+
+public interface IGitService
+{
+    string? GetCommitTitle(string repoPath, string commitHash);
+    string? GetCommitDiff(string repoPath, string commitHash);
+    List<(string Status, string FilePath)>? GetCommitFiles(string repoPath, string commitHash);
+}

--- a/src/tendril/Ivy.Tendril/Services/IGithubService.cs
+++ b/src/tendril/Ivy.Tendril/Services/IGithubService.cs
@@ -1,0 +1,8 @@
+namespace Ivy.Tendril.Services;
+
+public interface IGithubService
+{
+    List<RepoConfig> GetRepos();
+    Task<List<string>> GetAssigneesAsync(string owner, string repo);
+    Task<List<string>> GetLabelsAsync(string owner, string repo);
+}


### PR DESCRIPTION
# Summary

## Changes

Extracted `IGithubService` and `IGitService` interfaces from the concrete `GithubService` and `GitService` classes. Updated DI registrations to use the dual concrete+interface pattern and migrated all consumers to depend on interfaces instead of concrete types.

## API Changes

- New interface: `IGithubService` with `GetRepos()`, `GetAssigneesAsync()`, `GetLabelsAsync()`
- New interface: `IGitService` with `GetCommitTitle()`, `GetCommitDiff()`, `GetCommitFiles()`
- `GithubService` now implements `IGithubService`
- `GitService` now implements `IGitService`
- DI: `IGithubService` and `IGitService` are now resolvable from the service container

## Files Modified

- **New interfaces:**
  - `src/tendril/Ivy.Tendril/Services/IGithubService.cs`
  - `src/tendril/Ivy.Tendril/Services/IGitService.cs`
- **Updated services:**
  - `src/tendril/Ivy.Tendril/Services/GithubService.cs` — implements IGithubService
  - `src/tendril/Ivy.Tendril/Services/GitService.cs` — implements IGitService
- **DI registration:**
  - `src/tendril/Ivy.Tendril/Program.cs` — added interface registrations
- **Consumers:**
  - `src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs` — uses IGitService, IGithubService
  - `src/tendril/Ivy.Tendril/Apps/ReviewApp.cs` — uses IGitService
  - `src/tendril/Ivy.Tendril/Apps/Plans/Dialogs/CreateIssueDialog.cs` — uses IGithubService

## Commits

- 9581dd96b [01927] Extract IGithubService and IGitService interfaces