### PR TITLE
[01103] Extract shared useUploadWithProgress hook

### DIFF
--- a/src/frontend/src/widgets/inputs/ContentInputWidget/useFileAttachments.ts
+++ b/src/frontend/src/widgets/inputs/ContentInputWidget/useFileAttachments.ts
@@ -1,7 +1,7 @@
-import { useCallback, useState, useRef, useEffect } from "react";
+import { useCallback, useState, useRef } from "react";
 import { toast } from "@/hooks/use-toast";
 import { validateFileWithToast, validateFileCount } from "../file-input-validation";
-import { uploadFileWithProgress } from "@/widgets/filePicker/shared";
+import { useUploadWithProgress } from "../shared/useUploadWithProgress";
 
 interface UseFileAttachmentsOptions {
   uploadUrl?: string;
@@ -16,62 +16,18 @@ interface UseFileAttachmentsOptions {
 export function useFileAttachments(options: UseFileAttachmentsOptions) {
   const { uploadUrl, accept, maxFileSize, maxFiles, currentFileCount, disabled } = options;
   const [isDragging, setIsDragging] = useState(false);
-  const [uploadProgress, setUploadProgress] = useState<Map<string, number>>(new Map());
+  const { uploadProgress, uploadSingleFile, cancelUpload } = useUploadWithProgress();
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const abortControllersRef = useRef<Map<string, () => void>>(new Map());
-
-  // Abort any pending uploads when the component unmounts
-  useEffect(() => {
-    return () => {
-      abortControllersRef.current.forEach((abort) => abort());
-    };
-  }, []);
 
   const uploadFile = useCallback(
     async (file: File): Promise<void> => {
       if (!uploadUrl) return;
       if (!validateFileWithToast({ file, accept, maxFileSize })) return;
 
-      const clientFileId = `upload-${crypto.randomUUID()}-${file.size}-${file.name}`;
-
-      setUploadProgress((prev) => new Map(prev).set(clientFileId, 0));
-
-      const { promise, abort } = uploadFileWithProgress(uploadUrl, file, (progress) => {
-        setUploadProgress((prev) => new Map(prev).set(clientFileId, progress));
-      });
-
-      abortControllersRef.current.set(clientFileId, abort);
-
-      try {
-        await promise;
-      } catch (error: any) {
-        if (error.message !== "Upload aborted") {
-          console.error("File upload error:", error);
-          toast({
-            title: "Upload failed",
-            description: error.message || `Could not upload ${file.name}`,
-            variant: "destructive",
-          });
-        }
-      } finally {
-        setUploadProgress((prev) => {
-          const next = new Map(prev);
-          next.delete(clientFileId);
-          return next;
-        });
-        abortControllersRef.current.delete(clientFileId);
-      }
+      await uploadSingleFile(uploadUrl, file);
     },
-    [uploadUrl, accept, maxFileSize],
+    [uploadUrl, accept, maxFileSize, uploadSingleFile],
   );
-
-  const cancelUpload = useCallback((clientFileId: string) => {
-    const abort = abortControllersRef.current.get(clientFileId);
-    if (abort) {
-      abort();
-      abortControllersRef.current.delete(clientFileId);
-    }
-  }, []);
 
   const uploadFiles = useCallback(
     async (files: File[]) => {

--- a/src/frontend/src/widgets/inputs/FileInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/FileInputWidget.tsx
@@ -14,10 +14,10 @@ import {
   textVariant,
 } from "@/components/ui/input/file-input-variant";
 import { validateFileWithToast, validateFileCount } from "./file-input-validation";
-import { uploadFileWithProgress } from "@/widgets/filePicker/shared";
 import { EMPTY_ARRAY } from "@/lib/constants";
 import { FileItem } from "./shared/types";
 import { FileAttachmentList } from "./shared/FileAttachmentList";
+import { useUploadWithProgress } from "./shared/useUploadWithProgress";
 
 interface FileInputWidgetProps {
   id: string;
@@ -58,19 +58,15 @@ export const FileInputWidget: React.FC<FileInputWidgetProps> = ({
 }) => {
   const handleEvent = useEventHandler();
   const [isDragging, setIsDragging] = useState(false);
-  const [uploadProgress, setUploadProgress] = useState<Map<string, number>>(new Map());
+  const {
+    uploadProgress,
+    uploadSingleFile,
+    cancelUpload: cancelClientUpload,
+  } = useUploadWithProgress();
   const inputRef = useRef<HTMLInputElement>(null);
   const filesSelectedInCurrentDialogRef = useRef(false);
   const dialogWasOpenRef = useRef(false);
   const blurFiredRef = useRef(false);
-  const abortControllersRef = useRef<Map<string, () => void>>(new Map());
-
-  // Abort any pending uploads when the component unmounts
-  useEffect(() => {
-    return () => {
-      abortControllersRef.current.forEach((abort) => abort());
-    };
-  }, []);
 
   // Be defensive in case events is undefined at runtime
   const hasCancelHandler = Array.isArray(events) && events.includes("OnCancel");
@@ -85,37 +81,9 @@ export const FileInputWidget: React.FC<FileInputWidgetProps> = ({
         return;
       }
 
-      const clientFileId = `upload-${crypto.randomUUID()}-${file.size}-${file.name}`;
-
-      setUploadProgress((prev) => new Map(prev).set(clientFileId, 0));
-
-      const { promise, abort } = uploadFileWithProgress(uploadUrl, file, (progress) => {
-        setUploadProgress((prev) => new Map(prev).set(clientFileId, progress));
-      });
-
-      abortControllersRef.current.set(clientFileId, abort);
-
-      try {
-        await promise;
-      } catch (error: any) {
-        if (error.message !== "Upload aborted") {
-          console.error("File upload error:", error);
-          toast({
-            title: "Upload failed",
-            description: error.message || `Could not upload ${file.name}`,
-            variant: "destructive",
-          });
-        }
-      } finally {
-        setUploadProgress((prev) => {
-          const next = new Map(prev);
-          next.delete(clientFileId);
-          return next;
-        });
-        abortControllersRef.current.delete(clientFileId);
-      }
+      await uploadSingleFile(uploadUrl, file);
     },
-    [uploadUrl, accept, maxFileSize, minFileSize],
+    [uploadUrl, accept, maxFileSize, minFileSize, uploadSingleFile],
   );
 
   const handleBlur = useCallback(() => {
@@ -202,10 +170,8 @@ export const FileInputWidget: React.FC<FileInputWidgetProps> = ({
   const handleCancel = useCallback(
     (fileId: string) => {
       // Check if this is a client-side upload in progress
-      const abort = abortControllersRef.current.get(fileId);
-      if (abort) {
-        abort();
-        abortControllersRef.current.delete(fileId);
+      if (uploadProgress.has(fileId)) {
+        cancelClientUpload(fileId);
       } else if (hasCancelHandler) {
         handleEvent("OnCancel", id, [fileId]);
       }
@@ -214,7 +180,7 @@ export const FileInputWidget: React.FC<FileInputWidgetProps> = ({
         inputRef.current.value = "";
       }
     },
-    [hasCancelHandler, handleEvent, id],
+    [uploadProgress, cancelClientUpload, hasCancelHandler, handleEvent, id],
   );
 
   const handleDragLeave = useCallback((e: React.DragEvent) => {

--- a/src/frontend/src/widgets/inputs/shared/index.ts
+++ b/src/frontend/src/widgets/inputs/shared/index.ts
@@ -1,2 +1,3 @@
 export { FileAttachmentList } from "./FileAttachmentList";
 export { FileUploadStatus, type FileItem } from "./types";
+export { useUploadWithProgress } from "./useUploadWithProgress";

--- a/src/frontend/src/widgets/inputs/shared/useUploadWithProgress.test.ts
+++ b/src/frontend/src/widgets/inputs/shared/useUploadWithProgress.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * Tests for the useUploadWithProgress hook.
+ *
+ * Since @testing-library/react is not available in this project,
+ * we verify the source code contains the correct patterns for:
+ * - Upload orchestration via uploadFileWithProgress
+ * - Progress state management
+ * - Cleanup on unmount
+ * - Cancel via abort function
+ */
+describe("useUploadWithProgress", () => {
+  const hookSource = fs.readFileSync(
+    path.resolve(__dirname, "./useUploadWithProgress.ts"),
+    "utf-8",
+  );
+
+  it("should import uploadFileWithProgress from filePicker shared", () => {
+    expect(hookSource).toContain(
+      'import { uploadFileWithProgress } from "@/widgets/filePicker/shared"',
+    );
+  });
+
+  it("should manage uploadProgress state as a Map<string, number>", () => {
+    expect(hookSource).toContain("useState<Map<string, number>>(new Map())");
+  });
+
+  it("should manage abortControllers ref as a Map<string, () => void>", () => {
+    expect(hookSource).toContain("useRef<Map<string, () => void>>(new Map())");
+  });
+
+  it("should generate unique client file IDs using crypto.randomUUID", () => {
+    expect(hookSource).toContain("crypto.randomUUID()");
+    expect(hookSource).toContain("upload-");
+  });
+
+  it("should call uploadFileWithProgress with uploadUrl, file, and progress callback", () => {
+    expect(hookSource).toContain("uploadFileWithProgress(uploadUrl, file,");
+  });
+
+  it("should store abort function in abortControllersRef", () => {
+    expect(hookSource).toContain("abortControllersRef.current.set(clientFileId, abort)");
+  });
+
+  it("should clean up progress and abort controller in finally block", () => {
+    // Both cleanup operations must be in the finally block
+    const finallyIndex = hookSource.indexOf("} finally {");
+    expect(finallyIndex).toBeGreaterThan(-1);
+
+    const finallyBlock = hookSource.slice(finallyIndex);
+    expect(finallyBlock).toContain("next.delete(clientFileId)");
+    expect(finallyBlock).toContain("abortControllersRef.current.delete(clientFileId)");
+  });
+
+  it("should abort pending uploads on unmount via useEffect cleanup", () => {
+    expect(hookSource).toContain("abortControllersRef.current.forEach((abort) => abort())");
+  });
+
+  it("should provide cancelUpload that calls abort and removes the controller", () => {
+    // Find the cancelUpload function
+    const cancelIndex = hookSource.indexOf("const cancelUpload = useCallback");
+    expect(cancelIndex).toBeGreaterThan(-1);
+
+    const cancelBlock = hookSource.slice(
+      cancelIndex,
+      hookSource.indexOf("}, [])", cancelIndex) + 10,
+    );
+    expect(cancelBlock).toContain("abortControllersRef.current.get(clientFileId)");
+    expect(cancelBlock).toContain("abort()");
+    expect(cancelBlock).toContain("abortControllersRef.current.delete(clientFileId)");
+  });
+
+  it("should return uploadProgress, uploadSingleFile, and cancelUpload", () => {
+    expect(hookSource).toContain("return { uploadProgress, uploadSingleFile, cancelUpload }");
+  });
+
+  it("should show toast on non-abort errors", () => {
+    expect(hookSource).toContain('error.message !== "Upload aborted"');
+    expect(hookSource).toContain('"Upload failed"');
+  });
+});
+
+describe("useUploadWithProgress consumers", () => {
+  const fileInputSource = fs.readFileSync(
+    path.resolve(__dirname, "../FileInputWidget.tsx"),
+    "utf-8",
+  );
+  const useFileAttachmentsSource = fs.readFileSync(
+    path.resolve(__dirname, "../ContentInputWidget/useFileAttachments.ts"),
+    "utf-8",
+  );
+
+  it("FileInputWidget should import useUploadWithProgress instead of uploadFileWithProgress", () => {
+    expect(fileInputSource).toContain("useUploadWithProgress");
+    expect(fileInputSource).not.toContain("import { uploadFileWithProgress }");
+  });
+
+  it("useFileAttachments should import useUploadWithProgress instead of uploadFileWithProgress", () => {
+    expect(useFileAttachmentsSource).toContain("useUploadWithProgress");
+    expect(useFileAttachmentsSource).not.toContain("import { uploadFileWithProgress }");
+  });
+
+  it("FileInputWidget should use uploadSingleFile from the hook", () => {
+    expect(fileInputSource).toContain("uploadSingleFile");
+  });
+
+  it("useFileAttachments should use uploadSingleFile from the hook", () => {
+    expect(useFileAttachmentsSource).toContain("uploadSingleFile");
+  });
+
+  it("FileInputWidget should not have its own uploadProgress useState", () => {
+    // Should not have a direct useState for uploadProgress — it comes from the hook
+    expect(fileInputSource).not.toContain("useState<Map<string, number>>");
+  });
+
+  it("useFileAttachments should not have its own uploadProgress useState", () => {
+    expect(useFileAttachmentsSource).not.toContain("useState<Map<string, number>>");
+  });
+
+  it("neither consumer should have its own abortControllersRef", () => {
+    expect(fileInputSource).not.toContain("abortControllersRef");
+    expect(useFileAttachmentsSource).not.toContain("abortControllersRef");
+  });
+});

--- a/src/frontend/src/widgets/inputs/shared/useUploadWithProgress.ts
+++ b/src/frontend/src/widgets/inputs/shared/useUploadWithProgress.ts
@@ -1,0 +1,57 @@
+import { useState, useRef, useCallback, useEffect } from "react";
+import { uploadFileWithProgress } from "@/widgets/filePicker/shared";
+import { toast } from "@/hooks/use-toast";
+
+export function useUploadWithProgress() {
+  const [uploadProgress, setUploadProgress] = useState<Map<string, number>>(new Map());
+  const abortControllersRef = useRef<Map<string, () => void>>(new Map());
+
+  // Abort any pending uploads when the component unmounts
+  useEffect(() => {
+    return () => {
+      abortControllersRef.current.forEach((abort) => abort());
+    };
+  }, []);
+
+  const uploadSingleFile = useCallback(async (uploadUrl: string, file: File): Promise<void> => {
+    const clientFileId = `upload-${crypto.randomUUID()}-${file.size}-${file.name}`;
+
+    setUploadProgress((prev) => new Map(prev).set(clientFileId, 0));
+
+    const { promise, abort } = uploadFileWithProgress(uploadUrl, file, (progress) => {
+      setUploadProgress((prev) => new Map(prev).set(clientFileId, progress));
+    });
+
+    abortControllersRef.current.set(clientFileId, abort);
+
+    try {
+      await promise;
+    } catch (error: any) {
+      if (error.message !== "Upload aborted") {
+        console.error("File upload error:", error);
+        toast({
+          title: "Upload failed",
+          description: error.message || `Could not upload ${file.name}`,
+          variant: "destructive",
+        });
+      }
+    } finally {
+      setUploadProgress((prev) => {
+        const next = new Map(prev);
+        next.delete(clientFileId);
+        return next;
+      });
+      abortControllersRef.current.delete(clientFileId);
+    }
+  }, []);
+
+  const cancelUpload = useCallback((clientFileId: string) => {
+    const abort = abortControllersRef.current.get(clientFileId);
+    if (abort) {
+      abort();
+      abortControllersRef.current.delete(clientFileId);
+    }
+  }, []);
+
+  return { uploadProgress, uploadSingleFile, cancelUpload };
+}


### PR DESCRIPTION
## Summary

Extracted duplicated upload orchestration code from `FileInputWidget.tsx` and `useFileAttachments.ts` into a new shared `useUploadWithProgress` hook. Both consumers now delegate progress tracking, abort controller management, error handling, and cleanup to the hook, eliminating ~94 lines of duplication. Also fixed a pre-existing trailing whitespace issue in `Server.cs` caught by DotnetFormat.

## API Changes

- **New:** `useUploadWithProgress()` hook in `src/frontend/src/widgets/inputs/shared/useUploadWithProgress.ts` — returns `{ uploadProgress, uploadSingleFile, cancelUpload }`
- **New export:** `useUploadWithProgress` added to `shared/index.ts` barrel export

## Files Modified

- **New files:**
  - `src/frontend/src/widgets/inputs/shared/useUploadWithProgress.ts` — shared hook
  - `src/frontend/src/widgets/inputs/shared/useUploadWithProgress.test.ts` — 18 tests
- **Modified:**
  - `src/frontend/src/widgets/inputs/FileInputWidget.tsx` — replaced inline upload logic with hook
  - `src/frontend/src/widgets/inputs/ContentInputWidget/useFileAttachments.ts` — replaced inline upload logic with hook
  - `src/frontend/src/widgets/inputs/shared/index.ts` — added export
  - `src/Ivy/Server.cs` — whitespace fix (DotnetFormat)

## Commits

- `2cdddcfbf` [01103] Extract shared useUploadWithProgress hook to eliminate upload orchestration duplication
- `ac8a4d415` [01103] Fix trailing whitespace in Server.cs from DotnetFormat