### PR TITLE
[01193] Add unit tests for SignatureInputWidget

### DIFF
--- a/src/frontend/src/widgets/inputs/SignatureInputWidget.test.ts
+++ b/src/frontend/src/widgets/inputs/SignatureInputWidget.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import { resolveColor, CHROMATIC_COLORS, DEFAULT_SEMANTIC_COLORS } from "./SignatureInputWidget";
+
+/** A full color map combining chromatic + default semantic colors, matching runtime defaults. */
+const fullColorMap: Record<string, string> = {
+  ...CHROMATIC_COLORS,
+  ...DEFAULT_SEMANTIC_COLORS,
+};
+
+describe("resolveColor", () => {
+  it("returns fallback when color is undefined", () => {
+    expect(resolveColor(undefined, "#000", fullColorMap)).toBe("#000");
+  });
+
+  it("returns fallback when color is empty string", () => {
+    expect(resolveColor("", "#000", fullColorMap)).toBe("#000");
+  });
+
+  it("passes through hex colors", () => {
+    expect(resolveColor("#ff0000", "#000", fullColorMap)).toBe("#ff0000");
+  });
+
+  it("passes through rgb colors", () => {
+    expect(resolveColor("rgb(255,0,0)", "#000", fullColorMap)).toBe("rgb(255,0,0)");
+  });
+
+  it("passes through rgba colors", () => {
+    expect(resolveColor("rgba(255,0,0,0.5)", "#000", fullColorMap)).toBe("rgba(255,0,0,0.5)");
+  });
+
+  it("resolves named colors from colorMap", () => {
+    expect(resolveColor("blue", "#000", fullColorMap)).toBe("#3b82f6");
+  });
+
+  it("performs case-insensitive lookup", () => {
+    expect(resolveColor("Blue", "#000", fullColorMap)).toBe("#3b82f6");
+    expect(resolveColor("BLUE", "#000", fullColorMap)).toBe("#3b82f6");
+  });
+
+  it("resolves semantic colors", () => {
+    expect(resolveColor("primary", "#000", fullColorMap)).toBe("#3b82f6");
+    expect(resolveColor("destructive", "#000", fullColorMap)).toBe("#ef4444");
+  });
+
+  it("returns fallback for unknown color names", () => {
+    expect(resolveColor("nonexistent", "#fff", fullColorMap)).toBe("#fff");
+  });
+});
+
+describe("CHROMATIC_COLORS", () => {
+  it("contains all expected named colors", () => {
+    const expectedColors = [
+      "black",
+      "white",
+      "red",
+      "blue",
+      "green",
+      "yellow",
+      "orange",
+      "purple",
+      "pink",
+      "gray",
+      "slate",
+      "zinc",
+      "neutral",
+      "stone",
+      "amber",
+      "lime",
+      "emerald",
+      "teal",
+      "cyan",
+      "sky",
+      "indigo",
+      "violet",
+      "fuchsia",
+      "rose",
+    ];
+    for (const color of expectedColors) {
+      expect(CHROMATIC_COLORS).toHaveProperty(color);
+    }
+  });
+
+  it("all values are valid hex strings", () => {
+    for (const [key, value] of Object.entries(CHROMATIC_COLORS)) {
+      expect(value, `${key} should be a valid hex color`).toMatch(/^#[0-9a-f]{6}$/);
+    }
+  });
+});
+
+describe("DEFAULT_SEMANTIC_COLORS", () => {
+  it("contains all expected semantic colors", () => {
+    const expectedKeys = [
+      "primary",
+      "secondary",
+      "destructive",
+      "muted",
+      "foreground",
+      "background",
+    ];
+    for (const key of expectedKeys) {
+      expect(DEFAULT_SEMANTIC_COLORS).toHaveProperty(key);
+    }
+  });
+
+  it("semantic aliases match their base chromatic colors", () => {
+    expect(DEFAULT_SEMANTIC_COLORS.primary).toBe(CHROMATIC_COLORS.blue);
+    expect(DEFAULT_SEMANTIC_COLORS.destructive).toBe(CHROMATIC_COLORS.red);
+    expect(DEFAULT_SEMANTIC_COLORS.secondary).toBe(CHROMATIC_COLORS.gray);
+  });
+
+  it("all values are valid hex strings", () => {
+    for (const [key, value] of Object.entries(DEFAULT_SEMANTIC_COLORS)) {
+      expect(value, `${key} should be a valid hex color`).toMatch(/^#[0-9a-f]{6}$/);
+    }
+  });
+});

--- a/src/frontend/src/widgets/inputs/SignatureInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/SignatureInputWidget.tsx
@@ -25,7 +25,43 @@ interface SignatureInputWidgetProps {
   "data-testid"?: string;
 }
 
-function resolveColor(
+export const CHROMATIC_COLORS: Record<string, string> = {
+  black: "#000000",
+  white: "#ffffff",
+  slate: "#64748b",
+  gray: "#6b7280",
+  zinc: "#71717a",
+  neutral: "#737373",
+  stone: "#78716c",
+  red: "#ef4444",
+  orange: "#f97316",
+  amber: "#f59e0b",
+  yellow: "#eab308",
+  lime: "#84cc16",
+  green: "#22c55e",
+  emerald: "#10b981",
+  teal: "#14b8a6",
+  cyan: "#06b6d4",
+  sky: "#0ea5e9",
+  blue: "#3b82f6",
+  indigo: "#6366f1",
+  violet: "#8b5cf6",
+  purple: "#a855f7",
+  fuchsia: "#d946ef",
+  pink: "#ec4899",
+  rose: "#f43f5e",
+};
+
+export const DEFAULT_SEMANTIC_COLORS: Record<string, string> = {
+  primary: "#3b82f6",
+  secondary: "#6b7280",
+  destructive: "#ef4444",
+  muted: "#6b7280",
+  foreground: "#000000",
+  background: "#ffffff",
+};
+
+export function resolveColor(
   color: string | undefined,
   fallback: string,
   colorMap: Record<string, string>,
@@ -63,39 +99,15 @@ export const SignatureInputWidget: React.FC<SignatureInputWidgetProps> = ({
 
   const colorMap = useMemo<Record<string, string>>(
     () => ({
-      // Chromatic colors (static — no CSS variable equivalents)
-      black: "#000000",
-      white: "#ffffff",
-      slate: "#64748b",
-      gray: "#6b7280",
-      zinc: "#71717a",
-      neutral: "#737373",
-      stone: "#78716c",
-      red: "#ef4444",
-      orange: "#f97316",
-      amber: "#f59e0b",
-      yellow: "#eab308",
-      lime: "#84cc16",
-      green: "#22c55e",
-      emerald: "#10b981",
-      teal: "#14b8a6",
-      cyan: "#06b6d4",
-      sky: "#0ea5e9",
-      blue: "#3b82f6",
-      indigo: "#6366f1",
-      violet: "#8b5cf6",
-      purple: "#a855f7",
-      fuchsia: "#d946ef",
-      pink: "#ec4899",
-      rose: "#f43f5e",
+      ...CHROMATIC_COLORS,
       // Semantic colors — track actual theme CSS vars
-      primary: colors.primary || "#3b82f6",
-      secondary: colors.secondary || "#6b7280",
-      destructive: colors.destructive || "#ef4444",
-      muted: colors.mutedForeground || "#6b7280",
+      primary: colors.primary || DEFAULT_SEMANTIC_COLORS.primary,
+      secondary: colors.secondary || DEFAULT_SEMANTIC_COLORS.secondary,
+      destructive: colors.destructive || DEFAULT_SEMANTIC_COLORS.destructive,
+      muted: colors.mutedForeground || DEFAULT_SEMANTIC_COLORS.muted,
       // Surface colors
-      foreground: colors.foreground || "#000000",
-      background: colors.background || "#ffffff",
+      foreground: colors.foreground || DEFAULT_SEMANTIC_COLORS.foreground,
+      background: colors.background || DEFAULT_SEMANTIC_COLORS.background,
     }),
     [colors],
   );


### PR DESCRIPTION
# Summary

## Changes

Added 14 Vitest unit tests for `resolveColor` and color map constants in `SignatureInputWidget`. Extracted static chromatic colors into an exported `CHROMATIC_COLORS` constant and default semantic colors into `DEFAULT_SEMANTIC_COLORS`, eliminating duplication between the module-level constants and the component's `useMemo`. Exported the `resolveColor` function for direct testing.

## API Changes

- `export const CHROMATIC_COLORS: Record<string, string>` — new exported constant with 24 named color hex values
- `export const DEFAULT_SEMANTIC_COLORS: Record<string, string>` — new exported constant with 6 semantic color defaults (primary, secondary, destructive, muted, foreground, background)
- `export function resolveColor(color, fallback, colorMap)` — existing function now exported (was previously module-private)

## Files Modified

- `src/frontend/src/widgets/inputs/SignatureInputWidget.tsx` — exported `resolveColor`, extracted `CHROMATIC_COLORS` and `DEFAULT_SEMANTIC_COLORS`, refactored `useMemo` to use extracted constants
- `src/frontend/src/widgets/inputs/SignatureInputWidget.test.ts` — new test file with 14 tests covering resolveColor behavior and color map validation

## Commits

- 3ff274d62 [01193] Add unit tests for SignatureInputWidget resolveColor and color maps