### PR TITLE
[01974] Fix scrollbar issue in full-screen overlays

### DIFF
--- a/src/frontend/src/components/ConnectionModal.tsx
+++ b/src/frontend/src/components/ConnectionModal.tsx
@@ -2,7 +2,7 @@ import { TextShimmer } from "./TextShimmer";
 
 export function ConnectionModal() {
   return (
-    <div className="fixed inset-0 bg-background/80 flex items-center justify-center z-[1000]">
+    <div className="fixed inset-0 bg-background/80 flex items-center justify-center z-[1000] overflow-hidden">
       <div className="px-8 py-4 bg-card border border-border rounded-lg shadow-lg">
         <TextShimmer>Connection lost. Trying to reconnect...</TextShimmer>
       </div>

--- a/src/frontend/src/components/markdown/ImageOverlay.tsx
+++ b/src/frontend/src/components/markdown/ImageOverlay.tsx
@@ -86,7 +86,7 @@ export const ImageOverlay: React.FC<ImageOverlayProps> = ({
   const content = (
     <div
       ref={overlayRef}
-      className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 cursor-zoom-out"
+      className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 cursor-zoom-out overflow-hidden"
       onClick={(e) => {
         if (e.target === e.currentTarget) onClose();
       }}


### PR DESCRIPTION
# Summary

## Changes

Added `overflow-hidden` CSS class to two full-screen overlay components (ConnectionModal and ImageOverlay) to prevent unwanted scrollbars. This follows the same pattern applied to LoadingScreen in plan 01969.

## API Changes

None.

## Files Modified

- **src/frontend/src/components/ConnectionModal.tsx** — Added `overflow-hidden` to root div className
- **src/frontend/src/components/markdown/ImageOverlay.tsx** — Added `overflow-hidden` to overlay div className

## Commits

- [01974] Add overflow-hidden to full-screen overlay components (726121ba2)