### PR TITLE
[01200] Add unit tests for input widget pure utility functions

### DIFF
--- a/src/frontend/src/widgets/inputs/ColorInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/ColorInputWidget.tsx
@@ -33,7 +33,7 @@ interface ColorInputWidgetProps {
 }
 
 // Hoisted color map for backend Colors enum
-const enumColorsToCssVar: Record<string, string> = {
+export const enumColorsToCssVar: Record<string, string> = {
   black: "var(--color-black)",
   white: "var(--color-white)",
   slate: "var(--color-slate)",
@@ -120,7 +120,7 @@ const ColorSwatchGrid: React.FC<ColorSwatchGridProps> = ({
   );
 };
 
-function parseHexAlpha(hex: string): { rgb: string; alpha: number } {
+export function parseHexAlpha(hex: string): { rgb: string; alpha: number } {
   if (!hex || !hex.startsWith("#")) return { rgb: hex || "#000000", alpha: 255 };
   const clean = hex.slice(1);
   if (clean.length === 8) {
@@ -132,7 +132,7 @@ function parseHexAlpha(hex: string): { rgb: string; alpha: number } {
   return { rgb: hex.length === 7 ? hex : "#000000", alpha: 255 };
 }
 
-function combineHexAlpha(rgb: string, alpha: number): string {
+export function combineHexAlpha(rgb: string, alpha: number): string {
   const base = rgb.startsWith("#") ? rgb : "#" + rgb;
   const hex6 = base.length === 7 ? base : "#000000";
   if (alpha >= 255) return hex6; // fully opaque → keep 6-char hex

--- a/src/frontend/src/widgets/inputs/DateTimeInputWidget/__tests__/timeStepSnap.test.ts
+++ b/src/frontend/src/widgets/inputs/DateTimeInputWidget/__tests__/timeStepSnap.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseTimeSpanStepToSeconds,
+  parseLocalTimeToSeconds,
+  formatSecondsToHms,
+  snapLocalTimeSeconds,
+} from "../timeStepSnap";
+
+// ---------------------------------------------------------------------------
+// parseTimeSpanStepToSeconds
+// ---------------------------------------------------------------------------
+
+describe("parseTimeSpanStepToSeconds", () => {
+  it("parses 1 hour", () => {
+    expect(parseTimeSpanStepToSeconds("01:00:00")).toBe(3600);
+  });
+
+  it("parses 15 minutes", () => {
+    expect(parseTimeSpanStepToSeconds("00:15:00")).toBe(900);
+  });
+
+  it("parses 30 seconds", () => {
+    expect(parseTimeSpanStepToSeconds("00:00:30")).toBe(30);
+  });
+
+  it("parses days.hours:minutes:seconds format", () => {
+    // 1 day (86400) + 2 hours (7200) + 30 minutes (1800) = 95400
+    expect(parseTimeSpanStepToSeconds("1.02:30:00")).toBe(95400);
+  });
+
+  it("returns 1 for undefined", () => {
+    expect(parseTimeSpanStepToSeconds(undefined)).toBe(1);
+  });
+
+  it("returns 1 for empty string", () => {
+    expect(parseTimeSpanStepToSeconds("")).toBe(1);
+  });
+
+  it("parses fractional seconds", () => {
+    expect(parseTimeSpanStepToSeconds("00:00:01.5")).toBe(1.5);
+  });
+
+  it("parses zero", () => {
+    expect(parseTimeSpanStepToSeconds("00:00:00")).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseLocalTimeToSeconds
+// ---------------------------------------------------------------------------
+
+describe("parseLocalTimeToSeconds", () => {
+  it("parses 12:30:00 to 45000", () => {
+    expect(parseLocalTimeToSeconds("12:30:00")).toBe(45000);
+  });
+
+  it("parses 00:00:00 to 0", () => {
+    expect(parseLocalTimeToSeconds("00:00:00")).toBe(0);
+  });
+
+  it("parses 23:59:59 to 86399", () => {
+    expect(parseLocalTimeToSeconds("23:59:59")).toBe(86399);
+  });
+
+  it("returns null for 24:00:00 (invalid hour)", () => {
+    expect(parseLocalTimeToSeconds("24:00:00")).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(parseLocalTimeToSeconds("")).toBeNull();
+  });
+
+  it("parses HH:mm format without seconds", () => {
+    expect(parseLocalTimeToSeconds("12:30")).toBe(45000);
+  });
+
+  it("returns null for invalid format", () => {
+    expect(parseLocalTimeToSeconds("abc")).toBeNull();
+  });
+
+  it("returns null for out-of-range minutes", () => {
+    expect(parseLocalTimeToSeconds("12:60:00")).toBeNull();
+  });
+
+  it("returns null for out-of-range seconds", () => {
+    expect(parseLocalTimeToSeconds("12:30:60")).toBeNull();
+  });
+
+  it("handles whitespace", () => {
+    expect(parseLocalTimeToSeconds("  12:30:00  ")).toBe(45000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatSecondsToHms
+// ---------------------------------------------------------------------------
+
+describe("formatSecondsToHms", () => {
+  it("formats 3661 to 01:01:01", () => {
+    expect(formatSecondsToHms(3661)).toBe("01:01:01");
+  });
+
+  it("formats 0 to 00:00:00", () => {
+    expect(formatSecondsToHms(0)).toBe("00:00:00");
+  });
+
+  it("formats 86399 to 23:59:59", () => {
+    expect(formatSecondsToHms(86399)).toBe("23:59:59");
+  });
+
+  it("formats 3600 to 01:00:00", () => {
+    expect(formatSecondsToHms(3600)).toBe("01:00:00");
+  });
+
+  it("formats 60 to 00:01:00", () => {
+    expect(formatSecondsToHms(60)).toBe("00:01:00");
+  });
+
+  it("formats 1 to 00:00:01", () => {
+    expect(formatSecondsToHms(1)).toBe("00:00:01");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// snapLocalTimeSeconds
+// ---------------------------------------------------------------------------
+
+describe("snapLocalTimeSeconds", () => {
+  it("snaps to nearest grid point", () => {
+    // Grid: 0, 900, 1800, 2700... Step=900 (15 min)
+    // Math.round(500/900)=1 → snaps to 900
+    expect(snapLocalTimeSeconds(500, 900)).toBe(900);
+    // Math.round(400/900)=0 → snaps to 0
+    expect(snapLocalTimeSeconds(400, 900)).toBe(0);
+    // Math.round(1350/900)=2 → snaps to 1800
+    expect(snapLocalTimeSeconds(1350, 900)).toBe(1800);
+  });
+
+  it("returns value unchanged when stepSec <= 0", () => {
+    expect(snapLocalTimeSeconds(500, 0)).toBe(500);
+    expect(snapLocalTimeSeconds(500, -1)).toBe(500);
+  });
+
+  it("respects min bound", () => {
+    // minSec=3600, step=900. Grid: 3600, 4500, 5400...
+    // 3000 < min so clamped to 3600
+    expect(snapLocalTimeSeconds(3000, 900, 3600)).toBe(3600);
+  });
+
+  it("respects max bound", () => {
+    // step=3600, max=7200. Grid: 0, 3600, 7200
+    // 8000 > max but nearest grid <= max is 7200
+    expect(snapLocalTimeSeconds(8000, 3600, null, 7200)).toBe(7200);
+  });
+
+  it("value at grid boundary stays", () => {
+    expect(snapLocalTimeSeconds(3600, 900)).toBe(3600);
+  });
+
+  it("snaps with min and max bounds", () => {
+    // min=3600, max=7200, step=1800. Grid: 3600, 5400, 7200
+    expect(snapLocalTimeSeconds(4000, 1800, 3600, 7200)).toBe(3600);
+    expect(snapLocalTimeSeconds(5000, 1800, 3600, 7200)).toBe(5400);
+    expect(snapLocalTimeSeconds(6500, 1800, 3600, 7200)).toBe(7200);
+  });
+
+  it("handles non-finite step", () => {
+    expect(snapLocalTimeSeconds(500, Infinity)).toBe(500);
+    expect(snapLocalTimeSeconds(500, NaN)).toBe(500);
+  });
+});

--- a/src/frontend/src/widgets/inputs/NumberInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/NumberInputWidget.tsx
@@ -18,7 +18,7 @@ interface Affix {
   text?: string;
 }
 
-const renderAffix = (affix?: Affix): React.ReactNode => {
+export const renderAffix = (affix?: Affix): React.ReactNode => {
   if (!affix) return null;
 
   if (affix.icon) {
@@ -49,7 +49,7 @@ const formatStyleMap = {
 type FormatStyle = keyof typeof formatStyleMap;
 
 // Type limits for validation
-const TYPE_LIMITS = {
+export const TYPE_LIMITS = {
   byte: { min: 0, max: 255 },
   sbyte: { min: -128, max: 127 },
   short: { min: -32768, max: 32767 },
@@ -98,7 +98,7 @@ interface NumberInputWidgetProps extends Omit<NumberInputBaseProps, "onValueChan
 }
 
 // Function to validate and cap values based on target type
-const validateAndCapValue = (value: number | null, targetType?: string): number | null => {
+export const validateAndCapValue = (value: number | null, targetType?: string): number | null => {
   if (value === null) return null;
   if (!targetType) return value;
 

--- a/src/frontend/src/widgets/inputs/__tests__/colorInputUtils.test.ts
+++ b/src/frontend/src/widgets/inputs/__tests__/colorInputUtils.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from "vitest";
+import { parseHexAlpha, combineHexAlpha, enumColorsToCssVar } from "../ColorInputWidget";
+
+// ---------------------------------------------------------------------------
+// parseHexAlpha
+// ---------------------------------------------------------------------------
+
+describe("parseHexAlpha", () => {
+  it("parses 8-char hex into rgb and alpha", () => {
+    expect(parseHexAlpha("#FF000080")).toEqual({ rgb: "#FF0000", alpha: 128 });
+  });
+
+  it("parses 8-char hex with full alpha", () => {
+    expect(parseHexAlpha("#FF0000FF")).toEqual({ rgb: "#FF0000", alpha: 255 });
+  });
+
+  it("parses 8-char hex with zero alpha", () => {
+    expect(parseHexAlpha("#FF000000")).toEqual({ rgb: "#FF0000", alpha: 0 });
+  });
+
+  it("treats 6-char hex as fully opaque", () => {
+    expect(parseHexAlpha("#FF0000")).toEqual({ rgb: "#FF0000", alpha: 255 });
+  });
+
+  it("returns default for empty input", () => {
+    expect(parseHexAlpha("")).toEqual({ rgb: "#000000", alpha: 255 });
+  });
+
+  it("returns input as rgb when missing # prefix", () => {
+    const result = parseHexAlpha("FF0000");
+    expect(result).toEqual({ rgb: "FF0000", alpha: 255 });
+  });
+
+  it("returns default for null-like input", () => {
+    expect(parseHexAlpha(undefined as unknown as string)).toEqual({
+      rgb: "#000000",
+      alpha: 255,
+    });
+  });
+
+  it("handles short hex strings by falling back to #000000", () => {
+    expect(parseHexAlpha("#FFF")).toEqual({ rgb: "#000000", alpha: 255 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// combineHexAlpha
+// ---------------------------------------------------------------------------
+
+describe("combineHexAlpha", () => {
+  it("combines rgb and alpha into 8-char hex", () => {
+    expect(combineHexAlpha("#FF0000", 128)).toBe("#FF000080");
+  });
+
+  it("returns 6-char hex when alpha is 255 (fully opaque)", () => {
+    expect(combineHexAlpha("#FF0000", 255)).toBe("#FF0000");
+  });
+
+  it("returns 6-char hex when alpha exceeds 255", () => {
+    expect(combineHexAlpha("#FF0000", 300)).toBe("#FF0000");
+  });
+
+  it("clamps alpha to 0 minimum", () => {
+    expect(combineHexAlpha("#FF0000", -10)).toBe("#FF000000");
+  });
+
+  it("combines with zero alpha", () => {
+    expect(combineHexAlpha("#FF0000", 0)).toBe("#FF000000");
+  });
+
+  it("prepends # when input lacks it", () => {
+    expect(combineHexAlpha("FF0000", 128)).toBe("#FF000080");
+  });
+
+  it("falls back to #000000 for invalid base length", () => {
+    expect(combineHexAlpha("#FFF", 128)).toBe("#00000080");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// enumColorsToCssVar
+// ---------------------------------------------------------------------------
+
+describe("enumColorsToCssVar", () => {
+  const expectedColors = [
+    "black",
+    "white",
+    "slate",
+    "gray",
+    "zinc",
+    "neutral",
+    "stone",
+    "red",
+    "orange",
+    "amber",
+    "yellow",
+    "lime",
+    "green",
+    "emerald",
+    "teal",
+    "cyan",
+    "sky",
+    "blue",
+    "indigo",
+    "violet",
+    "purple",
+    "fuchsia",
+    "pink",
+    "rose",
+    "primary",
+    "secondary",
+    "destructive",
+    "success",
+    "warning",
+    "info",
+    "muted",
+  ];
+
+  it("contains all expected color names", () => {
+    for (const color of expectedColors) {
+      expect(enumColorsToCssVar).toHaveProperty(color);
+    }
+  });
+
+  it("all values follow var(--color-<name>) format", () => {
+    for (const [name, value] of Object.entries(enumColorsToCssVar)) {
+      expect(value).toBe(`var(--color-${name})`);
+    }
+  });
+
+  it("has exactly the expected number of entries", () => {
+    expect(Object.keys(enumColorsToCssVar)).toHaveLength(expectedColors.length);
+  });
+});

--- a/src/frontend/src/widgets/inputs/__tests__/fileInputValidation.test.ts
+++ b/src/frontend/src/widgets/inputs/__tests__/fileInputValidation.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from "vitest";
+import { formatBytes, validateSingleFile, validateFileCount } from "../file-input-validation";
+
+// ---------------------------------------------------------------------------
+// formatBytes
+// ---------------------------------------------------------------------------
+
+describe("formatBytes", () => {
+  it("formats 0 bytes", () => {
+    expect(formatBytes(0)).toBe("0 B");
+  });
+
+  it("formats 1024 bytes as KB", () => {
+    expect(formatBytes(1024)).toBe("1.00 KB");
+  });
+
+  it("formats 1048576 bytes as MB", () => {
+    expect(formatBytes(1048576)).toBe("1.00 MB");
+  });
+
+  it("formats 1536 bytes as 1.50 KB", () => {
+    expect(formatBytes(1536)).toBe("1.50 KB");
+  });
+
+  it("formats large values in GB", () => {
+    expect(formatBytes(1073741824)).toBe("1.00 GB");
+  });
+
+  it("drops decimals for values >= 10", () => {
+    // 10240 bytes = 10 KB, should show no decimals
+    expect(formatBytes(10240)).toBe("10 KB");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateSingleFile
+// ---------------------------------------------------------------------------
+
+describe("validateSingleFile", () => {
+  it("returns valid for file with no constraints", () => {
+    const file = new File(["content"], "test.txt", { type: "text/plain" });
+    expect(validateSingleFile({ file })).toEqual({ valid: true });
+  });
+
+  it("rejects wrong MIME type with wildcard accept", () => {
+    const file = new File(["content"], "test.txt", { type: "text/plain" });
+    const result = validateSingleFile({ file, accept: "image/*" });
+    expect(result.valid).toBe(false);
+    expect(result.title).toBe("Invalid file type");
+  });
+
+  it("accepts correct MIME wildcard", () => {
+    const file = new File(["x"], "photo.png", { type: "image/png" });
+    const result = validateSingleFile({ file, accept: "image/*" });
+    expect(result.valid).toBe(true);
+  });
+
+  it("rejects wrong extension with extension-based accept", () => {
+    const file = new File(["x"], "test.gif", { type: "image/gif" });
+    const result = validateSingleFile({ file, accept: ".png,.jpg" });
+    expect(result.valid).toBe(false);
+  });
+
+  it("accepts correct extension", () => {
+    const file = new File(["x"], "photo.png", { type: "image/png" });
+    const result = validateSingleFile({ file, accept: ".png,.jpg" });
+    expect(result.valid).toBe(true);
+  });
+
+  it("accepts exact MIME type match", () => {
+    const file = new File(["x"], "photo.png", { type: "image/png" });
+    const result = validateSingleFile({ file, accept: "image/png" });
+    expect(result.valid).toBe(true);
+  });
+
+  it("rejects file exceeding maxFileSize", () => {
+    const content = "x".repeat(2000);
+    const file = new File([content], "big.txt", { type: "text/plain" });
+    const result = validateSingleFile({ file, maxFileSize: 1000 });
+    expect(result.valid).toBe(false);
+    expect(result.title).toBe("File too large");
+    expect(result.error).toContain("big.txt");
+  });
+
+  it("rejects file below minFileSize", () => {
+    const file = new File(["x"], "tiny.txt", { type: "text/plain" });
+    const result = validateSingleFile({ file, minFileSize: 1000 });
+    expect(result.valid).toBe(false);
+    expect(result.title).toBe("File too small");
+    expect(result.error).toContain("tiny.txt");
+  });
+
+  it("accepts file within size bounds", () => {
+    const content = "x".repeat(500);
+    const file = new File([content], "ok.txt", { type: "text/plain" });
+    const result = validateSingleFile({ file, minFileSize: 100, maxFileSize: 1000 });
+    expect(result.valid).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateFileCount
+// ---------------------------------------------------------------------------
+
+describe("validateFileCount", () => {
+  it("returns valid when under limit", () => {
+    expect(validateFileCount(2, 1, 5)).toEqual({ valid: true });
+  });
+
+  it("returns invalid when exceeding limit", () => {
+    const result = validateFileCount(3, 3, 5);
+    expect(result.valid).toBe(false);
+    expect(result.title).toBe("Too many files");
+    expect(result.error).toContain("2 more file");
+  });
+
+  it("returns invalid when already at limit (remaining=0)", () => {
+    const result = validateFileCount(5, 1, 5);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("already reached");
+  });
+
+  it("returns valid when maxFiles is undefined", () => {
+    expect(validateFileCount(100, 50, undefined)).toEqual({ valid: true });
+  });
+
+  it("returns valid when exactly at limit", () => {
+    expect(validateFileCount(3, 2, 5)).toEqual({ valid: true });
+  });
+});

--- a/src/frontend/src/widgets/inputs/__tests__/numberInputUtils.test.ts
+++ b/src/frontend/src/widgets/inputs/__tests__/numberInputUtils.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from "vitest";
+import { validateAndCapValue, TYPE_LIMITS, renderAffix } from "../NumberInputWidget";
+
+// ---------------------------------------------------------------------------
+// validateAndCapValue
+// ---------------------------------------------------------------------------
+
+describe("validateAndCapValue", () => {
+  it("returns null for null input", () => {
+    expect(validateAndCapValue(null, "int")).toBeNull();
+  });
+
+  it("returns value unchanged when no targetType", () => {
+    expect(validateAndCapValue(42, undefined)).toBe(42);
+  });
+
+  it("returns value unchanged for unrecognized type", () => {
+    expect(validateAndCapValue(42, "unknown")).toBe(42);
+  });
+
+  it("caps byte max (300 → 255)", () => {
+    expect(validateAndCapValue(300, "byte")).toBe(255);
+  });
+
+  it("caps byte min (-1 → 0)", () => {
+    expect(validateAndCapValue(-1, "byte")).toBe(0);
+  });
+
+  it("floors integer types (3.7 int → 3)", () => {
+    expect(validateAndCapValue(3.7, "int")).toBe(3);
+  });
+
+  it("does not floor float types (3.7 float → 3.7)", () => {
+    expect(validateAndCapValue(3.7, "float")).toBe(3.7);
+  });
+
+  it("does not floor double types", () => {
+    expect(validateAndCapValue(1.5, "double")).toBe(1.5);
+  });
+
+  it("does not floor decimal types", () => {
+    expect(validateAndCapValue(2.99, "decimal")).toBe(2.99);
+  });
+
+  it("caps sbyte range (-200 → -128)", () => {
+    expect(validateAndCapValue(-200, "sbyte")).toBe(-128);
+  });
+
+  it("caps sbyte max (200 → 127)", () => {
+    expect(validateAndCapValue(200, "sbyte")).toBe(127);
+  });
+
+  it("caps short min boundary", () => {
+    expect(validateAndCapValue(-40000, "short")).toBe(-32768);
+  });
+
+  it("caps ushort max boundary", () => {
+    expect(validateAndCapValue(70000, "ushort")).toBe(65535);
+  });
+
+  it("caps uint max boundary", () => {
+    expect(validateAndCapValue(5000000000, "uint")).toBe(4294967295);
+  });
+
+  it("allows values within type range", () => {
+    expect(validateAndCapValue(100, "byte")).toBe(100);
+    expect(validateAndCapValue(-50, "sbyte")).toBe(-50);
+    expect(validateAndCapValue(1000, "short")).toBe(1000);
+    expect(validateAndCapValue(50000, "ushort")).toBe(50000);
+  });
+
+  // Boundary value tests for each type in TYPE_LIMITS
+  for (const [typeName, limits] of Object.entries(TYPE_LIMITS)) {
+    describe(`${typeName} boundaries`, () => {
+      it(`min value (${limits.min}) stays unchanged`, () => {
+        const result = validateAndCapValue(limits.min, typeName);
+        expect(result).toBe(limits.min);
+      });
+
+      it(`max value (${limits.max}) stays unchanged`, () => {
+        const result = validateAndCapValue(limits.max, typeName);
+        expect(result).toBe(limits.max);
+      });
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// TYPE_LIMITS
+// ---------------------------------------------------------------------------
+
+describe("TYPE_LIMITS", () => {
+  const expectedTypes = [
+    "byte",
+    "sbyte",
+    "short",
+    "ushort",
+    "int",
+    "uint",
+    "long",
+    "ulong",
+    "float",
+    "double",
+    "decimal",
+  ];
+
+  it("contains all expected numeric types", () => {
+    for (const type of expectedTypes) {
+      expect(TYPE_LIMITS).toHaveProperty(type);
+    }
+  });
+
+  it("each entry has min and max", () => {
+    for (const [, limits] of Object.entries(TYPE_LIMITS)) {
+      expect(limits).toHaveProperty("min");
+      expect(limits).toHaveProperty("max");
+      expect(typeof limits.min).toBe("number");
+      expect(typeof limits.max).toBe("number");
+      expect(limits.min).toBeLessThanOrEqual(limits.max);
+    }
+  });
+
+  it("unsigned types have min=0", () => {
+    expect(TYPE_LIMITS.byte.min).toBe(0);
+    expect(TYPE_LIMITS.ushort.min).toBe(0);
+    expect(TYPE_LIMITS.uint.min).toBe(0);
+    expect(TYPE_LIMITS.ulong.min).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderAffix
+// ---------------------------------------------------------------------------
+
+describe("renderAffix", () => {
+  it("returns null for undefined", () => {
+    expect(renderAffix(undefined)).toBeNull();
+  });
+
+  it("returns null for empty object", () => {
+    expect(renderAffix({})).toBeNull();
+  });
+
+  it("returns a React element for icon affix", () => {
+    const result = renderAffix({ icon: "star" });
+    expect(result).not.toBeNull();
+    expect(result).toBeTruthy();
+  });
+
+  it("returns a React element for text affix", () => {
+    const result = renderAffix({ text: "USD" });
+    expect(result).not.toBeNull();
+    expect(result).toBeTruthy();
+  });
+
+  it("prefers icon over text when both present", () => {
+    const result = renderAffix({ icon: "star", text: "USD" });
+    // When icon is present, it takes precedence
+    expect(result).not.toBeNull();
+  });
+});

--- a/src/frontend/src/widgets/inputs/__tests__/selectUtils.test.ts
+++ b/src/frontend/src/widgets/inputs/__tests__/selectUtils.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeSelectAllValues,
+  computeClearAllValues,
+  convertValuesToOriginalType,
+} from "../select-utils";
+
+// ---------------------------------------------------------------------------
+// computeSelectAllValues
+// ---------------------------------------------------------------------------
+
+describe("computeSelectAllValues", () => {
+  it("selects all visible options when selection is empty", () => {
+    const visible = [{ value: "a" }, { value: "b" }, { value: "c" }];
+    const result = computeSelectAllValues([], visible);
+    expect(result).toEqual(["a", "b", "c"]);
+  });
+
+  it("preserves selections outside visible set", () => {
+    const visible = [{ value: "b" }, { value: "c" }];
+    const result = computeSelectAllValues(["a"], visible);
+    expect(result).toEqual(["a", "b", "c"]);
+  });
+
+  it("excludes disabled options", () => {
+    const visible = [
+      { value: "a", disabled: false },
+      { value: "b", disabled: true },
+      { value: "c" },
+    ];
+    const result = computeSelectAllValues([], visible);
+    expect(result).toEqual(["a", "c"]);
+  });
+
+  it("respects maxSelections cap", () => {
+    const visible = [{ value: "a" }, { value: "b" }, { value: "c" }, { value: "d" }];
+    const result = computeSelectAllValues([], visible, 2);
+    expect(result).toHaveLength(2);
+  });
+
+  it("prioritizes outside selections when hitting maxSelections", () => {
+    const visible = [{ value: "b" }, { value: "c" }];
+    const result = computeSelectAllValues(["a"], visible, 2);
+    expect(result).toContain("a");
+    expect(result).toHaveLength(2);
+  });
+
+  it("deduplicates values", () => {
+    const visible = [{ value: "a" }, { value: "b" }];
+    const result = computeSelectAllValues(["a"], visible);
+    const aCount = result.filter((v) => v.toString() === "a").length;
+    expect(aCount).toBe(1);
+  });
+
+  it("handles numeric values", () => {
+    const visible = [{ value: 1 }, { value: 2 }, { value: 3 }];
+    const result = computeSelectAllValues([], visible);
+    expect(result).toEqual([1, 2, 3]);
+  });
+
+  it("handles null/undefined maxSelections", () => {
+    const visible = [{ value: "a" }, { value: "b" }];
+    expect(computeSelectAllValues([], visible, null)).toEqual(["a", "b"]);
+    expect(computeSelectAllValues([], visible, undefined)).toEqual(["a", "b"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeClearAllValues
+// ---------------------------------------------------------------------------
+
+describe("computeClearAllValues", () => {
+  it("returns empty array when minSelections is 0", () => {
+    expect(computeClearAllValues(["a", "b", "c"], 0)).toEqual([]);
+  });
+
+  it("returns empty array when minSelections is undefined", () => {
+    expect(computeClearAllValues(["a", "b", "c"], undefined)).toEqual([]);
+  });
+
+  it("returns empty array when minSelections is null", () => {
+    expect(computeClearAllValues(["a", "b", "c"], null)).toEqual([]);
+  });
+
+  it("keeps first N items when minSelections > 0", () => {
+    expect(computeClearAllValues(["a", "b", "c", "d", "e"], 2)).toEqual(["a", "b"]);
+  });
+
+  it("keeps all items when minSelections >= selected count", () => {
+    expect(computeClearAllValues(["a", "b"], 5)).toEqual(["a", "b"]);
+  });
+
+  it("returns empty array for empty selection", () => {
+    expect(computeClearAllValues([], 0)).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// convertValuesToOriginalType
+// ---------------------------------------------------------------------------
+
+describe("convertValuesToOriginalType", () => {
+  const numberOptions = [
+    { value: 1, label: "One" },
+    { value: 2, label: "Two" },
+    { value: 3, label: "Three" },
+  ];
+
+  const stringOptions = [
+    { value: "a", label: "A" },
+    { value: "b", label: "B" },
+    { value: "c", label: "C" },
+  ];
+
+  it("returns numbers when original is number array", () => {
+    const result = convertValuesToOriginalType(["1", "2"], [1], numberOptions);
+    expect(result).toEqual([1, 2]);
+  });
+
+  it("returns strings when original is string array", () => {
+    const result = convertValuesToOriginalType(["a", "b"], ["a"], stringOptions);
+    expect(result).toEqual(["a", "b"]);
+  });
+
+  it("returns empty array for empty stringValues with array original", () => {
+    const result = convertValuesToOriginalType([], ["a"], stringOptions);
+    expect(result).toEqual([]);
+  });
+
+  it("returns null for empty stringValues with null original (single select)", () => {
+    const result = convertValuesToOriginalType([], null, stringOptions, false);
+    expect(result).toBeNull();
+  });
+
+  it("returns empty array for empty stringValues with null original (selectMany)", () => {
+    const result = convertValuesToOriginalType([], null, stringOptions, true);
+    expect(result).toEqual([]);
+  });
+
+  it("returns single option value for single select with match", () => {
+    const result = convertValuesToOriginalType(["a"], null, stringOptions, false);
+    expect(result).toBe("a");
+  });
+
+  it("returns option.value type for number options in selectMany with null original", () => {
+    const result = convertValuesToOriginalType(["1", "2"], null, numberOptions, true);
+    expect(result).toEqual([1, 2]);
+  });
+
+  it("returns string values when options map has no match", () => {
+    const result = convertValuesToOriginalType(["x"], null, [], false);
+    expect(result).toBe("x");
+  });
+
+  it("returns empty array for empty stringValues with undefined original (selectMany)", () => {
+    const result = convertValuesToOriginalType([], undefined, stringOptions, true);
+    expect(result).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Added 5 Vitest unit test files covering pure utility functions across input widgets: ColorInputWidget, NumberInputWidget, select-utils, timeStepSnap, and file-input-validation. Exported 6 previously private module-level functions/constants to enable direct testing.

## API Changes

- `parseHexAlpha`, `combineHexAlpha`, `enumColorsToCssVar` are now exported from `ColorInputWidget.tsx`
- `validateAndCapValue`, `TYPE_LIMITS`, `renderAffix` are now exported from `NumberInputWidget.tsx`

## Files Modified

**New test files:**
- `src/frontend/src/widgets/inputs/__tests__/colorInputUtils.test.ts` (18 tests)
- `src/frontend/src/widgets/inputs/__tests__/numberInputUtils.test.ts` (45 tests)
- `src/frontend/src/widgets/inputs/__tests__/selectUtils.test.ts` (23 tests)
- `src/frontend/src/widgets/inputs/DateTimeInputWidget/__tests__/timeStepSnap.test.ts` (31 tests)
- `src/frontend/src/widgets/inputs/__tests__/fileInputValidation.test.ts` (20 tests)

**Modified source files (export additions only):**
- `src/frontend/src/widgets/inputs/ColorInputWidget.tsx`
- `src/frontend/src/widgets/inputs/NumberInputWidget.tsx`

## Commits

- `dc3d52c0f` [01200] Add unit tests for input widget pure utility functions