### PR TITLE
[01958] Remove accidentally re-added PendingNotifications property from IJobService

### DIFF
--- a/src/tendril/Ivy.Tendril/Services/IJobService.cs
+++ b/src/tendril/Ivy.Tendril/Services/IJobService.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using Ivy.Tendril.Apps.Jobs;
 
 namespace Ivy.Tendril.Services;
@@ -7,10 +6,6 @@ public interface IJobService
 {
     event Action? JobsChanged;
     event Action<JobNotification>? NotificationReady;
-
-    [Obsolete("Use NotificationReady event instead. Will be removed in a future version.")]
-    ConcurrentQueue<JobNotification> PendingNotifications { get; }
-
 
     string StartJob(string type, string[] args, string? inboxFilePath);
     string StartJob(string type, params string[] args);


### PR DESCRIPTION
# Summary

## Changes

Removed the accidentally re-added `PendingNotifications` property from the `IJobService` interface, along with its `[Obsolete]` attribute and the now-unused `using System.Collections.Concurrent;` directive. This fixes the build errors (CS0246 and CS0535) introduced by plan 01946.

## API Changes

- **Removed:** `IJobService.PendingNotifications` property (`ConcurrentQueue<JobNotification>`) — was already obsolete and had no consumers.

## Files Modified

- `src/tendril/Ivy.Tendril/Services/IJobService.cs` — Removed obsolete property declaration and unused using directive

## Commits

- 38542c9d0 [01958] Remove accidentally re-added PendingNotifications property from IJobService