### PR TITLE
[01130] Extract shared MockState<T> test helper to eliminate duplication

### DIFF
--- a/src/Ivy.Test/ContentInputTests.cs
+++ b/src/Ivy.Test/ContentInputTests.cs
@@ -1,34 +1,7 @@
-using System.Reactive.Subjects;
-using System.Runtime.CompilerServices;
-
 namespace Ivy.Test;
 
 public class ContentInputTests
 {
-    private class MockState<T>(T value) : IState<T>
-    {
-        private readonly Subject<T> _subject = new();
-        public T Value { get; set; } = value;
-
-        [OverloadResolutionPriority(1)]
-        public T Set(T value) { Value = value; return Value; }
-        public T Set(Func<T, T> setter) { Value = setter(Value); return Value; }
-        public T Reset() => Set(default(T)!);
-        public Type GetStateType() => typeof(T);
-
-        public IDisposable Subscribe(IObserver<T> observer)
-        {
-            observer.OnNext(Value);
-            return _subject.Subscribe(observer);
-        }
-
-        public void Dispose() => _subject.Dispose();
-        public IDisposable SubscribeAny(Action action) => _subject.Subscribe(_ => action());
-        public IDisposable SubscribeAny(Action<object?> action) => _subject.Subscribe(x => action(x));
-        public IEffectTrigger ToTrigger() => EffectTrigger.OnStateChange(this);
-        public object? GetValueAsObject() => Value;
-    }
-
     [Fact]
     public void ToContentInput_SetsPropsFromUploadContext()
     {

--- a/src/Ivy.Test/DictationTests.cs
+++ b/src/Ivy.Test/DictationTests.cs
@@ -1,6 +1,4 @@
 using System.Net;
-using System.Reactive.Subjects;
-using System.Runtime.CompilerServices;
 
 namespace Ivy.Test;
 
@@ -83,30 +81,6 @@ public class DictationTests
     public void AzureSpeechTranscriptionService_Constructor_ThrowsOnEmptyKey()
     {
         Assert.Throws<ArgumentException>(() => new AzureSpeechTranscriptionService("region", ""));
-    }
-
-    private class MockState<T>(T value) : IState<T>
-    {
-        private readonly Subject<T> _subject = new();
-        public T Value { get; set; } = value;
-
-        [OverloadResolutionPriority(1)]
-        public T Set(T value) { Value = value; return Value; }
-        public T Set(Func<T, T> setter) { Value = setter(Value); return Value; }
-        public T Reset() => Set(default(T)!);
-        public Type GetStateType() => typeof(T);
-
-        public IDisposable Subscribe(IObserver<T> observer)
-        {
-            observer.OnNext(Value);
-            return _subject.Subscribe(observer);
-        }
-
-        public void Dispose() => _subject.Dispose();
-        public IDisposable SubscribeAny(Action action) => _subject.Subscribe(_ => action());
-        public IDisposable SubscribeAny(Action<object?> action) => _subject.Subscribe(x => action(x));
-        public IEffectTrigger ToTrigger() => EffectTrigger.OnStateChange(this);
-        public object? GetValueAsObject() => Value;
     }
 
     private class MockHttpHandler(string responseContent, HttpStatusCode statusCode) : HttpMessageHandler

--- a/src/Ivy.Test/FolderInputTests.cs
+++ b/src/Ivy.Test/FolderInputTests.cs
@@ -1,34 +1,7 @@
-using System.Reactive.Subjects;
-using System.Runtime.CompilerServices;
-
 namespace Ivy.Test;
 
 public class FolderInputTests
 {
-    private class MockState<T>(T value) : IState<T>
-    {
-        private readonly Subject<T> _subject = new();
-        public T Value { get; set; } = value;
-
-        [OverloadResolutionPriority(1)]
-        public T Set(T value) { Value = value; return Value; }
-        public T Set(Func<T, T> setter) { Value = setter(Value); return Value; }
-        public T Reset() => Set(default(T)!);
-        public Type GetStateType() => typeof(T);
-
-        public IDisposable Subscribe(IObserver<T> observer)
-        {
-            observer.OnNext(Value);
-            return _subject.Subscribe(observer);
-        }
-
-        public void Dispose() => _subject.Dispose();
-        public IDisposable SubscribeAny(Action action) => _subject.Subscribe(_ => action());
-        public IDisposable SubscribeAny(Action<object?> action) => _subject.Subscribe(x => action(x));
-        public IEffectTrigger ToTrigger() => EffectTrigger.OnStateChange(this);
-        public object? GetValueAsObject() => Value;
-    }
-
     [Fact]
     public void FolderInput_DefaultProperties()
     {

--- a/src/Ivy.Test/InputWidgetTests.cs
+++ b/src/Ivy.Test/InputWidgetTests.cs
@@ -1,33 +1,7 @@
-using System.Reactive.Subjects;
-using System.Runtime.CompilerServices;
-
 namespace Ivy.Test;
 
 public class InputWidgetTests
 {
-    private class MockState<T>(T value) : IState<T>
-    {
-        private readonly Subject<T> _subject = new();
-        public T Value { get; set; } = value;
-
-        [OverloadResolutionPriority(1)]
-        public T Set(T value) { Value = value; return Value; }
-        public T Set(Func<T, T> setter) { Value = setter(Value); return Value; }
-        public T Reset() => Set(default(T)!);
-        public Type GetStateType() => typeof(T);
-
-        public IDisposable Subscribe(IObserver<T> observer)
-        {
-            observer.OnNext(Value);
-            return _subject.Subscribe(observer);
-        }
-
-        public void Dispose() => _subject.Dispose();
-        public IDisposable SubscribeAny(Action action) => _subject.Subscribe(_ => action());
-        public IDisposable SubscribeAny(Action<object?> action) => _subject.Subscribe(x => action(x));
-        public IEffectTrigger ToTrigger() => EffectTrigger.OnStateChange(this);
-        public object? GetValueAsObject() => Value;
-    }
 
 
 

--- a/src/Ivy.Test/TestHelpers/MockState.cs
+++ b/src/Ivy.Test/TestHelpers/MockState.cs
@@ -1,0 +1,28 @@
+using System.Reactive.Subjects;
+using System.Runtime.CompilerServices;
+
+namespace Ivy.Test;
+
+internal class MockState<T>(T value) : IState<T>
+{
+    private readonly Subject<T> _subject = new();
+    public T Value { get; set; } = value;
+
+    [OverloadResolutionPriority(1)]
+    public T Set(T value) { Value = value; return Value; }
+    public T Set(Func<T, T> setter) { Value = setter(Value); return Value; }
+    public T Reset() => Set(default(T)!);
+    public Type GetStateType() => typeof(T);
+
+    public IDisposable Subscribe(IObserver<T> observer)
+    {
+        observer.OnNext(Value);
+        return _subject.Subscribe(observer);
+    }
+
+    public void Dispose() => _subject.Dispose();
+    public IDisposable SubscribeAny(Action action) => _subject.Subscribe(_ => action());
+    public IDisposable SubscribeAny(Action<object?> action) => _subject.Subscribe(x => action(x));
+    public IEffectTrigger ToTrigger() => EffectTrigger.OnStateChange(this);
+    public object? GetValueAsObject() => Value;
+}

--- a/src/Ivy.Test/TextInputTests.cs
+++ b/src/Ivy.Test/TextInputTests.cs
@@ -1,6 +1,3 @@
-using System.Reactive.Subjects;
-using System.Runtime.CompilerServices;
-
 namespace Ivy.Test;
 
 //Todo: I don't really think we need these tests, as if TextInput<string> works, then TextInput should work too.
@@ -228,58 +225,4 @@ public class TextInputTests
         Assert.Null(nullableStringInput.Value);
     }
 
-    private class MockState<T>(T value) : IState<T>
-    {
-        private readonly Subject<T> _subject = new();
-
-        public T Value { get; set; } = value;
-
-        [OverloadResolutionPriority(1)]
-        public T Set(T value)
-        {
-            Value = value;
-            return Value;
-        }
-
-        public T Set(Func<T, T> setter)
-        {
-            Value = setter(Value);
-            return Value;
-        }
-
-        public T Reset()
-        {
-            return Set(default(T)!);
-        }
-
-        public Type GetStateType() => typeof(T);
-
-        public IDisposable Subscribe(IObserver<T> observer)
-        {
-            observer.OnNext(Value);
-            return _subject.Subscribe(observer);
-        }
-
-        public void Dispose()
-        {
-            _subject.Dispose();
-        }
-
-        public IDisposable SubscribeAny(Action action)
-        {
-            return _subject.Subscribe(_ => action());
-        }
-
-        public IDisposable SubscribeAny(Action<object?> action)
-        {
-            return _subject.Subscribe(x => action(x));
-        }
-
-        public IEffectTrigger ToTrigger()
-        {
-            return EffectTrigger.OnStateChange(this);
-        }
-
-        public object? GetValueAsObject() => Value;
-    }
 }


### PR DESCRIPTION
## Changes

Extracted the duplicated `MockState<T>` test helper class from 5 test files into a single shared `internal class` at `src/Ivy.Test/TestHelpers/MockState.cs`. Removed the private copies from `InputWidgetTests.cs`, `DictationTests.cs`, `FolderInputTests.cs`, `ContentInputTests.cs`, and `TextInputTests.cs`, eliminating 135 lines of duplicated code.

## API Changes

None.

## Files Modified

- **Created:** `src/Ivy.Test/TestHelpers/MockState.cs` — shared `internal class MockState<T>` implementing `IState<T>`
- **Edited:** `src/Ivy.Test/InputWidgetTests.cs` — removed private MockState class and unused usings
- **Edited:** `src/Ivy.Test/DictationTests.cs` — removed private MockState class and unused usings
- **Edited:** `src/Ivy.Test/FolderInputTests.cs` — removed private MockState class and unused usings
- **Edited:** `src/Ivy.Test/ContentInputTests.cs` — removed private MockState class and unused usings
- **Edited:** `src/Ivy.Test/TextInputTests.cs` — removed private MockState class (expanded format) and unused usings

## Commits

- `72058e904` [01130] Extract shared MockState<T> test helper to eliminate duplication