### PR TITLE
[01212] Clarify formatBytes negative input behavior

### DIFF
--- a/src/frontend/src/lib/formatters.ts
+++ b/src/frontend/src/lib/formatters.ts
@@ -1,9 +1,11 @@
+/** Formats a byte count into a human-readable string (e.g. 1536 → "1.50 KB").
+ *  Non-positive values return "0 B". */
 export const formatBytes = (bytes: number, precision?: number): string => {
-  if (bytes === 0) return "0 B";
+  if (bytes <= 0) return "0 B";
 
   const units = ["B", "KB", "MB", "GB", "TB", "PB"];
   const base = 1024;
-  const exponent = Math.floor(Math.log(Math.abs(bytes)) / Math.log(base));
+  const exponent = Math.floor(Math.log(bytes) / Math.log(base));
   const unitIndex = Math.min(Math.max(exponent, 0), units.length - 1);
   const value = bytes / Math.pow(base, unitIndex);
 

--- a/src/frontend/src/widgets/inputs/__tests__/fileInputValidation.test.ts
+++ b/src/frontend/src/widgets/inputs/__tests__/fileInputValidation.test.ts
@@ -31,6 +31,14 @@ describe("formatBytes", () => {
     // 10240 bytes = 10 KB, should show no decimals
     expect(formatBytes(10240)).toBe("10 KB");
   });
+
+  it("formats negative bytes as 0 B", () => {
+    expect(formatBytes(-1024)).toBe("0 B");
+  });
+
+  it("formats negative fractional bytes as 0 B", () => {
+    expect(formatBytes(-0.5)).toBe("0 B");
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Changes

Added a guard clause to `formatBytes` that clamps non-positive inputs to `"0 B"`, removed the now-unnecessary `Math.abs()` wrapper, and added a JSDoc comment documenting the behavior. Two new test cases verify negative input handling.

## API Changes

- `formatBytes(bytes, precision?)` — negative inputs now return `"0 B"` instead of a negative formatted string (e.g. `"-1.50 GB"`). No consumers pass negative values, so this is a non-breaking clarification.

## Files Modified

- `src/frontend/src/lib/formatters.ts` — guard clause, JSDoc, removed `Math.abs()`
- `src/frontend/src/widgets/inputs/__tests__/fileInputValidation.test.ts` — 2 new negative-input test cases

## Commits

- ee3e98f8f [01212] Clamp negative formatBytes inputs to 0 B and add tests