### PR TITLE
[01929] Fix IJobService interface to use service interfaces instead of concrete types

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/PlanCountsServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/PlanCountsServiceTests.cs
@@ -169,8 +169,8 @@ public class PlanCountsServiceTests : IDisposable
         public List<JobItem> GetJobs() => _jobs;
         public JobItem? GetJob(string id) => _jobs.FirstOrDefault(j => j.Id == id);
 
-        public void SetPlanReaderService(PlanReaderService planReaderService) => throw new NotImplementedException();
-        public void SetTelemetryService(TelemetryService telemetryService) => throw new NotImplementedException();
+        public void SetPlanReaderService(IPlanReaderService planReaderService) => throw new NotImplementedException();
+        public void SetTelemetryService(ITelemetryService telemetryService) => throw new NotImplementedException();
         public string StartJob(string type, string[] args, string? inboxFilePath) => throw new NotImplementedException();
         public string StartJob(string type, params string[] args) => throw new NotImplementedException();
         public void CompleteJob(string id, int? exitCode, bool timedOut = false, bool staleOutput = false) => throw new NotImplementedException();

--- a/src/tendril/Ivy.Tendril/Program.cs
+++ b/src/tendril/Ivy.Tendril/Program.cs
@@ -56,16 +56,18 @@ server.Services.AddSingleton<PlanReaderService>(sp =>
     return planService;
 });
 server.Services.AddSingleton<IPlanReaderService>(sp => sp.GetRequiredService<PlanReaderService>());
-server.Services.AddSingleton<TelemetryService>(sp =>
+server.Services.AddSingleton<ITelemetryService>(sp =>
 {
     var config = sp.GetRequiredService<IConfigService>();
     return new TelemetryService(config.Settings.Telemetry);
 });
+server.Services.AddSingleton<TelemetryService>(sp =>
+    (TelemetryService)sp.GetRequiredService<ITelemetryService>());
 server.Services.AddSingleton<JobService>(sp =>
 {
     var jobService = new JobService(sp.GetRequiredService<IConfigService>(), sp.GetRequiredService<ModelPricingService>());
-    jobService.SetPlanReaderService(sp.GetRequiredService<PlanReaderService>());
-    jobService.SetTelemetryService(sp.GetRequiredService<TelemetryService>());
+    jobService.SetPlanReaderService(sp.GetRequiredService<IPlanReaderService>());
+    jobService.SetTelemetryService(sp.GetRequiredService<ITelemetryService>());
     return jobService;
 });
 server.Services.AddSingleton<IJobService>(sp => sp.GetRequiredService<JobService>());

--- a/src/tendril/Ivy.Tendril/Services/IJobService.cs
+++ b/src/tendril/Ivy.Tendril/Services/IJobService.cs
@@ -8,8 +8,8 @@ public interface IJobService
     event Action? JobsChanged;
     ConcurrentQueue<JobNotification> PendingNotifications { get; }
 
-    void SetPlanReaderService(PlanReaderService planReaderService);
-    void SetTelemetryService(TelemetryService telemetryService);
+    void SetPlanReaderService(IPlanReaderService planReaderService);
+    void SetTelemetryService(ITelemetryService telemetryService);
     string StartJob(string type, string[] args, string? inboxFilePath);
     string StartJob(string type, params string[] args);
     void CompleteJob(string id, int? exitCode, bool timedOut = false, bool staleOutput = false);

--- a/src/tendril/Ivy.Tendril/Services/ITelemetryService.cs
+++ b/src/tendril/Ivy.Tendril/Services/ITelemetryService.cs
@@ -1,0 +1,9 @@
+namespace Ivy.Tendril.Services;
+
+public interface ITelemetryService
+{
+    void TrackAppStarted();
+    void TrackPlanCreated();
+    void TrackPrCreated();
+    void TrackJobCompleted(string jobType, string status, int? durationSeconds);
+}

--- a/src/tendril/Ivy.Tendril/Services/JobService.cs
+++ b/src/tendril/Ivy.Tendril/Services/JobService.cs
@@ -12,10 +12,10 @@ public class JobService : IJobService
     private readonly ConcurrentDictionary<string, JobItem> _jobs = new();
     private readonly ConcurrentQueue<string> _jobQueue = new();
     private int _counter;
-    private PlanReaderService? _planReaderService;
+    private IPlanReaderService? _planReaderService;
     private readonly IConfigService? _configService;
     private readonly ModelPricingService? _modelPricingService;
-    private TelemetryService? _telemetryService;
+    private ITelemetryService? _telemetryService;
     private readonly TimeSpan _jobTimeout;
     private readonly TimeSpan _staleOutputTimeout;
     private readonly int _maxConcurrentJobs;
@@ -66,12 +66,12 @@ public class JobService : IJobService
         _inboxPath = inboxPath;
     }
 
-    public void SetPlanReaderService(PlanReaderService planReaderService)
+    public void SetPlanReaderService(IPlanReaderService planReaderService)
     {
         _planReaderService = planReaderService;
     }
 
-    public void SetTelemetryService(TelemetryService telemetryService)
+    public void SetTelemetryService(ITelemetryService telemetryService)
     {
         _telemetryService = telemetryService;
     }

--- a/src/tendril/Ivy.Tendril/Services/TelemetryService.cs
+++ b/src/tendril/Ivy.Tendril/Services/TelemetryService.cs
@@ -2,7 +2,7 @@ using PostHog;
 
 namespace Ivy.Tendril.Services;
 
-public class TelemetryService : IAsyncDisposable
+public class TelemetryService : ITelemetryService, IAsyncDisposable
 {
     private readonly PostHogClient? _client;
     private readonly string _distinctId;


### PR DESCRIPTION
# Summary

## Changes

Extracted `ITelemetryService` interface from `TelemetryService` and updated `IJobService.SetPlanReaderService`/`SetTelemetryService` to accept interface types (`IPlanReaderService`/`ITelemetryService`) instead of concrete types. Updated all consuming code: `JobService` fields and method signatures, `Program.cs` DI registrations, and test mocks.

## API Changes

- **New:** `ITelemetryService` interface with methods `TrackAppStarted()`, `TrackPlanCreated()`, `TrackPrCreated()`, `TrackJobCompleted(string, string, int?)`
- **Changed:** `IJobService.SetPlanReaderService(PlanReaderService)` → `SetPlanReaderService(IPlanReaderService)`
- **Changed:** `IJobService.SetTelemetryService(TelemetryService)` → `SetTelemetryService(ITelemetryService)`
- **Changed:** DI: `ITelemetryService` is now the primary registration; `TelemetryService` forwards to it

## Files Modified

- **New:** `src/tendril/Ivy.Tendril/Services/ITelemetryService.cs` — new interface
- **Modified:** `src/tendril/Ivy.Tendril/Services/TelemetryService.cs` — implements `ITelemetryService`
- **Modified:** `src/tendril/Ivy.Tendril/Services/IJobService.cs` — interface method signatures
- **Modified:** `src/tendril/Ivy.Tendril/Services/JobService.cs` — field types and method signatures
- **Modified:** `src/tendril/Ivy.Tendril/Program.cs` — DI registrations
- **Modified:** `src/tendril/Ivy.Tendril.Test/PlanCountsServiceTests.cs` — test mock signatures

## Commits

- [01929] Fix IJobService interface to use service interfaces instead of concrete types (ad599303c)