### PR TITLE
[01221] Switch Tendril publish workflow to NuGet trusted publishing

### DIFF
--- a/.github/workflows/publish-tendril.yml
+++ b/.github/workflows/publish-tendril.yml
@@ -2,6 +2,7 @@ name: Publish Ivy.Tendril
 
 permissions:
   contents: read
+  id-token: write
 
 on:
   workflow_dispatch:
@@ -46,5 +47,11 @@ jobs:
           fi
           dotnet pack tendril/Ivy.Tendril/Ivy.Tendril.csproj --configuration Release --no-build --output ./nupkg $VERSION_ARG
 
+      - name: NuGet login (trusted publishing)
+        uses: NuGet/login@v1
+        id: nuget-auth
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
       - name: Push to NuGet
-        run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+        run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ steps.nuget-auth.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate


### PR DESCRIPTION
## Summary

### Changes

Switched the `publish-tendril.yml` GitHub Actions workflow from long-lived `secrets.NUGET_API_KEY` to OIDC-based trusted publishing using the official `NuGet/login@v1` action. Added `id-token: write` permission for OIDC token issuance.

Note: The plan originally proposed manual curl-based token exchange, but the official NuGet trusted publishing documentation recommends the `NuGet/login@v1` action which handles OIDC internally. This is more maintainable and less error-prone.

### API Changes

None.

### Files Modified

- `.github/workflows/publish-tendril.yml` — Added `id-token: write` permission, replaced `secrets.NUGET_API_KEY` push step with `NuGet/login@v1` action + output-based push

### Prerequisites

The following must be configured before running this workflow:

1. **NuGet trusted publishing policy** on nuget.org (user confirmed this is done)
2. **`NUGET_USER` secret** in GitHub repository settings — set to the nuget.org username (profile name) that owns the trusted publishing policy
3. The old `NUGET_API_KEY` secret can be removed after confirming the new flow works

## Commits

- c9337913c [01221] Switch Tendril publish workflow to NuGet trusted publishing