### PR TITLE
[01118] Remove validateFile wrapper in filePicker shared.ts

### DIFF
--- a/src/frontend/src/widgets/filePicker/FileDialogWidget.tsx
+++ b/src/frontend/src/widgets/filePicker/FileDialogWidget.tsx
@@ -1,7 +1,8 @@
 import React, { useCallback, useEffect, useRef } from "react";
 import { useEventHandler } from "@/components/event-handler";
 import { hasFileSystemAccess } from "./browserSupport";
-import { validateFile, uploadFile, acceptToPickerTypes } from "./shared";
+import { uploadFile, acceptToPickerTypes } from "./shared";
+import { validateFileWithToast } from "@/widgets/inputs/file-input-validation";
 import { EMPTY_ARRAY } from "@/lib/constants";
 
 interface FileDialogFileInfo {
@@ -50,7 +51,9 @@ export const FileDialogWidget: React.FC<FileDialogWidgetProps> = ({
   const handleFiles = useCallback(
     async (files: File[]) => {
       // Validate all files
-      const validFiles = files.filter((f) => validateFile(f, accept, maxFileSize, minFileSize));
+      const validFiles = files.filter((f) =>
+        validateFileWithToast({ file: f, accept, maxFileSize, minFileSize }),
+      );
       if (validFiles.length === 0) return;
 
       if (mode === "Upload" && uploadUrl) {

--- a/src/frontend/src/widgets/filePicker/shared.ts
+++ b/src/frontend/src/widgets/filePicker/shared.ts
@@ -1,5 +1,3 @@
-import { validateFileWithToast } from "@/widgets/inputs/file-input-validation";
-
 /**
  * Get the full upload URL, accounting for the ivy-host meta tag.
  */
@@ -10,19 +8,6 @@ export function getFullUrl(path: string): string {
     return host + path;
   }
   return path;
-}
-
-/**
- * Validate a file against accept, maxFileSize, and minFileSize constraints.
- * Shows a toast on validation failure and returns false.
- */
-export function validateFile(
-  file: File,
-  accept?: string,
-  maxFileSize?: number,
-  minFileSize?: number,
-): boolean {
-  return validateFileWithToast({ file, accept, maxFileSize, minFileSize });
 }
 
 /**


### PR DESCRIPTION
## Summary

Removed the `validateFile` pass-through wrapper from `shared.ts` and updated `FileDialogWidget.tsx` to import and call `validateFileWithToast` directly from `@/widgets/inputs/file-input-validation`. This eliminates an unnecessary layer of indirection added during plan 01108.

## API Changes

None. The removed `validateFile` function was only used internally by `FileDialogWidget.tsx` — no external consumers.

## Files Modified

- **src/frontend/src/widgets/filePicker/FileDialogWidget.tsx** — Updated imports and call site to use `validateFileWithToast` directly
- **src/frontend/src/widgets/filePicker/shared.ts** — Removed `validateFile` wrapper function and its `validateFileWithToast` import

## Commits

- `69bdb4f6f` — [01118] Remove validateFile wrapper in filePicker shared.ts