### PR TITLE
[01964] Update Tendril Prerequisites Documentation and Software Check

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/OnboardingApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/OnboardingApp.cs
@@ -78,7 +78,7 @@ public class SoftwareCheckStepView(IState<int> stepperIndex) : ViewBase
             isChecking.Set(true);
             var results = new Dictionary<string, bool>();
 
-            results["dotnet"] = await CheckCommand("dotnet", "--version");
+            results["gh"] = await CheckCommand("gh", "--version");
             results["claude"] = await CheckCommand("claude", "--version");
             results["git"] = await CheckCommand("git", "--version");
             results["powershell"] = await CheckCommand("pwsh", "-Version")
@@ -90,7 +90,7 @@ public class SoftwareCheckStepView(IState<int> stepperIndex) : ViewBase
         }
 
         var allRequiredPassed = checkResults.Value != null
-            && checkResults.Value["dotnet"]
+            && checkResults.Value["gh"]
             && checkResults.Value["claude"]
             && checkResults.Value["git"]
             && checkResults.Value["powershell"];
@@ -99,8 +99,8 @@ public class SoftwareCheckStepView(IState<int> stepperIndex) : ViewBase
                | Text.H2("Required Software")
                | Text.Markdown(
                    "Tendril requires the following software to be installed:\n\n" +
-                   "- **.NET 10.0 SDK** - For running the application\n" +
                    "- **Claude CLI** - For AI agent orchestration\n" +
+                   "- **GitHub CLI** - For PR creation and GitHub integration\n" +
                    "- **Git** - For version control\n" +
                    "- **PowerShell** - For running scripts and hooks\n\n" +
                    "**Optional:**\n" +
@@ -109,9 +109,9 @@ public class SoftwareCheckStepView(IState<int> stepperIndex) : ViewBase
                | (checkResults.Value != null
                    ? (Layout.Vertical()
                       | Text.H3("Results")
-                      | (checkResults.Value["dotnet"]
-                          ? Text.Success("\u2713 .NET SDK is installed")
-                          : Text.Danger("\u2717 .NET SDK not found - Install from https://dotnet.microsoft.com/download"))
+                      | (checkResults.Value["gh"]
+                          ? Text.Success("\u2713 GitHub CLI is installed")
+                          : Text.Danger("\u2717 GitHub CLI not found - Install from https://cli.github.com/"))
                       | (checkResults.Value["claude"]
                           ? Text.Success("\u2713 Claude CLI is installed")
                           : Text.Danger("\u2717 Claude CLI not found - Install from https://docs.anthropic.com/en/docs/claude-code"))

--- a/src/tendril/README.md
+++ b/src/tendril/README.md
@@ -18,10 +18,14 @@ Tendril is a terminal UI application built on [Ivy Framework](https://github.com
 
 ## Prerequisites
 
-- [.NET 10.0 SDK](https://dotnet.microsoft.com/download)
+### For Running Tendril
 - [Claude CLI](https://docs.anthropic.com/en/docs/claude-code) (`claude`)
+- [GitHub CLI](https://cli.github.com/) (`gh`)
 - PowerShell
 - Git
+
+### For Development
+- [.NET 10.0 SDK](https://dotnet.microsoft.com/download)
 
 ## Setup
 


### PR DESCRIPTION
# Summary

## Changes

Replaced the .NET SDK prerequisite check with GitHub CLI (`gh`) in the Tendril onboarding software check and updated the README prerequisites to separate runtime vs development requirements. GitHub CLI is now listed as a required tool, while .NET SDK is moved to a development-only section.

## API Changes

None.

## Files Modified

- **src/tendril/README.md** — Restructured prerequisites into "For Running Tendril" and "For Development" sections, added GitHub CLI
- **src/tendril/Ivy.Tendril/Apps/OnboardingApp.cs** — Replaced `dotnet` check with `gh` check, updated description text and result display

## Commits

- bf77bc7c8 [01964] Replace .NET SDK check with GitHub CLI in prerequisites and onboarding