### PR TITLE
[01942] Remove Obsolete PendingNotifications Queue

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/JobServiceNotificationTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/JobServiceNotificationTests.cs
@@ -1,4 +1,3 @@
-#pragma warning disable CS0618 // PendingNotifications is obsolete — these tests verify backward compatibility
 using Ivy.Tendril.Services;
 
 namespace Ivy.Tendril.Test;
@@ -16,9 +15,11 @@ public class JobServiceNotificationTests
         var service = CreateService();
         var id = service.StartJob("MakePr", Path.GetTempPath());
 
+        JobNotification? notification = null;
+        service.NotificationReady += n => notification = n;
         service.CompleteJob(id, exitCode: 0);
 
-        Assert.True(service.PendingNotifications.TryDequeue(out var notification));
+        Assert.NotNull(notification);
         Assert.Equal("MakePr Completed", notification.Title);
         Assert.True(notification.IsSuccess);
     }
@@ -29,9 +30,11 @@ public class JobServiceNotificationTests
         var service = CreateService();
         var id = service.StartJob("ExecutePlan", Path.GetTempPath());
 
+        JobNotification? notification = null;
+        service.NotificationReady += n => notification = n;
         service.CompleteJob(id, exitCode: 1);
 
-        Assert.True(service.PendingNotifications.TryDequeue(out var notification));
+        Assert.NotNull(notification);
         Assert.Equal("ExecutePlan Failed", notification.Title);
         Assert.False(notification.IsSuccess);
     }
@@ -42,9 +45,11 @@ public class JobServiceNotificationTests
         var service = CreateService();
         var id = service.StartJob("ExpandPlan", Path.GetTempPath());
 
+        JobNotification? notification = null;
+        service.NotificationReady += n => notification = n;
         service.CompleteJob(id, exitCode: null, timedOut: true);
 
-        Assert.True(service.PendingNotifications.TryDequeue(out var notification));
+        Assert.NotNull(notification);
         Assert.Equal("ExpandPlan Timed Out", notification.Title);
         Assert.False(notification.IsSuccess);
     }

--- a/src/tendril/Ivy.Tendril.Test/JobServiceTimeoutTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/JobServiceTimeoutTests.cs
@@ -1,4 +1,3 @@
-#pragma warning disable CS0618 // PendingNotifications is obsolete — these tests verify backward compatibility
 using Ivy.Tendril.Services;
 
 namespace Ivy.Tendril.Test;
@@ -15,12 +14,13 @@ public class JobServiceTimeoutTests
     {
         var service = CreateService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
 
-        // Use StartJob with a real process that completes quickly, then simulate timeout via CompleteJob
-        // Instead, directly test CompleteJob by starting a trivial job first
         var id = service.StartJob("ExecutePlan", Path.GetTempPath());
         var job = service.GetJob(id);
         Assert.NotNull(job);
         Assert.Equal("Running", job.Status);
+
+        JobNotification? notification = null;
+        service.NotificationReady += n => notification = n;
 
         // Simulate timeout completion
         service.CompleteJob(id, exitCode: null, timedOut: true, staleOutput: false);
@@ -32,7 +32,6 @@ public class JobServiceTimeoutTests
         Assert.NotNull(job.CompletedAt);
         Assert.NotNull(job.DurationSeconds);
 
-        var notification = service.PendingNotifications.TryDequeue(out var result) ? result : null;
         Assert.NotNull(notification);
         Assert.Equal("ExecutePlan Timed Out", notification.Title);
     }
@@ -44,6 +43,9 @@ public class JobServiceTimeoutTests
 
         var id = service.StartJob("ExecutePlan", Path.GetTempPath());
 
+        JobNotification? notification = null;
+        service.NotificationReady += n => notification = n;
+
         // Simulate stale output timeout
         service.CompleteJob(id, exitCode: null, timedOut: true, staleOutput: true);
 
@@ -52,7 +54,6 @@ public class JobServiceTimeoutTests
         Assert.Equal("Timeout", job.Status);
         Assert.Contains("No output for 10 minutes", job.StatusMessage);
 
-        var notification = service.PendingNotifications.TryDequeue(out var result) ? result : null;
         Assert.NotNull(notification);
         Assert.Equal("ExecutePlan Timed Out", notification.Title);
     }
@@ -64,6 +65,9 @@ public class JobServiceTimeoutTests
 
         var id = service.StartJob("ExecutePlan", Path.GetTempPath());
 
+        JobNotification? notification = null;
+        service.NotificationReady += n => notification = n;
+
         service.CompleteJob(id, exitCode: 0);
 
         var job = service.GetJob(id);
@@ -71,7 +75,6 @@ public class JobServiceTimeoutTests
         Assert.Equal("Completed", job.Status);
         Assert.Null(job.StatusMessage);
 
-        var notification = service.PendingNotifications.TryDequeue(out var result) ? result : null;
         Assert.NotNull(notification);
         Assert.Equal("ExecutePlan Completed", notification.Title);
     }
