### PR TITLE
[01152] Add aria-labels to role="button" widgets for WCAG 4.1.2 compliance

### DIFF
--- a/src/frontend/src/widgets/cameraInput/CameraInputWidget.tsx
+++ b/src/frontend/src/widgets/cameraInput/CameraInputWidget.tsx
@@ -256,6 +256,7 @@ const CameraInputWidget: React.FC<CameraInputWidgetProps> = ({
             className={cn("flex flex-col items-center gap-2", !disabled && "cursor-pointer")}
             onClick={disabled ? undefined : startCamera}
             role="button"
+            aria-label="Start camera"
             tabIndex={disabled ? -1 : 0}
             onKeyDown={(e) => {
               if (disabled) return;

--- a/src/frontend/src/widgets/dataTables/DataTableFooter.tsx
+++ b/src/frontend/src/widgets/dataTables/DataTableFooter.tsx
@@ -207,6 +207,7 @@ const FooterCell: React.FC<{
           open && "bg-accent text-accent-foreground",
         )}
         role="button"
+        aria-label="Page size"
         tabIndex={0}
         onPointerDown={() => {
           // Ensure focus is on the trigger so `onBlur` can close the dropdown.

--- a/src/frontend/src/widgets/dataTables/options/DataTableFilterOption.tsx
+++ b/src/frontend/src/widgets/dataTables/options/DataTableFilterOption.tsx
@@ -277,6 +277,7 @@ export const DataTableFilterOption: React.FC<{
         }
       }}
       role="button"
+      aria-label="Edit filter"
       tabIndex={0}
       className={cn(
         "flex items-center w-full h-full justify-between",

--- a/src/frontend/src/widgets/effects/ConfettiWidget.tsx
+++ b/src/frontend/src/widgets/effects/ConfettiWidget.tsx
@@ -84,6 +84,7 @@ const ConfettiWidget: React.FC<ConfettiWidgetProps> = ({ children, trigger = "Au
         onClick={handleClick}
         onMouseEnter={handleMouseEnter}
         role="button"
+        aria-label="Trigger confetti"
         tabIndex={0}
         onKeyDown={handleKeyDown}
       >

--- a/src/frontend/src/widgets/expandable/ExpandableWidget.tsx
+++ b/src/frontend/src/widgets/expandable/ExpandableWidget.tsx
@@ -121,6 +121,7 @@ export const ExpandableWidget: React.FC<ExpandableWidgetProps> = ({
           data-collapsible-trigger
           data-disabled={disabled}
           role="button"
+          aria-label={isOpen ? "Collapse section" : "Expand section"}
           tabIndex={disabled ? -1 : 0}
           onKeyDown={(e) => {
             if (e.key === "Enter" || e.key === " ") {

--- a/src/frontend/src/widgets/inputs/AudioInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/AudioInputWidget.tsx
@@ -267,6 +267,7 @@ export const AudioInputWidget: React.FC<AudioInputWidgetProps> = ({
               }
         }
         role="button"
+        aria-label={recording ? "Stop recording" : "Start recording"}
         tabIndex={disabled ? -1 : 0}
         onBlur={(e) => {
           if (disabled) return;

--- a/src/frontend/src/widgets/layouts/tabs/components/Sortable.tsx
+++ b/src/frontend/src/widgets/layouts/tabs/components/Sortable.tsx
@@ -83,6 +83,7 @@ export function SortableDropdownMenuItem({
         }
       }}
       role="button"
+      aria-label={children?.toString() ?? "Tab"}
       tabIndex={0}
       className={cn(
         "group w-full flex items-center p-1 text-sm cursor-pointer select-none rounded-sm transition-colors hover:bg-accent",

--- a/src/frontend/src/widgets/primitives/BoxWidget.tsx
+++ b/src/frontend/src/widgets/primitives/BoxWidget.tsx
@@ -122,6 +122,7 @@ export const BoxWidget: React.FC<BoxWidgetProps> = ({
           }
         }}
         role="button"
+        aria-label="Interactive region"
         tabIndex={0}
       >
         {children}

--- a/src/frontend/src/widgets/primitives/ImageWidget.tsx
+++ b/src/frontend/src/widgets/primitives/ImageWidget.tsx
@@ -253,6 +253,7 @@ export const ImageWidget: React.FC<ImageWidgetProps> = ({
               : undefined
           }
           role={overlay || hasOnClick ? "button" : undefined}
+          aria-label={overlay ? "View image overlay" : hasOnClick ? "Image action" : undefined}
           tabIndex={overlay || hasOnClick ? 0 : undefined}
         >
           {content}

--- a/src/frontend/src/widgets/stackedProgress/StackedProgressWidget.tsx
+++ b/src/frontend/src/widgets/stackedProgress/StackedProgressWidget.tsx
@@ -84,6 +84,7 @@ export const StackedProgressWidget: React.FC<StackedProgressWidgetProps> = ({
               <div
                 key={index}
                 role={hasSelectHandler ? "button" : undefined}
+                aria-label={hasSelectHandler ? `Select segment ${index + 1}` : undefined}
                 tabIndex={hasSelectHandler ? 0 : undefined}
                 onClick={hasSelectHandler ? () => handleSelect(index) : undefined}
                 onKeyDown={
@@ -138,6 +139,7 @@ export const StackedProgressWidget: React.FC<StackedProgressWidgetProps> = ({
                 <div
                   key={originalIndex}
                   role={hasSelectHandler ? "button" : undefined}
+                  aria-label={hasSelectHandler ? `Select segment ${originalIndex + 1}` : undefined}
                   tabIndex={hasSelectHandler ? 0 : undefined}
                   onClick={hasSelectHandler ? () => handleSelect(originalIndex) : undefined}
                   onKeyDown={


### PR DESCRIPTION
## Summary

Added `aria-label` attributes to 10 `role="button"` elements across 10 widget files to satisfy WCAG 4.1.2 (Name, Role, Value). Labels are static where the button purpose is fixed and dynamic where the button state varies (e.g., recording/not-recording, expanded/collapsed).

## API Changes

None.

## Files Modified

- **Audio/Camera inputs:** `AudioInputWidget.tsx`, `CameraInputWidget.tsx`
- **Layout widgets:** `ExpandableWidget.tsx`, `Sortable.tsx` (tabs)
- **Primitive widgets:** `BoxWidget.tsx`, `ImageWidget.tsx`
- **Data table widgets:** `DataTableFilterOption.tsx`, `DataTableFooter.tsx`
- **Effect widgets:** `ConfettiWidget.tsx`
- **Progress widgets:** `StackedProgressWidget.tsx`

## Commits

- `84df8efba` — [01152] Add aria-labels to role="button" widgets for WCAG 4.1.2 compliance