### PR TITLE
[01951] Refactor PlanReaderService caches into generic TimeCache<T> helper

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/TimeCacheTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/TimeCacheTests.cs
@@ -1,0 +1,78 @@
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Test;
+
+public class TimeCacheTests
+{
+    [Fact]
+    public void GetOrCompute_CallsComputeOnFirstAccess()
+    {
+        var cache = new TimeCache<int>(TimeSpan.FromMinutes(1));
+        int callCount = 0;
+
+        var result = cache.GetOrCompute(() => { callCount++; return 42; });
+
+        Assert.Equal(42, result);
+        Assert.Equal(1, callCount);
+    }
+
+    [Fact]
+    public void GetOrCompute_ReturnsCachedValueWithinExpiration()
+    {
+        var cache = new TimeCache<int>(TimeSpan.FromSeconds(1));
+        int callCount = 0;
+
+        cache.GetOrCompute(() => { callCount++; return 42; });
+        var result = cache.GetOrCompute(() => { callCount++; return 99; });
+
+        Assert.Equal(42, result);
+        Assert.Equal(1, callCount);
+    }
+
+    [Fact]
+    public void GetOrCompute_RecomputesAfterExpiration()
+    {
+        var cache = new TimeCache<int>(TimeSpan.FromMilliseconds(100));
+        int callCount = 0;
+
+        cache.GetOrCompute(() => { callCount++; return 42; });
+        Thread.Sleep(150);
+        var result = cache.GetOrCompute(() => { callCount++; return 99; });
+
+        Assert.Equal(99, result);
+        Assert.Equal(2, callCount);
+    }
+
+    [Fact]
+    public void Invalidate_ForcesCacheRecompute()
+    {
+        var cache = new TimeCache<int>(TimeSpan.FromMinutes(1));
+        int callCount = 0;
+
+        cache.GetOrCompute(() => { callCount++; return 42; });
+        cache.Invalidate();
+        var result = cache.GetOrCompute(() => { callCount++; return 99; });
+
+        Assert.Equal(99, result);
+        Assert.Equal(2, callCount);
+    }
+
+    [Fact]
+    public void IsValid_ReturnsTrueForValidCache()
+    {
+        var cache = new TimeCache<int>(TimeSpan.FromMinutes(1));
+        cache.GetOrCompute(() => 42);
+
+        Assert.True(cache.IsValid);
+    }
+
+    [Fact]
+    public void IsValid_ReturnsFalseForExpiredCache()
+    {
+        var cache = new TimeCache<int>(TimeSpan.FromMilliseconds(50));
+        cache.GetOrCompute(() => 42);
+        Thread.Sleep(100);
+
+        Assert.False(cache.IsValid);
+    }
+}

--- a/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
@@ -8,35 +8,13 @@ public class PlanReaderService(IConfigService config) : IPlanReaderService
 {
     private readonly IConfigService _config = config;
 
-    // Cache for GetHourlyTokenBurn results
-    private List<HourlyTokenBurn>? _hourlyBurnCache;
-    private DateTime? _hourlyBurnCacheTime;
-    private static readonly TimeSpan HourlyBurnCacheExpiration = TimeSpan.FromMinutes(2);
+    private readonly TimeCache<List<HourlyTokenBurn>> _hourlyBurnCache = new(TimeSpan.FromMinutes(2));
 
     private static readonly Regex FolderNameRegex = new(@"^(\d{5})-(.+)$", RegexOptions.Compiled);
 
-    // Cache for GetRecommendations results
-    private List<Recommendation>? _recommendationsCache;
-    private DateTime? _recommendationsCacheTime;
-    private static readonly TimeSpan RecommendationsCacheExpiration = TimeSpan.FromMinutes(2);
-
-    // Cache for ComputePlanCounts results
-    private PlanCountSnapshot? _planCountsCache;
-    private DateTime? _planCountsCacheTime;
-    private static readonly TimeSpan PlanCountsCacheExpiration = TimeSpan.FromMinutes(2);
-
-    private void InvalidatePlanCountsCache()
-    {
-        _planCountsCache = null;
-        _planCountsCacheTime = null;
-        _hourlyBurnCache = null;
-        _hourlyBurnCacheTime = null;
-    }
-
-    // Cache for GetPlanTotalCost/GetPlanTotalTokens results
-    private Dictionary<string, (decimal Cost, int Tokens)>? _planCostCache;
-    private DateTime? _planCostCacheTime;
-    private static readonly TimeSpan PlanCostCacheExpiration = TimeSpan.FromSeconds(90);
+    private readonly TimeCache<List<Recommendation>> _recommendationsCache = new(TimeSpan.FromMinutes(2));
+    private readonly TimeCache<PlanCountSnapshot> _planCountsCache = new(TimeSpan.FromMinutes(2));
+    private readonly TimeCache<Dictionary<string, (decimal Cost, int Tokens)>> _planCostCache = new(TimeSpan.FromSeconds(90));
 
     public string PlansDirectory => _config.PlanFolder;
 
@@ -71,9 +49,8 @@ public class PlanReaderService(IConfigService config) : IPlanReaderService
                     updated = Regex.Replace(updated, @"(?m)^updated:\s*.*$",
                         $"updated: {DateTime.UtcNow:yyyy-MM-ddTHH:mm:ssZ}");
                     FileHelper.WriteAllText(planYamlPath, updated);
-                    InvalidatePlanCountsCache();
-                    _recommendationsCache = null;
-                    _recommendationsCacheTime = null;
+                    _planCountsCache.Invalidate();
+                    _recommendationsCache.Invalidate();
                 }
             }
             catch (Exception ex)
