### PR TITLE
[01938] Consolidate YAML serialization helpers into shared class

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -101,7 +101,7 @@ public class ContentView(
         var recommendations = new List<RecommendationYaml>();
         if (File.Exists(recommendationsPath))
         {
-            recommendations = PlanReaderService.YamlDeserializer.Deserialize<List<RecommendationYaml>>(
+            recommendations = YamlHelper.Deserializer.Deserialize<List<RecommendationYaml>>(
                 File.ReadAllText(recommendationsPath)) ?? new();
         }
 

--- a/src/tendril/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/tendril/Ivy.Tendril/Services/ConfigService.cs
@@ -1,6 +1,3 @@
-using YamlDotNet.Serialization;
-using YamlDotNet.Serialization.NamingConventions;
-
 namespace Ivy.Tendril.Services;
 
 public record RepoConfig
@@ -108,16 +105,6 @@ public class TendrilSettings
 
 public class ConfigService : IConfigService
 {
-    // Shared deserializer with lenient validation (.IgnoreUnmatchedProperties).
-    // This allows config.yaml to contain keys that aren't in TendrilSettings without
-    // throwing errors, improving resilience to config changes and forward/backward
-    // compatibility. Both the constructor and SetTendrilHome use this deserializer
-    // to ensure consistent behavior.
-    private static readonly IDeserializer CamelCaseDeserializer = new DeserializerBuilder()
-        .WithNamingConvention(CamelCaseNamingConvention.Instance)
-        .IgnoreUnmatchedProperties()
-        .Build();
-
     private TendrilSettings _settings;
     private string _configPath;
     private string _tendrilHome;
@@ -162,7 +149,7 @@ public class ConfigService : IConfigService
             try
             {
                 var yaml = File.ReadAllText(_configPath);
-                _settings = CamelCaseDeserializer.Deserialize<TendrilSettings>(yaml) ?? new TendrilSettings();
+                _settings = YamlHelper.Deserializer.Deserialize<TendrilSettings>(yaml) ?? new TendrilSettings();
                 NeedsOnboarding = false;
             }
             catch (Exception)
@@ -230,7 +217,7 @@ public class ConfigService : IConfigService
 
     public void SaveSettings()
     {
-        var yaml = PlanReaderService.YamlSerializerCompact.Serialize(_settings);
+        var yaml = YamlHelper.SerializerCompact.Serialize(_settings);
         File.WriteAllText(_configPath, yaml);
     }
 
@@ -265,7 +252,7 @@ public class ConfigService : IConfigService
         if (File.Exists(_configPath))
         {
             var yaml = File.ReadAllText(_configPath);
-            var loadedSettings = CamelCaseDeserializer.Deserialize<TendrilSettings>(yaml);
+            var loadedSettings = YamlHelper.Deserializer.Deserialize<TendrilSettings>(yaml);
             if (loadedSettings != null)
             {
                 _settings = loadedSettings;

--- a/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
@@ -2,9 +2,6 @@ using System.Text.RegularExpressions;
 
 using Ivy.Tendril.Apps.Plans;
 
-using YamlDotNet.Serialization;
-using YamlDotNet.Serialization.NamingConventions;
-
 namespace Ivy.Tendril.Services;
 
 public class PlanReaderService(IConfigService config) : IPlanReaderService
@@ -33,24 +30,6 @@ public class PlanReaderService(IConfigService config) : IPlanReaderService
         _planCountsCache = null;
         _planCountsCacheTime = null;
     }
-
-    public static readonly IDeserializer YamlDeserializer = new DeserializerBuilder()
-        .WithNamingConvention(CamelCaseNamingConvention.Instance)
-        .IgnoreUnmatchedProperties()
-        .Build();
-
-    public static readonly ISerializer YamlSerializer = new SerializerBuilder()
-        .WithNamingConvention(CamelCaseNamingConvention.Instance)
-        .Build();
-
-    /// <summary>
-    /// Shared YAML serializer with OmitDefaults configuration for compact output.
-    /// Used when writing configuration files where default values should be suppressed.
-    /// </summary>
-    public static readonly ISerializer YamlSerializerCompact = new SerializerBuilder()
-        .WithNamingConvention(CamelCaseNamingConvention.Instance)
-        .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitDefaults)
-        .Build();
 
     public string PlansDirectory => _config.PlanFolder;
 
@@ -211,12 +190,12 @@ public class PlanReaderService(IConfigService config) : IPlanReaderService
         if (!File.Exists(planYamlPath)) return;
 
         var yaml = FileHelper.ReadAllText(planYamlPath);
-        var planYaml = YamlDeserializer.Deserialize<PlanYaml>(yaml) ?? new PlanYaml();
+        var planYaml = YamlHelper.Deserializer.Deserialize<PlanYaml>(yaml) ?? new PlanYaml();
 
         planYaml.State = newState.ToString();
         planYaml.Updated = DateTime.UtcNow;
 
-        FileHelper.WriteAllText(planYamlPath, YamlSerializer.Serialize(planYaml));
+        FileHelper.WriteAllText(planYamlPath, YamlHelper.Serializer.Serialize(planYaml));
         InvalidatePlanCountsCache();
     }
 
@@ -239,9 +218,9 @@ public class PlanReaderService(IConfigService config) : IPlanReaderService
         if (File.Exists(planYamlPath))
         {
             var yaml = FileHelper.ReadAllText(planYamlPath);
-            var planYaml = YamlDeserializer.Deserialize<PlanYaml>(yaml) ?? new PlanYaml();
+            var planYaml = YamlHelper.Deserializer.Deserialize<PlanYaml>(yaml) ?? new PlanYaml();
             planYaml.Updated = DateTime.UtcNow;
-            FileHelper.WriteAllText(planYamlPath, YamlSerializer.Serialize(planYaml));
+            FileHelper.WriteAllText(planYamlPath, YamlHelper.Serializer.Serialize(planYaml));
             InvalidatePlanCountsCache();
         }
     }
@@ -441,9 +420,9 @@ public class PlanReaderService(IConfigService config) : IPlanReaderService
             if (File.Exists(planYamlPath))
             {
                 var yaml = FileHelper.ReadAllText(planYamlPath);
-                var planYaml = YamlDeserializer.Deserialize<PlanYaml>(yaml) ?? new PlanYaml();
+                var planYaml = YamlHelper.Deserializer.Deserialize<PlanYaml>(yaml) ?? new PlanYaml();
                 planYaml.Updated = DateTime.UtcNow;
-                FileHelper.WriteAllText(planYamlPath, YamlSerializer.Serialize(planYaml));
+                FileHelper.WriteAllText(planYamlPath, YamlHelper.Serializer.Serialize(planYaml));
                 InvalidatePlanCountsCache();
             }
         }
