### PR TITLE
[01114] Add ShortcutKey to ContentInput documentation

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/04_Inputs/18_ContentInput.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/04_Inputs/18_ContentInput.md
@@ -55,6 +55,7 @@ text.ToContentInput(upload)
 | `.MaxFiles(int)` | Maximum number of attachments |
 | `.Files(IEnumerable<FileUpload>)` | Display current file attachments |
 | `.Disabled(bool)` | Disable the input |
+| `.ShortcutKey(string)` | Keyboard shortcut to focus the input (e.g., `"Ctrl+K"`) |
 | `.Invalid(string)` | Show validation error |
 
 ## Events


### PR DESCRIPTION
## Summary

Added the `.ShortcutKey(string)` configuration method to the ContentInput documentation table. This completes the documentation that was missed when plan 01098 added the `ShortcutKey` property to the `ContentInput` widget class.

## API Changes

None.

## Files Modified

- **Documentation:** `src/Ivy.Docs.Shared/Docs/02_Widgets/04_Inputs/18_ContentInput.md` — added `.ShortcutKey(string)` row to Configuration table

## Commits

- 88267d7ea