### PR TITLE
[01162] Deduplicate shortcut keys in TextInputAffixes demo

### DIFF
--- a/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/TextInputApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/TextInputApp.cs
@@ -225,9 +225,9 @@ public class TextInputAffixes : ViewBase
                | nullableState.ToTextInput().Prefix("https://").Suffix(".com").Placeholder("domain")
 
                | Text.Monospaced("Nullable + Invalid + ShortcutKey")
-               | nullableState.ToTextInput().Prefix("@").Invalid("Required field").ShortcutKey("Ctrl+U")
+               | nullableState.ToTextInput().Prefix("@").Invalid("Required field").ShortcutKey("Ctrl+P")
                | nullableState.ToTextInput().Suffix(Icons.Search).Invalid("Invalid input").ShortcutKey("Ctrl+F")
-               | nullableState.ToTextInput().Prefix(Icons.Mail).Suffix(".com").Invalid("Error").ShortcutKey("Ctrl+E");
+               | nullableState.ToTextInput().Prefix(Icons.Mail).Suffix(".com").Invalid("Error").ShortcutKey("Ctrl+B");
     }
 }
 


### PR DESCRIPTION
## Changes

Changed the shortcut keys in the `TextInputAffixes` "Nullable + Invalid + ShortcutKey" demo row to avoid duplicating keys used by the Variants grid. `Ctrl+U` changed to `Ctrl+P` (prefix column) and `Ctrl+E` changed to `Ctrl+B` ("Both" column).

## API Changes

None.

## Files Modified

- `src/Ivy.Samples.Shared/Apps/Widgets/Inputs/TextInputApp.cs` — Updated shortcut key strings in TextInputAffixes.Build()

## Commits

- 03a77d93e