### PR TITLE
[01156] Add optional AriaLabel prop to Box widget

### DIFF
--- a/src/Ivy/Widgets/Primitives/Box.cs
+++ b/src/Ivy/Widgets/Primitives/Box.cs
@@ -38,6 +38,8 @@ public record Box : WidgetBase<Box>
 
     [Prop] public HoverEffect HoverVariant { get; set; } = HoverEffect.None;
 
+    [Prop] public string? AriaLabel { get; set; }
+
     [Event] public EventHandler<Event<Box>>? OnClick { get; set; }
 }
 
@@ -96,6 +98,8 @@ public static class BoxExtensions
     public static Box Grow(this Box box) => box.Width(Size.Grow());
 
     public static Box Hover(this Box box, HoverEffect variant) => box with { HoverVariant = variant };
+
+    public static Box AriaLabel(this Box box, string label) => box with { AriaLabel = label };
 
     private static HoverEffect HoverVariantWithClick(this Box box) => box.HoverVariant == HoverEffect.None ? HoverEffect.PointerAndTranslate : box.HoverVariant;
 

--- a/src/frontend/src/widgets/primitives/BoxWidget.tsx
+++ b/src/frontend/src/widgets/primitives/BoxWidget.tsx
@@ -40,6 +40,7 @@ interface BoxWidgetProps {
   events?: string[];
   aspectRatio?: number;
   hoverVariant?: HoverEffect;
+  ariaLabel?: string;
 }
 
 export const BoxWidget: React.FC<BoxWidgetProps> = ({
@@ -61,6 +62,7 @@ export const BoxWidget: React.FC<BoxWidgetProps> = ({
   aspectRatio,
   events = EMPTY_ARRAY,
   hoverVariant = "None",
+  ariaLabel,
 }) => {
   const eventHandler = useEventHandler();
   const isClickable = events.includes("OnClick");
@@ -122,7 +124,7 @@ export const BoxWidget: React.FC<BoxWidgetProps> = ({
           }
         }}
         role="button"
-        aria-label="Interactive region"
+        aria-label={ariaLabel ?? "Interactive region"}
         tabIndex={0}
       >
         {children}


### PR DESCRIPTION
## Summary

Added an optional `AriaLabel` string property to the `Box` widget backend and frontend. When set, it overrides the default `"Interactive region"` aria-label on clickable Box elements, allowing app authors to provide context-specific accessibility labels.

## API Changes

- **`Box.AriaLabel`** (`string?`) — new `[Prop]` property on `Box` record in `Box.cs`
- **`BoxExtensions.AriaLabel(this Box box, string label)`** — new extension method for fluent API usage
- **`BoxWidgetProps.ariaLabel`** (`string?`) — new optional prop on the React `BoxWidget` component

## Files Modified

- `src/Ivy/Widgets/Primitives/Box.cs` — Added `AriaLabel` property and extension method
- `src/frontend/src/widgets/primitives/BoxWidget.tsx` — Added `ariaLabel` prop with fallback to `"Interactive region"`

## Commits

- 63467678a