### PR TITLE
[01947] Invalidate hourly burn cache on plan changes

### DIFF
--- a/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
@@ -29,6 +29,8 @@ public class PlanReaderService(IConfigService config) : IPlanReaderService
     {
         _planCountsCache = null;
         _planCountsCacheTime = null;
+        _hourlyBurnCache = null;
+        _hourlyBurnCacheTime = null;
     }
 
     // Cache for GetPlanTotalCost/GetPlanTotalTokens results
@@ -889,6 +891,8 @@ public class PlanReaderService(IConfigService config) : IPlanReaderService
         // Invalidate caches after state change
         _recommendationsCache = null;
         _recommendationsCacheTime = null;
+        _hourlyBurnCache = null;
+        _hourlyBurnCacheTime = null;
         InvalidatePlanCountsCache();
     }
 


### PR DESCRIPTION
# Summary

## Changes

Added explicit `_hourlyBurnCache` invalidation to `PlanReaderService` so that hourly burn data refreshes immediately when plans change state. The helper method `InvalidatePlanCountsCache()` now also clears the hourly burn cache, and `UpdateRecommendationState()` gets direct invalidation alongside its existing cache clearing.

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/Services/PlanReaderService.cs** — Added `_hourlyBurnCache = null` and `_hourlyBurnCacheTime = null` to `InvalidatePlanCountsCache()` helper and `UpdateRecommendationState()` cache invalidation block.

## Commits

- 116a2ae91 [01947] Invalidate hourly burn cache on plan changes