### PR TITLE
[01960] Add Roslyn analyzer to enforce UseService interface usage

### DIFF
--- a/src/Ivy.Analyser.Test/UseServiceInterfaceAnalyzerTests.cs
+++ b/src/Ivy.Analyser.Test/UseServiceInterfaceAnalyzerTests.cs
@@ -1,0 +1,169 @@
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using Ivy.Analyser.Analyzers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Xunit;
+
+namespace Ivy.Analyser.Test;
+
+public class UseServiceInterfaceAnalyzerTests
+{
+    private const string Stubs = @"
+using System;
+using TestServices;
+
+namespace Ivy
+{
+    public abstract class ViewBase
+    {
+        public abstract object Build();
+        protected T UseService<T>() { throw new NotImplementedException(); }
+    }
+}
+
+namespace TestServices
+{
+    public interface IConfigService { }
+    public class ConfigService : IConfigService { }
+
+    public interface IJobService { }
+    public class JobService : IJobService { }
+
+    public class NoInterfaceService { }
+}
+";
+
+    private static async Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(string source)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(Stubs + source);
+        var references = new[]
+        {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+        };
+
+        var runtimeDir = System.IO.Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+        var runtimeRef = MetadataReference.CreateFromFile(System.IO.Path.Combine(runtimeDir, "System.Runtime.dll"));
+
+        var compilation = CSharpCompilation.Create("TestAssembly",
+            new[] { syntaxTree },
+            references.Append(runtimeRef),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var analyzer = new UseServiceInterfaceAnalyzer();
+        var compilationWithAnalyzers = compilation.WithAnalyzers(ImmutableArray.Create<DiagnosticAnalyzer>(analyzer));
+        return await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync();
+    }
+
+    [Fact]
+    public async Task ConcreteType_WithInterface_ReportsWarning()
+    {
+        var source = @"
+class MyView : Ivy.ViewBase
+{
+    public override object Build()
+    {
+        var config = UseService<ConfigService>();
+        return new object();
+    }
+}";
+
+        var diagnostics = await GetDiagnosticsAsync(source);
+        Assert.Single(diagnostics);
+        Assert.Equal(UseServiceInterfaceAnalyzer.DiagnosticId, diagnostics[0].Id);
+        Assert.Contains("ConfigService", diagnostics[0].GetMessage());
+    }
+
+    [Fact]
+    public async Task InterfaceType_NoDiagnostic()
+    {
+        var source = @"
+class MyView : Ivy.ViewBase
+{
+    public override object Build()
+    {
+        var config = UseService<IConfigService>();
+        return new object();
+    }
+}";
+
+        var diagnostics = await GetDiagnosticsAsync(source);
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task ConcreteType_WithoutInterface_NoDiagnostic()
+    {
+        var source = @"
+class MyView : Ivy.ViewBase
+{
+    public override object Build()
+    {
+        var svc = UseService<NoInterfaceService>();
+        return new object();
+    }
+}";
+
+        var diagnostics = await GetDiagnosticsAsync(source);
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task ThisQualified_ConcreteType_ReportsWarning()
+    {
+        var source = @"
+class MyView : Ivy.ViewBase
+{
+    public override object Build()
+    {
+        var job = this.UseService<JobService>();
+        return new object();
+    }
+}";
+
+        var diagnostics = await GetDiagnosticsAsync(source);
+        Assert.Single(diagnostics);
+        Assert.Equal(UseServiceInterfaceAnalyzer.DiagnosticId, diagnostics[0].Id);
+        Assert.Contains("JobService", diagnostics[0].GetMessage());
+    }
+
+    [Fact]
+    public async Task NonBuildMethod_StillChecked()
+    {
+        var source = @"
+class MyView : Ivy.ViewBase
+{
+    public override object Build() { return new object(); }
+
+    public void SomeMethod()
+    {
+        var config = UseService<ConfigService>();
+    }
+}";
+
+        var diagnostics = await GetDiagnosticsAsync(source);
+        Assert.Single(diagnostics);
+        Assert.Equal(UseServiceInterfaceAnalyzer.DiagnosticId, diagnostics[0].Id);
+    }
+
+    [Fact]
+    public async Task MultipleViolations_ReportsAll()
+    {
+        var source = @"
+class MyView : Ivy.ViewBase
+{
+    public override object Build()
+    {
+        var config = UseService<ConfigService>();
+        var job = UseService<JobService>();
+        return new object();
+    }
+}";
+
+        var diagnostics = await GetDiagnosticsAsync(source);
+        Assert.Equal(2, diagnostics.Length);
+        Assert.All(diagnostics, d => Assert.Equal(UseServiceInterfaceAnalyzer.DiagnosticId, d.Id));
+    }
+}

--- a/src/Ivy.Analyser/Analyzers/UseServiceInterfaceAnalyzer.cs
+++ b/src/Ivy.Analyser/Analyzers/UseServiceInterfaceAnalyzer.cs
@@ -1,0 +1,107 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Ivy.Analyser.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class UseServiceInterfaceAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "IVYSERVICE001";
+        private const string Title = "UseService should use interface type";
+        private const string MessageFormat = "UseService<{0}> should use interface I{0} instead. Using concrete types breaks testability and violates dependency inversion.";
+        private const string Description = "When calling UseService<T>(), prefer interface types over concrete types when an interface is available in the same namespace.";
+        private const string Category = "Usage";
+
+        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId,
+            Title,
+            MessageFormat,
+            Category,
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: Description);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+            ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+            context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+        }
+
+        private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+        {
+            var invocation = (InvocationExpressionSyntax)context.Node;
+
+            if (!IsUseServiceCall(invocation, out var genericName) || genericName == null)
+                return;
+
+            if (genericName.TypeArgumentList.Arguments.Count != 1)
+                return;
+
+            var typeArgument = genericName.TypeArgumentList.Arguments[0];
+            var typeSymbol = context.SemanticModel.GetTypeInfo(typeArgument).Type;
+
+            if (typeSymbol == null || typeSymbol.TypeKind == TypeKind.Interface)
+                return;
+
+            var interfaceName = "I" + typeSymbol.Name;
+            var interfaceSymbol = FindInterfaceInNamespace(typeSymbol, interfaceName);
+
+            if (interfaceSymbol != null)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    Rule,
+                    typeArgument.GetLocation(),
+                    typeSymbol.Name));
+            }
+        }
+
+        private static bool IsUseServiceCall(InvocationExpressionSyntax invocation, out GenericNameSyntax? genericName)
+        {
+            genericName = null;
+
+            if (invocation.Expression is GenericNameSyntax gns &&
+                gns.Identifier.Text == "UseService")
+            {
+                genericName = gns;
+                return true;
+            }
+
+            if (invocation.Expression is MemberAccessExpressionSyntax memberAccess &&
+                memberAccess.Name is GenericNameSyntax gns2 &&
+                gns2.Identifier.Text == "UseService")
+            {
+                genericName = gns2;
+                return true;
+            }
+
+            return false;
+        }
+
+        private static INamedTypeSymbol? FindInterfaceInNamespace(
+            ITypeSymbol typeSymbol,
+            string interfaceName)
+        {
+            var containingNamespace = typeSymbol.ContainingNamespace;
+            if (containingNamespace == null)
+                return null;
+
+            foreach (var member in containingNamespace.GetMembers(interfaceName))
+            {
+                if (member is INamedTypeSymbol { TypeKind: TypeKind.Interface } interfaceSymbol &&
+                    interfaceSymbol.DeclaredAccessibility == Accessibility.Public)
+                {
+                    return interfaceSymbol;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Ivy.Analyser/README.md
+++ b/src/Ivy.Analyser/README.md
@@ -234,6 +234,39 @@ This means any custom hooks you create following the `UseX` pattern will be auto
 **Message:** `Ivy hook '{hookName}' must be called at the top of the Build() method, before any other statements.`  
 **Description:** All hooks must be called at the very top of the Build() method, before any other non-hook statements. This ensures hooks are called in a consistent order on every render.
 
+### IVYSERVICE001 - UseService Should Use Interface (Warning)
+
+**Severity:** Warning  
+**Message:** `UseService<{ConcreteType}> should use interface I{ConcreteType} instead. Using concrete types breaks testability and violates dependency inversion.`  
+**Description:** When calling UseService<T>(), always prefer interface types over concrete types when an interface is available. This ensures proper dependency injection, testability, and adherence to SOLID principles.
+
+#### ✅ Valid Usage
+
+```csharp
+public override object? Build()
+{
+    var config = UseService<IConfigService>();     // ✅ Valid - using interface
+    var job = UseService<IJobService>();           // ✅ Valid - using interface
+    var git = UseService<IGitService>();           // ✅ Valid - using interface
+    
+    return new Button();
+}
+```
+
+#### ❌ Invalid Usage
+
+```csharp
+public override object? Build()
+{
+    var config = UseService<ConfigService>();     // ⚠️ Warning IVYSERVICE001 - use IConfigService
+    var job = UseService<JobService>();           // ⚠️ Warning IVYSERVICE001 - use IJobService
+    
+    return new Button();
+}
+```
+
+**Note:** This warning only appears when a corresponding interface (prefixed with 'I') exists in the same namespace. If no interface exists, no warning is shown.
+
 ## Configuration
 
 The analyzer runs automatically when you build your project. No additional configuration is needed.
@@ -248,12 +281,14 @@ If you need to suppress the analyzer for specific cases, you can use:
 #pragma warning disable IVYHOOK003  // Suppress loop warning
 #pragma warning disable IVYHOOK004  // Suppress switch warning
 #pragma warning disable IVYHOOK005  // Suppress not-at-top warning
+#pragma warning disable IVYSERVICE001  // Suppress UseService interface warning
 var state = UseState(false); // This will not trigger the analyzer
 #pragma warning restore IVYHOOK001
 #pragma warning restore IVYHOOK002
 #pragma warning restore IVYHOOK003
 #pragma warning restore IVYHOOK004
 #pragma warning restore IVYHOOK005
+#pragma warning restore IVYSERVICE001
 ```
 
 However, this is **not recommended** as it may lead to runtime errors.


### PR DESCRIPTION
# Summary

## Changes

Added a new Roslyn analyzer `IVYSERVICE001` to the `Ivy.Analyser` project that warns when `UseService<T>()` is called with a concrete type and a corresponding `I{TypeName}` interface exists in the same namespace. This prevents future regressions where developers accidentally use concrete service types instead of their interfaces.

## API Changes

- **New diagnostic:** `IVYSERVICE001` — Warning severity, category "Usage"
  - Message: `UseService<{ConcreteType}> should use interface I{ConcreteType} instead. Using concrete types breaks testability and violates dependency inversion.`
  - Triggers when `UseService<T>()` or `this.UseService<T>()` is called with a concrete class that has a public `I{ClassName}` interface in the same namespace

## Files Modified

- **New:** `src/Ivy.Analyser/Analyzers/UseServiceInterfaceAnalyzer.cs` — The analyzer implementation
- **New:** `src/Ivy.Analyser.Test/UseServiceInterfaceAnalyzerTests.cs` — 6 unit tests
- **Modified:** `src/Ivy.Analyser/README.md` — Added IVYSERVICE001 documentation section

## Commits

- 8ad86a8e7 Add Roslyn analyzer to enforce UseService interface usage