### PR TITLE
[01195] Slim scrollbar for FileAttachmentList compact variant

### DIFF
--- a/src/frontend/src/index.css
+++ b/src/frontend/src/index.css
@@ -329,6 +329,25 @@ ivy-widget {
   pointer-events: none !important;
 }
 
+/* Slim scrollbar for compact inline areas (~4px) */
+.slim-scrollbar::-webkit-scrollbar {
+  height: 4px;
+}
+.slim-scrollbar::-webkit-scrollbar-track {
+  background: transparent;
+}
+.slim-scrollbar::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 2px;
+}
+.slim-scrollbar::-webkit-scrollbar-thumb:hover {
+  background: var(--muted-foreground);
+}
+.slim-scrollbar {
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+}
+
 /* Native scrollbar styling for theme consistency */
 @layer base {
   /* Webkit browsers (Chrome, Safari, Edge) */

--- a/src/frontend/src/widgets/inputs/ContentInputWidget/ContentInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/ContentInputWidget/ContentInputWidget.tsx
@@ -233,29 +233,33 @@ export const ContentInputWidget: React.FC<ContentInputWidgetProps> = ({
           invalid && "border-destructive",
         )}
       >
-        {uploadUrl && (
-          <div className="flex items-center">
-            <button
-              type="button"
-              tabIndex={-1}
-              disabled={disabled}
-              onClick={openFilePicker}
-              className={cn(
-                paperclipButtonVariant({ density }),
-                "shrink-0",
-                disabled ? "cursor-not-allowed opacity-50" : "cursor-pointer",
-              )}
-              aria-label="Attach file"
-            >
-              <Paperclip className={paperclipIconVariant({ density })} />
-            </button>
+        {(uploadUrl || fileList.length > 0) && (
+          <div className={cn("flex items-center", toolbarVariant({ density }))}>
+            {uploadUrl && (
+              <button
+                type="button"
+                tabIndex={-1}
+                disabled={disabled}
+                onClick={openFilePicker}
+                className={cn(
+                  paperclipButtonVariant({ density }),
+                  "shrink-0",
+                  disabled ? "cursor-not-allowed opacity-50" : "cursor-pointer",
+                )}
+                aria-label="Attach file"
+              >
+                <Paperclip className={paperclipIconVariant({ density })} />
+              </button>
+            )}
             {fileList.length > 0 && (
-              <FileAttachmentList
-                files={fileList}
-                onCancel={handleCancel}
-                hasCancelHandler={hasCancelHandler}
-                density={density}
-              />
+              <div className="flex-1 min-w-0 overflow-x-auto slim-scrollbar">
+                <FileAttachmentList
+                  files={fileList}
+                  onCancel={handleCancel}
+                  hasCancelHandler={hasCancelHandler}
+                  density={density}
+                />
+              </div>
             )}
           </div>
         )}
@@ -289,12 +293,14 @@ export const ContentInputWidget: React.FC<ContentInputWidgetProps> = ({
           )}
         </div>
 
-        <div className={toolbarVariant({ density })}>
-          {isDragging && <span className={dropTextVariant({ density })}>Drop files here</span>}
-          {shortcutKey && !isFocused && (
-            <kbd className={shortcutBadgeVariant({ density })}>{shortcutDisplay}</kbd>
-          )}
-        </div>
+        {(isDragging || (shortcutKey && !isFocused)) && (
+          <div className={toolbarVariant({ density })}>
+            {isDragging && <span className={dropTextVariant({ density })}>Drop files here</span>}
+            {shortcutKey && !isFocused && (
+              <kbd className={shortcutBadgeVariant({ density })}>{shortcutDisplay}</kbd>
+            )}
+          </div>
+        )}
 
         <input
           ref={fileInputRef}

--- a/src/frontend/src/widgets/inputs/shared/FileAttachmentList.tsx
+++ b/src/frontend/src/widgets/inputs/shared/FileAttachmentList.tsx
@@ -6,16 +6,19 @@ import { Densities } from "@/types/density";
 import { FileItem, FileUploadStatus } from "./types";
 import { formatBytes } from "../file-input-validation";
 
-const compactContainerVariant = cva("flex flex-nowrap overflow-x-auto flex-1 min-w-0", {
-  variants: {
-    density: {
-      Small: "gap-1 py-1",
-      Medium: "gap-2 py-1.5",
-      Large: "gap-2 py-2",
+const compactContainerVariant = cva(
+  "flex flex-nowrap overflow-x-auto flex-1 min-w-0 slim-scrollbar",
+  {
+    variants: {
+      density: {
+        Small: "gap-1 py-1",
+        Medium: "gap-2 py-1.5",
+        Large: "gap-2 py-2",
+      },
     },
+    defaultVariants: { density: "Medium" },
   },
-  defaultVariants: { density: "Medium" },
-});
+);
 
 const compactItemVariant = cva(
   "flex items-center border border-muted-foreground/25 rounded-md bg-muted/30",


### PR DESCRIPTION
## Summary

Added a `.slim-scrollbar` CSS utility class to `index.css` (4px scrollbar, theme colors). Applied it to the `compactContainerVariant` in `FileAttachmentList.tsx`. Restructured `ContentInputWidget.tsx` to place the paperclip button and file attachment list in the same row at the top of the content input (above the textarea), with the bottom toolbar now conditional on drag/shortcut state.

## API Changes

None.

## Files Modified

- **CSS:** `src/frontend/src/index.css` — Added `.slim-scrollbar` utility class with webkit and Firefox scrollbar styles
- **Component:** `src/frontend/src/widgets/inputs/shared/FileAttachmentList.tsx` — Added `slim-scrollbar` class to compact container variant
- **Component:** `src/frontend/src/widgets/inputs/ContentInputWidget/ContentInputWidget.tsx` — Moved paperclip + file chips to top row above textarea; made bottom toolbar conditional

## Commits

- `70f3b117b`