### PR TITLE
[01111] Add keyboard handler for Enter/Space on FolderInput widget

### DIFF
--- a/src/frontend/src/widgets/inputs/FolderInputWidget/FolderInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/FolderInputWidget/FolderInputWidget.tsx
@@ -97,6 +97,13 @@ export const FolderInputWidget: React.FC<FolderInputWidgetProps> = ({
           disabled ? "cursor-not-allowed opacity-50" : "cursor-pointer",
         )}
         onClick={handleBrowse}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            handleBrowse();
+          }
+        }}
+        role="button"
         onBlur={() => {
           if (hasOnBlur) handleEvent("OnBlur", id, []);
         }}


### PR DESCRIPTION
## Summary

Added an `onKeyDown` handler to the FolderInput widget's outer `div` that triggers `handleBrowse` when Enter or Space is pressed. Also added `role="button"` for proper ARIA semantics. This allows keyboard-only users to activate the folder picker after tabbing to it.

## API Changes

None.

## Files Modified

- **Frontend:** `src/frontend/src/widgets/inputs/FolderInputWidget/FolderInputWidget.tsx` — added `onKeyDown` handler and `role="button"` attribute

## Commits

- 49349b54e