### PR TITLE
[01977] Add CodeFixProvider for IVYSERVICE001 analyzer

### DIFF
--- a/src/Ivy-Framework.slnx
+++ b/src/Ivy-Framework.slnx
@@ -38,6 +38,8 @@
     <Project Path="Ivy.Docs.Tools.Test/Ivy.Docs.Tools.Test.csproj" />
     <Project Path="Ivy.Docs.Tools/Ivy.Docs.Tools.csproj" />
   </Folder>
+  <Project Path="Ivy.Analyser.Tests/Ivy.Analyser.Tests.csproj" />
+  <Project Path="Ivy.Analyser/Ivy.Analyser.csproj" />
   <Project Path="Ivy.Benchmarks.Docs/Ivy.Benchmarks.Docs.csproj" />
   <Project Path="Ivy.Desktop/Ivy.Desktop.csproj" />
   <Project Path="Ivy.Docs.Helpers/Ivy.Docs.Helpers.csproj" />

--- a/src/Ivy.Analyser.Tests/CSharpCodeFixVerifier.cs
+++ b/src/Ivy.Analyser.Tests/CSharpCodeFixVerifier.cs
@@ -1,0 +1,49 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
+
+namespace Ivy.Analyser.Tests
+{
+    public static class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
+        where TAnalyzer : DiagnosticAnalyzer, new()
+        where TCodeFix : CodeFixProvider, new()
+    {
+        public static DiagnosticResult Diagnostic(string diagnosticId) =>
+            new DiagnosticResult(diagnosticId, DiagnosticSeverity.Warning);
+
+        public static async Task VerifyAnalyzerAsync(string source)
+        {
+            var test = new CSharpAnalyzerTest<TAnalyzer, DefaultVerifier>
+            {
+                TestCode = source,
+            };
+            await test.RunAsync();
+        }
+
+        public static async Task VerifyCodeFixAsync(string source, DiagnosticResult expected, string fixedSource)
+        {
+            var test = new CSharpCodeFixTest<TAnalyzer, TCodeFix, DefaultVerifier>
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+            };
+            test.ExpectedDiagnostics.Add(expected);
+            await test.RunAsync();
+        }
+
+        public static async Task VerifyCodeFixAsync(string source, DiagnosticResult[] expected, string fixedSource)
+        {
+            var test = new CSharpCodeFixTest<TAnalyzer, TCodeFix, DefaultVerifier>
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+                // BatchFixer applies one fix per iteration, so we need as many iterations as diagnostics
+                NumberOfFixAllIterations = expected.Length,
+            };
+            test.ExpectedDiagnostics.AddRange(expected);
+            await test.RunAsync();
+        }
+    }
+}

