### PR TITLE
[01202] Apply slim-scrollbar to compact UI areas

### DIFF
--- a/src/frontend/src/index.css
+++ b/src/frontend/src/index.css
@@ -331,6 +331,7 @@ ivy-widget {
 
 /* Slim scrollbar for compact inline areas (~4px) */
 .slim-scrollbar::-webkit-scrollbar {
+  width: 4px;
   height: 4px;
 }
 .slim-scrollbar::-webkit-scrollbar-track {

--- a/src/frontend/src/widgets/article/TableOfContents.tsx
+++ b/src/frontend/src/widgets/article/TableOfContents.tsx
@@ -196,7 +196,7 @@ export const TableOfContents: React.FC<TableOfContentsProps> = ({
 
   return (
     <div
-      className="flex-1 min-h-48 overflow-y-auto overflow-x-hidden scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent"
+      className="flex-1 min-h-48 overflow-y-auto overflow-x-hidden slim-scrollbar"
       data-toc-container
     >
       <nav className="relative pr-2">

--- a/src/frontend/src/widgets/inputs/SelectInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/SelectInputWidget.tsx
@@ -859,7 +859,7 @@ const CheckboxVariant: React.FC<SelectInputWidgetProps> = ({
               <div
                 className={cn(
                   "flex flex-col gap-4",
-                  filteredOptions.length > 6 ? "max-h-48 overflow-y-auto pr-2 -mr-2" : "",
+                  filteredOptions.length > 6 ? "max-h-48 overflow-y-auto slim-scrollbar" : "",
                 )}
                 data-testid={dataTestId}
               >


### PR DESCRIPTION
## Summary

Updated the `.slim-scrollbar` CSS class to support vertical scrollbars by adding `width: 4px` alongside the existing `height: 4px`. Applied the class to TableOfContents sidebar (replacing three Tailwind scrollbar utilities) and SelectInputWidget checkbox/toggle list (replacing the `pr-2 -mr-2` padding compensation hack).

## API Changes

None.

## Files Modified

- **CSS:** `src/frontend/src/index.css` — added `width: 4px` to `.slim-scrollbar::-webkit-scrollbar`
- **TableOfContents:** `src/frontend/src/widgets/article/TableOfContents.tsx` — replaced `scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent` with `slim-scrollbar`
- **SelectInputWidget:** `src/frontend/src/widgets/inputs/SelectInputWidget.tsx` — replaced `pr-2 -mr-2` padding hack with `slim-scrollbar`

## Commits

- 56fcb3d1b [01202] Apply slim-scrollbar to TableOfContents and SelectInputWidget compact areas