### PR TITLE
(shortcut): respect modifier shortcuts when is focused inside the text areas

### DIFF
--- a/src/frontend/src/widgets/button/ButtonWidget.tsx
+++ b/src/frontend/src/widgets/button/ButtonWidget.tsx
@@ -189,12 +189,14 @@ export const ButtonWidget: React.FC<ButtonWidgetProps> = ({
 
     const handleKeyDown = (event: KeyboardEvent) => {
       const eventTarget = event.target as HTMLElement;
+      const shortcutUsesModifierChord = shortcutObj.ctrl || shortcutObj.meta || shortcutObj.alt;
       if (
-        eventTarget.tagName === "INPUT" ||
-        eventTarget.tagName === "TEXTAREA" ||
-        eventTarget.isContentEditable
+        !shortcutUsesModifierChord &&
+        (eventTarget.tagName === "INPUT" ||
+          eventTarget.tagName === "TEXTAREA" ||
+          eventTarget.isContentEditable)
       ) {
-        return; // Don't intercept shortcuts while typing
+        return;
       }
 
       const modifierMatch =


### PR DESCRIPTION
Investigated -> problem was only with using text areas, other text inputs are working fine
Fixed

https://github.com/user-attachments/assets/eae7c03f-be20-455b-ad62-98ac1fe8dc5b