@@ -83,13 +86,15 @@ public class JobServiceTimeoutTests
 
         var id = service.StartJob("ExecutePlan", Path.GetTempPath());
 
+        JobNotification? notification = null;
+        service.NotificationReady += n => notification = n;
+
         service.CompleteJob(id, exitCode: 1);
 
         var job = service.GetJob(id);
         Assert.NotNull(job);
         Assert.Equal("Failed", job.Status);
 
-        var notification = service.PendingNotifications.TryDequeue(out var result) ? result : null;
         Assert.NotNull(notification);
         Assert.Equal("ExecutePlan Failed", notification.Title);
     }

--- a/src/tendril/Ivy.Tendril.Test/PlanCountsServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/PlanCountsServiceTests.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using Ivy.Tendril.Apps.Jobs;
 using Ivy.Tendril.Services;
 
@@ -158,8 +157,8 @@ public class PlanCountsServiceTests : IDisposable
 
 #pragma warning disable CS0067
         public event Action? JobsChanged;
+        public event Action<JobNotification>? NotificationReady;
 #pragma warning restore CS0067
-        public ConcurrentQueue<JobNotification> PendingNotifications { get; } = new();
 
         public void AddJob(string id, string status)
         {

--- a/src/tendril/Ivy.Tendril/Services/IJobService.cs
+++ b/src/tendril/Ivy.Tendril/Services/IJobService.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using Ivy.Tendril.Apps.Jobs;
 
 namespace Ivy.Tendril.Services;
@@ -7,9 +6,6 @@ public interface IJobService
 {
     event Action? JobsChanged;
     event Action<JobNotification>? NotificationReady;
-
-    [Obsolete("Use NotificationReady event instead. Will be removed in a future version.")]
-    ConcurrentQueue<JobNotification> PendingNotifications { get; }
 
     void SetPlanReaderService(IPlanReaderService planReaderService);
     void SetTelemetryService(ITelemetryService telemetryService);

--- a/src/tendril/Ivy.Tendril/Services/JobService.cs
+++ b/src/tendril/Ivy.Tendril/Services/JobService.cs
@@ -27,9 +27,6 @@ public class JobService : IJobService
     public event Action? JobsChanged;
     public event Action<JobNotification>? NotificationReady;
 
-    [Obsolete("Use NotificationReady event instead. Will be removed in a future version.")]
-    public ConcurrentQueue<JobNotification> PendingNotifications { get; } = new();
-
     private static readonly string PromptsRoot =
         Path.GetFullPath(Path.Combine(System.AppContext.BaseDirectory, "..", "..", "..", ".promptwares"));
 
@@ -200,9 +197,6 @@ public class JobService : IJobService
                 ResetPlanStateToBlocked(job);
 
                 var blockedNotification = new JobNotification("Job Blocked", $"{planFile}: {blockReason}", false);
-#pragma warning disable CS0618 // Obsolete PendingNotifications kept for backward compatibility
-                PendingNotifications.Enqueue(blockedNotification);
-#pragma warning restore CS0618
                 RaiseNotification(blockedNotification);
                 RaiseJobsChanged();
                 return id;
@@ -486,9 +480,6 @@ public class JobService : IJobService
         if (!isSuccess && job.StatusMessage != null)
             message += $": {job.StatusMessage}";
         var completionNotification = new JobNotification(title, message, isSuccess);
-#pragma warning disable CS0618 // Obsolete PendingNotifications kept for backward compatibility
-        PendingNotifications.Enqueue(completionNotification);
-#pragma warning restore CS0618
         RaiseNotification(completionNotification);
 
         if (job.Status is "Failed" or "Timeout")


### PR DESCRIPTION
# Summary

## Changes

Removed the obsolete `PendingNotifications` ConcurrentQueue property from `IJobService` and `JobService`, along with all enqueue calls. Updated all test files to use the `NotificationReady` event instead of polling the queue, and removed CS0618 pragma suppressions.

## API Changes

- Removed: `IJobService.PendingNotifications` (`ConcurrentQueue<JobNotification>`)
- Removed: `JobService.PendingNotifications` (`ConcurrentQueue<JobNotification>`)
- No new APIs added — all consumers already migrated to `NotificationReady` event in plan 01922.

## Files Modified

- **Interface/Service:**
  - `src/tendril/Ivy.Tendril/Services/IJobService.cs` — Removed `PendingNotifications` property and `[Obsolete]` attribute
  - `src/tendril/Ivy.Tendril/Services/JobService.cs` — Removed property, two `Enqueue()` calls, and CS0618 pragmas
- **Tests:**
  - `src/tendril/Ivy.Tendril.Test/JobServiceNotificationTests.cs` — Migrated to `NotificationReady` event
  - `src/tendril/Ivy.Tendril.Test/JobServiceTimeoutTests.cs` — Migrated to `NotificationReady` event
  - `src/tendril/Ivy.Tendril.Test/PlanCountsServiceTests.cs` — Updated `FakeJobService` to match new interface

## Commits

- dfde21702 [01942] Remove obsolete PendingNotifications queue from IJobService/JobService