### PR TITLE
[01981] Align TUI search with FTS5 semantics

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/PlanDatabaseServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/PlanDatabaseServiceTests.cs
@@ -326,11 +326,13 @@ public class PlanDatabaseServiceTests : IDisposable
             cmd.ExecuteNonQuery();
         }
 
-        Assert.Empty(_db.SearchPlans("fulltext"));
+        // FTS5 phrase matching should fail when index is cleared (no LIKE fallback for phrases)
+        Assert.Empty(_db.SearchPlans("\"Find me via fulltext\""));
 
         _db.RebuildFtsIndex();
 
-        Assert.Single(_db.SearchPlans("fulltext"));
+        // After rebuild, FTS5 phrase matching works again
+        Assert.Single(_db.SearchPlans("\"Find me via fulltext\""));
     }
 
     [Fact]
@@ -417,5 +419,33 @@ public class PlanDatabaseServiceTests : IDisposable
         // Verify schema is complete by exercising multiple tables
         var counts = _db.ComputePlanCounts();
         Assert.Equal(1, counts.Drafts);
+    }
+
+    [Fact]
+    public void SearchPlans_FallbackToLikeForPartialSubstring()
+    {
+        _db.UpsertPlan(CreateTestPlan(1500, "Widget Feature",
+            latestContent: "Add new widget with button"));
+
+        // FTS5 won't match partial substring "idg"
+        // Should fall back to LIKE and find "Widget"
+        var results = _db.SearchPlans("idg");
+        Assert.Single(results);
+        Assert.Equal("Widget Feature", results[0].Title);
+    }
+
+    [Fact]
+    public void SearchPlans_PrefersFts5OverLike()
+    {
+        _db.UpsertPlan(CreateTestPlan(1500, "Widget Feature",
+            latestContent: "widget widget widget"));
+        _db.UpsertPlan(CreateTestPlan(1501, "Button Widget",
+            latestContent: "Single widget mention"));
+
+        // FTS5 should match and rank by term frequency
+        var results = _db.SearchPlans("widget");
+        Assert.Equal(2, results.Count);
+        // Higher term frequency ranks first in FTS5
+        Assert.Equal(1500, results[0].Id);
     }
 }

