### PR TITLE
[01148] Consolidate duplicated test server infrastructure between Ivy.Test and Ivy.Integration.Tests

### DIFF
--- a/src/Ivy.Integration.Tests/AppHubIntegrationTests.cs
+++ b/src/Ivy.Integration.Tests/AppHubIntegrationTests.cs
@@ -1,7 +1,7 @@
 using System.Text.Json.Nodes;
 using Microsoft.AspNetCore.SignalR.Client;
 
-namespace Ivy.Test.Integration;
+namespace Ivy.Integration.Tests;
 
 public class AppHubIntegrationTests : IAsyncLifetime
 {

--- a/src/Ivy.Integration.Tests/Ivy.Integration.Tests.csproj
+++ b/src/Ivy.Integration.Tests/Ivy.Integration.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.0-*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/src/Ivy.Integration.Tests/IvyTestFixture.cs
+++ b/src/Ivy.Integration.Tests/IvyTestFixture.cs
@@ -1,30 +1,19 @@
-using Microsoft.AspNetCore.Builder;
-
 namespace Ivy.Integration.Tests;
 
 public class IvyTestFixture : IAsyncLifetime
 {
-    private WebApplication? _app;
+    private IvyTestServer? _server;
     public HttpClient Client { get; private set; } = null!;
 
     public async Task InitializeAsync()
     {
-        var server = new Server(new ServerArgs
-        {
-            Port = 0,
-            Silent = true,
-            Host = "127.0.0.1"
-        });
-        _app = server.BuildWebApplication();
-        if (_app == null)
-            throw new InvalidOperationException("Failed to build WebApplication");
-        await _app.StartAsync();
-        Client = new HttpClient { BaseAddress = new Uri(_app.Urls.First()) };
+        _server = await IvyTestServer.CreateAsync();
+        Client = new HttpClient { BaseAddress = new Uri(_server.BaseUrl) };
     }
 
     public async Task DisposeAsync()
     {
         Client.Dispose();
-        if (_app != null) await _app.StopAsync();
+        if (_server != null) await _server.DisposeAsync();
     }
 }

--- a/src/Ivy.Integration.Tests/IvyTestServer.cs
+++ b/src/Ivy.Integration.Tests/IvyTestServer.cs
@@ -1,7 +1,7 @@
 using Ivy.Core.Server;
 using Microsoft.AspNetCore.SignalR.Client;
 
-namespace Ivy.Test.Integration;
+namespace Ivy.Integration.Tests;
 
 public class IvyTestServer : IAsyncDisposable
 {

--- a/src/Ivy.Test/Ivy.Test.csproj
+++ b/src/Ivy.Test/Ivy.Test.csproj
@@ -23,7 +23,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.0-*" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Summary

## Changes

Consolidated duplicated test server infrastructure by moving `IvyTestServer` and `AppHubIntegrationTests` from `Ivy.Test/Integration/` into `Ivy.Integration.Tests/`. Refactored `IvyTestFixture` to delegate server bootstrapping to `IvyTestServer` instead of duplicating it. Removed the now-empty `Ivy.Test/Integration/` directory and the unused `SignalR.Client` dependency from `Ivy.Test`.

## API Changes

None. All changes are internal to test projects — no public APIs were added, changed, or removed.

## Files Modified

- **Moved:** `src/Ivy.Test/Integration/IvyTestServer.cs` -> `src/Ivy.Integration.Tests/IvyTestServer.cs` (namespace changed to `Ivy.Integration.Tests`)
- **Moved:** `src/Ivy.Test/Integration/AppHubIntegrationTests.cs` -> `src/Ivy.Integration.Tests/AppHubIntegrationTests.cs` (namespace changed to `Ivy.Integration.Tests`)
- **Modified:** `src/Ivy.Integration.Tests/IvyTestFixture.cs` (refactored to wrap `IvyTestServer`)
- **Modified:** `src/Ivy.Integration.Tests/Ivy.Integration.Tests.csproj` (added `SignalR.Client` package)
- **Modified:** `src/Ivy.Test/Ivy.Test.csproj` (removed unused `SignalR.Client` package)

## Commits

- `641aff1ea` [01148] Consolidate test server infrastructure into Ivy.Integration.Tests