@@ -205,9 +182,8 @@ public class PlanReaderService(IConfigService config) : IPlanReaderService
         planYaml.Updated = DateTime.UtcNow;
 
         FileHelper.WriteAllText(planYamlPath, YamlHelper.Serializer.Serialize(planYaml));
-        InvalidatePlanCountsCache();
-        _recommendationsCache = null;
-        _recommendationsCacheTime = null;
+        _planCountsCache.Invalidate();
+        _recommendationsCache.Invalidate();
     }
 
     /// <summary>
@@ -232,7 +208,7 @@ public class PlanReaderService(IConfigService config) : IPlanReaderService
             var planYaml = YamlHelper.Deserializer.Deserialize<PlanYaml>(yaml) ?? new PlanYaml();
             planYaml.Updated = DateTime.UtcNow;
             FileHelper.WriteAllText(planYamlPath, YamlHelper.Serializer.Serialize(planYaml));
-            InvalidatePlanCountsCache();
+            _planCountsCache.Invalidate();
         }
     }
 
@@ -434,7 +410,7 @@ public class PlanReaderService(IConfigService config) : IPlanReaderService
                 var planYaml = YamlHelper.Deserializer.Deserialize<PlanYaml>(yaml) ?? new PlanYaml();
                 planYaml.Updated = DateTime.UtcNow;
                 FileHelper.WriteAllText(planYamlPath, YamlHelper.Serializer.Serialize(planYaml));
-                InvalidatePlanCountsCache();
+                _planCountsCache.Invalidate();
             }
         }
     }
@@ -482,18 +458,15 @@ public class PlanReaderService(IConfigService config) : IPlanReaderService
     /// <returns>Total cost in dollars, or <c>0</c> if no costs file exists.</returns>
     public decimal GetPlanTotalCost(string folderPath)
     {
-        if (_planCostCache != null &&
-            _planCostCacheTime != null &&
-            DateTime.UtcNow - _planCostCacheTime.Value < PlanCostCacheExpiration &&
-            _planCostCache.TryGetValue(folderPath, out var cached))
+        var dict = _planCostCache.GetOrCompute(() => new Dictionary<string, (decimal, int)>());
+        if (dict.TryGetValue(folderPath, out var cached))
         {
             return cached.Cost;
         }
 
         var cost = ComputePlanCost(folderPath);
         var tokens = ComputePlanTokens(folderPath);
-        EnsurePlanCostCache();
-        _planCostCache![folderPath] = (cost, tokens);
+        dict[folderPath] = (cost, tokens);
 
         return cost;
     }
