### PR TITLE
[01966] Move StackedProgress to BarChart header in Dashboard

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/DashboardApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/DashboardApp.cs
@@ -185,9 +185,11 @@ public class DashboardApp : ViewBase
             .Width(Size.Full());
 
         var content = Layout.Vertical().Gap(2)
-            | new Box(projectProgress).Padding(5)
             | dataTable
-            | combinedChart;
+            | new Card(
+                header: new Box(projectProgress).Padding(2),
+                content: combinedChart
+            );
 
         return new HeaderLayout(
             header: statsRow,


### PR DESCRIPTION
# Summary

## Changes

Moved the StackedProgress project filter from a standalone Box element to the header of a Card that wraps the BarChart in DashboardApp. This creates a unified visual component where the project selector is grouped with the chart it controls.

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/Apps/DashboardApp.cs** — Replaced `new Box(projectProgress).Padding(5)` as a separate layout element with a `new Card(header: ..., content: combinedChart)` wrapping the bar chart.

## Commits

- acb23b18f [01966] Move StackedProgress to BarChart header in Dashboard