### PR TITLE
[01218] Add slim-scrollbar to inline overflow containers

### DIFF
--- a/src/frontend/src/components/GraphvizRenderer.tsx
+++ b/src/frontend/src/components/GraphvizRenderer.tsx
@@ -239,7 +239,7 @@ const GraphvizRenderer = memo(({ content }: GraphvizRendererProps) => {
       <div className="absolute top-2 right-2 z-10">
         <CopyToClipboardButton textToCopy={content} />
       </div>
-      <div className="graphviz-container rounded-md border bg-background p-4 overflow-x-auto">
+      <div className="graphviz-container rounded-md border bg-background p-4 overflow-x-auto slim-scrollbar">
         {isLoading && (
           <div className="flex items-center justify-center p-8 text-muted-foreground">
             <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-primary"></div>

--- a/src/frontend/src/components/MermaidRenderer.tsx
+++ b/src/frontend/src/components/MermaidRenderer.tsx
@@ -260,7 +260,7 @@ const MermaidRenderer = memo(({ content }: MermaidRendererProps) => {
       <div className="absolute top-2 right-2 z-10">
         <CopyToClipboardButton textToCopy={content} />
       </div>
-      <div className="mermaid-container rounded-md border bg-background p-4 overflow-x-auto">
+      <div className="mermaid-container rounded-md border bg-background p-4 overflow-x-auto slim-scrollbar">
         {isLoading && (
           <div className="flex items-center justify-center p-8 text-muted-foreground">
             <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-primary"></div>

--- a/src/frontend/src/widgets/primitives/RichTextBlockWidget.tsx
+++ b/src/frontend/src/widgets/primitives/RichTextBlockWidget.tsx
@@ -304,7 +304,10 @@ export const RichTextBlockWidget: React.FC<RichTextBlockWidgetProps> = ({
 
           if (run.codeBlock !== undefined) {
             return (
-              <pre key={`run-${index}`} className="rounded-md bg-muted p-4 overflow-x-auto">
+              <pre
+                key={`run-${index}`}
+                className="rounded-md bg-muted p-4 overflow-x-auto slim-scrollbar"
+              >
                 <code className={run.codeBlock ? `language-${run.codeBlock}` : undefined}>
                   {run.content}
                 </code>

--- a/src/frontend/src/widgets/primitives/TerminalWidget.tsx
+++ b/src/frontend/src/widgets/primitives/TerminalWidget.tsx
@@ -55,7 +55,7 @@ const TerminalWidget = ({
             />
           </div>
         )}
-        <div className="bg-zinc-900 p-4 font-mono text-body overflow-x-auto">
+        <div className="bg-zinc-900 p-4 font-mono text-body overflow-x-auto slim-scrollbar">
           {lines.map((line, i) => {
             const lineKey = `term-line-${i}`;
             return (


### PR DESCRIPTION
## Changes

Added the `slim-scrollbar` CSS class to four inline horizontal-overflow containers (terminal output, code blocks, Mermaid diagrams, and Graphviz diagrams) to replace the default browser scrollbar with a slim 4px variant. No CSS changes were needed as the `.slim-scrollbar` rule already exists from prior plans.

## API Changes

None.

## Files Modified

- **Frontend widgets:**
  - `src/frontend/src/widgets/primitives/TerminalWidget.tsx` — added `slim-scrollbar` to terminal code display
  - `src/frontend/src/widgets/primitives/RichTextBlockWidget.tsx` — added `slim-scrollbar` to `<pre>` code blocks
- **Frontend components:**
  - `src/frontend/src/components/MermaidRenderer.tsx` — added `slim-scrollbar` to Mermaid diagram container
  - `src/frontend/src/components/GraphvizRenderer.tsx` — added `slim-scrollbar` to Graphviz diagram container

## Commits

- `5addafd23` [01218] Add slim-scrollbar to inline overflow containers