### PR TITLE
[01183] Remove unused dictationLanguage prop from frontend TextInput widget

### DIFF
--- a/src/Ivy/Widgets/Inputs/TextInput.cs
+++ b/src/Ivy/Widgets/Inputs/TextInput.cs
@@ -79,7 +79,7 @@ public abstract record TextInputBase : WidgetBase<TextInputBase>, IAnyTextInput
 
     [Prop] public string? DictationUploadUrl { get; set; }
 
-    [Prop] public string? DictationLanguage { get; set; }
+    public string? DictationLanguage { get; set; }
 
     [Prop] public string? DictationTranscription { get; set; }
 

--- a/src/frontend/src/widgets/inputs/TextInputWidget/TextInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/TextInputWidget/TextInputWidget.tsx
@@ -30,7 +30,6 @@ export const TextInputWidget: React.FC<TextInputWidgetProps> = ({
   autoFocus,
   dictation,
   dictationUploadUrl,
-  dictationLanguage: _dictationLanguage,
   dictationTranscription,
   dictationTranscriptionVersion,
   "data-testid": dataTestId,

--- a/src/frontend/src/widgets/inputs/TextInputWidget/types.ts
+++ b/src/frontend/src/widgets/inputs/TextInputWidget/types.ts
@@ -37,7 +37,6 @@ export interface TextInputWidgetProps {
   autoFocus?: boolean;
   dictation?: boolean;
   dictationUploadUrl?: string;
-  dictationLanguage?: string;
   dictationTranscription?: string;
   dictationTranscriptionVersion?: number;
   "data-testid"?: string;


### PR DESCRIPTION
## Summary

Removed the unused `dictationLanguage` prop from the frontend TextInput widget and stopped serializing it from the backend. The backend property is retained (without `[Prop]`) since `EnableDictation()` still writes to it, but language selection is handled entirely server-side so the frontend never needed it.

## API Changes

- `TextInputWidgetProps` (TypeScript): removed `dictationLanguage?: string` property
- `TextInputBase` (C#): removed `[Prop]` attribute from `DictationLanguage` property (property itself retained as internal state)

## Files Modified

- **Frontend:**
  - `src/frontend/src/widgets/inputs/TextInputWidget/TextInputWidget.tsx` — removed `dictationLanguage` from props destructuring
  - `src/frontend/src/widgets/inputs/TextInputWidget/types.ts` — removed `dictationLanguage` from `TextInputWidgetProps` interface
- **Backend:**
  - `src/Ivy/Widgets/Inputs/TextInput.cs` — removed `[Prop]` attribute from `DictationLanguage`

## Commits

- e2d180ded