### PR TITLE
[01965] Reclaim whitespace in BarChart when axes are hidden

### DIFF
--- a/src/frontend/src/widgets/charts/AreaChartWidget.tsx
+++ b/src/frontend/src/widgets/charts/AreaChartWidget.tsx
@@ -187,7 +187,7 @@ const AreaChartWidget: React.FC<AreaChartWidgetProps> = ({
   // Memoize complete option configuration
   const option = useMemo(
     () => ({
-      grid: generateEChartGrid(cartesianGrid, !!toolbox && toolbox.enabled !== false, yAxis),
+      grid: generateEChartGrid(cartesianGrid, !!toolbox && toolbox.enabled !== false, yAxis, xAxis),
       color: chartColors,
       tooltip: generateTooltip(tooltip, "cross", {
         foreground: themeColors.foreground,

--- a/src/frontend/src/widgets/charts/BarChartWidget.tsx
+++ b/src/frontend/src/widgets/charts/BarChartWidget.tsx
@@ -216,7 +216,7 @@ const BarChartWidget: React.FC<BarChartWidgetProps> = ({
   // Memoize option configuration
   const option = useMemo(
     () => ({
-      grid: generateEChartGrid(cartesianGrid, !!toolbox && toolbox.enabled !== false, yAxis),
+      grid: generateEChartGrid(cartesianGrid, !!toolbox && toolbox.enabled !== false, yAxis, xAxis),
       color: chartColors,
       textStyle: generateTextStyle(themeColors.foreground, themeColors.fontSans),
       xAxis: generateXAxis(

--- a/src/frontend/src/widgets/charts/LineChartWidget.tsx
+++ b/src/frontend/src/widgets/charts/LineChartWidget.tsx
@@ -70,7 +70,7 @@ const LineChartWidget: React.FC<LineChartWidgetProps> = ({
   // Memoize option configuration
   const option = useMemo(
     () => ({
-      grid: generateEChartGrid(cartesianGrid, !!toolbox && toolbox.enabled !== false, yAxis),
+      grid: generateEChartGrid(cartesianGrid, !!toolbox && toolbox.enabled !== false, yAxis, xAxis),
       xAxis: generateXAxis(
         ChartType.Line,
         categories as string[],

--- a/src/frontend/src/widgets/charts/ScatterChartWidget.tsx
+++ b/src/frontend/src/widgets/charts/ScatterChartWidget.tsx
@@ -385,7 +385,7 @@ const ScatterChartWidget: React.FC<ScatterChartWidgetProps> = ({
   // Memoize option configuration
   const option = useMemo(
     () => ({
-      grid: generateEChartGrid(cartesianGrid, !!toolbox && toolbox.enabled !== false, yAxis),
+      grid: generateEChartGrid(cartesianGrid, !!toolbox && toolbox.enabled !== false, yAxis, xAxis),
       xAxis: generateScatterXAxis(xAxis, {
         mutedForeground: themeColors.mutedForeground,
         fontSans: themeColors.fontSans,

--- a/src/frontend/src/widgets/charts/sharedUtils.ts
+++ b/src/frontend/src/widgets/charts/sharedUtils.ts
@@ -161,16 +161,20 @@ export function generateEChartGrid(
   cartesianGrid?: CartesianGridProps,
   hasToolbox: boolean = false,
   yAxis?: YAxisProps[],
+  xAxis?: XAxisProps[],
 ) {
   // When all Y axes are hidden, remove left/right padding so the chart uses full width
   const allYAxesHidden = yAxis && yAxis.length > 0 && yAxis.every((axis) => axis.hide === true);
+
+  // When all X axes are hidden, remove bottom padding
+  const allXAxesHidden = xAxis && xAxis.length > 0 && xAxis.every((axis) => axis.hide === true);
 
   const defaultGrid = {
     show: false, // Hide grid border to remove the square frame
     left: allYAxesHidden ? 0 : "3%",
     right: allYAxesHidden ? 0 : "4%",
     top: hasToolbox ? 40 : 15,
-    bottom: 50, // Space for legend below axis labels
+    bottom: allXAxesHidden ? 10 : 50, // Reduce bottom padding when X axis is hidden
     containLabel: true,
     borderWidth: 0, // Ensure no border is drawn
   };


### PR DESCRIPTION
# Summary

## Changes

Updated the `generateEChartGrid` function in `sharedUtils.ts` to accept an optional `xAxis` parameter and reduce bottom padding from 50 to 10 when all X axes are hidden. Updated all four chart widget components (BarChart, LineChart, AreaChart, ScatterChart) to pass the `xAxis` prop through to the grid function.

## API Changes

None. This is a frontend-only visual fix with no public API surface changes.

## Files Modified

- **Chart shared utilities:** `src/frontend/src/widgets/charts/sharedUtils.ts` — added `xAxis` parameter and bottom padding logic
- **Chart widgets:** `BarChartWidget.tsx`, `LineChartWidget.tsx`, `AreaChartWidget.tsx`, `ScatterChartWidget.tsx` — pass `xAxis` to `generateEChartGrid`

## Commits

- 10aae41c5 [01965] Reclaim whitespace in chart grid when X axes are hidden