### PR TITLE
[01980] Use IPlanWatcherService interface in Program.cs service resolution

### DIFF
--- a/src/tendril/Ivy.Tendril/Program.cs
+++ b/src/tendril/Ivy.Tendril/Program.cs
@@ -123,7 +123,7 @@ server.UseWebApplication(app =>
         Environment.SetEnvironmentVariable("TENDRIL_URL", serverUrl);
 
     // Eagerly resolve watcher services so their FileSystemWatchers start immediately
-    app.Services.GetRequiredService<PlanWatcherService>();
+    app.Services.GetRequiredService<IPlanWatcherService>();
     app.Services.GetRequiredService<IInboxWatcherService>();
 
     // Start database sync in background


### PR DESCRIPTION
# Summary

## Changes

Changed `Program.cs` line 126 to resolve `IPlanWatcherService` instead of the concrete `PlanWatcherService` type, completing the interface extraction work from plan 01902.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Program.cs` — Changed service resolution from concrete type to interface

## Commits

- e9fd160af [01980] Use IPlanWatcherService interface in Program.cs service resolution