--- a/src/tendril/Ivy.Tendril/Services/PlanDatabaseService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanDatabaseService.cs
@@ -431,18 +431,45 @@ public class PlanDatabaseService : IPlanDatabaseService, IDisposable
 
     public List<PlanFile> SearchPlans(string query)
     {
-<<<<<<< HEAD
-        using var cmd = _connection.CreateCommand();
-        cmd.CommandText = """
-            SELECT p.Id, p.Title, p.Project, p.Level, p.State, p.FolderPath, p.FolderName,
-                   p.YamlRaw, p.RevisionCount, p.LatestRevisionContent, p.Created, p.Updated
-            FROM Plans p
-            INNER JOIN PlanSearch fts ON fts.rowid = p.Id
-            WHERE PlanSearch MATCH @query
-            ORDER BY rank, p.Id
-            """;
-        cmd.Parameters.AddWithValue("@query", query);
+        lock (_lock)
+        {
+            // Try FTS5 first
+            using var ftsCmd = _connection.CreateCommand();
+            ftsCmd.CommandText = """
+                SELECT p.Id, p.Title, p.Project, p.Level, p.State, p.FolderPath, p.FolderName,
+                       p.YamlRaw, p.RevisionCount, p.LatestRevisionContent, p.Created, p.Updated
+                FROM Plans p
+                INNER JOIN PlanSearch fts ON fts.rowid = p.Id
+                WHERE PlanSearch MATCH @query
+                ORDER BY rank, p.Id
+                """;
+            ftsCmd.Parameters.AddWithValue("@query", query);
 
+            var plans = ExecuteSearchQuery(ftsCmd);
+
+            // If FTS5 returns no results, fall back to LIKE for substring matching
+            if (plans.Count == 0)
+            {
+                var search = $"%{query}%";
+                using var likeCmd = _connection.CreateCommand();
+                likeCmd.CommandText = """
+                    SELECT Id, Title, Project, Level, State, FolderPath, FolderName,
+                           YamlRaw, RevisionCount, LatestRevisionContent, Created, Updated
+                    FROM Plans
+                    WHERE Title LIKE @search OR LatestRevisionContent LIKE @search
+                          OR CAST(Id AS TEXT) LIKE @search OR Project LIKE @search
+                    ORDER BY Id
+                    """;
+                likeCmd.Parameters.AddWithValue("@search", search);
+                plans = ExecuteSearchQuery(likeCmd);
+            }
+
+            return plans;
+        }
+    }
+
+    private List<PlanFile> ExecuteSearchQuery(SqliteCommand cmd)
+    {
         var planIds = new List<int>();
         var rawPlans = new List<(int Id, string Title, string Project, string Level, string State,
             string FolderPath, string FolderName, string YamlRaw, int RevisionCount,
@@ -450,65 +477,41 @@ public class PlanDatabaseService : IPlanDatabaseService, IDisposable
 
         using var reader = cmd.ExecuteReader();
         while (reader.Read())
-=======
-        lock (_lock)
->>>>>>> origin/main
         {
-            var search = $"%{query}%";
-            using var cmd = _connection.CreateCommand();
-            cmd.CommandText = """
-                SELECT Id, Title, Project, Level, State, FolderPath, FolderName,
-                       YamlRaw, RevisionCount, LatestRevisionContent, Created, Updated
-                FROM Plans
-                WHERE Title LIKE @search OR LatestRevisionContent LIKE @search
-                      OR CAST(Id AS TEXT) LIKE @search OR Project LIKE @search
-                ORDER BY Id
-                """;
-            cmd.Parameters.AddWithValue("@search", search);
-
-            var planIds = new List<int>();
-            var rawPlans = new List<(int Id, string Title, string Project, string Level, string State,
-                string FolderPath, string FolderName, string YamlRaw, int RevisionCount,
-                string LatestContent, string Created, string Updated)>();
-
-            using var reader = cmd.ExecuteReader();
-            while (reader.Read())
-            {
-                var planId = reader.GetInt32(0);
-                planIds.Add(planId);
-                rawPlans.Add((planId, reader.GetString(1), reader.GetString(2), reader.GetString(3),
-                    reader.GetString(4), reader.GetString(5), reader.GetString(6), reader.GetString(7),
-                    reader.GetInt32(8), reader.GetString(9), reader.GetString(10), reader.GetString(11)));
-            }
-
-            if (rawPlans.Count == 0)
-                return [];
-
-            var allRepos = BatchGetList(planIds, "Repos", "RepoPath");
-            var allCommits = BatchGetList(planIds, "Commits", "CommitHash");
-            var allPrs = BatchGetList(planIds, "PullRequests", "PrUrl");
-            var allVerifications = BatchGetVerifications(planIds);
-            var allRelatedPlans = BatchGetList(planIds, "RelatedPlans", "RelatedPlanPath");
-            var allDependsOn = BatchGetList(planIds, "DependsOn", "DependsOnPlanPath");
-
-            var plans = new List<PlanFile>();
-            foreach (var row in rawPlans)
-            {
-                var plan = BuildPlanFileFromRow(row.Id, row.Title, row.Project, row.Level, row.State,
-                    row.FolderPath, row.FolderName, row.YamlRaw, row.RevisionCount, row.LatestContent,
-                    row.Created, row.Updated,
-                    allRepos.GetValueOrDefault(row.Id, []),
-                    allCommits.GetValueOrDefault(row.Id, []),
-                    allPrs.GetValueOrDefault(row.Id, []),
-                    allVerifications.GetValueOrDefault(row.Id, []),
-                    allRelatedPlans.GetValueOrDefault(row.Id, []),
-                    allDependsOn.GetValueOrDefault(row.Id, []));
-                if (plan != null)
-                    plans.Add(plan);
-            }
-
-            return plans;
+            var planId = reader.GetInt32(0);
+            planIds.Add(planId);
+            rawPlans.Add((planId, reader.GetString(1), reader.GetString(2), reader.GetString(3),
+                reader.GetString(4), reader.GetString(5), reader.GetString(6), reader.GetString(7),
+                reader.GetInt32(8), reader.GetString(9), reader.GetString(10), reader.GetString(11)));
         }
+
+        if (rawPlans.Count == 0)
+            return [];
+
+        var allRepos = BatchGetList(planIds, "Repos", "RepoPath");
+        var allCommits = BatchGetList(planIds, "Commits", "CommitHash");
+        var allPrs = BatchGetList(planIds, "PullRequests", "PrUrl");
+        var allVerifications = BatchGetVerifications(planIds);
+        var allRelatedPlans = BatchGetList(planIds, "RelatedPlans", "RelatedPlanPath");
+        var allDependsOn = BatchGetList(planIds, "DependsOn", "DependsOnPlanPath");
+
+        var plans = new List<PlanFile>();
+        foreach (var row in rawPlans)
+        {
+            var plan = BuildPlanFileFromRow(row.Id, row.Title, row.Project, row.Level, row.State,
+                row.FolderPath, row.FolderName, row.YamlRaw, row.RevisionCount, row.LatestContent,
+                row.Created, row.Updated,
+                allRepos.GetValueOrDefault(row.Id, []),
+                allCommits.GetValueOrDefault(row.Id, []),
+                allPrs.GetValueOrDefault(row.Id, []),
+                allVerifications.GetValueOrDefault(row.Id, []),
+                allRelatedPlans.GetValueOrDefault(row.Id, []),
+                allDependsOn.GetValueOrDefault(row.Id, []));
+            if (plan != null)
+                plans.Add(plan);
+        }
+
+        return plans;
     }
 
     public void UpsertPlan(PlanFile plan)


### PR DESCRIPTION
# Summary

## Changes

Resolved merge conflict markers in `PlanDatabaseService.SearchPlans` (from plan 01971 merge) and implemented FTS5-first search with LIKE substring fallback. When FTS5 MATCH returns no results, the method now falls back to a LIKE query matching against title, content, ID, and project fields. Extracted shared query execution logic into a new `ExecuteSearchQuery` helper method.

## API Changes

- `PlanDatabaseService.SearchPlans(string query)` — behavior changed: now tries FTS5 MATCH first, falls back to LIKE `%query%` if no FTS5 results. Previously had merge conflict markers making it non-functional.
- `PlanDatabaseService.ExecuteSearchQuery(SqliteCommand cmd)` — new private helper method for shared query result processing.

## Files Modified

- **Services/PlanDatabaseService.cs** — Resolved conflict markers, added FTS5+LIKE fallback logic, extracted `ExecuteSearchQuery` helper
- **PlanDatabaseServiceTests.cs** — Added `SearchPlans_FallbackToLikeForPartialSubstring` and `SearchPlans_PrefersFts5OverLike` tests; updated `RebuildFtsIndex_RepopulatesSearch` to use phrase query

## Commits

- [01981] Add LIKE fallback to SearchPlans for substring matching (eeabed8b1)