### PR TITLE
[01171] Add dark mode support to SignatureInputWidget

### DIFF
--- a/src/frontend/src/widgets/inputs/SignatureInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/SignatureInputWidget.tsx
@@ -1,9 +1,10 @@
 import { useEventHandler } from "@/components/event-handler";
 import { InvalidIcon } from "@/components/InvalidIcon";
+import { useThemeWithMonitoring } from "@/components/theme-provider";
 import { inputStyles } from "@/lib/styles";
 import { cn } from "@/lib/utils";
 import { Eraser } from "lucide-react";
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { EMPTY_ARRAY } from "@/lib/constants";
 
 interface Point {
@@ -24,41 +25,11 @@ interface SignatureInputWidgetProps {
   "data-testid"?: string;
 }
 
-const colorMap: Record<string, string> = {
-  black: "#000000",
-  white: "#ffffff",
-  slate: "#64748b",
-  gray: "#6b7280",
-  zinc: "#71717a",
-  neutral: "#737373",
-  stone: "#78716c",
-  red: "#ef4444",
-  orange: "#f97316",
-  amber: "#f59e0b",
-  yellow: "#eab308",
-  lime: "#84cc16",
-  green: "#22c55e",
-  emerald: "#10b981",
-  teal: "#14b8a6",
-  cyan: "#06b6d4",
-  sky: "#0ea5e9",
-  blue: "#3b82f6",
-  indigo: "#6366f1",
-  violet: "#8b5cf6",
-  purple: "#a855f7",
-  fuchsia: "#d946ef",
-  pink: "#ec4899",
-  rose: "#f43f5e",
-  primary: "#3b82f6",
-  secondary: "#6b7280",
-  destructive: "#ef4444",
-  success: "#22c55e",
-  warning: "#f59e0b",
-  info: "#0ea5e9",
-  muted: "#6b7280",
-};
-
-function resolveColor(color: string | undefined, fallback: string): string {
+function resolveColor(
+  color: string | undefined,
+  fallback: string,
+  colorMap: Record<string, string>,
+): string {
   if (!color) return fallback;
   if (color.startsWith("#") || color.startsWith("rgb")) return color;
   return colorMap[color.toLowerCase()] ?? fallback;
@@ -77,6 +48,10 @@ export const SignatureInputWidget: React.FC<SignatureInputWidgetProps> = ({
   "data-testid": dataTestId,
 }) => {
   const eventHandler = useEventHandler();
+  const { colors, isDark } = useThemeWithMonitoring({
+    monitorDOM: true,
+    monitorSystem: true,
+  });
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const isFocusedRef = useRef(false);
@@ -86,8 +61,49 @@ export const SignatureInputWidget: React.FC<SignatureInputWidgetProps> = ({
   const pathsRef = useRef<Point[][]>([]);
   const currentPathRef = useRef<Point[]>([]);
 
-  const penColor = resolveColor(pen, "#000000");
-  const bgColor = resolveColor(background, "#ffffff");
+  const colorMap = useMemo<Record<string, string>>(
+    () => ({
+      // Chromatic colors (static — no CSS variable equivalents)
+      black: "#000000",
+      white: "#ffffff",
+      slate: "#64748b",
+      gray: "#6b7280",
+      zinc: "#71717a",
+      neutral: "#737373",
+      stone: "#78716c",
+      red: "#ef4444",
+      orange: "#f97316",
+      amber: "#f59e0b",
+      yellow: "#eab308",
+      lime: "#84cc16",
+      green: "#22c55e",
+      emerald: "#10b981",
+      teal: "#14b8a6",
+      cyan: "#06b6d4",
+      sky: "#0ea5e9",
+      blue: "#3b82f6",
+      indigo: "#6366f1",
+      violet: "#8b5cf6",
+      purple: "#a855f7",
+      fuchsia: "#d946ef",
+      pink: "#ec4899",
+      rose: "#f43f5e",
+      // Semantic colors — track actual theme CSS vars
+      primary: colors.primary || "#3b82f6",
+      secondary: colors.secondary || "#6b7280",
+      destructive: colors.destructive || "#ef4444",
+      muted: colors.mutedForeground || "#6b7280",
+      // Surface colors
+      foreground: colors.foreground || "#000000",
+      background: colors.background || "#ffffff",
+    }),
+    [colors],
+  );
+
+  const defaultPen = colors.foreground || (isDark ? "#e4e4e7" : "#000000");
+  const defaultBg = colors.background || (isDark ? "#09090b" : "#ffffff");
+  const penColor = resolveColor(pen, defaultPen, colorMap);
+  const bgColor = resolveColor(background, defaultBg, colorMap);
 
   const clearCanvas = useCallback(() => {
     const canvas = canvasRef.current;


### PR DESCRIPTION
## Summary

Made the `SignatureInputWidget` theme-aware by integrating `useThemeWithMonitoring` from the theme service. The canvas background and pen colors now derive from CSS variables (`--background`, `--foreground`) instead of hardcoded hex values, and the `colorMap` semantic entries (primary, secondary, destructive, muted) track the actual theme CSS variable values via `useMemo`. The canvas automatically repaints when the theme changes.

## API Changes

None. The C# `SignatureInput.Pen` and `SignatureInput.Background` props remain optional `Colors?` — when null, the frontend picks theme-appropriate defaults.

## Files Modified

- **Frontend:**
  - `src/frontend/src/widgets/inputs/SignatureInputWidget.tsx` — Added `useThemeWithMonitoring` hook, moved `colorMap` into `useMemo` with theme-derived semantic colors, replaced hardcoded pen/background defaults with theme CSS variable values

## Commits

- `801c809a3` [01171] Add dark mode support to SignatureInputWidget via theme service