### PR TITLE
[01143] Add ShortcutKey demo to remaining input variants (Email, Tel, Url, Textarea)

### DIFF
--- a/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/TextInputApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/TextInputApp.cs
@@ -65,7 +65,7 @@ public class TextInputApp : SampleBase
                   | withValue.ToPasswordInput().Invalid("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam nec purus nec eros")
 
                   | Text.Monospaced("TextInputVariant.Textarea")
-                  | withoutValue.ToTextareaInput().Placeholder("Placeholder")
+                  | withoutValue.ToTextareaInput().Placeholder("Placeholder").ShortcutKey("Ctrl+T")
                   | withValue.ToTextareaInput()
                   | withValue.ToTextareaInput().Disabled()
                   | withValue.ToTextareaInput().Invalid("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam nec purus nec eros")
@@ -75,6 +75,24 @@ public class TextInputApp : SampleBase
                   | withValue.ToSearchInput()
                   | withValue.ToSearchInput().Disabled()
                   | withValue.ToSearchInput().Invalid("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam nec purus nec eros")
+
+                  | Text.Monospaced("TextInputVariant.Email")
+                  | withoutValue.ToEmailInput().Placeholder("Placeholder").ShortcutKey("Ctrl+E")
+                  | withValue.ToEmailInput()
+                  | withValue.ToEmailInput().Disabled()
+                  | withValue.ToEmailInput().Invalid("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam nec purus nec eros")
+
+                  | Text.Monospaced("TextInputVariant.Tel")
+                  | withoutValue.ToTelInput().Placeholder("Placeholder").ShortcutKey("Ctrl+J")
+                  | withValue.ToTelInput()
+                  | withValue.ToTelInput().Disabled()
+                  | withValue.ToTelInput().Invalid("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam nec purus nec eros")
+
+                  | Text.Monospaced("TextInputVariant.Url")
+                  | withoutValue.ToUrlInput().Placeholder("Placeholder").ShortcutKey("Ctrl+U")
+                  | withValue.ToUrlInput()
+                  | withValue.ToUrlInput().Disabled()
+                  | withValue.ToUrlInput().Invalid("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam nec purus nec eros")
                )
 
                | Text.H2("Affixes")


### PR DESCRIPTION
## Summary

### Changes

Added ShortcutKey demonstrations to the Variants grid in TextInputApp.cs for all remaining input types. Added `.ShortcutKey("Ctrl+T")` to the existing Textarea row's empty cell, and added three new 5-column variant rows for Email (Ctrl+E), Tel (Ctrl+J), and Url (Ctrl+U) inputs, each with empty/placeholder, with-value, disabled, and invalid states.

### API Changes

None.

### Files Modified

- **src/Ivy.Samples.Shared/Apps/Widgets/Inputs/TextInputApp.cs** — Added ShortcutKey to Textarea row; added Email, Tel, and Url variant rows with ShortcutKey demos

## Commits

- `61d7380a7` [01143] Add ShortcutKey demo to Email, Tel, Url variants and Textarea