### PR TITLE
[01088] Multi-line PowerShell command rendering in Jobs sheet

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/JobsApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/JobsApp.cs
@@ -224,7 +224,7 @@ public class JobsApp : ViewBase
                 dataTable,
                 new Sheet(
                     onClose: () => showCommand.Set(null),
-                    content: new Markdown($"```\n{cmd}\n```"),
+                    content: new CodeBlock(cmd, Languages.Text).WrapLines(),
                     title: "Promptware Command"
                 ).Width(Size.Half()).Resizable()
             );


### PR DESCRIPTION
# Summary

## Changes

Replaced the `Markdown` code block widget with a `CodeBlock` widget using `.WrapLines()` for the "Show Command" sheet in the Jobs datatable. PowerShell commands now wrap visually instead of requiring horizontal scrolling.

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/Apps/JobsApp.cs** — Changed line 227 from `new Markdown(...)` to `new CodeBlock(cmd, Languages.Text).WrapLines()`

## Commits

- `7565850bf` — [01088] Use CodeBlock with WrapLines for PowerShell command display in Jobs sheet