### PR TITLE
[01963] Fix draft count badge to include Failed plans

### DIFF
--- a/src/tendril/Ivy.Tendril/Services/PlanCountsService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanCountsService.cs
@@ -44,9 +44,9 @@ public class PlanCountsService : IPlanCountsService
         var jobs = _jobService.GetJobs();
 
         return new PlanCounts(
-            Drafts: snapshot.Drafts,
+            Drafts: snapshot.Drafts + snapshot.Failed,
             ActiveJobs: jobs.Count(j => j.Status == "Running" || j.Status == "Queued"),
-            Reviews: snapshot.ReadyForReview + snapshot.Failed,
+            Reviews: snapshot.ReadyForReview,
             Icebox: snapshot.Icebox,
             Recommendations: snapshot.PendingRecommendations
         );


### PR DESCRIPTION
# Summary

## Changes

Updated `PlanCountsService.ComputeCounts()` to include Failed plans in the Drafts badge count, matching what `PlansApp` displays in the Drafts view. Also removed Failed from the Reviews count to prevent double-counting.

## API Changes

None.

## Files Modified

- **Services/PlanCountsService.cs** — Changed `Drafts: snapshot.Drafts` to `Drafts: snapshot.Drafts + snapshot.Failed` and `Reviews: snapshot.ReadyForReview + snapshot.Failed` to `Reviews: snapshot.ReadyForReview`

## Commits

- 27b12f281 [01963] Fix draft count badge to include Failed plans in Drafts count