### PR TITLE
[01216] Move parseHexAlpha and combineHexAlpha to color-utils.ts

### DIFF
--- a/src/frontend/src/widgets/inputs/ColorInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/ColorInputWidget.tsx
@@ -6,7 +6,7 @@ import { X, Check } from "lucide-react";
 import React, { useMemo, useState } from "react";
 import { useOptimisticValue } from "./shared/useOptimisticValue";
 import { cn } from "@/lib/utils";
-import { enumColorsToCssVar, convertToHex } from "./color-utils";
+import { enumColorsToCssVar, convertToHex, parseHexAlpha, combineHexAlpha } from "./color-utils";
 import {
   colorInputVariant,
   colorInputPickerVariant,
@@ -84,26 +84,6 @@ const ColorSwatchGrid: React.FC<ColorSwatchGridProps> = ({
     </div>
   );
 };
-
-export function parseHexAlpha(hex: string): { rgb: string; alpha: number } {
-  if (!hex || !hex.startsWith("#")) return { rgb: hex || "#000000", alpha: 255 };
-  const clean = hex.slice(1);
-  if (clean.length === 8) {
-    return {
-      rgb: "#" + clean.slice(0, 6),
-      alpha: parseInt(clean.slice(6, 8), 16),
-    };
-  }
-  return { rgb: hex.length === 7 ? hex : "#000000", alpha: 255 };
-}
-
-export function combineHexAlpha(rgb: string, alpha: number): string {
-  const base = rgb.startsWith("#") ? rgb : "#" + rgb;
-  const hex6 = base.length === 7 ? base : "#000000";
-  if (alpha >= 255) return hex6; // fully opaque → keep 6-char hex
-  const aa = Math.max(0, Math.min(255, alpha)).toString(16).padStart(2, "0");
-  return hex6 + aa;
-}
 
 interface AlphaSliderProps {
   color: string;

--- a/src/frontend/src/widgets/inputs/__tests__/colorInputUtils.test.ts
+++ b/src/frontend/src/widgets/inputs/__tests__/colorInputUtils.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseHexAlpha, combineHexAlpha } from "../ColorInputWidget";
-import { enumColorsToCssVar } from "../color-utils";
+import { parseHexAlpha, combineHexAlpha, enumColorsToCssVar } from "../color-utils";
 
 // ---------------------------------------------------------------------------
 // parseHexAlpha

--- a/src/frontend/src/widgets/inputs/color-utils.ts
+++ b/src/frontend/src/widgets/inputs/color-utils.ts
@@ -113,3 +113,23 @@ export function convertToHex(colorValue: string): string {
   }
   return colorValue;
 }
+
+export function parseHexAlpha(hex: string): { rgb: string; alpha: number } {
+  if (!hex || !hex.startsWith("#")) return { rgb: hex || "#000000", alpha: 255 };
+  const clean = hex.slice(1);
+  if (clean.length === 8) {
+    return {
+      rgb: "#" + clean.slice(0, 6),
+      alpha: parseInt(clean.slice(6, 8), 16),
+    };
+  }
+  return { rgb: hex.length === 7 ? hex : "#000000", alpha: 255 };
+}
+
+export function combineHexAlpha(rgb: string, alpha: number): string {
+  const base = rgb.startsWith("#") ? rgb : "#" + rgb;
+  const hex6 = base.length === 7 ? base : "#000000";
+  if (alpha >= 255) return hex6; // fully opaque → keep 6-char hex
+  const aa = Math.max(0, Math.min(255, alpha)).toString(16).padStart(2, "0");
+  return hex6 + aa;
+}


### PR DESCRIPTION
## Changes

Moved `parseHexAlpha` and `combineHexAlpha` from `ColorInputWidget.tsx` to `color-utils.ts`, consolidating all color utility functions in a single module. Updated all import paths in `ColorInputWidget.tsx` and `colorInputUtils.test.ts`.

## API Changes

- `parseHexAlpha` — re-exported from `color-utils.ts` instead of `ColorInputWidget.tsx`
- `combineHexAlpha` — re-exported from `color-utils.ts` instead of `ColorInputWidget.tsx`

No signature changes. The functions are identical.

## Files Modified

- `src/frontend/src/widgets/inputs/color-utils.ts` — Added both functions
- `src/frontend/src/widgets/inputs/ColorInputWidget.tsx` — Removed function definitions, updated import
- `src/frontend/src/widgets/inputs/__tests__/colorInputUtils.test.ts` — Updated import to source from `color-utils`

## Commits

- e4bb9e10e [01216] Move parseHexAlpha and combineHexAlpha to color-utils.ts