### PR TITLE
[01945] Extract IModelPricingService interface for consistency with service interface pattern

### DIFF
--- a/src/tendril/Ivy.Tendril/Program.cs
+++ b/src/tendril/Ivy.Tendril/Program.cs
@@ -29,7 +29,9 @@ server.SetMetaTitle("Ivy Tendril");
 var configService = new ConfigService();
 server.Services.AddSingleton<IConfigService>(configService);
 server.Services.AddSingleton<ConfigService>(configService);
-server.Services.AddSingleton<ModelPricingService>();
+var modelPricingService = new ModelPricingService();
+server.Services.AddSingleton<IModelPricingService>(modelPricingService);
+server.Services.AddSingleton<ModelPricingService>(modelPricingService);
 
 // Register IChatClient if LLM is configured
 if (configService.Settings.Llm is { } llmConfig && !string.IsNullOrEmpty(llmConfig.ApiKey))
@@ -67,7 +69,7 @@ server.Services.AddSingleton<TelemetryService>(sp =>
     (TelemetryService)sp.GetRequiredService<ITelemetryService>());
 server.Services.AddSingleton<JobService>(sp =>
 {
-    var jobService = new JobService(sp.GetRequiredService<IConfigService>(), sp.GetRequiredService<ModelPricingService>());
+    var jobService = new JobService(sp.GetRequiredService<IConfigService>(), sp.GetRequiredService<IModelPricingService>());
     jobService.SetPlanReaderService(sp.GetRequiredService<IPlanReaderService>());
     jobService.SetTelemetryService(sp.GetRequiredService<ITelemetryService>());
     return jobService;

--- a/src/tendril/Ivy.Tendril/Services/IModelPricingService.cs
+++ b/src/tendril/Ivy.Tendril/Services/IModelPricingService.cs
@@ -1,0 +1,7 @@
+namespace Ivy.Tendril.Services;
+
+public interface IModelPricingService
+{
+    ModelPricing GetPricing(string modelName);
+    CostCalculation CalculateSessionCost(string sessionId);
+}

--- a/src/tendril/Ivy.Tendril/Services/JobService.cs
+++ b/src/tendril/Ivy.Tendril/Services/JobService.cs
@@ -14,7 +14,7 @@ public class JobService : IJobService
     private int _counter;
     private IPlanReaderService? _planReaderService;
     private readonly IConfigService? _configService;
-    private readonly ModelPricingService? _modelPricingService;
+    private readonly IModelPricingService? _modelPricingService;
     private ITelemetryService? _telemetryService;
     private readonly TimeSpan _jobTimeout;
     private readonly TimeSpan _staleOutputTimeout;
@@ -47,7 +47,7 @@ public class JobService : IJobService
         ["CreateIssue"] = Path.Combine(PromptsRoot, "CreateIssue.ps1"),
     };
 
-    public JobService(IConfigService configService, ModelPricingService? modelPricingService = null)
+    public JobService(IConfigService configService, IModelPricingService? modelPricingService = null)
     {
         _syncContext = SynchronizationContext.Current;
         _configService = configService;

--- a/src/tendril/Ivy.Tendril/Services/ModelPricingService.cs
+++ b/src/tendril/Ivy.Tendril/Services/ModelPricingService.cs
@@ -17,7 +17,7 @@ public record CostCalculation
     public double TotalCost { get; init; }
 }
 
-public class ModelPricingService
+public class ModelPricingService : IModelPricingService
 {
     private static readonly IDeserializer DefaultDeserializer = new DeserializerBuilder().Build();
 


### PR DESCRIPTION
# Summary

## Changes

Extracted `IModelPricingService` interface from the concrete `ModelPricingService` class, updated `JobService` to depend on the interface instead of the concrete type, and registered both interface and concrete type in DI following the established `IConfigService` dual-registration pattern.

## API Changes

- New interface: `IModelPricingService` with methods `GetPricing(string modelName)` and `CalculateSessionCost(string sessionId)`
- `ModelPricingService` now implements `IModelPricingService`
- `JobService` constructor parameter changed from `ModelPricingService?` to `IModelPricingService?`

## Files Modified

- **New:** `src/tendril/Ivy.Tendril/Services/IModelPricingService.cs` — interface definition
- **Modified:** `src/tendril/Ivy.Tendril/Services/ModelPricingService.cs` — implements interface
- **Modified:** `src/tendril/Ivy.Tendril/Services/JobService.cs` — field and constructor use interface
- **Modified:** `src/tendril/Ivy.Tendril/Program.cs` — dual DI registration and interface resolution

## Commits

- 5712dfdea [01945] Extract IModelPricingService interface for consistency with service interface pattern