--- a/src/Ivy.Analyser.Tests/Ivy.Analyser.Tests.csproj
+++ b/src/Ivy.Analyser.Tests/Ivy.Analyser.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>latest</LangVersion>
+    <NoWarn>NU1701</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.3" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Ivy.Analyser\Ivy.Analyser.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Ivy.Analyser.Tests/UseServiceInterfaceCodeFixProviderTests.cs
+++ b/src/Ivy.Analyser.Tests/UseServiceInterfaceCodeFixProviderTests.cs
@@ -1,0 +1,192 @@
+using Ivy.Analyser.Analyzers;
+using Xunit;
+
+using Verifier = Ivy.Analyser.Tests.CSharpCodeFixVerifier<
+    Ivy.Analyser.Analyzers.UseServiceInterfaceAnalyzer,
+    Ivy.Analyser.Analyzers.UseServiceInterfaceCodeFixProvider>;
+
+namespace Ivy.Analyser.Tests
+{
+    public class UseServiceInterfaceCodeFixProviderTests
+    {
+        [Fact]
+        public async Task CodeFix_ReplacesConcrete_WithInterface()
+        {
+            const string testCode = @"
+namespace TestNamespace
+{
+    public interface IConfigService { }
+    public class ConfigService { }
+
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            var config = UseService<{|#0:ConfigService|}>();
+        }
+
+        private T UseService<T>() => default;
+    }
+}";
+
+            const string fixedCode = @"
+namespace TestNamespace
+{
+    public interface IConfigService { }
+    public class ConfigService { }
+
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            var config = UseService<IConfigService>();
+        }
+
+        private T UseService<T>() => default;
+    }
+}";
+
+            var expected = Verifier.Diagnostic(UseServiceInterfaceAnalyzer.DiagnosticId)
+                .WithLocation(0)
+                .WithArguments("ConfigService");
+
+            await Verifier.VerifyCodeFixAsync(testCode, expected, fixedCode);
+        }
+
+        [Fact]
+        public async Task CodeFix_NotOffered_WhenInterfaceDoesNotExist()
+        {
+            const string testCode = @"
+namespace TestNamespace
+{
+    // No IConfigService interface exists
+    public class ConfigService { }
+
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            var config = UseService<ConfigService>();
+        }
+
+        private T UseService<T>() => default;
+    }
+}";
+
+            // No diagnostic expected because interface doesn't exist
+            await Verifier.VerifyAnalyzerAsync(testCode);
+        }
+
+        [Fact]
+        public async Task CodeFix_WorksWithMemberAccess()
+        {
+            const string testCode = @"
+namespace TestNamespace
+{
+    public interface IJobService { }
+    public class JobService { }
+
+    public class ServiceProvider
+    {
+        public T UseService<T>() => default;
+    }
+
+    public class TestClass
+    {
+        private ServiceProvider provider = new ServiceProvider();
+
+        public void TestMethod()
+        {
+            var job = provider.UseService<{|#0:JobService|}>();
+        }
+    }
+}";
+
+            const string fixedCode = @"
+namespace TestNamespace
+{
+    public interface IJobService { }
+    public class JobService { }
+
+    public class ServiceProvider
+    {
+        public T UseService<T>() => default;
+    }
+
+    public class TestClass
+    {
+        private ServiceProvider provider = new ServiceProvider();
+
+        public void TestMethod()
+        {
+            var job = provider.UseService<IJobService>();
+        }
+    }
+}";
+
+            var expected = Verifier.Diagnostic(UseServiceInterfaceAnalyzer.DiagnosticId)
+                .WithLocation(0)
+                .WithArguments("JobService");
+
+            await Verifier.VerifyCodeFixAsync(testCode, expected, fixedCode);
+        }
+
+        [Fact]
+        public async Task CodeFix_FixAll_HandlesMultipleViolations()
+        {
+            const string testCode = @"
+namespace TestNamespace
+{
+    public interface IConfigService { }
+    public class ConfigService { }
+
+    public interface IJobService { }
+    public class JobService { }
+
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            var config = UseService<{|#0:ConfigService|}>();
+            var job = UseService<{|#1:JobService|}>();
+        }
+
+        private T UseService<T>() => default;
+    }
+}";
+
+            const string fixedCode = @"
+namespace TestNamespace
+{
+    public interface IConfigService { }
+    public class ConfigService { }
+
+    public interface IJobService { }
+    public class JobService { }
+
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            var config = UseService<IConfigService>();
+            var job = UseService<IJobService>();
+        }
+
+        private T UseService<T>() => default;
+    }
+}";
+
+            var expected = new[]
+            {
+                Verifier.Diagnostic(UseServiceInterfaceAnalyzer.DiagnosticId)
+                    .WithLocation(0)
+                    .WithArguments("ConfigService"),
+                Verifier.Diagnostic(UseServiceInterfaceAnalyzer.DiagnosticId)
+                    .WithLocation(1)
+                    .WithArguments("JobService")
+            };
+
+            await Verifier.VerifyCodeFixAsync(testCode, expected, fixedCode);
+        }
+    }
+}

