### PR TITLE
[01116] Add aria-label to FolderInput browse button

### DIFF
--- a/src/frontend/src/widgets/inputs/FolderInputWidget/FolderInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/FolderInputWidget/FolderInputWidget.tsx
@@ -110,6 +110,7 @@ export const FolderInputWidget: React.FC<FolderInputWidgetProps> = ({
           }
         }}
         role="button"
+        aria-label="Browse for folder"
         onBlur={() => {
           if (hasOnBlur) handleEvent("OnBlur", id, []);
         }}


### PR DESCRIPTION
## Summary

Added `aria-label="Browse for folder"` to the FolderInput widget's outer `<div>` element that serves as the browse button. This complements the existing `role="button"` attribute (added by plan 01111) so screen readers now announce both the element's role and its purpose.

## API Changes

None.

## Files Modified

- `src/frontend/src/widgets/inputs/FolderInputWidget/FolderInputWidget.tsx` — Added `aria-label` attribute to browse button div

## Commits

- f8b77ee06