### PR TITLE
[01129] Switch CodeBlock sample language grid from 2 to 3 columns

### DIFF
--- a/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/CodeBlockApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/CodeBlockApp.cs
@@ -230,7 +230,7 @@ public class CodeBlockApp : SampleBase
             );
         }
 
-        return Layout.Grid().Columns(2).Gap(4) | cards.ToArray();
+        return Layout.Grid().Columns(3).Gap(4) | cards.ToArray();
     }
 
     private object CreateOptionsVariants()


### PR DESCRIPTION
## Summary

Changed the `CreateLanguageVariants()` grid layout from 2 columns to 3 columns in the CodeBlock sample app. This reduces vertical scrolling from 7 rows to 5 rows for the 13+ language cards.

## API Changes

None.

## Files Modified

- `src/Ivy.Samples.Shared/Apps/Widgets/Primitives/CodeBlockApp.cs` — Changed `Columns(2)` to `Columns(3)` at line 233

## Commits

- `8f3b777e5` — [01129] Switch CodeBlock sample language grid from 2 to 3 columns