--- a/src/Ivy.Analyser/Analyzers/UseServiceInterfaceCodeFixProvider.cs
+++ b/src/Ivy.Analyser/Analyzers/UseServiceInterfaceCodeFixProvider.cs
@@ -1,0 +1,106 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Ivy.Analyser.Analyzers
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(UseServiceInterfaceCodeFixProvider)), Shared]
+    public class UseServiceInterfaceCodeFixProvider : CodeFixProvider
+    {
+        public override ImmutableArray<string> FixableDiagnosticIds =>
+            ImmutableArray.Create(UseServiceInterfaceAnalyzer.DiagnosticId);
+
+        public override FixAllProvider GetFixAllProvider() =>
+            WellKnownFixAllProviders.BatchFixer;
+
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+            if (root == null)
+                return;
+
+            var diagnostic = context.Diagnostics.First();
+            var diagnosticSpan = diagnostic.Location.SourceSpan;
+
+            // Find the type argument node that triggered the diagnostic
+            var typeArgument = root.FindNode(diagnosticSpan) as TypeSyntax;
+            if (typeArgument == null)
+                return;
+
+            // Get semantic model to verify interface exists
+            var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+            if (semanticModel == null)
+                return;
+
+            var typeInfo = semanticModel.GetTypeInfo(typeArgument, context.CancellationToken);
+            var typeSymbol = typeInfo.Type;
+            if (typeSymbol == null)
+                return;
+
+            // Construct interface name by prefixing with 'I'
+            var interfaceName = "I" + typeSymbol.Name;
+
+            // Verify the interface exists using the same logic as the analyzer
+            var interfaceSymbol = FindInterfaceInNamespace(typeSymbol, interfaceName);
+            if (interfaceSymbol == null)
+                return; // Don't offer fix if interface doesn't exist
+
+            // Register the code fix
+            var title = $"Use interface {interfaceName}";
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: title,
+                    createChangedDocument: c => ReplaceWithInterfaceAsync(context.Document, typeArgument, interfaceName, c),
+                    equivalenceKey: title),
+                diagnostic);
+        }
+
+        private static async Task<Document> ReplaceWithInterfaceAsync(
+            Document document,
+            TypeSyntax typeArgument,
+            string interfaceName,
+            CancellationToken cancellationToken)
+        {
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            if (root == null)
+                return document;
+
+            // Create new identifier with interface name
+            var newTypeArgument = SyntaxFactory.IdentifierName(interfaceName)
+                .WithTriviaFrom(typeArgument);
+
+            // Replace the type argument in the syntax tree
+            var newRoot = root.ReplaceNode(typeArgument, newTypeArgument);
+
+            return document.WithSyntaxRoot(newRoot);
+        }
+
+        // Reuse the same interface lookup logic as UseServiceInterfaceAnalyzer
+        private static INamedTypeSymbol? FindInterfaceInNamespace(
+            ITypeSymbol typeSymbol,
+            string interfaceName)
+        {
+            var containingNamespace = typeSymbol.ContainingNamespace;
+            if (containingNamespace == null)
+                return null;
+
+            foreach (var member in containingNamespace.GetMembers(interfaceName))
+            {
+                if (member is INamedTypeSymbol { TypeKind: TypeKind.Interface } interfaceSymbol &&
+                    interfaceSymbol.DeclaredAccessibility == Accessibility.Public)
+                {
+                    return interfaceSymbol;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Ivy.Analyser/Ivy.Analyser.csproj
+++ b/src/Ivy.Analyser/Ivy.Analyser.csproj
@@ -22,7 +22,7 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
-    <NoWarn>$(NoWarn);RS2007;RS2008</NoWarn>
+    <NoWarn>$(NoWarn);RS2007;RS2008;RS1038</NoWarn>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
@@ -33,6 +33,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ivy.Analyser/README.md
+++ b/src/Ivy.Analyser/README.md
@@ -267,6 +267,36 @@ public override object? Build()
 
 **Note:** This warning only appears when a corresponding interface (prefixed with 'I') exists in the same namespace. If no interface exists, no warning is shown.
 
+#### Quick Fix
+
+The analyzer includes a CodeFixProvider that can automatically fix IVYSERVICE001 warnings with a single click.
+
+**How to use:**
+1. Place your cursor on the warning (red/yellow squiggle)
+2. Trigger the quick action menu:
+   - **Visual Studio:** Press `Ctrl+.` or click the lightbulb/screwdriver icon
+   - **VS Code:** Press `Ctrl+.` or click the lightbulb icon
+   - **Rider:** Press `Alt+Enter` or click the lightbulb icon
+3. Select **"Use interface I{ConcreteType}"** from the menu
+4. The concrete type will be automatically replaced with its interface
+
+**Example:**
+```csharp
+// Before fix:
+var config = UseService<ConfigService>();  // ⚠️ Warning IVYSERVICE001
+
+// After applying quick fix:
+var config = UseService<IConfigService>(); // ✅ Fixed
+```
+
+**Fix All:**
+You can apply the fix to multiple violations at once using "Fix All" in Visual Studio:
+- **Fix All in Document:** Fixes all IVYSERVICE001 warnings in the current file
+- **Fix All in Project:** Fixes all IVYSERVICE001 warnings in the project
+- **Fix All in Solution:** Fixes all IVYSERVICE001 warnings in the solution
+
+**Note:** The quick fix only appears when the corresponding interface (prefixed with 'I') exists in the same namespace. If no interface exists, the warning will still appear but no automatic fix will be offered.
+
 ## Configuration
 
 The analyzer runs automatically when you build your project. No additional configuration is needed.

--- a/src/Ivy.Analyser/packages.lock.json
+++ b/src/Ivy.Analyser/packages.lock.json
@@ -26,6 +26,31 @@
           "System.Threading.Tasks.Extensions": "4.6.0"
         }
       },
+      "Microsoft.CodeAnalysis.CSharp.Workspaces": {
+        "type": "Direct",
+        "requested": "[5.0.0, )",
+        "resolved": "5.0.0",
+        "contentHash": "Al/Q8B+yO8odSqGVpSvrShMFDvlQdIBU//F3E6Rb0YdiLSALE9wh/pvozPNnfmh5HDnvU+mkmSjpz4hQO++jaA==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.0",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.CSharp": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "[5.0.0]",
+          "System.Buffers": "4.6.0",
+          "System.Collections.Immutable": "9.0.0",
+          "System.Composition": "9.0.0",
+          "System.IO.Pipelines": "9.0.0",
+          "System.Memory": "4.6.0",
+          "System.Numerics.Vectors": "4.6.0",
+          "System.Reflection.Metadata": "9.0.0",
+          "System.Runtime.CompilerServices.Unsafe": "6.1.0",
+          "System.Text.Encoding.CodePages": "8.0.0",
+          "System.Threading.Channels": "8.0.0",
+          "System.Threading.Tasks.Extensions": "4.6.0"
+        }
+      },
       "NETStandard.Library": {
         "type": "Direct",
         "requested": "[2.0.3, )",
@@ -33,6 +58,19 @@
         "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.1.0"
+        }
+      },
+      "Humanizer.Core": {
+        "type": "Transitive",
+        "resolved": "2.14.1",
+        "contentHash": "lQKvtaTDOXnoVJ20ibTuSIOf2i0uO0MPbDhd1jm238I+U/2ZnRENj0cktKZhtchBMtCUSRQ5v4xBCUbKNmyVMw=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "owmu2Cr3IQ8yQiBleBHlGk8dSQ12oaF2e7TpzwJKEl4m84kkZJjEY1n33L67Y3zM5jPOjmmbdHjbfiL0RqcMRQ==",
+        "dependencies": {
+          "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
       "Microsoft.CodeAnalysis.Common": {
@@ -48,6 +86,28 @@
           "System.Reflection.Metadata": "9.0.0",
           "System.Runtime.CompilerServices.Unsafe": "6.1.0",
           "System.Text.Encoding.CodePages": "8.0.0",
+          "System.Threading.Tasks.Extensions": "4.6.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.Workspaces.Common": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "ZbUmIvT6lqTNKiv06Jl5wf0MTMi1vQ1oH7ou4CLcs2C/no/L7EhP3T8y3XXvn9VbqMcJaJnEsNA1jwYUMgc5jg==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.0",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
+          "System.Buffers": "4.6.0",
+          "System.Collections.Immutable": "9.0.0",
+          "System.Composition": "9.0.0",
+          "System.IO.Pipelines": "9.0.0",
+          "System.Memory": "4.6.0",
+          "System.Numerics.Vectors": "4.6.0",
+          "System.Reflection.Metadata": "9.0.0",
+          "System.Runtime.CompilerServices.Unsafe": "6.1.0",
+          "System.Text.Encoding.CodePages": "8.0.0",
+          "System.Threading.Channels": "8.0.0",
           "System.Threading.Tasks.Extensions": "4.6.0"
         }
       },
@@ -68,6 +128,64 @@
         "dependencies": {
           "System.Memory": "4.5.5",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
+      "System.Composition": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "3Djj70fFTraOarSKmRnmRy/zm4YurICm+kiCtI0dYRqGJnLX6nJ+G3WYuFJ173cAPax/gh96REcbNiVqcrypFQ==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "9.0.0",
+          "System.Composition.Convention": "9.0.0",
+          "System.Composition.Hosting": "9.0.0",
+          "System.Composition.Runtime": "9.0.0",
+          "System.Composition.TypedParts": "9.0.0"
+        }
+      },
+      "System.Composition.AttributedModel": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "iri00l/zIX9g4lHMY+Nz0qV1n40+jFYAmgsaiNn16xvt2RDwlqByNG4wgblagnDYxm3YSQQ0jLlC/7Xlk9CzyA=="
+      },
+      "System.Composition.Convention": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "+vuqVP6xpi582XIjJi6OCsIxuoTZfR0M7WWufk3uGDeCl3wGW6KnpylUJ3iiXdPByPE0vR5TjJgR6hDLez4FQg==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "9.0.0"
+        }
+      },
+      "System.Composition.Hosting": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "OFqSeFeJYr7kHxDfaViGM1ymk7d4JxK//VSoNF9Ux0gpqkLsauDZpu89kTHHNdCWfSljbFcvAafGyBoY094btQ==",
+        "dependencies": {
+          "System.Composition.Runtime": "9.0.0"
+        }
+      },
+      "System.Composition.Runtime": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "w1HOlQY1zsOWYussjFGZCEYF2UZXgvoYnS94NIu2CBnAGMbXFAX8PY8c92KwUItPmowal68jnVLBCzdrWLeEKA=="
+      },
+      "System.Composition.TypedParts": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "aRZlojCCGEHDKqh43jaDgaVpYETsgd7Nx4g1zwLKMtv4iTo0627715ajEFNpEEBTgLmvZuv8K0EVxc3sM4NWJA==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "9.0.0",
+          "System.Composition.Hosting": "9.0.0",
+          "System.Composition.Runtime": "9.0.0"
+        }
+      },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "eA3cinogwaNB4jdjQHOP3Z3EuyiDII7MT35jgtnsA4vkn0LUrrSHsU0nzHTzFzmaFYeKV7MYyMxOocFzsBHpTw==",
+        "dependencies": {
+          "System.Buffers": "4.5.1",
+          "System.Memory": "4.5.5",
+          "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
       "System.Memory": {
@@ -106,6 +224,14 @@
         "dependencies": {
           "System.Memory": "4.5.5",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
+      "System.Threading.Channels": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "CMaFr7v+57RW7uZfZkPExsPB6ljwzhjACWW1gfU35Y56rk72B/Wu+sTqxVmGSk4SFUlPc3cjeKND0zktziyjBA==",
+        "dependencies": {
+          "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
       "System.Threading.Tasks.Extensions": {


### PR DESCRIPTION
# Summary

## Changes

Added a Roslyn CodeFixProvider (`UseServiceInterfaceCodeFixProvider`) for the IVYSERVICE001 analyzer that offers a one-click quick fix to replace concrete types with their interfaces in `UseService<T>()` calls. Created a new test project (`Ivy.Analyser.Tests`) with 4 tests, and documented the quick fix in the analyzer README.

## API Changes

- **New class:** `Ivy.Analyser.Analyzers.UseServiceInterfaceCodeFixProvider` — CodeFixProvider that registers with diagnostic ID `IVYSERVICE001` and offers "Use interface I{ConcreteType}" code action
- **Modified:** `Ivy.Analyser.csproj` — added `Microsoft.CodeAnalysis.CSharp.Workspaces` package reference and suppressed `RS1038` warning
- **New project:** `Ivy.Analyser.Tests` — test project for analyzer and code fix testing

## Files Modified

**New files:**
- `src/Ivy.Analyser/Analyzers/UseServiceInterfaceCodeFixProvider.cs` — the CodeFixProvider implementation
- `src/Ivy.Analyser.Tests/Ivy.Analyser.Tests.csproj` — test project definition
- `src/Ivy.Analyser.Tests/UseServiceInterfaceCodeFixProviderTests.cs` — 4 test cases
- `src/Ivy.Analyser.Tests/CSharpCodeFixVerifier.cs` — custom test verifier helper

**Modified files:**
- `src/Ivy.Analyser/Ivy.Analyser.csproj` — added Workspaces package, suppressed RS1038
- `src/Ivy.Analyser/README.md` — added Quick Fix documentation section
- `src/Ivy-Framework.slnx` — added Ivy.Analyser and Ivy.Analyser.Tests projects

## Commits

- 999c676e4 [01977] Add CodeFixProvider for IVYSERVICE001 analyzer
- 8f12f696f Merge pull request #3316 from Ivy-Interactive/plan-01230-Ivy-Framework
- 683ef0b3f [01230] Add convertToHex test for theme color lookup path