### PR TITLE
[01224] Add automated version bumping for Tendril NuGet publish

### DIFF
--- a/.github/workflows/publish-tendril.yml
+++ b/.github/workflows/publish-tendril.yml
@@ -5,10 +5,6 @@ permissions:
 
 on:
   workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version to publish (e.g. 1.0.2). Leave empty to use Directory.Build.props version.'
-        required: false
 
 jobs:
   publish:
@@ -20,6 +16,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
@@ -39,12 +37,7 @@ jobs:
         run: dotnet build tendril/Ivy.Tendril/Ivy.Tendril.csproj --configuration Release --no-restore
 
       - name: Pack
-        run: |
-          VERSION_ARG=""
-          if [ -n "${{ github.event.inputs.version }}" ]; then
-            VERSION_ARG="/p:Version=${{ github.event.inputs.version }}"
-          fi
-          dotnet pack tendril/Ivy.Tendril/Ivy.Tendril.csproj --configuration Release --no-build --output ./nupkg $VERSION_ARG
+        run: dotnet pack tendril/Ivy.Tendril/Ivy.Tendril.csproj --configuration Release --no-build --output ./nupkg
 
       - name: Push to NuGet
         run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/src/tendril/Directory.Build.props
+++ b/src/tendril/Directory.Build.props
@@ -1,5 +1,2 @@
 <Project>
-  <PropertyGroup>
-    <Version>1.0.1</Version>
-  </PropertyGroup>
 </Project>

--- a/src/tendril/Ivy.Tendril/Ivy.Tendril.csproj
+++ b/src/tendril/Ivy.Tendril/Ivy.Tendril.csproj
@@ -7,6 +7,8 @@
     <NoWarn>CS8618;CS8603;CS8602;CS8604;CS9113</NoWarn>
     <RootNamespace>Ivy.Tendril</RootNamespace>
     <UserSecretsId>a8f3c2e1-4b7d-4e9f-a1c3-8d6e2f5b9a7c</UserSecretsId>
+    <MinVerTagPrefix>tendril/v</MinVerTagPrefix>
+    <MinVerDefaultPreReleaseIdentifiers>preview.0</MinVerDefaultPreReleaseIdentifiers>
   </PropertyGroup>
   <PropertyGroup>
     <PackAsTool>true</PackAsTool>
@@ -35,6 +37,7 @@
     <PackageReference Include="OpenAI" Version="2.9.1" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.4.1" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.0" />
+    <PackageReference Include="MinVer" Version="6.0.0" PrivateAssets="all" />
     <PackageReference Include="PostHog" Version="1.0.8" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Changes

Added MinVer 6.0.0 to Ivy.Tendril for automatic version derivation from git tags using the `tendril/v` prefix. Removed the hardcoded `<Version>` from `Directory.Build.props` and simplified the publish workflow by removing the manual version input and VERSION_ARG logic, while adding `fetch-depth: 0` for full git history access.

## API Changes

None.

## Files Modified

- **Build configuration:**
  - `src/tendril/Ivy.Tendril/Ivy.Tendril.csproj` — Added MinVer package reference and configuration properties
  - `src/tendril/Directory.Build.props` — Removed hardcoded `<Version>1.0.1</Version>`
- **CI/CD:**
  - `.github/workflows/publish-tendril.yml` — Removed version input, added fetch-depth: 0, simplified Pack step

## Commits

- `1a543250a` [01224] Add MinVer for automated Tendril version bumping from git tags