### PR TITLE
[01166] Add .test.tsx pattern to vite.config.mjs test include

### DIFF
--- a/src/frontend/vite.config.mjs
+++ b/src/frontend/vite.config.mjs
@@ -98,7 +98,7 @@ export default defineConfig({
     },
   },
   test: {
-    include: ["**/*.test.ts"],
+    include: ["**/*.test.ts", "**/*.test.tsx"],
     exclude: ["**/e2e/**", "**/node_modules/**", "**/dist/**"],
     environment: "happy-dom",
   },


### PR DESCRIPTION
## Summary

Added `"**/*.test.tsx"` to the Vitest `include` array in `vite.config.mjs` so that future `.test.tsx` test files (e.g., for React component tests using `@testing-library/react`) are picked up by the test runner.

## API Changes

None.

## Files Modified

- `src/frontend/vite.config.mjs` — Added `.test.tsx` glob pattern to Vitest test include config

## Commits

- f6c4def5e [01166] Add .test.tsx pattern to vite.config.mjs test include