### PR TITLE
[01972] Add PRAGMA integrity_check on startup

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/PlanDatabaseServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/PlanDatabaseServiceTests.cs
@@ -289,4 +289,53 @@ public class PlanDatabaseServiceTests : IDisposable
         Assert.Equal("Tendril", burn[0].Project);
         Assert.Equal(60000, burn[0].Tokens);
     }
+
+    [Fact]
+    public void Constructor_DetectsAndHandlesCorruptedDatabase()
+    {
+        var corruptDbPath = Path.Combine(Path.GetTempPath(), $"tendril-corrupt-{Guid.NewGuid()}.db");
+        try
+        {
+            // Write invalid data to simulate a corrupted database file
+            File.WriteAllBytes(corruptDbPath, new byte[] { 0x00, 0x01, 0x02, 0x03, 0xFF, 0xFE, 0xFD });
+
+            // Constructor should detect corruption and recreate the database
+            using var db = new PlanDatabaseService(corruptDbPath);
+
+            // Verify the service initialized successfully — tables exist and we can query
+            var plans = db.GetPlans();
+            Assert.Empty(plans);
+
+            // Verify we can insert and retrieve data (schema was created)
+            var plan = CreateTestPlan(9999, "Post-Corruption Plan");
+            db.UpsertPlan(plan);
+            var result = db.GetPlanById(9999);
+            Assert.NotNull(result);
+            Assert.Equal("Post-Corruption Plan", result.Title);
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            if (File.Exists(corruptDbPath)) File.Delete(corruptDbPath);
+            if (File.Exists(corruptDbPath + "-wal")) File.Delete(corruptDbPath + "-wal");
+            if (File.Exists(corruptDbPath + "-shm")) File.Delete(corruptDbPath + "-shm");
+        }
+    }
+
+    [Fact]
+    public void Constructor_PassesIntegrityCheckForHealthyDatabase()
+    {
+        // The _db created in the constructor should work fine with a clean database
+        // Verify it's fully functional (implicit integrity check passed)
+        var plan = CreateTestPlan(8888, "Healthy DB Plan");
+        _db.UpsertPlan(plan);
+
+        var result = _db.GetPlanById(8888);
+        Assert.NotNull(result);
+        Assert.Equal("Healthy DB Plan", result.Title);
+
+        // Verify schema is complete by exercising multiple tables
+        var counts = _db.ComputePlanCounts();
+        Assert.Equal(1, counts.Drafts);
+    }
 }

--- a/src/tendril/Ivy.Tendril/Services/PlanDatabaseService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanDatabaseService.cs
@@ -7,7 +7,7 @@ namespace Ivy.Tendril.Services;
 
 public class PlanDatabaseService : IPlanDatabaseService, IDisposable
 {
-    private readonly SqliteConnection _connection;
+    private SqliteConnection _connection;
     private readonly object _lock = new();
 
     private static readonly HashSet<string> AllowedTableColumns = new(StringComparer.Ordinal)
@@ -26,6 +26,36 @@ public class PlanDatabaseService : IPlanDatabaseService, IDisposable
     {
         _connection = new SqliteConnection($"Data Source={databasePath};Mode=ReadWriteCreate");
         _connection.Open();
+
+        // Check database integrity before use
+        var isCorrupted = false;
+        try
+        {
+            using var integrityCmd = _connection.CreateCommand();
+            integrityCmd.CommandText = "PRAGMA integrity_check";
+            var integrityResult = integrityCmd.ExecuteScalar()?.ToString();
+            isCorrupted = integrityResult != "ok";
+        }
+        catch (SqliteException)
+        {
+            isCorrupted = true;
+        }
+
+        if (isCorrupted)
+        {
+            // Corruption detected - release file handles and delete the database
+            SqliteConnection.ClearPool(_connection);
+            _connection.Dispose();
+            File.Delete(databasePath);
+            if (File.Exists(databasePath + "-wal"))
+                File.Delete(databasePath + "-wal");
+            if (File.Exists(databasePath + "-shm"))
+                File.Delete(databasePath + "-shm");
+
+            // Reopen clean database
+            _connection = new SqliteConnection($"Data Source={databasePath};Mode=ReadWriteCreate");
+            _connection.Open();
+        }
 
         using var pragmaCmd = _connection.CreateCommand();
         pragmaCmd.CommandText = "PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;";


### PR DESCRIPTION
# Summary

## Changes

Added SQLite database integrity checking on startup in `PlanDatabaseService`. The constructor now runs `PRAGMA integrity_check` immediately after opening the connection. If corruption is detected (or the pragma throws), the database and its WAL/SHM files are deleted and a clean database is reopened, allowing the existing `PerformInitialSync()` to repopulate from the file system.

## API Changes

None. The `PlanDatabaseService` constructor signature and `IPlanDatabaseService` interface are unchanged. The `_connection` field changed from `readonly` to mutable (internal implementation detail).

## Files Modified

- **src/tendril/Ivy.Tendril/Services/PlanDatabaseService.cs** — Added integrity check logic in constructor
- **src/tendril/Ivy.Tendril.Test/PlanDatabaseServiceTests.cs** — Added two tests: corruption detection/recovery and healthy database validation

## Commits

- a9c2583ee [01972] Add PRAGMA integrity_check on startup