### PR TITLE
[01955] Replace JobQueue ConcurrentQueue with Channel

### DIFF
--- a/src/tendril/Ivy.Tendril/Services/JobService.cs
+++ b/src/tendril/Ivy.Tendril/Services/JobService.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Text.RegularExpressions;
+using System.Threading.Channels;
 using Ivy.Tendril.Apps.Jobs;
 using Ivy.Tendril.Apps.Plans;
 
@@ -10,7 +11,7 @@ public record JobNotification(string Title, string Message, bool IsSuccess);
 public class JobService : IJobService
 {
     private readonly ConcurrentDictionary<string, JobItem> _jobs = new();
-    private readonly ConcurrentQueue<string> _jobQueue = new();
+    private readonly Channel<string> _jobQueue = Channel.CreateUnbounded<string>();
     private int _counter;
     private readonly IPlanReaderService? _planReaderService;
     private readonly IConfigService? _configService;
@@ -215,7 +216,7 @@ public class JobService : IJobService
         {
             job.Status = "Queued";
             job.StatusMessage = $"Waiting (max {_maxConcurrentJobs} concurrent jobs)";
-            _jobQueue.Enqueue(id);
+            _jobQueue.Writer.TryWrite(id);
             RaiseJobsChanged();
             return id;
         }
@@ -621,13 +622,13 @@ public class JobService : IJobService
 
     private void ProcessJobQueue()
     {
-        while (_jobQueue.TryPeek(out var queuedId))
+        while (_jobQueue.Reader.TryPeek(out var queuedId))
         {
             // Try to acquire a job slot (non-blocking)
             if (!_jobSlotSemaphore.Wait(0))
                 break;
 
-            if (!_jobQueue.TryDequeue(out queuedId))
+            if (!_jobQueue.Reader.TryRead(out queuedId))
             {
                 // Failed to dequeue — release the slot we just acquired
                 _jobSlotSemaphore.Release();


### PR DESCRIPTION
# Summary

## Changes

Replaced `ConcurrentQueue<string>` with `Channel<string>` (from `System.Threading.Channels`) for the `_jobQueue` field in `JobService.cs`. Updated all queue operations to use the Channel Reader/Writer API while maintaining the existing synchronous processing behavior.

## API Changes

None. All changes are internal to `JobService` — no public API surface was modified.

## Files Modified

- **src/tendril/Ivy.Tendril/Services/JobService.cs** — Field type change, import addition, and queue operation updates (`Enqueue` → `Writer.TryWrite`, `TryPeek` → `Reader.TryPeek`, `TryDequeue` → `Reader.TryRead`)

## Commits

- 03c223f1b3dbe7e94a6adccefa05d73cdbfb8196 [01955] Replace JobQueue ConcurrentQueue with Channel