### PR TITLE
[01155] Validate OAuth redirect URL in AuthController to prevent open redirect

### DIFF
--- a/src/Ivy/Core/Auth/AuthController.cs
+++ b/src/Ivy/Core/Auth/AuthController.cs
@@ -145,7 +145,7 @@ public class AuthController() : Controller
 
             var path = (serverArgs.BasePath ?? "").Trim().Replace('\\', '/').TrimStart('/').TrimEnd('/');
             var redirectUrl = string.IsNullOrEmpty(path) ? "/?oauthLogin=1" : $"/{path}/?oauthLogin=1";
-            return Redirect(redirectUrl);
+            return LocalRedirect(redirectUrl);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary

Replaced `Redirect(redirectUrl)` with `LocalRedirect(redirectUrl)` in the `OAuthCallback` method of `AuthController.cs`. This prevents open redirect attacks by ensuring the redirect URL is validated as local before redirecting, addressing the CodeQL `cs/web/unvalidated-url-redirection` finding.

## API Changes

None. The behavior is identical for all valid `BasePath` values — `LocalRedirect()` only rejects URLs that are not local (e.g., starting with `//` or `/\`).

## Files Modified

- `src/Ivy/Core/Auth/AuthController.cs` — Changed `Redirect()` to `LocalRedirect()` at line 148

## Commits

- c119d1493 — [01155] Use LocalRedirect instead of Redirect in OAuthCallback to prevent open redirect