### PR TITLE
[01948] Invalidate recommendations cache in TransitionState and RecoverStuckPlans

### DIFF
--- a/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
@@ -65,6 +65,8 @@ public class PlanReaderService(IConfigService config) : IPlanReaderService
                         $"updated: {DateTime.UtcNow:yyyy-MM-ddTHH:mm:ssZ}");
                     FileHelper.WriteAllText(planYamlPath, updated);
                     InvalidatePlanCountsCache();
+                    _recommendationsCache = null;
+                    _recommendationsCacheTime = null;
                 }
             }
             catch (Exception ex)
@@ -197,6 +199,8 @@ public class PlanReaderService(IConfigService config) : IPlanReaderService
 
         FileHelper.WriteAllText(planYamlPath, YamlHelper.Serializer.Serialize(planYaml));
         InvalidatePlanCountsCache();
+        _recommendationsCache = null;
+        _recommendationsCacheTime = null;
     }
 
     /// <summary>


### PR DESCRIPTION
# Summary

## Changes

Added `_recommendationsCache` and `_recommendationsCacheTime` invalidation to `TransitionState()` and `RecoverStuckPlans()` in `PlanReaderService.cs`. This ensures the recommendations cache is cleared whenever a plan's state changes, preventing stale `SourcePlanStatus` values from being served.

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/Services/PlanReaderService.cs** — Added cache invalidation lines in `TransitionState()` (after line 199) and `RecoverStuckPlans()` (after line 67)

## Commits

- 0a2ff0a91 [01948] Invalidate recommendations cache in TransitionState and RecoverStuckPlans