### PR TITLE
[01113] Move shortcut utilities to shared @/lib/shortcut module

### DIFF
--- a/src/frontend/src/lib/shortcut.ts
+++ b/src/frontend/src/lib/shortcut.ts
@@ -34,10 +34,6 @@ export const parseShortcut = (shortcutStr?: string): ParsedShortcut | null => {
 };
 
 /**
- * Formats a shortcut string for display as React nodes.
- * Converts modifier keys to platform-appropriate symbols (e.g., ⌘ on Mac).
- */
-/**
  * Maps a key name to a KeyboardEvent.code value.
  * Uses event.code for matching so modifiers like Alt don't produce special characters on Mac.
  */
@@ -80,6 +76,10 @@ export const keyToCode = (key: string): string => {
   return specialKeys[k] ?? key;
 };
 
+/**
+ * Formats a shortcut string for display as React nodes.
+ * Converts modifier keys to platform-appropriate symbols (e.g., ⌘ on Mac).
+ */
 export const formatShortcutForDisplay = (shortcutStr?: string): React.ReactNode[] => {
   if (!shortcutStr) return [];
   const parts = shortcutStr.split("+").map((p) => p.trim());

--- a/src/frontend/src/widgets/button/ButtonWidget.tsx
+++ b/src/frontend/src/widgets/button/ButtonWidget.tsx
@@ -17,11 +17,7 @@ import { Loader2 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { BorderRadius, getColor, getWidth } from "@/lib/styles";
 import { Densities } from "@/types/density";
-import {
-  parseShortcut,
-  formatShortcutForDisplay,
-  keyToCode,
-} from "@/widgets/inputs/TextInputWidget/utils/shortcut";
+import { parseShortcut, formatShortcutForDisplay, keyToCode } from "@/lib/shortcut";
 
 const ButtonWithTooltip = withTooltip(Button);
 

--- a/src/frontend/src/widgets/inputs/ContentInputWidget/ContentInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/ContentInputWidget/ContentInputWidget.tsx
@@ -11,11 +11,7 @@ import { useFileAttachments } from "./useFileAttachments";
 import { FileAttachmentList } from "./FileAttachmentList";
 import { ContentInputWidgetProps } from "./types";
 import { EMPTY_ARRAY } from "@/lib/constants";
-import {
-  formatShortcutForDisplay,
-  parseShortcut,
-  keyToCode,
-} from "@/widgets/inputs/TextInputWidget/utils/shortcut";
+import { formatShortcutForDisplay, parseShortcut, keyToCode } from "@/lib/shortcut";
 
 export const ContentInputWidget: React.FC<ContentInputWidgetProps> = ({
   id,

--- a/src/frontend/src/widgets/inputs/TextInputWidget/hooks/useShortcutKey.ts
+++ b/src/frontend/src/widgets/inputs/TextInputWidget/hooks/useShortcutKey.ts
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react";
-import { parseShortcut, keyToCode } from "../utils/shortcut";
+import { parseShortcut, keyToCode } from "@/lib/shortcut";
 
 interface UseShortcutKeyParams {
   shortcutKey: string | undefined;

--- a/src/frontend/src/widgets/inputs/TextInputWidget/hooks/useTextInput.ts
+++ b/src/frontend/src/widgets/inputs/TextInputWidget/hooks/useTextInput.ts
@@ -1,6 +1,6 @@
 import React, { useRef, useEffect, useCallback } from "react";
 
-export { parseShortcut, formatShortcutForDisplay } from "../utils/shortcut";
+export { parseShortcut, formatShortcutForDisplay } from "@/lib/shortcut";
 
 export const useCursorPosition = (
   value?: string,


### PR DESCRIPTION
## Changes

Moved shortcut utility functions (`parseShortcut`, `formatShortcutForDisplay`, `keyToCode`, `isMac`, `ParsedShortcut`) from `src/frontend/src/widgets/inputs/TextInputWidget/utils/shortcut.ts` to the shared `src/frontend/src/lib/shortcut.ts` module. Updated all 4 consumer files to import from the new `@/lib/shortcut` path and deleted the original file.

## API Changes

None. All exports remain identical — only the module location changed from `@/widgets/inputs/TextInputWidget/utils/shortcut` to `@/lib/shortcut`.

## Files Modified

- **New:** `src/frontend/src/lib/shortcut.ts` — shared shortcut utilities
- **Deleted:** `src/frontend/src/widgets/inputs/TextInputWidget/utils/shortcut.ts`
- **Updated imports:**
  - `src/frontend/src/widgets/button/ButtonWidget.tsx`
  - `src/frontend/src/widgets/inputs/ContentInputWidget/ContentInputWidget.tsx`
  - `src/frontend/src/widgets/inputs/TextInputWidget/hooks/useShortcutKey.ts`
  - `src/frontend/src/widgets/inputs/TextInputWidget/hooks/useTextInput.ts`

## Commits

- d2dab593b [01113] Move shortcut utilities to shared @/lib/shortcut module