@@ -455,7 +434,7 @@ public class PlanReaderService(IConfigService config) : IPlanReaderService
         {
             var planYamlPath = Path.Combine(folderPath, "plan.yaml");
             var yamlContent = FileHelper.ReadAllText(planYamlPath);
-            var planYaml = YamlDeserializer.Deserialize<PlanYaml>(yamlContent);
+            var planYaml = YamlHelper.Deserializer.Deserialize<PlanYaml>(yamlContent);
             if (planYaml == null) return null;
 
             var folderName = Path.GetFileName(folderPath);
@@ -578,7 +557,7 @@ public class PlanReaderService(IConfigService config) : IPlanReaderService
                 var planYamlPath = Path.Combine(dir, "plan.yaml");
                 if (!File.Exists(planYamlPath)) continue;
 
-                var planYaml = YamlDeserializer.Deserialize<PlanYaml>(FileHelper.ReadAllText(planYamlPath));
+                var planYaml = YamlHelper.Deserializer.Deserialize<PlanYaml>(FileHelper.ReadAllText(planYamlPath));
                 if (planYaml == null) continue;
 
                 var project = planYaml.Project ?? "";
@@ -697,11 +676,11 @@ public class PlanReaderService(IConfigService config) : IPlanReaderService
             try
             {
                 var planYaml = FileHelper.ReadAllText(planYamlPath);
-                var plan = YamlDeserializer.Deserialize<PlanYaml>(planYaml);
+                var plan = YamlHelper.Deserializer.Deserialize<PlanYaml>(planYaml);
                 if (plan == null) continue;
 
                 var yaml = FileHelper.ReadAllText(recommendationsPath);
-                var items = YamlDeserializer.Deserialize<List<RecommendationYaml>>(yaml);
+                var items = YamlHelper.Deserializer.Deserialize<List<RecommendationYaml>>(yaml);
                 if (items == null) continue;
 
                 var match = FolderNameRegex.Match(folderName);
@@ -806,7 +785,7 @@ public class PlanReaderService(IConfigService config) : IPlanReaderService
                 if (File.Exists(recommendationsPath))
                 {
                     var recYaml = FileHelper.ReadAllText(recommendationsPath);
-                    var items = YamlDeserializer.Deserialize<List<RecommendationYaml>>(recYaml);
+                    var items = YamlHelper.Deserializer.Deserialize<List<RecommendationYaml>>(recYaml);
                     if (items != null)
                     {
                         foreach (var item in items)
@@ -840,7 +819,7 @@ public class PlanReaderService(IConfigService config) : IPlanReaderService
         if (!File.Exists(recommendationsPath)) return;
 
         var yaml = FileHelper.ReadAllText(recommendationsPath);
-        var items = YamlDeserializer.Deserialize<List<RecommendationYaml>>(yaml);
+        var items = YamlHelper.Deserializer.Deserialize<List<RecommendationYaml>>(yaml);
         if (items == null) return;
 
         var item = items.FirstOrDefault(r => r.Title == recommendationTitle);
@@ -851,7 +830,7 @@ public class PlanReaderService(IConfigService config) : IPlanReaderService
         {
             item.DeclineReason = declineReason;
         }
-        FileHelper.WriteAllText(recommendationsPath, YamlSerializer.Serialize(items));
+        FileHelper.WriteAllText(recommendationsPath, YamlHelper.Serializer.Serialize(items));
 
         // Invalidate caches after state change
         _recommendationsCache = null;

--- a/src/tendril/Ivy.Tendril/Services/YamlHelper.cs
+++ b/src/tendril/Ivy.Tendril/Services/YamlHelper.cs
@@ -1,0 +1,36 @@
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace Ivy.Tendril.Services;
+
+/// <summary>
+/// Shared YAML serialization helpers for consistent configuration handling.
+/// All services use these static instances instead of creating their own builders.
+/// </summary>
+public static class YamlHelper
+{
+    /// <summary>
+    /// Lenient deserializer with camelCase naming and unmatched property ignoring.
+    /// Use this for loading config files where forward/backward compatibility is needed.
+    /// </summary>
+    public static readonly IDeserializer Deserializer = new DeserializerBuilder()
+        .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        .IgnoreUnmatchedProperties()
+        .Build();
+
+    /// <summary>
+    /// Standard serializer with camelCase naming.
+    /// </summary>
+    public static readonly ISerializer Serializer = new SerializerBuilder()
+        .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        .Build();
+
+    /// <summary>
+    /// Compact serializer that omits default values for cleaner output.
+    /// Use this for writing config files where brevity is desired.
+    /// </summary>
+    public static readonly ISerializer SerializerCompact = new SerializerBuilder()
+        .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitDefaults)
+        .Build();
+}


### PR DESCRIPTION
# Summary

## Changes

Consolidated four duplicate YAML serialization instances across ConfigService and PlanReaderService into a single shared `YamlHelper` static class. Removed YamlDotNet imports from both consumer files and updated all call sites.

## API Changes

- **New:** `Ivy.Tendril.Services.YamlHelper` static class with `Deserializer`, `Serializer`, and `SerializerCompact` public static fields
- **Removed:** `PlanReaderService.YamlDeserializer`, `PlanReaderService.YamlSerializer`, `PlanReaderService.YamlSerializerCompact` (public static fields)
- **Removed:** `ConfigService.CamelCaseDeserializer` (private static field)

## Files Modified

- **New:** `src/tendril/Ivy.Tendril/Services/YamlHelper.cs` — shared YAML helpers
- **Modified:** `src/tendril/Ivy.Tendril/Services/ConfigService.cs` — removed deserializer field, updated usages
- **Modified:** `src/tendril/Ivy.Tendril/Services/PlanReaderService.cs` — removed all YAML fields, updated usages
- **Modified:** `src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs` — updated YamlDeserializer reference

## Commits

- 9e9f8b7ab [01938] Consolidate YAML serialization helpers into shared YamlHelper class