### PR TITLE
[01158] Broad WCAG audit: fix accessible names, keyboard support, and invalid ARIA across widget library

### DIFF
--- a/src/frontend/src/widgets/badge/BadgeWidget.tsx
+++ b/src/frontend/src/widgets/badge/BadgeWidget.tsx
@@ -117,6 +117,18 @@ export const BadgeWidget: React.FC<BadgeWidgetProps> = ({
         isClickable && "cursor-pointer hover:opacity-80 transition-opacity",
       )}
       onClick={isClickable ? handleClick : undefined}
+      {...(isClickable
+        ? {
+            role: "button",
+            tabIndex: 0,
+            onKeyDown: (e: React.KeyboardEvent) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                handleClick();
+              }
+            },
+          }
+        : {})}
     >
       {iconPosition === "Left" && icon && icon !== "None" && (
         <Icon style={iconStyles} name={icon} />

--- a/src/frontend/src/widgets/blades/BladeWidget.tsx
+++ b/src/frontend/src/widgets/blades/BladeWidget.tsx
@@ -49,6 +49,7 @@ export function BladeWidget({ index, title, children, id, width, slots }: BladeW
         </div>
         <div className="flex items-center h-[70px]">
           <button
+            aria-label="Refresh"
             onClick={() => eventHandler("OnRefresh", id, [])}
             className={buttonVariant({ variant: "ghost", size: "icon" })}
           >
@@ -56,6 +57,7 @@ export function BladeWidget({ index, title, children, id, width, slots }: BladeW
           </button>
           {index > 0 && (
             <button
+              aria-label="Close"
               onClick={() => eventHandler("OnClose", id, [])}
               className={buttonVariant({ variant: "ghost", size: "icon" })}
             >

--- a/src/frontend/src/widgets/calendar/CalendarWidget.tsx
+++ b/src/frontend/src/widgets/calendar/CalendarWidget.tsx
@@ -291,6 +291,9 @@ const MonthView: React.FC<MonthViewProps> = ({
               return (
                 <div
                   key={key}
+                  role="gridcell"
+                  tabIndex={0}
+                  aria-label={format(day, "EEEE, MMMM d, yyyy")}
                   className={cn(
                     "border-r border-border last:border-r-0 p-1 overflow-hidden cursor-pointer hover:bg-accent/30 transition-colors min-h-[4.5rem]",
                     !inMonth && "bg-muted/30",
@@ -299,6 +302,13 @@ const MonthView: React.FC<MonthViewProps> = ({
                   onClick={() => {
                     const dayStart = startOfDay(day);
                     onSelectSlot(dayStart.toISOString(), endOfDay(day).toISOString());
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      const dayStart = startOfDay(day);
+                      onSelectSlot(dayStart.toISOString(), endOfDay(day).toISOString());
+                    }
                   }}
                   onDragOver={
                     enableDragDrop
@@ -493,6 +503,9 @@ const TimeGrid: React.FC<TimeGridProps> = ({
                 {HOURS.map((hour) => (
                   <div
                     key={hour}
+                    role="button"
+                    tabIndex={0}
+                    aria-label={`${format(day, "EEEE, MMMM d")} at ${format(new Date(2000, 0, 1, hour), "HH:mm")}`}
                     className="absolute w-full border-t border-border/50 cursor-pointer hover:bg-accent/20"
                     style={{
                       top: hour * HOUR_HEIGHT,
@@ -504,6 +517,16 @@ const TimeGrid: React.FC<TimeGridProps> = ({
                       const slotEnd = new Date(day);
                       slotEnd.setHours(hour + 1, 0, 0, 0);
                       onSelectSlot(slotStart.toISOString(), slotEnd.toISOString());
+                    }}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        const slotStart = new Date(day);
+                        slotStart.setHours(hour, 0, 0, 0);
+                        const slotEnd = new Date(day);
+                        slotEnd.setHours(hour + 1, 0, 0, 0);
+                        onSelectSlot(slotStart.toISOString(), slotEnd.toISOString());
+                      }
                     }}
                     onDragOver={
                       enableDragDrop

--- a/src/frontend/src/widgets/card/CardWidget.tsx
+++ b/src/frontend/src/widgets/card/CardWidget.tsx
@@ -72,6 +72,17 @@ export const CardWidget: React.FC<CardWidgetProps> = ({
       disabled={disabled}
       className={cn(cardStyles.container, hoverClass)}
       onClick={disabled ? undefined : handleClick}
+      {...(events.includes("OnClick") && !disabled
+        ? {
+            tabIndex: 0,
+            onKeyDown: (e: React.KeyboardEvent) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                handleClick();
+              }
+            },
+          }
+        : {})}
     >
       {!headerIsEmpty ? (
         <CardHeader className={cn(cardStyles.header.base, sizeClasses.header)}>

--- a/src/frontend/src/widgets/dataTables/DataTableFooter.tsx
+++ b/src/frontend/src/widgets/dataTables/DataTableFooter.tsx
@@ -179,10 +179,18 @@ const FooterCell: React.FC<{
             key={i}
             role="option"
             aria-selected={i === selectedIndex}
+            tabIndex={0}
             onMouseDown={(e) => {
               e.preventDefault();
               setSelectedIndex(i);
               setOpen(false);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                setSelectedIndex(i);
+                setOpen(false);
+              }
             }}
             className={cn(
               "px-2 py-1 text-xs cursor-pointer whitespace-nowrap transition-colors",

--- a/src/frontend/src/widgets/effects/AnimationWidget.tsx
+++ b/src/frontend/src/widgets/effects/AnimationWidget.tsx
@@ -354,6 +354,18 @@ const AnimationWidget: React.FC<AnimationWidgetProps> = (props) => {
             onHoverStart={handleHoverStart}
             onHoverEnd={handleHoverEnd}
             onAnimationComplete={handleAnimationComplete}
+            {...(trigger === "Click"
+              ? {
+                  role: "button",
+                  tabIndex: 0,
+                  onKeyDown: (e: React.KeyboardEvent) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      handleClick();
+                    }
+                  },
+                }
+              : {})}
             style={{
               cursor: trigger === "Click" ? "pointer" : "default",
               display: "inline-block",

--- a/src/frontend/src/widgets/expandable/ExpandableWidget.tsx
+++ b/src/frontend/src/widgets/expandable/ExpandableWidget.tsx
@@ -108,7 +108,8 @@ export const ExpandableWidget: React.FC<ExpandableWidgetProps> = ({
         "p-0",
       )}
       data-disabled={disabled}
-      role="details"
+      role="group"
+      aria-label={isOpen ? "Expanded section" : "Collapsed section"}
     >
       <CollapsibleTrigger asChild>
         <div
@@ -136,7 +137,6 @@ export const ExpandableWidget: React.FC<ExpandableWidgetProps> = ({
               disabled && "text-muted-foreground",
               "flex items-center gap-2",
             )}
-            role="summary"
           >
             {icon && icon !== "None" && <Icon style={iconStyles} name={icon} />}
             {slots?.Header}

--- a/src/frontend/src/widgets/inputs/DateTimeInputWidget/MonthVariant.tsx
+++ b/src/frontend/src/widgets/inputs/DateTimeInputWidget/MonthVariant.tsx
@@ -136,6 +136,7 @@ export const MonthVariant: React.FC<MonthVariantProps> = ({
                 variant="ghost"
                 size="icon"
                 className="h-7 w-7"
+                aria-label="Previous year"
                 onClick={() => setViewYear((y) => y - 1)}
               >
                 <ChevronLeft className="h-4 w-4" />
@@ -145,6 +146,7 @@ export const MonthVariant: React.FC<MonthVariantProps> = ({
                 variant="ghost"
                 size="icon"
                 className="h-7 w-7"
+                aria-label="Next year"
                 onClick={() => setViewYear((y) => y + 1)}
               >
                 <ChevronRight className="h-4 w-4" />

--- a/src/frontend/src/widgets/inputs/DateTimeInputWidget/YearVariant.tsx
+++ b/src/frontend/src/widgets/inputs/DateTimeInputWidget/YearVariant.tsx
@@ -141,6 +141,7 @@ export const YearVariant: React.FC<YearVariantProps> = ({
                 variant="ghost"
                 size="icon"
                 className="h-7 w-7"
+                aria-label="Previous decade"
                 onClick={() => setDecadeStart((d) => d - 10)}
               >
                 <ChevronLeft className="h-4 w-4" />
@@ -152,6 +153,7 @@ export const YearVariant: React.FC<YearVariantProps> = ({
                 variant="ghost"
                 size="icon"
                 className="h-7 w-7"
+                aria-label="Next decade"
                 onClick={() => setDecadeStart((d) => d + 10)}
               >
                 <ChevronRight className="h-4 w-4" />

--- a/src/frontend/src/widgets/inputs/shared/FileAttachmentList.tsx
+++ b/src/frontend/src/widgets/inputs/shared/FileAttachmentList.tsx
@@ -119,6 +119,7 @@ export const FileAttachmentList: React.FC<FileAttachmentListProps> = ({
             type="button"
             variant="ghost"
             size="icon"
+            aria-label="Cancel upload"
             className={`${cancelBtnSize} shrink-0`}
             onClick={(e) => {
               e.stopPropagation();
@@ -146,6 +147,7 @@ export const FileAttachmentList: React.FC<FileAttachmentListProps> = ({
           type="button"
           variant="ghost"
           size="icon"
+          aria-label="Cancel upload"
           className={compactCancelVariant({ density })}
           onClick={(e) => {
             e.stopPropagation();
@@ -222,6 +224,7 @@ export const FileAttachmentList: React.FC<FileAttachmentListProps> = ({
                   type="button"
                   variant="ghost"
                   size="icon"
+                  aria-label="Remove file"
                   className={`${cancelBtnSize} shrink-0`}
                   onClick={(e) => {
                     e.stopPropagation();
@@ -270,6 +273,7 @@ export const FileAttachmentList: React.FC<FileAttachmentListProps> = ({
                 type="button"
                 variant="ghost"
                 size="icon"
+                aria-label="Remove file"
                 className={compactCancelVariant({ density })}
                 onClick={(e) => {
                   e.stopPropagation();

--- a/src/frontend/src/widgets/layouts/sidebar/SidebarLayoutWidget.tsx
+++ b/src/frontend/src/widgets/layouts/sidebar/SidebarLayoutWidget.tsx
@@ -828,6 +828,7 @@ export const SidebarMenuWidget: React.FC<SidebarMenuWidgetProps> = ({
         containerRef.current = el;
       }}
       role="menu"
+      aria-label="Sidebar menu"
       tabIndex={0}
       onFocus={() => {
         if (searchActive && flatItems.length > 0) setSelectedIndex(0);

--- a/src/frontend/src/widgets/layouts/tabs/components/Sortable.tsx
+++ b/src/frontend/src/widgets/layouts/tabs/components/Sortable.tsx
@@ -94,6 +94,7 @@ export function SortableDropdownMenuItem({
       {showClose && (
         <button
           type="button"
+          aria-label="Close tab"
           className="ml-auto opacity-60 p-1 hover:opacity-100 invisible group-hover:visible cursor-pointer"
           onClick={(e) => {
             e.stopPropagation();

--- a/src/frontend/src/widgets/layouts/tabs/components/TabContent.tsx
+++ b/src/frontend/src/widgets/layouts/tabs/components/TabContent.tsx
@@ -52,6 +52,7 @@ export const TabContentRenderer: React.FC<TabContentRendererProps> = ({
         {isActive && showRefresh && (
           <button
             type="button"
+            aria-label="Refresh tab"
             onClick={(e) => {
               e.stopPropagation();
               isUserInitiatedChangeRef.current = true;
@@ -65,6 +66,7 @@ export const TabContentRenderer: React.FC<TabContentRendererProps> = ({
         {showClose && (
           <button
             type="button"
+            aria-label="Close tab"
             onClick={(e) => {
               e.stopPropagation();
               isUserInitiatedChangeRef.current = true;

--- a/src/frontend/src/widgets/layouts/tabs/components/Variants.tsx
+++ b/src/frontend/src/widgets/layouts/tabs/components/Variants.tsx
@@ -139,6 +139,7 @@ export const ContentVariant: React.FC<ContentVariantProps> = ({
                   tabRefs.current[index] = el;
                 }}
                 role="tab"
+                id={`tab-${id}`}
                 value={id}
                 aria-selected={index === activeIndex}
                 tabIndex={0}
@@ -197,6 +198,7 @@ export const ContentVariant: React.FC<ContentVariantProps> = ({
             <div
               key={id}
               role="tabpanel"
+              aria-labelledby={`tab-${id}`}
               aria-hidden={!isActive}
               className={cn(
                 "overflow-auto border-none",

--- a/src/frontend/src/widgets/primitives/StepperWidget.tsx
+++ b/src/frontend/src/widgets/primitives/StepperWidget.tsx
@@ -70,6 +70,7 @@ export const StepperWidget: React.FC<StepperWidgetProps> = ({
             <React.Fragment key={item.label || item.symbol}>
               <button
                 type="button"
+                aria-label={item.label || `Step ${index + 1}`}
                 onClick={() => handleSelect(index)}
                 disabled={!isClickable}
                 className={cn(

--- a/src/frontend/src/widgets/toolbar/ToolbarWidget.tsx
+++ b/src/frontend/src/widgets/toolbar/ToolbarWidget.tsx
@@ -30,7 +30,12 @@ const ToolbarItemGroup: React.FC<ToolbarItemGroupProps> = ({
     if (item.variant === "Group" && item.children) {
       const groupKey = item.label || `group-${i}`;
       return (
-        <div key={groupKey} className="flex items-center gap-1" role="group">
+        <div
+          key={groupKey}
+          className="flex items-center gap-1"
+          role="group"
+          aria-label={item.label || "Toolbar group"}
+        >
           <ToolbarItemGroup
             items={item.children}
             onItemClick={onItemClick}
@@ -100,6 +105,7 @@ export const ToolbarWidget: React.FC<ToolbarWidgetProps> = ({
   return (
     <div
       role="toolbar"
+      aria-label="Toolbar"
       aria-disabled={disabled}
       className={cn(
         "flex items-center gap-2 p-2 bg-background border rounded-md",

--- a/src/frontend/src/widgets/tree/TreeItem.tsx
+++ b/src/frontend/src/widgets/tree/TreeItem.tsx
@@ -108,6 +108,7 @@ export const TreeItem: React.FC<TreeItemWidgetProps> = ({
               onKeyDown={(e) => e.stopPropagation()}
               onPointerDown={(e) => e.stopPropagation()}
               role="toolbar"
+              aria-label="Row actions"
             >
               {rowActions.map((action) => (
                 <ActionRenderer
@@ -166,6 +167,7 @@ export const TreeItem: React.FC<TreeItemWidgetProps> = ({
           onKeyDown={(e) => e.stopPropagation()}
           onPointerDown={(e) => e.stopPropagation()}
           role="toolbar"
+          aria-label="Row actions"
         >
           {rowActions.map((action) => (
             <ActionRenderer


### PR DESCRIPTION
## Summary

## Changes

Added WCAG accessibility improvements across 17 widget components in three categories: keyboard support and ARIA roles for interactive non-semantic elements (calendar cells, badges, cards, animations, data table options), aria-labels for icon-only buttons (blades, tabs, file attachments, date pickers, steppers), and fixes for invalid/unlabeled ARIA roles (expandable, tree, toolbar, sidebar menu, tab panels).

## API Changes

None.

## Files Modified

- **Category A - Keyboard support:** CalendarWidget.tsx, BadgeWidget.tsx, CardWidget.tsx, AnimationWidget.tsx, DataTableFooter.tsx
- **Category B - Icon-only button labels:** BladeWidget.tsx, TabContent.tsx, Sortable.tsx, FileAttachmentList.tsx, MonthVariant.tsx, YearVariant.tsx, StepperWidget.tsx
- **Category C - ARIA role fixes:** ExpandableWidget.tsx, TreeItem.tsx, ToolbarWidget.tsx, SidebarLayoutWidget.tsx, Variants.tsx

## Commits

- 891367e4d [01158] Broad WCAG audit: fix accessible names, keyboard support, and invalid ARIA across widget library