@@ -506,31 +479,17 @@ public class PlanReaderService(IConfigService config) : IPlanReaderService
     /// <returns>Total token count, or <c>0</c> if no costs file exists.</returns>
     public int GetPlanTotalTokens(string folderPath)
     {
-        if (_planCostCache != null &&
-            _planCostCacheTime != null &&
-            DateTime.UtcNow - _planCostCacheTime.Value < PlanCostCacheExpiration &&
-            _planCostCache.TryGetValue(folderPath, out var cached))
+        var dict = _planCostCache.GetOrCompute(() => new Dictionary<string, (decimal, int)>());
+        if (dict.TryGetValue(folderPath, out var cached))
         {
             return cached.Tokens;
         }
 
         var cost = ComputePlanCost(folderPath);
         var tokens = ComputePlanTokens(folderPath);
-        EnsurePlanCostCache();
-        _planCostCache![folderPath] = (cost, tokens);
+        dict[folderPath] = (cost, tokens);
 
         return tokens;
-    }
-
-    private void EnsurePlanCostCache()
-    {
-        if (_planCostCache == null ||
-            _planCostCacheTime == null ||
-            DateTime.UtcNow - _planCostCacheTime.Value >= PlanCostCacheExpiration)
-        {
-            _planCostCache = new Dictionary<string, (decimal, int)>();
-            _planCostCacheTime = DateTime.UtcNow;
-        }
     }
 
     private static decimal ComputePlanCost(string folderPath)
@@ -582,22 +541,8 @@ public class PlanReaderService(IConfigService config) : IPlanReaderService
     /// Correlates <c>costs.csv</c> entries with log file timestamps to determine when tokens were consumed.
     /// Plans without both a costs file and a logs directory are skipped.
     /// </remarks>
