### PR TITLE
[01219] Add build guard for rust_cli dependency in Ivy.Tendril.Docs

### DIFF
--- a/src/Ivy.Docs.Shared/Ivy.Docs.Shared.csproj
+++ b/src/Ivy.Docs.Shared/Ivy.Docs.Shared.csproj
@@ -38,9 +38,19 @@
     <Compile Include="**/*.cs" Exclude="obj/**/*.cs;bin/**/*.cs;Generated/**/*.cs" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <SkipDocsTransform Condition="'$(SkipDocsTransform)' == ''">false</SkipDocsTransform>
+  </PropertyGroup>
 
+  <Target Name="CheckCargoInstalled" BeforeTargets="TransformMarkdown" Condition="'$(SkipDocsTransform)' != 'true'">
+    <Exec Command="cargo --version" IgnoreExitCode="true" StandardOutputImportance="low" StandardErrorImportance="low" ConsoleToMSBuild="true">
+      <Output TaskParameter="ExitCode" PropertyName="_CargoExitCode" />
+    </Exec>
+    <Error Condition="'$(_CargoExitCode)' != '0'"
+           Text="Rust toolchain (cargo) is required to build docs. Install from https://rustup.rs/ or set SkipDocsTransform=true to skip." />
+  </Target>
 
-  <Target Name="GenerateApiDocsManifest" AfterTargets="ResolveProjectReferences" BeforeTargets="TransformMarkdown">
+  <Target Name="GenerateApiDocsManifest" AfterTargets="ResolveProjectReferences" BeforeTargets="TransformMarkdown" Condition="'$(SkipDocsTransform)' != 'true'">
     <PropertyGroup>
       <DocsToolProject>$([System.IO.Path]::GetFullPath('$([System.IO.Path]::Combine($(MSBuildProjectDirectory), '..', 'Ivy.Docs.Tools', 'Ivy.Docs.Tools.csproj'))'))</DocsToolProject>
       <ApiDocsInputPath>$([System.IO.Path]::Combine($(MSBuildProjectDirectory), 'Docs', '*.md'))</ApiDocsInputPath>
@@ -49,7 +59,7 @@
     <Exec Command="dotnet run --project &quot;$(DocsToolProject)&quot; -- generate-api-docs &quot;$(ApiDocsInputPath)&quot; &quot;$(ApiDocsManifestPath)&quot;" WorkingDirectory="$(MSBuildProjectDirectory)" />
   </Target>
 
-  <Target Name="TransformMarkdown" AfterTargets="GenerateApiDocsManifest" BeforeTargets="CoreCompile">
+  <Target Name="TransformMarkdown" AfterTargets="GenerateApiDocsManifest" BeforeTargets="CoreCompile" Condition="'$(SkipDocsTransform)' != 'true'">
     <PropertyGroup>
       <DocsToolPath>$([System.IO.Path]::GetFullPath('$([System.IO.Path]::Combine($(MSBuildProjectDirectory), '..', 'Ivy.Docs.Tools', 'bin', $(Configuration), $(TargetFramework), 'Ivy.Docs.Tools.dll'))'))</DocsToolPath>
       <DocsInputPath>$([System.IO.Path]::Combine($(MSBuildProjectDirectory), 'Docs', '*.md'))</DocsInputPath>

--- a/src/tendril/Ivy.Tendril.Docs/GlobalUsings.cs
+++ b/src/tendril/Ivy.Tendril.Docs/GlobalUsings.cs
@@ -1,3 +1,1 @@
-global using Ivy;
-global using Ivy.Core;
 global using Ivy.Docs.Helpers;

--- a/src/tendril/Ivy.Tendril.Docs/Ivy.Tendril.Docs.csproj
+++ b/src/tendril/Ivy.Tendril.Docs/Ivy.Tendril.Docs.csproj
@@ -26,7 +26,19 @@
     <Compile Include="**/*.cs" Exclude="obj/**/*.cs;bin/**/*.cs;Generated/**/*.cs" />
   </ItemGroup>
 
-  <Target Name="TransformMarkdown" AfterTargets="ResolveProjectReferences" BeforeTargets="CoreCompile">
+  <PropertyGroup>
+    <SkipDocsTransform Condition="'$(SkipDocsTransform)' == ''">false</SkipDocsTransform>
+  </PropertyGroup>
+
+  <Target Name="CheckCargoInstalled" BeforeTargets="TransformMarkdown" Condition="'$(SkipDocsTransform)' != 'true'">
+    <Exec Command="cargo --version" IgnoreExitCode="true" StandardOutputImportance="low" StandardErrorImportance="low" ConsoleToMSBuild="true">
+      <Output TaskParameter="ExitCode" PropertyName="_CargoExitCode" />
+    </Exec>
+    <Error Condition="'$(_CargoExitCode)' != '0'"
+           Text="Rust toolchain (cargo) is required to build docs. Install from https://rustup.rs/ or set SkipDocsTransform=true to skip." />
+  </Target>
+
+  <Target Name="TransformMarkdown" AfterTargets="ResolveProjectReferences" BeforeTargets="CoreCompile" Condition="'$(SkipDocsTransform)' != 'true'">
     <PropertyGroup>
       <DocsInputPath>$([System.IO.Path]::Combine($(MSBuildProjectDirectory), 'Docs', '*.md'))</DocsInputPath>
       <DocsOutputPath>$([System.IO.Path]::Combine($(MSBuildProjectDirectory), 'Generated'))</DocsOutputPath>


### PR DESCRIPTION
## Summary

Added MSBuild build guards to both `Ivy.Tendril.Docs.csproj` and `Ivy.Docs.Shared.csproj` that detect whether the Rust toolchain (cargo) is installed before attempting to run the docs markdown transform. When cargo is missing, the build emits a clear error with install instructions. A `SkipDocsTransform` MSBuild property allows bypassing the transform entirely.

## API Changes

- New MSBuild property: `SkipDocsTransform` (default `false`) — set to `true` to skip the cargo-based markdown transform during build
- New MSBuild target: `CheckCargoInstalled` — runs before `TransformMarkdown`, validates cargo availability

## Files Modified

- `src/tendril/Ivy.Tendril.Docs/Ivy.Tendril.Docs.csproj` — Added `CheckCargoInstalled` target, `SkipDocsTransform` property, conditions on both targets
- `src/Ivy.Docs.Shared/Ivy.Docs.Shared.csproj` — Same guard pattern applied
- `src/tendril/Ivy.Tendril.Docs/GlobalUsings.cs` — Removed unused global usings (dotnet format fix)

## Commits

- `b389bfb63` [01219] Add build guard for rust_cli dependency in docs projects
- `f9a0a86c0` [01219] Fix dotnet format: remove unused global usings