### PR TITLE
[01092] Add Powershell to Languages enum in CodeBlock

### DIFF
--- a/src/Ivy/Widgets/Primitives/CodeBlock.cs
+++ b/src/Ivy/Widgets/Primitives/CodeBlock.cs
@@ -33,6 +33,8 @@ public enum Languages
     Yaml,
     [Description("CSV")]
     Csv,
+    [Description("PowerShell")]
+    Powershell,
 }
 
 /// <summary>

--- a/src/frontend/src/widgets/primitives/CodeBlockWidget.tsx
+++ b/src/frontend/src/widgets/primitives/CodeBlockWidget.tsx
@@ -38,6 +38,7 @@ const languageMap: Record<string, string> = {
   Xml: "xml",
   Yaml: "yaml",
   Csv: "text",
+  Powershell: "powershell",
 };
 
 const mapLanguageToPrism = (language: string): string | undefined => {

--- a/src/tendril/Ivy.Tendril/Apps/FileApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/FileApp.cs
@@ -34,6 +34,8 @@ public class FileApp : ViewBase
         { ".config", Languages.Xml },
         { ".csproj", Languages.Xml },
         { ".sln", Languages.Text },
+        { ".ps1", Languages.Powershell },
+        { ".psm1", Languages.Powershell },
     };
 
     public static Languages GetLanguage(string extension)


### PR DESCRIPTION
# Summary

## Changes

Added `Powershell` to the `Languages` enum in `CodeBlock.cs` with a `[Description("PowerShell")]` attribute. Added the corresponding `Powershell: "powershell"` mapping in the frontend `CodeBlockWidget.tsx` languageMap for Prism syntax highlighting. Added `.ps1` and `.psm1` file extension mappings to `Languages.Powershell` in Tendril's `FileApp.cs`.

## API Changes

- `Languages.Powershell` — new enum value in `Ivy.Languages`
- `FileApp.GetLanguage(".ps1")` and `FileApp.GetLanguage(".psm1")` now return `Languages.Powershell` instead of `Languages.Text`

## Files Modified

- `src/Ivy/Widgets/Primitives/CodeBlock.cs` — added `Powershell` enum value
- `src/frontend/src/widgets/primitives/CodeBlockWidget.tsx` — added Prism language mapping
- `src/tendril/Ivy.Tendril/Apps/FileApp.cs` — added `.ps1` and `.psm1` extension mappings

## Commits

- db4c336c0