### PR TITLE
[01107] Add .npmrc to src/frontend/.gitignore

### DIFF
--- a/src/frontend/.gitignore
+++ b/src/frontend/.gitignore
@@ -34,3 +34,6 @@ doctor.txt
 doctor-output.json
 
 package-lock.json
+
+# Worktree artifact (pnpm compatibility)
+.npmrc


### PR DESCRIPTION
## Changes

Added `.npmrc` to `src/frontend/.gitignore` to prevent the worktree-generated pnpm compatibility file from being accidentally committed. This was a recurring issue first seen during plan 01101.

## API Changes

None.

## Files Modified

- `src/frontend/.gitignore` — Added `.npmrc` entry with descriptive comment

## Commits

- `daf695a7c` — Add .npmrc to frontend .gitignore