### PR TITLE
[01983] Add CLI commands for database management (db-version, db-migrate, db-reset)

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/DatabaseCommandsTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/DatabaseCommandsTests.cs
@@ -1,0 +1,192 @@
+using Ivy.Tendril.Database;
+
+namespace Ivy.Tendril.Test;
+
+public class DatabaseCommandsTests : IDisposable
+{
+    private readonly string _dbPath;
+    private readonly string _originalTendrilHome;
+
+    public DatabaseCommandsTests()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"tendril-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        _dbPath = Path.Combine(tempDir, "tendril.db");
+
+        _originalTendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME") ?? "";
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", tempDir);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", _originalTendrilHome);
+        var dir = Path.GetDirectoryName(_dbPath)!;
+        if (Directory.Exists(dir))
+        {
+            try { Directory.Delete(dir, true); }
+            catch { /* best effort cleanup */ }
+        }
+    }
+
+    [Fact]
+    public void DbVersion_ShowsCurrentAndLatestVersion()
+    {
+        // Initialize DB with migrations first
+        DatabaseCommands.DbMigrate(_dbPath);
+
+        var output = CaptureConsoleOutput(() =>
+        {
+            var result = DatabaseCommands.DbVersion(_dbPath);
+            Assert.Equal(0, result);
+        });
+
+        Assert.Contains("Database version:", output);
+        Assert.Contains("Latest version:", output);
+        Assert.Contains("Status:", output);
+        Assert.Contains("Up to date", output);
+    }
+
+    [Fact]
+    public void DbMigrate_AppliesPendingMigrations()
+    {
+        var output = CaptureConsoleOutput(() =>
+        {
+            var result = DatabaseCommands.DbMigrate(_dbPath);
+            Assert.Equal(0, result);
+        });
+
+        // Verify migrations were applied by checking version
+        var versionOutput = CaptureConsoleOutput(() => DatabaseCommands.DbVersion(_dbPath));
+        Assert.Contains("Up to date", versionOutput);
+    }
+
+    [Fact]
+    public void DbMigrate_WhenUpToDate_ReportsUpToDate()
+    {
+        // Run migrations first
+        DatabaseCommands.DbMigrate(_dbPath);
+
+        // Run again — should report up to date
+        var output = CaptureConsoleOutput(() =>
+        {
+            var result = DatabaseCommands.DbMigrate(_dbPath);
+            Assert.Equal(0, result);
+        });
+
+        Assert.Contains("up to date", output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void DbReset_DropsTablesAndReappliesMigrations()
+    {
+        // Apply migrations to create tables
+        DatabaseCommands.DbMigrate(_dbPath);
+
+        // Reset with --force to skip confirmation
+        var output = CaptureConsoleOutput(() =>
+        {
+            var result = DatabaseCommands.DbReset(_dbPath, ["db-reset", "--force"]);
+            Assert.Equal(0, result);
+        });
+
+        Assert.Contains("Resetting database", output);
+        Assert.Contains("Dropping existing tables", output);
+
+        // Verify migrations were re-applied
+        var versionOutput = CaptureConsoleOutput(() => DatabaseCommands.DbVersion(_dbPath));
+        Assert.Contains("Up to date", versionOutput);
+    }
+
+    [Fact]
+    public void DbReset_WithoutForce_AbortsOnNonYResponse()
+    {
+        DatabaseCommands.DbMigrate(_dbPath);
+
+        var output = CaptureConsoleOutputWithInput("n\n", () =>
+        {
+            var result = DatabaseCommands.DbReset(_dbPath, ["db-reset"]);
+            Assert.Equal(1, result);
+        });
+
+        Assert.Contains("Aborted", output);
+    }
+
+    [Fact]
+    public void Handle_UnknownCommand_ReturnsNegativeOne()
+    {
+        var result = DatabaseCommands.Handle(["unknown-command"]);
+        Assert.Equal(-1, result);
+    }
+
+    [Fact]
+    public void Handle_EmptyArgs_ReturnsNegativeOne()
+    {
+        var result = DatabaseCommands.Handle([]);
+        Assert.Equal(-1, result);
+    }
+
+    [Fact]
+    public void Handle_DbVersion_ReturnsZero()
+    {
+        var result = CaptureConsoleOutput(() =>
+        {
+            Assert.Equal(0, DatabaseCommands.Handle(["db-version"]));
+        });
+    }
+
+    [Fact]
+    public void Handle_DbMigrate_ReturnsZero()
+    {
+        var result = CaptureConsoleOutput(() =>
+        {
+            Assert.Equal(0, DatabaseCommands.Handle(["db-migrate"]));
+        });
+    }
+
+    [Fact]
+    public void Handle_DbReset_WithForce_ReturnsZero()
+    {
+        DatabaseCommands.DbMigrate(_dbPath);
+
+        var output = CaptureConsoleOutput(() =>
+        {
+            Assert.Equal(0, DatabaseCommands.Handle(["db-reset", "--force"]));
+        });
+    }
+
+    private static string CaptureConsoleOutput(Action action)
+    {
+        var originalOut = Console.Out;
+        using var writer = new StringWriter();
+        Console.SetOut(writer);
+        try
+        {
+            action();
+            return writer.ToString();
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
+    }
+
+    private static string CaptureConsoleOutputWithInput(string input, Action action)
+    {
+        var originalOut = Console.Out;
+        var originalIn = Console.In;
+        using var writer = new StringWriter();
+        using var reader = new StringReader(input);
+        Console.SetOut(writer);
+        Console.SetIn(reader);
+        try
+        {
+            action();
+            return writer.ToString();
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+            Console.SetIn(originalIn);
+        }
+    }
+}

--- a/src/tendril/Ivy.Tendril/Database/DatabaseCommands.cs
+++ b/src/tendril/Ivy.Tendril/Database/DatabaseCommands.cs
@@ -1,0 +1,117 @@
+using Microsoft.Data.Sqlite;
+
+namespace Ivy.Tendril.Database;
+
+public static class DatabaseCommands
+{
+    /// <summary>
+    /// Handles database CLI commands. Returns exit code (0 = success, 1 = error),
+    /// or -1 if the args don't match a database command.
+    /// </summary>
+    public static int Handle(string[] args)
+    {
+        if (args.Length == 0) return -1;
+
+        var tendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME");
+        if (string.IsNullOrEmpty(tendrilHome))
+        {
+            Console.Error.WriteLine("Error: TENDRIL_HOME environment variable is not set.");
+            return 1;
+        }
+
+        var dbPath = Path.Combine(tendrilHome, "tendril.db");
+
+        return args[0] switch
+        {
+            "db-version" => DbVersion(dbPath),
+            "db-migrate" => DbMigrate(dbPath),
+            "db-reset" => DbReset(dbPath, args),
+            _ => -1
+        };
+    }
+
+    internal static int DbVersion(string dbPath)
+    {
+        using var connection = OpenConnection(dbPath);
+        var migrator = new DatabaseMigrator(connection);
+        var current = migrator.GetCurrentVersion();
+        var latest = migrator.GetLatestVersion();
+        var status = current == latest ? "Up to date"
+            : current > latest ? "Newer than application"
+            : "Needs migration";
+
+        Console.WriteLine($"Database version: {current}");
+        Console.WriteLine($"Latest version:   {latest}");
+        Console.WriteLine($"Status:           {status}");
+        return 0;
+    }
+
+    internal static int DbMigrate(string dbPath)
+    {
+        using var connection = OpenConnection(dbPath);
+        var migrator = new DatabaseMigrator(connection);
+        migrator.ApplyMigrations();
+        return 0;
+    }
+
+    internal static int DbReset(string dbPath, string[] args)
+    {
+        var force = args.Any(a => a == "--force");
+
+        if (!force)
+        {
+            Console.Write("WARNING: This will delete all data in the database.\nAre you sure? (y/N): ");
+            var response = Console.ReadLine();
+            if (!string.Equals(response?.Trim(), "y", StringComparison.OrdinalIgnoreCase))
+            {
+                Console.WriteLine("Aborted.");
+                return 1;
+            }
+        }
+
+        Console.WriteLine("Resetting database...");
+
+        using var connection = OpenConnection(dbPath);
+
+        // Get all table names
+        var tables = new List<string>();
+        using (var cmd = connection.CreateCommand())
+        {
+            cmd.CommandText = "SELECT name FROM sqlite_master WHERE type='table' AND name != 'sqlite_sequence';";
+            using var reader = cmd.ExecuteReader();
+            while (reader.Read())
+                tables.Add(reader.GetString(0));
+        }
+
+        // Drop all tables
+        Console.WriteLine("  Dropping existing tables");
+        foreach (var table in tables)
+        {
+            using var dropCmd = connection.CreateCommand();
+            dropCmd.CommandText = $"DROP TABLE IF EXISTS \"{table}\";";
+            dropCmd.ExecuteNonQuery();
+        }
+
+        // Reset version
+        using (var versionCmd = connection.CreateCommand())
+        {
+            versionCmd.CommandText = "PRAGMA user_version = 0;";
+            versionCmd.ExecuteNonQuery();
+        }
+
+        // Re-apply all migrations
+        var migrator = new DatabaseMigrator(connection);
+        migrator.ApplyMigrations();
+        return 0;
+    }
+
+    private static SqliteConnection OpenConnection(string dbPath)
+    {
+        var connection = new SqliteConnection($"Data Source={dbPath}");
+        connection.Open();
+        using var pragmaCmd = connection.CreateCommand();
+        pragmaCmd.CommandText = "PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;";
+        pragmaCmd.ExecuteNonQuery();
+        return connection;
+    }
+}

--- a/src/tendril/Ivy.Tendril/Program.cs
+++ b/src/tendril/Ivy.Tendril/Program.cs
@@ -2,11 +2,16 @@ using Ivy;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Ivy.Tendril.AppShell;
+using Ivy.Tendril.Database;
 using Ivy.Tendril.Services;
 using Microsoft.Extensions.Logging;
 using OpenAI;
 using System.ClientModel;
 
+// Handle database CLI commands before starting the server
+var dbExitCode = DatabaseCommands.Handle(args);
+if (dbExitCode >= 0)
+    return dbExitCode;
 
 AppDomain.CurrentDomain.UnhandledException += (sender, e) =>
 {
@@ -152,3 +157,4 @@ var appShellSettings = new AppShellSettings()
     .UseTabs(preventDuplicates: true);
 server.UseAppShell(() => new TendrilAppShell(appShellSettings));
 await server.RunAsync();
+return 0;


### PR DESCRIPTION
# Summary

## Changes

Added three CLI commands (`db-version`, `db-migrate`, `db-reset`) to Tendril for database management without restarting the server. Commands are handled in Program.cs before the server starts via a new `DatabaseCommands` static class.

## API Changes

- New static class `Ivy.Tendril.Database.DatabaseCommands` with:
  - `Handle(string[] args)` — routes CLI args to database commands, returns exit code or -1
  - `DbVersion(string dbPath)` — prints current/latest version and migration status
  - `DbMigrate(string dbPath)` — applies pending migrations
  - `DbReset(string dbPath, string[] args)` — drops all tables and re-applies migrations (`--force` skips confirmation)
- `Program.cs` now intercepts `db-version`, `db-migrate`, `db-reset` args before starting the Ivy server

## Files Modified

- **New:** `src/tendril/Ivy.Tendril/Database/DatabaseCommands.cs` — CLI command implementation
- **New:** `src/tendril/Ivy.Tendril.Test/DatabaseCommandsTests.cs` — 10 tests for CLI commands
- **Modified:** `src/tendril/Ivy.Tendril/Program.cs` — added CLI intercept at top
- **Fixed:** `src/tendril/Ivy.Tendril/Services/PlanDatabaseService.cs` — resolved pre-existing merge conflict markers

## Commits

- b0ece3215 [01983] Fix merge conflict markers in PlanDatabaseService.cs
- 92969a372 [01983] Add CLI commands for database management (db-version, db-migrate, db-reset)