### PR TITLE
[01157] Ctrl+Enter / Cmd+Enter exits textarea input

### DIFF
--- a/src/frontend/src/widgets/inputs/TextInputWidget/TextInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/TextInputWidget/TextInputWidget.tsx
@@ -245,6 +245,7 @@ export const TextInputWidget: React.FC<TextInputWidgetProps> = ({
           onBlur={handleBlur}
           onFocus={handleFocus}
           onClear={handleClear}
+          onSubmit={handleSubmit}
           inputRef={inputRef}
           isFocused={isFocused}
           density={density}

--- a/src/frontend/src/widgets/inputs/TextInputWidget/variants/TextareaVariant.tsx
+++ b/src/frontend/src/widgets/inputs/TextInputWidget/variants/TextareaVariant.tsx
@@ -19,6 +19,7 @@ interface TextareaVariantProps {
   onBlur: (e: React.FocusEvent<HTMLTextAreaElement>) => void;
   onFocus: (e: React.FocusEvent<HTMLTextAreaElement>) => void;
   onClear: (e: React.MouseEvent) => void;
+  onSubmit?: () => void;
   width?: string;
   inputRef?: React.RefObject<HTMLInputElement | HTMLTextAreaElement | null>;
   isFocused: boolean;
@@ -32,6 +33,7 @@ export const TextareaVariant: React.FC<TextareaVariantProps> = ({
   onBlur,
   onFocus,
   onClear,
+  onSubmit,
   inputRef,
   isFocused,
   density = Densities.Medium,
@@ -41,6 +43,14 @@ export const TextareaVariant: React.FC<TextareaVariantProps> = ({
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     savePosition();
     onChange(e);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+      e.preventDefault();
+      onSubmit?.();
+      e.currentTarget.blur();
+    }
   };
 
   const handlePaste = usePasteHandler(props.maxLength, (value) => {
@@ -82,6 +92,7 @@ export const TextareaVariant: React.FC<TextareaVariantProps> = ({
           onChange={handleChange}
           onBlur={onBlur}
           onFocus={onFocus}
+          onKeyDown={handleKeyDown}
           onPaste={handlePaste}
           style={textareaStyles}
           className={cn(


### PR DESCRIPTION
# Summary

Added Ctrl+Enter (Windows/Linux) and Cmd+Enter (Mac) keyboard shortcut to the TextareaVariant to fire `OnSubmit` and blur the textarea. This brings textarea keyboard behavior in line with other text input variants (Default, Password, Search) which already support submit-on-Enter.

## API Changes

- `TextareaVariantProps` interface: added optional `onSubmit?: () => void` prop
- `TextareaVariant` component: added `onKeyDown` handler for Ctrl/Cmd+Enter

## Files Modified

- **src/frontend/src/widgets/inputs/TextInputWidget/variants/TextareaVariant.tsx** — Added `onSubmit` prop, `handleKeyDown` handler, and wired `onKeyDown` to the `<Textarea>` element
- **src/frontend/src/widgets/inputs/TextInputWidget/TextInputWidget.tsx** — Passed `onSubmit={handleSubmit}` to `TextareaVariant`

## Commits

- `7d674d0b2` [01157] Add Ctrl+Enter / Cmd+Enter to submit and blur textarea input