### PR TITLE
[01209] Add slim-scrollbar to FileAttachmentList card variant

### DIFF
--- a/src/frontend/src/widgets/inputs/shared/FileAttachmentList.tsx
+++ b/src/frontend/src/widgets/inputs/shared/FileAttachmentList.tsx
@@ -182,7 +182,7 @@ export const FileAttachmentList: React.FC<FileAttachmentListProps> = ({
       density === Densities.Small ? "h-3 w-3" : density === Densities.Large ? "h-5 w-5" : "h-4 w-4";
 
     return (
-      <div className="space-y-2">
+      <div className="space-y-2 slim-scrollbar">
         {/* Client-side uploading files */}
         {uploadProgress &&
           Array.from(uploadProgress.entries()).map(([clientId, progress]) =>


### PR DESCRIPTION
## Summary

Added the `slim-scrollbar` CSS class to the card variant's container div in `FileAttachmentList.tsx`. This is a one-line preventative consistency fix that ensures the card variant uses the same slim 4px scrollbar as the compact variant (added in plan 01195) when overflow scrolling occurs.

## API Changes

None.

## Files Modified

- `src/frontend/src/widgets/inputs/shared/FileAttachmentList.tsx` — Added `slim-scrollbar` class to card variant container div

## Commits

- `e93e785` [01209] Add slim-scrollbar to FileAttachmentList card variant