### PR TITLE
[01124] Fix cross-platform path separator in Cleanup-WorktreeFrontend.ps1

### DIFF
--- a/src/tendril/Ivy.Tendril/.promptwares/ExecutePlan/Tools/Cleanup-WorktreeFrontend.ps1
+++ b/src/tendril/Ivy.Tendril/.promptwares/ExecutePlan/Tools/Cleanup-WorktreeFrontend.ps1
@@ -36,7 +36,8 @@ foreach ($worktree in $worktrees) {
         Where-Object { $_.Directory.Name -eq "frontend" })
 
     foreach ($npmrcFile in $npmrcFiles) {
-        $relativePath = $npmrcFile.FullName.Replace($worktree.FullName + "\", "").Replace("\", "/")
+        $sep = [System.IO.Path]::DirectorySeparatorChar
+        $relativePath = $npmrcFile.FullName.Replace($worktree.FullName + $sep, "").Replace("\", "/")
 
         # Check if this file is tracked in git
         Push-Location $worktree.FullName


### PR DESCRIPTION
## Summary

Replaced the hardcoded Windows backslash (`\`) path separator on line 39 of `Cleanup-WorktreeFrontend.ps1` with `[System.IO.Path]::DirectorySeparatorChar`. This fixes silent failure of the cleanup script on macOS/Linux where paths use forward slashes.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/.promptwares/ExecutePlan/Tools/Cleanup-WorktreeFrontend.ps1` - Fixed cross-platform path separator for relative path computation

## Commits

- 0dfe1a839 - Fix cross-platform path separator