### PR TITLE
[01956] Extract IInboxWatcherService interface for consistency

### DIFF
--- a/src/tendril/Ivy.Tendril/Program.cs
+++ b/src/tendril/Ivy.Tendril/Program.cs
@@ -96,11 +96,12 @@ server.Services.AddSingleton<InboxWatcherService>(sp =>
     var jobService = sp.GetRequiredService<IJobService>();
     return new InboxWatcherService(config, jobService);
 });
+server.Services.AddSingleton<IInboxWatcherService>(sp => sp.GetRequiredService<InboxWatcherService>());
 server.UseWebApplication(app =>
 {
     // Eagerly resolve watcher services so their FileSystemWatchers start immediately
     app.Services.GetRequiredService<PlanWatcherService>();
-    app.Services.GetRequiredService<InboxWatcherService>();
+    app.Services.GetRequiredService<IInboxWatcherService>();
     app.Services.GetRequiredService<TelemetryService>().TrackAppStarted();
     app.UseAssets(server.Args, app.Services.GetRequiredService<ILogger<Server>>(), "Assets", "tendril/assets");
 });

--- a/src/tendril/Ivy.Tendril/Services/IInboxWatcherService.cs
+++ b/src/tendril/Ivy.Tendril/Services/IInboxWatcherService.cs
@@ -1,0 +1,5 @@
+namespace Ivy.Tendril.Services;
+
+public interface IInboxWatcherService : IDisposable
+{
+}

--- a/src/tendril/Ivy.Tendril/Services/InboxWatcherService.cs
+++ b/src/tendril/Ivy.Tendril/Services/InboxWatcherService.cs
@@ -2,7 +2,7 @@ using System.Collections.Concurrent;
 
 namespace Ivy.Tendril.Services;
 
-public class InboxWatcherService : IDisposable
+public class InboxWatcherService : IInboxWatcherService, IDisposable
 {
     private readonly IJobService _jobService;
     private readonly FileSystemWatcher? _watcher;


### PR DESCRIPTION
# Summary

## Changes

Extracted `IInboxWatcherService` interface from `InboxWatcherService` to match the established pattern used by all other Tendril services. Updated DI registration in `Program.cs` to register the interface alias and changed the consumer to resolve via the interface.

## API Changes

- **New:** `IInboxWatcherService` interface (extends `IDisposable`, no additional members)
- **Changed:** `InboxWatcherService` now implements `IInboxWatcherService`
- **Changed:** DI consumer in `Program.cs` resolves `IInboxWatcherService` instead of concrete `InboxWatcherService`

## Files Modified

- `src/tendril/Ivy.Tendril/Services/IInboxWatcherService.cs` — new interface file
- `src/tendril/Ivy.Tendril/Services/InboxWatcherService.cs` — added interface implementation
- `src/tendril/Ivy.Tendril/Program.cs` — added interface DI registration, updated consumer

## Commits

- 9070d358b [01956] Extract IInboxWatcherService interface for consistency