### PR TITLE
[01172] Move uploaded files to header of ContentInput as horizontal scrollable list

### DIFF
--- a/src/frontend/src/widgets/inputs/ContentInputWidget/ContentInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/ContentInputWidget/ContentInputWidget.tsx
@@ -233,6 +233,33 @@ export const ContentInputWidget: React.FC<ContentInputWidgetProps> = ({
           invalid && "border-destructive",
         )}
       >
+        {uploadUrl && (
+          <div className="flex items-center">
+            <button
+              type="button"
+              tabIndex={-1}
+              disabled={disabled}
+              onClick={openFilePicker}
+              className={cn(
+                paperclipButtonVariant({ density }),
+                "shrink-0",
+                disabled ? "cursor-not-allowed opacity-50" : "cursor-pointer",
+              )}
+              aria-label="Attach file"
+            >
+              <Paperclip className={paperclipIconVariant({ density })} />
+            </button>
+            {fileList.length > 0 && (
+              <FileAttachmentList
+                files={fileList}
+                onCancel={handleCancel}
+                hasCancelHandler={hasCancelHandler}
+                density={density}
+              />
+            )}
+          </div>
+        )}
+
         <div className="relative">
           <textarea
             ref={textareaRef}
@@ -262,31 +289,7 @@ export const ContentInputWidget: React.FC<ContentInputWidgetProps> = ({
           )}
         </div>
 
-        {fileList.length > 0 && (
-          <FileAttachmentList
-            files={fileList}
-            onCancel={handleCancel}
-            hasCancelHandler={hasCancelHandler}
-            density={density}
-          />
-        )}
-
         <div className={toolbarVariant({ density })}>
-          {uploadUrl && (
-            <button
-              type="button"
-              tabIndex={-1}
-              disabled={disabled}
-              onClick={openFilePicker}
-              className={cn(
-                paperclipButtonVariant({ density }),
-                disabled ? "cursor-not-allowed opacity-50" : "cursor-pointer",
-              )}
-              aria-label="Attach file"
-            >
-              <Paperclip className={paperclipIconVariant({ density })} />
-            </button>
-          )}
           {isDragging && <span className={dropTextVariant({ density })}>Drop files here</span>}
           {shortcutKey && !isFocused && (
             <kbd className={shortcutBadgeVariant({ density })}>{shortcutDisplay}</kbd>

--- a/src/frontend/src/widgets/inputs/shared/FileAttachmentList.tsx
+++ b/src/frontend/src/widgets/inputs/shared/FileAttachmentList.tsx
@@ -6,12 +6,12 @@ import { Densities } from "@/types/density";
 import { FileItem, FileUploadStatus } from "./types";
 import { formatBytes } from "../file-input-validation";
 
-const compactContainerVariant = cva("flex flex-wrap", {
+const compactContainerVariant = cva("flex flex-nowrap overflow-x-auto flex-1 min-w-0", {
   variants: {
     density: {
-      Small: "gap-1 px-2 pb-1",
-      Medium: "gap-2 px-3 pb-2",
-      Large: "gap-2 px-3 pb-2",
+      Small: "gap-1 py-1",
+      Medium: "gap-2 py-1.5",
+      Large: "gap-2 py-2",
     },
   },
   defaultVariants: { density: "Medium" },


### PR DESCRIPTION
## Summary

Moved the paperclip (attach file) button from the bottom toolbar into a new header row above the textarea in `ContentInputWidget`, co-located with the horizontal file attachment list. Updated `FileAttachmentList`'s compact container to use `flex-nowrap` with `overflow-x-auto` for horizontal scrolling, removing the horizontal padding that is now handled by the parent row.

## API Changes

None.

## Files Modified

- **Frontend:**
  - `src/frontend/src/widgets/inputs/ContentInputWidget/ContentInputWidget.tsx` — Moved paperclip button from toolbar to new header row; removed duplicate FileAttachmentList below textarea
  - `src/frontend/src/widgets/inputs/shared/FileAttachmentList.tsx` — Changed compact container from `flex-wrap` to `flex-nowrap overflow-x-auto flex-1 min-w-0`; replaced `px/pb` padding with `py` only

## Commits

- `43755977e` [01172] Move paperclip button into file attachment header row