### PR TITLE
[01159] Remove commented-out coverlet.collector from Ivy.Test.csproj

### DIFF
--- a/src/Ivy.Test/Ivy.Test.csproj
+++ b/src/Ivy.Test/Ivy.Test.csproj
@@ -13,10 +13,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-<!--    <PackageReference Include="coverlet.collector" Version="6.0.4">-->
-<!--      <PrivateAssets>all</PrivateAssets>-->
-<!--      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>-->
-<!--    </PackageReference>-->
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">


### PR DESCRIPTION
## Summary

Removed 4 lines of commented-out `coverlet.collector` package reference from `src/Ivy.Test/Ivy.Test.csproj`. This was dead code that added noise without value.

## API Changes

None.

## Files Modified

- `src/Ivy.Test/Ivy.Test.csproj` — removed commented-out PackageReference for coverlet.collector (lines 16-19)

## Commits

- 85d35e332