### PR TITLE
[01123] FileAttachmentList card variant density scaling

### DIFF
--- a/src/frontend/src/widgets/inputs/FileInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/FileInputWidget.tsx
@@ -403,6 +403,7 @@ export const FileInputWidget: React.FC<FileInputWidgetProps> = ({
                   onCancel={handleCancel}
                   hasCancelHandler={hasCancelHandler}
                   variant="card"
+                  density={density}
                 />
               </div>
             )}
@@ -429,6 +430,7 @@ export const FileInputWidget: React.FC<FileInputWidgetProps> = ({
                   onCancel={handleCancel}
                   hasCancelHandler={hasCancelHandler}
                   variant="card"
+                  density={density}
                 />
               </div>
             )}

--- a/src/frontend/src/widgets/inputs/shared/FileAttachmentList.tsx
+++ b/src/frontend/src/widgets/inputs/shared/FileAttachmentList.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { X } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Densities } from "@/types/density";
 import { FileItem, FileUploadStatus } from "./types";
 import { formatBytes } from "../file-input-validation";
 
@@ -9,6 +10,7 @@ interface FileAttachmentListProps {
   onCancel?: (fileId: string) => void;
   hasCancelHandler: boolean;
   variant?: "compact" | "card";
+  density?: Densities;
 }
 
 export const FileAttachmentList: React.FC<FileAttachmentListProps> = ({
@@ -16,10 +18,28 @@ export const FileAttachmentList: React.FC<FileAttachmentListProps> = ({
   onCancel,
   hasCancelHandler,
   variant = "compact",
+  density = Densities.Medium,
 }) => {
   if (files.length === 0) return null;
 
   if (variant === "card") {
+    const cardPadding =
+      density === Densities.Small ? "p-2" : density === Densities.Large ? "p-4" : "p-3";
+    const cardText =
+      density === Densities.Small
+        ? "text-xs"
+        : density === Densities.Large
+          ? "text-base"
+          : "text-sm";
+    const cancelBtnSize =
+      density === Densities.Small
+        ? "h-6 w-6"
+        : density === Densities.Large
+          ? "h-10 w-10"
+          : "h-8 w-8";
+    const cancelIconSize =
+      density === Densities.Small ? "h-3 w-3" : density === Densities.Large ? "h-5 w-5" : "h-4 w-4";
+
     return (
       <div className="space-y-2">
         {files.map((file) => {
@@ -30,10 +50,10 @@ export const FileAttachmentList: React.FC<FileAttachmentListProps> = ({
             <div
               key={file.id}
               data-file-item
-              className="flex items-center gap-3 p-3 border border-muted-foreground/25 rounded-md bg-transparent"
+              className={`flex items-center gap-3 ${cardPadding} border border-muted-foreground/25 rounded-md bg-transparent`}
             >
               <div className="flex-1 min-w-0">
-                <p className="text-sm font-medium truncate">{file.fileName}</p>
+                <p className={`${cardText} font-medium truncate`}>{file.fileName}</p>
                 {isLoading && (
                   <div className="mt-2">
                     <div className="w-full bg-muted rounded-full h-1.5">
@@ -50,13 +70,13 @@ export const FileAttachmentList: React.FC<FileAttachmentListProps> = ({
                   type="button"
                   variant="ghost"
                   size="icon"
-                  className="h-8 w-8 shrink-0"
+                  className={`${cancelBtnSize} shrink-0`}
                   onClick={(e) => {
                     e.stopPropagation();
                     onCancel?.(file.id);
                   }}
                 >
-                  <X className="h-4 w-4" />
+                  <X className={cancelIconSize} />
                 </Button>
               )}
             </div>


### PR DESCRIPTION
## Summary

Added density-responsive sizing to the `FileAttachmentList` card variant. The card padding, text size, cancel button, and cancel icon now scale according to the parent widget's density setting (Small/Medium/Large) instead of using hardcoded medium-size classes.

## API Changes

- `FileAttachmentListProps.density?: Densities` — new optional prop (defaults to `Densities.Medium`)

## Files Modified

- **src/frontend/src/widgets/inputs/shared/FileAttachmentList.tsx** — Added `density` prop with density-responsive class selection for card variant
- **src/frontend/src/widgets/inputs/FileInputWidget.tsx** — Passed `density` prop to both `FileAttachmentList` usages (Default and Drop variants)

## Commits

- b44da8d76 [01123] Add density-responsive sizing to FileAttachmentList card variant