-    public List<HourlyTokenBurn> GetHourlyTokenBurn(int days = 7)
-    {
-        if (_hourlyBurnCache != null &&
-            _hourlyBurnCacheTime != null &&
-            DateTime.UtcNow - _hourlyBurnCacheTime.Value < HourlyBurnCacheExpiration)
-        {
-            return _hourlyBurnCache;
-        }
-
-        var result = ComputeHourlyTokenBurn(days);
-
-        _hourlyBurnCache = result;
-        _hourlyBurnCacheTime = DateTime.UtcNow;
-
-        return result;
-    }
+    public List<HourlyTokenBurn> GetHourlyTokenBurn(int days = 7) =>
+        _hourlyBurnCache.GetOrCompute(() => ComputeHourlyTokenBurn(days));
 
     private List<HourlyTokenBurn> ComputeHourlyTokenBurn(int days)
     {
@@ -707,22 +652,8 @@ public class PlanReaderService(IConfigService config) : IPlanReaderService
     /// without full deserialization.
     /// </remarks>
     /// <returns>List of all recommendations ordered by date (most recent first).</returns>
-    public List<Recommendation> GetRecommendations()
-    {
-        if (_recommendationsCache != null &&
-            _recommendationsCacheTime != null &&
-            DateTime.UtcNow - _recommendationsCacheTime.Value < RecommendationsCacheExpiration)
-        {
-            return _recommendationsCache;
-        }
-
-        var result = ComputeRecommendations();
-
-        _recommendationsCache = result;
-        _recommendationsCacheTime = DateTime.UtcNow;
-
-        return result;
-    }
+    public List<Recommendation> GetRecommendations() =>
+        _recommendationsCache.GetOrCompute(ComputeRecommendations);
 
     private List<Recommendation> ComputeRecommendations()
     {
@@ -802,22 +733,8 @@ public class PlanReaderService(IConfigService config) : IPlanReaderService
     /// Results are cached for 2 minutes to reduce disk I/O during dashboard polling.
     /// </summary>
     /// <returns>A <see cref="PlanCountSnapshot"/> with counts for each status category and pending recommendations.</returns>
-    public PlanCountSnapshot ComputePlanCounts()
-    {
-        if (_planCountsCache != null &&
-            _planCountsCacheTime != null &&
-            DateTime.UtcNow - _planCountsCacheTime.Value < PlanCountsCacheExpiration)
-        {
-            return _planCountsCache;
-        }
-
-        var result = ComputePlanCountsInternal();
-
-        _planCountsCache = result;
-        _planCountsCacheTime = DateTime.UtcNow;
-
-        return result;
-    }
+    public PlanCountSnapshot ComputePlanCounts() =>
+        _planCountsCache.GetOrCompute(ComputePlanCountsInternal);
 
     private PlanCountSnapshot ComputePlanCountsInternal()
     {
@@ -893,11 +810,9 @@ public class PlanReaderService(IConfigService config) : IPlanReaderService
         FileHelper.WriteAllText(recommendationsPath, YamlHelper.Serializer.Serialize(items));
 
         // Invalidate caches after state change
-        _recommendationsCache = null;
-        _recommendationsCacheTime = null;
-        _hourlyBurnCache = null;
-        _hourlyBurnCacheTime = null;
-        InvalidatePlanCountsCache();
+        _recommendationsCache.Invalidate();
+        _hourlyBurnCache.Invalidate();
+        _planCountsCache.Invalidate();
     }
 
     private static DateTime? ExtractCompletedTimestamp(string logFilePath)

--- a/src/tendril/Ivy.Tendril/Services/TimeCache.cs
+++ b/src/tendril/Ivy.Tendril/Services/TimeCache.cs
@@ -1,0 +1,55 @@
+namespace Ivy.Tendril.Services;
+
+/// <summary>
+/// Generic time-based cache that stores a value with an expiration time.
+/// Thread-safe for single-writer scenarios (typical for service instances).
+/// </summary>
+/// <typeparam name="T">Type of cached value. Use nullable types for optional data.</typeparam>
+public class TimeCache<T>
+{
+    private T? _value;
+    private DateTime? _timestamp;
+    private readonly TimeSpan _expiration;
+
+    public TimeCache(TimeSpan expiration)
+    {
+        _expiration = expiration;
+    }
+
+    /// <summary>
+    /// Gets the cached value if still valid, otherwise computes and caches a new value.
+    /// </summary>
+    /// <param name="compute">Function to compute the value if cache is expired.</param>
+    /// <returns>The cached or newly computed value.</returns>
+    public T GetOrCompute(Func<T> compute)
+    {
+        if (_value != null &&
+            _timestamp != null &&
+            DateTime.UtcNow - _timestamp.Value < _expiration)
+        {
+            return _value;
+        }
+
+        var result = compute();
+        _value = result;
+        _timestamp = DateTime.UtcNow;
+        return result;
+    }
+
+    /// <summary>
+    /// Invalidates the cache, forcing the next GetOrCompute to recompute.
+    /// </summary>
+    public void Invalidate()
+    {
+        _value = default;
+        _timestamp = null;
+    }
+
+    /// <summary>
+    /// Gets whether the cache currently holds a valid value.
+    /// </summary>
+    public bool IsValid =>
+        _value != null &&
+        _timestamp != null &&
+        DateTime.UtcNow - _timestamp.Value < _expiration;
+}


### PR DESCRIPTION
# Summary

## Changes

Created a generic `TimeCache<T>` helper class and refactored all 4 time-based caches in `PlanReaderService` to use it. This reduced 12 cache-related fields (4 caches × 3 fields each) to 4 `TimeCache<T>` instances and simplified cached method bodies to one-liner expression bodies. Also fixed a pre-existing `FakeJobService` build error in `PlanCountsServiceTests.cs`.

## API Changes

- **New class:** `TimeCache<T>` in `Ivy.Tendril.Services` — public API: `GetOrCompute(Func<T>)`, `Invalidate()`, `IsValid`
- **Removed method:** `PlanReaderService.InvalidatePlanCountsCache()` (was private)
- **Removed method:** `PlanReaderService.EnsurePlanCostCache()` (was private)
- No public API changes to `PlanReaderService` — all public method signatures unchanged

## Files Modified

- **`src/tendril/Ivy.Tendril/Services/TimeCache.cs`** — New generic time-based cache helper
- **`src/tendril/Ivy.Tendril/Services/PlanReaderService.cs`** — Replaced 12 cache fields with 4 `TimeCache<T>` instances, simplified cached methods
- **`src/tendril/Ivy.Tendril.Test/TimeCacheTests.cs`** — New: 6 unit tests for TimeCache
- **`src/tendril/Ivy.Tendril.Test/PlanCountsServiceTests.cs`** — Added missing `NotificationReady` event to `FakeJobService`

## Commits

- ddf3a6fa7 [01951] Refactor PlanReaderService caches into generic TimeCache<T> helper