### PR TITLE
[01943] Fix remaining service interface usage in Tendril apps

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Recommendations/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Recommendations/ContentView.cs
@@ -22,7 +22,7 @@ public class ContentView(
     public override object? Build()
     {
         var client = UseService<IClientProvider>();
-        var config = UseService<ConfigService>();
+        var config = UseService<IConfigService>();
         var showPlan = UseState<string?>(null);
         var openFile = UseState<string?>(null);
         var showNotesDialog = UseState(false);


### PR DESCRIPTION
# Summary

## Changes

Updated `Recommendations/ContentView.cs` to use `IConfigService` interface instead of the concrete `ConfigService` type. The other two planned changes (CreateIssueDialog.cs and ReviewApp.cs) were already completed by dependency plan 01927.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Apps/Recommendations/ContentView.cs` — Changed `UseService<ConfigService>()` to `UseService<IConfigService>()`

## Commits

- e1d8017d1 [01943] Use IConfigService interface in Recommendations ContentView