### PR TITLE
[01199] Move resolveColor function from SignatureInputWidget to theme.ts

### DIFF
--- a/src/frontend/src/lib/theme.ts
+++ b/src/frontend/src/lib/theme.ts
@@ -58,6 +58,52 @@ export interface ThemeColors {
   radius: string;
 }
 
+export const CHROMATIC_COLORS: Record<string, string> = {
+  black: "#000000",
+  white: "#ffffff",
+  slate: "#64748b",
+  gray: "#6b7280",
+  zinc: "#71717a",
+  neutral: "#737373",
+  stone: "#78716c",
+  red: "#ef4444",
+  orange: "#f97316",
+  amber: "#f59e0b",
+  yellow: "#eab308",
+  lime: "#84cc16",
+  green: "#22c55e",
+  emerald: "#10b981",
+  teal: "#14b8a6",
+  cyan: "#06b6d4",
+  sky: "#0ea5e9",
+  blue: "#3b82f6",
+  indigo: "#6366f1",
+  violet: "#8b5cf6",
+  purple: "#a855f7",
+  fuchsia: "#d946ef",
+  pink: "#ec4899",
+  rose: "#f43f5e",
+};
+
+export const DEFAULT_SEMANTIC_COLORS: Record<string, string> = {
+  primary: "#3b82f6",
+  secondary: "#6b7280",
+  destructive: "#ef4444",
+  muted: "#6b7280",
+  foreground: "#000000",
+  background: "#ffffff",
+};
+
+export function resolveColor(
+  color: string | undefined,
+  fallback: string,
+  colorMap: Record<string, string>,
+): string {
+  if (!color) return fallback;
+  if (color.startsWith("#") || color.startsWith("rgb")) return color;
+  return colorMap[color.toLowerCase()] ?? fallback;
+}
+
 export function getThemeColors(): ThemeColors {
   return {
     background: getCSSVariable("--background"),

--- a/src/frontend/src/widgets/inputs/SignatureInputWidget.test.ts
+++ b/src/frontend/src/widgets/inputs/SignatureInputWidget.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { resolveColor, CHROMATIC_COLORS, DEFAULT_SEMANTIC_COLORS } from "./SignatureInputWidget";
+import { resolveColor, CHROMATIC_COLORS, DEFAULT_SEMANTIC_COLORS } from "@/lib/theme";
 
 /** A full color map combining chromatic + default semantic colors, matching runtime defaults. */
 const fullColorMap: Record<string, string> = {

--- a/src/frontend/src/widgets/inputs/SignatureInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/SignatureInputWidget.tsx
@@ -2,6 +2,7 @@ import { useEventHandler } from "@/components/event-handler";
 import { InvalidIcon } from "@/components/InvalidIcon";
 import { useThemeWithMonitoring } from "@/components/theme-provider";
 import { inputStyles } from "@/lib/styles";
+import { CHROMATIC_COLORS, DEFAULT_SEMANTIC_COLORS, resolveColor } from "@/lib/theme";
 import { cn } from "@/lib/utils";
 import { Eraser } from "lucide-react";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -23,52 +24,6 @@ interface SignatureInputWidgetProps {
   penThickness?: number;
   placeholder?: string;
   "data-testid"?: string;
-}
-
-export const CHROMATIC_COLORS: Record<string, string> = {
-  black: "#000000",
-  white: "#ffffff",
-  slate: "#64748b",
-  gray: "#6b7280",
-  zinc: "#71717a",
-  neutral: "#737373",
-  stone: "#78716c",
-  red: "#ef4444",
-  orange: "#f97316",
-  amber: "#f59e0b",
-  yellow: "#eab308",
-  lime: "#84cc16",
-  green: "#22c55e",
-  emerald: "#10b981",
-  teal: "#14b8a6",
-  cyan: "#06b6d4",
-  sky: "#0ea5e9",
-  blue: "#3b82f6",
-  indigo: "#6366f1",
-  violet: "#8b5cf6",
-  purple: "#a855f7",
-  fuchsia: "#d946ef",
-  pink: "#ec4899",
-  rose: "#f43f5e",
-};
-
-export const DEFAULT_SEMANTIC_COLORS: Record<string, string> = {
-  primary: "#3b82f6",
-  secondary: "#6b7280",
-  destructive: "#ef4444",
-  muted: "#6b7280",
-  foreground: "#000000",
-  background: "#ffffff",
-};
-
-export function resolveColor(
-  color: string | undefined,
-  fallback: string,
-  colorMap: Record<string, string>,
-): string {
-  if (!color) return fallback;
-  if (color.startsWith("#") || color.startsWith("rgb")) return color;
-  return colorMap[color.toLowerCase()] ?? fallback;
 }
 
 export const SignatureInputWidget: React.FC<SignatureInputWidgetProps> = ({


### PR DESCRIPTION
## Summary

Moved `resolveColor`, `CHROMATIC_COLORS`, and `DEFAULT_SEMANTIC_COLORS` from `SignatureInputWidget.tsx` to `theme.ts`, centralizing color resolution logic alongside existing theme utilities. Updated imports in `SignatureInputWidget.tsx` and its test file.

## API Changes

- `resolveColor(color, fallback, colorMap)` — now exported from `@/lib/theme` (was `@/widgets/inputs/SignatureInputWidget`)
- `CHROMATIC_COLORS` — now exported from `@/lib/theme`
- `DEFAULT_SEMANTIC_COLORS` — now exported from `@/lib/theme`

## Files Modified

- `src/frontend/src/lib/theme.ts` — added `CHROMATIC_COLORS`, `DEFAULT_SEMANTIC_COLORS`, and `resolveColor` exports
- `src/frontend/src/widgets/inputs/SignatureInputWidget.tsx` — removed local definitions, imports from `@/lib/theme`
- `src/frontend/src/widgets/inputs/SignatureInputWidget.test.ts` — updated import path to `@/lib/theme`

## Commits

- `bed22ab10` — [01199] Move resolveColor, CHROMATIC_COLORS, and DEFAULT_SEMANTIC_COLORS to theme.ts