### PR TITLE
[01127] Add SignalR hub integration tests for /ivy/messages

### DIFF
--- a/src/Ivy.Test/Integration/AppHubIntegrationTests.cs
+++ b/src/Ivy.Test/Integration/AppHubIntegrationTests.cs
@@ -1,0 +1,124 @@
+using System.Text.Json.Nodes;
+using Microsoft.AspNetCore.SignalR.Client;
+
+namespace Ivy.Test.Integration;
+
+public class AppHubIntegrationTests : IAsyncLifetime
+{
+    private IvyTestServer _server = null!;
+
+    public async Task InitializeAsync()
+    {
+        _server = await IvyTestServer.CreateAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _server.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task HubConnection_CanConnect_ReceivesRefresh()
+    {
+        await using var connection = _server.CreateHubConnection();
+
+        var refreshTcs = new TaskCompletionSource<object?>();
+        connection.On<object?>("Refresh", payload =>
+        {
+            refreshTcs.TrySetResult(payload);
+        });
+
+        await connection.StartAsync();
+        Assert.Equal(HubConnectionState.Connected, connection.State);
+
+        var payload = await refreshTcs.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.NotNull(payload);
+
+        var json = payload.ToString()!;
+        Assert.Contains("widgets", json);
+    }
+
+    [Fact]
+    public async Task HubConnection_SendEvent_IsProcessed()
+    {
+        await using var connection = _server.CreateHubConnection();
+
+        var refreshTcs = new TaskCompletionSource<object?>();
+        connection.On<object?>("Refresh", payload =>
+        {
+            refreshTcs.TrySetResult(payload);
+        });
+
+        await connection.StartAsync();
+        await refreshTcs.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        // Send an event for a non-existent widget — hub should not throw
+        await connection.InvokeAsync("Event", "click", "non-existent-widget", (JsonArray?)null);
+    }
+
+    [Fact]
+    public async Task HubConnection_Disconnect_CleansUpSession()
+    {
+        var connection = _server.CreateHubConnection();
+
+        var refreshTcs = new TaskCompletionSource<object?>();
+        connection.On<object?>("Refresh", payload =>
+        {
+            refreshTcs.TrySetResult(payload);
+        });
+
+        await connection.StartAsync();
+        await refreshTcs.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.True(_server.SessionStore.Sessions.Count > 0, "Session should exist after connect");
+
+        var connectionId = connection.ConnectionId!;
+        Assert.True(_server.SessionStore.Sessions.ContainsKey(connectionId), "Session store should contain connection");
+
+        await connection.StopAsync();
+        await connection.DisposeAsync();
+
+        // Give server time to process disconnect
+        await Task.Delay(500);
+
+        Assert.False(_server.SessionStore.Sessions.ContainsKey(connectionId), "Session should be removed after disconnect");
+    }
+
+    [Fact]
+    public async Task HubConnection_Reconnect_GetsNewSession()
+    {
+        // First connection
+        await using var connection1 = _server.CreateHubConnection();
+
+        var refreshTcs1 = new TaskCompletionSource<object?>();
+        connection1.On<object?>("Refresh", payload =>
+        {
+            refreshTcs1.TrySetResult(payload);
+        });
+
+        await connection1.StartAsync();
+        var payload1 = await refreshTcs1.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.NotNull(payload1);
+
+        await connection1.StopAsync();
+        await Task.Delay(500);
+
+        // Second connection
+        await using var connection2 = _server.CreateHubConnection();
+
+        var refreshTcs2 = new TaskCompletionSource<object?>();
+        connection2.On<object?>("Refresh", payload =>
+        {
+            refreshTcs2.TrySetResult(payload);
+        });
+
+        await connection2.StartAsync();
+        var payload2 = await refreshTcs2.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.NotNull(payload2);
+
+        Assert.Equal(HubConnectionState.Connected, connection2.State);
+
+        // Verify session store has exactly the second connection
+        Assert.True(_server.SessionStore.Sessions.ContainsKey(connection2.ConnectionId!));
+    }
+}

--- a/src/Ivy.Test/Integration/IvyTestServer.cs
+++ b/src/Ivy.Test/Integration/IvyTestServer.cs
@@ -1,0 +1,54 @@
+using Ivy.Core.Server;
+using Microsoft.AspNetCore.SignalR.Client;
+
+namespace Ivy.Test.Integration;
+
+public class IvyTestServer : IAsyncDisposable
+{
+    private readonly Microsoft.AspNetCore.Builder.WebApplication _app;
+    private readonly AppSessionStore _sessionStore;
+
+    public string BaseUrl { get; }
+    public AppSessionStore SessionStore => _sessionStore;
+
+    private IvyTestServer(Microsoft.AspNetCore.Builder.WebApplication app, AppSessionStore sessionStore, string baseUrl)
+    {
+        _app = app;
+        _sessionStore = sessionStore;
+        BaseUrl = baseUrl;
+    }
+
+    public static async Task<IvyTestServer> CreateAsync()
+    {
+        var sessionStore = new AppSessionStore();
+        var server = new Server(new ServerArgs { Port = 0, Silent = true, Host = "127.0.0.1" });
+        server.AddApp(new AppDescriptor
+        {
+            Id = "test-app",
+            Title = "Test App",
+            ViewFunc = ctx => "Hello Integration Test",
+            Group = [],
+            IsVisible = true
+        });
+
+        var app = server.BuildWebApplication(sessionStore)!;
+        await app.StartAsync();
+
+        var baseUrl = app.Urls.First();
+        return new IvyTestServer(app, sessionStore, baseUrl);
+    }
+
+    public HubConnection CreateHubConnection()
+    {
+        return new HubConnectionBuilder()
+            .WithUrl($"{BaseUrl}/ivy/messages?appId=test-app&machineId=test-machine&shell=false")
+            .Build();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _app.StopAsync();
+        await _app.DisposeAsync();
+        _sessionStore.Dispose();
+    }
+}

--- a/src/Ivy.Test/Ivy.Test.csproj
+++ b/src/Ivy.Test/Ivy.Test.csproj
@@ -23,6 +23,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.0-*" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Added SignalR hub integration tests for the `/ivy/messages` endpoint. Created a reusable `IvyTestServer` helper that spins up an in-process Ivy server with a test app on a random port, and an `AppHubIntegrationTests` class with 4 test cases covering connection, events, disconnect cleanup, and reconnection.

## API Changes

None.

## Files Modified

- **src/Ivy.Test/Ivy.Test.csproj** — Added `Microsoft.AspNetCore.SignalR.Client` package reference
- **src/Ivy.Test/Integration/IvyTestServer.cs** — New test server helper using `Server.BuildWebApplication()` on a random port
- **src/Ivy.Test/Integration/AppHubIntegrationTests.cs** — New integration test class with 4 test methods

## Commits

- b8b6a5ea5 [01127] Add SignalR hub integration tests for /ivy/messages