### PR TITLE
[01105] Add Bash and Powershell to CodeBlock sample app

### DIFF
--- a/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/CodeBlockApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/CodeBlockApp.cs
@@ -184,6 +184,37 @@ public class CodeBlockApp : SampleBase
                     <Nullable>enable</Nullable>
                   </PropertyGroup>
                 </Project>
+                """,
+
+            [Languages.Powershell] = """
+                function Get-Fibonacci {
+                    param([int]$Count = 10)
+                    $a, $b = 0, 1
+                    for ($i = 0; $i -lt $Count; $i++) {
+                        $a
+                        $a, $b = $b, ($a + $b)
+                    }
+                }
+
+                # Usage
+                Get-Fibonacci -Count 10
+                """,
+
+            [Languages.Bash] = """
+                #!/bin/bash
+                fibonacci() {
+                    local count=${1:-10}
+                    local a=0 b=1
+                    for ((i = 0; i < count; i++)); do
+                        echo $a
+                        local temp=$((a + b))
+                        a=$b
+                        b=$temp
+                    done
+                }
+
+                # Usage
+                fibonacci 10
                 """
         };
 


### PR DESCRIPTION
## Summary

Added `Languages.Powershell` and `Languages.Bash` entries to the `CreateLanguageVariants()` dictionary in `CodeBlockApp.cs`. Both entries contain fibonacci sequence sample code matching the style of existing language entries. The CodeBlock sample app now showcases all 14 supported languages.

## API Changes

None.

## Files Modified

- **src/Ivy.Samples.Shared/Apps/Widgets/Primitives/CodeBlockApp.cs** — Added Powershell and Bash language entries to the sample code dictionary

## Commits

- `ef5eabea2` — [01105] Add Bash and Powershell to CodeBlock sample app