### PR TITLE
[01961] Add async support to TimeCache<T>

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/TimeCacheTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/TimeCacheTests.cs
@@ -75,4 +75,102 @@ public class TimeCacheTests
 
         Assert.False(cache.IsValid);
     }
+
+    [Fact]
+    public async Task GetOrComputeAsync_CallsComputeOnFirstAccess()
+    {
+        var cache = new TimeCache<int>(TimeSpan.FromMinutes(1));
+        int callCount = 0;
+
+        var result = await cache.GetOrComputeAsync(async () =>
+        {
+            await Task.Delay(10);
+            callCount++;
+            return 42;
+        });
+
+        Assert.Equal(42, result);
+        Assert.Equal(1, callCount);
+    }
+
+    [Fact]
+    public async Task GetOrComputeAsync_ReturnsCachedValueWithinExpiration()
+    {
+        var cache = new TimeCache<int>(TimeSpan.FromSeconds(1));
+        int callCount = 0;
+
+        await cache.GetOrComputeAsync(async () =>
+        {
+            await Task.Delay(10);
+            callCount++;
+            return 42;
+        });
+
+        var result = await cache.GetOrComputeAsync(async () =>
+        {
+            await Task.Delay(10);
+            callCount++;
+            return 99;
+        });
+
+        Assert.Equal(42, result);
+        Assert.Equal(1, callCount);
+    }
+
+    [Fact]
+    public async Task GetOrComputeAsync_RecomputesAfterExpiration()
+    {
+        var cache = new TimeCache<int>(TimeSpan.FromMilliseconds(100));
+        int callCount = 0;
+
+        await cache.GetOrComputeAsync(async () =>
+        {
+            await Task.Delay(10);
+            callCount++;
+            return 42;
+        });
+
+        await Task.Delay(150);
+
+        var result = await cache.GetOrComputeAsync(async () =>
+        {
+            await Task.Delay(10);
+            callCount++;
+            return 99;
+        });
+
+        Assert.Equal(99, result);
+        Assert.Equal(2, callCount);
+    }
+
+    [Fact]
+    public async Task GetOrComputeAsync_PropagatesExceptions()
+    {
+        var cache = new TimeCache<int>(TimeSpan.FromMinutes(1));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await cache.GetOrComputeAsync(async () =>
+            {
+                await Task.Delay(10);
+                throw new InvalidOperationException("Test exception");
+            }));
+
+        Assert.False(cache.IsValid);
+    }
+
+    [Fact]
+    public async Task GetOrComputeAsync_WorksWithGetOrCompute()
+    {
+        var cache = new TimeCache<int>(TimeSpan.FromMinutes(1));
+
+        await cache.GetOrComputeAsync(async () =>
+        {
+            await Task.Delay(10);
+            return 42;
+        });
+
+        var result = cache.GetOrCompute(() => 99);
+
+        Assert.Equal(42, result);
+    }
 }

--- a/src/tendril/Ivy.Tendril/Services/TimeCache.cs
+++ b/src/tendril/Ivy.Tendril/Services/TimeCache.cs
@@ -3,6 +3,8 @@ namespace Ivy.Tendril.Services;
 /// <summary>
 /// Generic time-based cache that stores a value with an expiration time.
 /// Thread-safe for single-writer scenarios (typical for service instances).
+///
+/// Use GetOrCompute for synchronous computations and GetOrComputeAsync for async operations.
 /// </summary>
 /// <typeparam name="T">Type of cached value. Use nullable types for optional data.</typeparam>
 public class TimeCache<T>
@@ -31,6 +33,26 @@ public class TimeCache<T>
         }
 
         var result = compute();
+        _value = result;
+        _timestamp = DateTime.UtcNow;
+        return result;
+    }
+
+    /// <summary>
+    /// Gets the cached value if still valid, otherwise computes and caches a new value asynchronously.
+    /// </summary>
+    /// <param name="computeAsync">Async function to compute the value if cache is expired.</param>
+    /// <returns>The cached or newly computed value.</returns>
+    public async Task<T> GetOrComputeAsync(Func<Task<T>> computeAsync)
+    {
+        if (_value != null &&
+            _timestamp != null &&
+            DateTime.UtcNow - _timestamp.Value < _expiration)
+        {
+            return _value;
+        }
+
+        var result = await computeAsync();
         _value = result;
         _timestamp = DateTime.UtcNow;
         return result;


### PR DESCRIPTION
# Summary

## Changes

Added `GetOrComputeAsync(Func<Task<T>>)` method to `TimeCache<T>` for async cache computations. Updated class XML documentation to describe both sync and async usage. Added 5 async test cases to `TimeCacheTests`.

## API Changes

- **New method:** `TimeCache<T>.GetOrComputeAsync(Func<Task<T>> computeAsync)` — returns `Task<T>`, async variant of `GetOrCompute`
- Updated class summary XML doc to mention both sync and async usage patterns

## Files Modified

- `src/tendril/Ivy.Tendril/Services/TimeCache.cs` — added `GetOrComputeAsync` method and updated docs
- `src/tendril/Ivy.Tendril.Test/TimeCacheTests.cs` — added 5 async test cases

## Commits

- 89da8b0af [01961] Add async support to TimeCache<T>