### PR TITLE
[01097] Add Bash/Shell to Languages enum and FileApp.LanguageMap

### DIFF
--- a/src/Ivy/Widgets/Primitives/CodeBlock.cs
+++ b/src/Ivy/Widgets/Primitives/CodeBlock.cs
@@ -35,6 +35,8 @@ public enum Languages
     Csv,
     [Description("PowerShell")]
     Powershell,
+    [Description("Bash")]
+    Bash,
 }
 
 /// <summary>

--- a/src/frontend/src/widgets/primitives/CodeBlockWidget.tsx
+++ b/src/frontend/src/widgets/primitives/CodeBlockWidget.tsx
@@ -39,6 +39,7 @@ const languageMap: Record<string, string> = {
   Yaml: "yaml",
   Csv: "text",
   Powershell: "powershell",
+  Bash: "bash",
 };
 
 const mapLanguageToPrism = (language: string): string | undefined => {

--- a/src/tendril/Ivy.Tendril/Apps/FileApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/FileApp.cs
@@ -36,6 +36,8 @@ public class FileApp : ViewBase
         { ".sln", Languages.Text },
         { ".ps1", Languages.Powershell },
         { ".psm1", Languages.Powershell },
+        { ".sh", Languages.Bash },
+        { ".bash", Languages.Bash },
     };
 
     public static Languages GetLanguage(string extension)


### PR DESCRIPTION
## Summary

Added `Bash` as a new language option to the Ivy Framework, enabling syntax highlighting for shell scripts. This follows the same pattern as the PowerShell addition (plan 01092), adding the enum value, Prism mapping, and file extension mappings in three files.

## API Changes

- Added `Languages.Bash` enum value with `[Description("Bash")]` attribute in `CodeBlock.cs`
- Added `.sh` and `.bash` file extension mappings to `FileApp.LanguageMap`

## Files Modified

- `src/Ivy/Widgets/Primitives/CodeBlock.cs` — Added `Bash` to `Languages` enum
- `src/frontend/src/widgets/primitives/CodeBlockWidget.tsx` — Added `Bash: "bash"` to Prism language map
- `src/tendril/Ivy.Tendril/Apps/FileApp.cs` — Added `.sh` and `.bash` extension mappings

## Commits

- `6a8f4329b` [01097] Add Bash/Shell to Languages enum and FileApp.LanguageMap