### PR TITLE
[01230] Add convertToHex test for theme color lookup path

### DIFF
--- a/src/frontend/src/widgets/inputs/__tests__/colorUtils.test.ts
+++ b/src/frontend/src/widgets/inputs/__tests__/colorUtils.test.ts
@@ -58,6 +58,16 @@ describe("convertToHex", () => {
     // Without a proper DOM (getComputedStyle returns empty), named colors fall through
     expect(convertToHex("red")).toBe("red");
   });
+
+  it("resolves named colors to hex via theme color lookup when DOM is available", () => {
+    vi.spyOn(globalThis, "getComputedStyle").mockReturnValue({
+      getPropertyValue: () => "#ef4444",
+    } as unknown as CSSStyleDeclaration);
+
+    expect(convertToHex("red")).toBe("#ef4444");
+
+    vi.restoreAllMocks();
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Added a new vitest test case to `colorUtils.test.ts` that exercises the `convertToHex` theme color lookup success path. The test mocks `getComputedStyle` to return a valid hex value, verifying that `convertToHex("red")` resolves through `enumColorsToCssVar` -> `getThemeColorHex` -> mocked DOM and returns `#ef4444`.

## API Changes

None.

## Files Modified

- `src/frontend/src/widgets/inputs/__tests__/colorUtils.test.ts` -- added test case for theme color lookup when DOM is available

## Commits

- `683ef0b3f` — [01230] Add convertToHex test for theme color lookup path