### PR TITLE
[01223] Guard formatBytes against NaN and Infinity inputs

### DIFF
--- a/src/frontend/src/lib/formatters.ts
+++ b/src/frontend/src/lib/formatters.ts
@@ -1,7 +1,7 @@
 /** Formats a byte count into a human-readable string (e.g. 1536 → "1.50 KB").
  *  Non-positive values return "0 B". */
 export const formatBytes = (bytes: number, precision?: number): string => {
-  if (bytes <= 0) return "0 B";
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
 
   const units = ["B", "KB", "MB", "GB", "TB", "PB"];
   const base = 1024;

--- a/src/frontend/src/widgets/inputs/__tests__/fileInputValidation.test.ts
+++ b/src/frontend/src/widgets/inputs/__tests__/fileInputValidation.test.ts
@@ -39,6 +39,18 @@ describe("formatBytes", () => {
   it("formats negative fractional bytes as 0 B", () => {
     expect(formatBytes(-0.5)).toBe("0 B");
   });
+
+  it("formats NaN as 0 B", () => {
+    expect(formatBytes(NaN)).toBe("0 B");
+  });
+
+  it("formats Infinity as 0 B", () => {
+    expect(formatBytes(Infinity)).toBe("0 B");
+  });
+
+  it("formats -Infinity as 0 B", () => {
+    expect(formatBytes(-Infinity)).toBe("0 B");
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Changes

Added a `Number.isFinite()` guard to `formatBytes` so that `NaN`, `Infinity`, and `-Infinity` inputs return `"0 B"` instead of producing nonsensical output. Added three test cases covering each non-finite edge case.

## API Changes

None. The function signature is unchanged; only the behavior for non-finite inputs is corrected.

## Files Modified

- `src/frontend/src/lib/formatters.ts` - Added `!Number.isFinite(bytes)` check to the guard clause
- `src/frontend/src/widgets/inputs/__tests__/fileInputValidation.test.ts` - Added 3 test cases for NaN, Infinity, -Infinity

## Commits

- 621c53c8c [01223] Guard formatBytes against NaN and Infinity inputs