### PR TITLE
[01949] Extract IModelPricingService, ITelemetryService, and IPlanCountsService interfaces

### DIFF
--- a/src/tendril/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/tendril/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -56,7 +56,7 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
         Context.TryUseService<IAuthService>(out var auth);
         var user = UseState<UserInfo?>();
         var currentApp = UseState<AppHost?>();
-        var countsService = UseService<PlanCountsService>();
+        var countsService = UseService<IPlanCountsService>();
         var menuItems = UseState(() => BuildMenuItems(appRepository, countsService.Current));
         var counts = UseState(() => countsService.Current);
         var jobService = UseService<IJobService>();

--- a/src/tendril/Ivy.Tendril/Program.cs
+++ b/src/tendril/Ivy.Tendril/Program.cs
@@ -29,7 +29,9 @@ server.SetMetaTitle("Ivy Tendril");
 var configService = new ConfigService();
 server.Services.AddSingleton<IConfigService>(configService);
 server.Services.AddSingleton<ConfigService>(configService);
-server.Services.AddSingleton<ModelPricingService>();
+var modelPricingService = new ModelPricingService();
+server.Services.AddSingleton<IModelPricingService>(modelPricingService);
+server.Services.AddSingleton<ModelPricingService>(modelPricingService);
 
 // Register IChatClient if LLM is configured
 if (configService.Settings.Llm is { } llmConfig && !string.IsNullOrEmpty(llmConfig.ApiKey))
@@ -67,7 +69,7 @@ server.Services.AddSingleton<TelemetryService>(sp =>
     (TelemetryService)sp.GetRequiredService<ITelemetryService>());
 server.Services.AddSingleton<JobService>(sp =>
 {
-    var jobService = new JobService(sp.GetRequiredService<IConfigService>(), sp.GetRequiredService<ModelPricingService>());
+    var jobService = new JobService(sp.GetRequiredService<IConfigService>(), sp.GetRequiredService<IModelPricingService>());
     jobService.SetPlanReaderService(sp.GetRequiredService<IPlanReaderService>());
     jobService.SetTelemetryService(sp.GetRequiredService<ITelemetryService>());
     return jobService;
@@ -86,6 +88,7 @@ server.Services.AddSingleton<PlanCountsService>(sp =>
     var planWatcher = sp.GetRequiredService<IPlanWatcherService>();
     return new PlanCountsService(planReader, jobService, planWatcher);
 });
+server.Services.AddSingleton<IPlanCountsService>(sp => sp.GetRequiredService<PlanCountsService>());
 server.Services.AddSingleton<InboxWatcherService>(sp =>
 {
     var config = sp.GetRequiredService<IConfigService>();

--- a/src/tendril/Ivy.Tendril/Services/IModelPricingService.cs
+++ b/src/tendril/Ivy.Tendril/Services/IModelPricingService.cs
@@ -1,0 +1,7 @@
+namespace Ivy.Tendril.Services;
+
+public interface IModelPricingService
+{
+    ModelPricing GetPricing(string modelName);
+    CostCalculation CalculateSessionCost(string sessionId);
+}

--- a/src/tendril/Ivy.Tendril/Services/IPlanCountsService.cs
+++ b/src/tendril/Ivy.Tendril/Services/IPlanCountsService.cs
@@ -1,0 +1,7 @@
+namespace Ivy.Tendril.Services;
+
+public interface IPlanCountsService : IDisposable
+{
+    PlanCounts Current { get; }
+    event Action? CountsChanged;
+}

--- a/src/tendril/Ivy.Tendril/Services/JobService.cs
+++ b/src/tendril/Ivy.Tendril/Services/JobService.cs
@@ -14,7 +14,7 @@ public class JobService : IJobService
     private int _counter;
     private IPlanReaderService? _planReaderService;
     private readonly IConfigService? _configService;
-    private readonly ModelPricingService? _modelPricingService;
+    private readonly IModelPricingService? _modelPricingService;
     private ITelemetryService? _telemetryService;
     private readonly TimeSpan _jobTimeout;
     private readonly TimeSpan _staleOutputTimeout;
@@ -47,7 +47,7 @@ public class JobService : IJobService
         ["CreateIssue"] = Path.Combine(PromptsRoot, "CreateIssue.ps1"),
     };
 
-    public JobService(IConfigService configService, ModelPricingService? modelPricingService = null)
+    public JobService(IConfigService configService, IModelPricingService? modelPricingService = null)
     {
         _syncContext = SynchronizationContext.Current;
         _configService = configService;

--- a/src/tendril/Ivy.Tendril/Services/ModelPricingService.cs
+++ b/src/tendril/Ivy.Tendril/Services/ModelPricingService.cs
@@ -17,7 +17,7 @@ public record CostCalculation
     public double TotalCost { get; init; }
 }
 
-public class ModelPricingService
+public class ModelPricingService : IModelPricingService
 {
     private static readonly IDeserializer DefaultDeserializer = new DeserializerBuilder().Build();
 

--- a/src/tendril/Ivy.Tendril/Services/PlanCountsService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanCountsService.cs
@@ -2,7 +2,7 @@ namespace Ivy.Tendril.Services;
 
 public record PlanCounts(int Drafts, int ActiveJobs, int Reviews, int Icebox, int Recommendations);
 
-public class PlanCountsService : IDisposable
+public class PlanCountsService : IPlanCountsService
 {
     private readonly IPlanReaderService _planReaderService;
     private readonly IJobService _jobService;


### PR DESCRIPTION
# Summary

## Changes

Extracted `IModelPricingService` and `IPlanCountsService` interfaces from their concrete implementations. Updated all consumers (JobService, TendrilAppShell, Program.cs) to depend on interfaces instead of concrete types. ITelemetryService was already fully extracted in a prior commit, so no changes were needed for that service.

## API Changes

- New interface `IModelPricingService` with methods `GetPricing(string modelName)` and `CalculateSessionCost(string sessionId)`
- New interface `IPlanCountsService : IDisposable` with property `Current` and event `CountsChanged`
- `JobService` constructor parameter changed from `ModelPricingService?` to `IModelPricingService?`
- `TendrilAppShell` resolves `IPlanCountsService` instead of `PlanCountsService`

## Files Modified

- **New interfaces:**
  - `src/tendril/Ivy.Tendril/Services/IModelPricingService.cs`
  - `src/tendril/Ivy.Tendril/Services/IPlanCountsService.cs`
- **Updated implementations:**
  - `src/tendril/Ivy.Tendril/Services/ModelPricingService.cs` — implements `IModelPricingService`
  - `src/tendril/Ivy.Tendril/Services/PlanCountsService.cs` — implements `IPlanCountsService`
- **Updated consumers:**
  - `src/tendril/Ivy.Tendril/Services/JobService.cs` — uses `IModelPricingService`
  - `src/tendril/Ivy.Tendril/AppShell/TendrilAppShell.cs` — uses `IPlanCountsService`
  - `src/tendril/Ivy.Tendril/Program.cs` — dual registration for both services

## Commits

- e22f0f040 [01949] Extract IModelPricingService and IPlanCountsService interfaces