### PR TITLE
[01108] Extract shared validateFileWithToast to eliminate validation toast duplication

### DIFF
--- a/src/frontend/src/widgets/filePicker/shared.ts
+++ b/src/frontend/src/widgets/filePicker/shared.ts
@@ -1,5 +1,4 @@
-import { toast } from "@/hooks/use-toast";
-import { validateSingleFile } from "@/widgets/inputs/file-input-validation";
+import { validateFileWithToast } from "@/widgets/inputs/file-input-validation";
 
 /**
  * Get the full upload URL, accounting for the ivy-host meta tag.
@@ -23,16 +22,7 @@ export function validateFile(
   maxFileSize?: number,
   minFileSize?: number,
 ): boolean {
-  const result = validateSingleFile({ file, accept, maxFileSize, minFileSize });
-  if (!result.valid) {
-    toast({
-      title: result.title || "Validation Error",
-      description: result.error,
-      variant: "destructive",
-    });
-    return false;
-  }
-  return true;
+  return validateFileWithToast({ file, accept, maxFileSize, minFileSize });
 }
 
 /**

--- a/src/frontend/src/widgets/inputs/ContentInputWidget/useFileAttachments.ts
+++ b/src/frontend/src/widgets/inputs/ContentInputWidget/useFileAttachments.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState, useRef } from "react";
 import { toast } from "@/hooks/use-toast";
-import { validateSingleFile, validateFileCount } from "../file-input-validation";
+import { validateFileWithToast, validateFileCount } from "../file-input-validation";
 
 interface UseFileAttachmentsOptions {
   uploadUrl?: string;
@@ -17,26 +17,10 @@ export function useFileAttachments(options: UseFileAttachmentsOptions) {
   const [isDragging, setIsDragging] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  const validateFile = useCallback(
-    (file: File): boolean => {
-      const result = validateSingleFile({ file, accept, maxFileSize });
-      if (!result.valid) {
-        toast({
-          title: result.title || "Validation Error",
-          description: result.error,
-          variant: "destructive",
-        });
-        return false;
-      }
-      return true;
-    },
-    [accept, maxFileSize],
-  );
-
   const uploadFile = useCallback(
     async (file: File): Promise<void> => {
       if (!uploadUrl) return;
-      if (!validateFile(file)) return;
+      if (!validateFileWithToast({ file, accept, maxFileSize })) return;
 
       const getUploadUrl = () => {
         const ivyHostMeta = document.querySelector('meta[name="ivy-host"]');
@@ -62,7 +46,7 @@ export function useFileAttachments(options: UseFileAttachmentsOptions) {
         console.error("File upload error:", error);
       }
     },
-    [uploadUrl, validateFile],
+    [uploadUrl, accept, maxFileSize],
   );
 
   const uploadFiles = useCallback(

--- a/src/frontend/src/widgets/inputs/FileInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/FileInputWidget.tsx
@@ -13,7 +13,7 @@ import {
   uploadIconVariant,
   textVariant,
 } from "@/components/ui/input/file-input-variant";
-import { validateSingleFile, validateFileCount } from "./file-input-validation";
+import { validateFileWithToast, validateFileCount } from "./file-input-validation";
 import { EMPTY_ARRAY } from "@/lib/constants";
 import { FileItem } from "./shared/types";
 import { FileAttachmentList } from "./shared/FileAttachmentList";
@@ -66,34 +66,12 @@ export const FileInputWidget: React.FC<FileInputWidgetProps> = ({
   const hasCancelHandler = Array.isArray(events) && events.includes("OnCancel");
   const hasBlurHandler = Array.isArray(events) && events.includes("OnBlur");
 
-  const validateFile = useCallback(
-    (file: File): boolean => {
-      const result = validateSingleFile({
-        file,
-        accept,
-        maxFileSize,
-        minFileSize,
-      });
-
-      if (!result.valid) {
-        toast({
-          title: result.title || "Validation Error",
-          description: result.error,
-          variant: "destructive",
-        });
-        return false;
-      }
-      return true;
-    },
-    [accept, maxFileSize, minFileSize],
-  );
-
   const uploadFile = useCallback(
     async (file: File): Promise<void> => {
       if (!uploadUrl) return;
 
       // Validate file before upload - show toast on error
-      if (!validateFile(file)) {
+      if (!validateFileWithToast({ file, accept, maxFileSize, minFileSize })) {
         return;
       }
 
@@ -124,7 +102,7 @@ export const FileInputWidget: React.FC<FileInputWidgetProps> = ({
         console.error("File upload error:", error);
       }
     },
-    [uploadUrl, validateFile],
+    [uploadUrl, accept, maxFileSize, minFileSize],
   );
 
   const handleBlur = useCallback(() => {

--- a/src/frontend/src/widgets/inputs/file-input-validation.ts
+++ b/src/frontend/src/widgets/inputs/file-input-validation.ts
@@ -1,3 +1,5 @@
+import { toast } from "@/hooks/use-toast";
+
 export const formatBytes = (bytes: number): string => {
   const sizes = ["B", "KB", "MB", "GB", "TB"];
   if (bytes === 0) return "0 B";
@@ -75,6 +77,19 @@ export function validateSingleFile(ctx: FileValidationContext): ValidationResult
   }
 
   return { valid: true };
+}
+
+export function validateFileWithToast(ctx: FileValidationContext): boolean {
+  const result = validateSingleFile(ctx);
+  if (!result.valid) {
+    toast({
+      title: result.title || "Validation Error",
+      description: result.error,
+      variant: "destructive",
+    });
+    return false;
+  }
+  return true;
 }
 
 export function validateFileCount(


### PR DESCRIPTION
## Summary

### Changes

Extracted a shared `validateFileWithToast` function into `file-input-validation.ts` that wraps `validateSingleFile` with toast notification on failure. Replaced three duplicate validate-then-toast patterns in `FileInputWidget.tsx`, `useFileAttachments.ts`, and `shared.ts` with calls to this shared function.

### API Changes

- **Added** `validateFileWithToast(ctx: FileValidationContext): boolean` in `file-input-validation.ts`
- `validateSingleFile` and `validateFileCount` remain unchanged
- `shared.ts` `validateFile()` signature unchanged (now delegates to `validateFileWithToast`)

### Files Modified

- `src/frontend/src/widgets/inputs/file-input-validation.ts` — Added `validateFileWithToast` function and `toast` import
- `src/frontend/src/widgets/inputs/FileInputWidget.tsx` — Removed `useCallback` wrapper, replaced with direct `validateFileWithToast` call
- `src/frontend/src/widgets/inputs/ContentInputWidget/useFileAttachments.ts` — Same as above
- `src/frontend/src/widgets/filePicker/shared.ts` — Replaced inline implementation with delegation to `validateFileWithToast`

## Commits

- 1d0eec6de