### PR TITLE
[01982] Add InitialPrompt to UpsertPlanInternal INSERT/UPDATE statement

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/ContentViewTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/ContentViewTests.cs
@@ -8,7 +8,7 @@ public class ContentViewTests
     {
         var metadata = new PlanMetadata(
             1, "Test", "Bug", "Test Plan", PlanStatus.Failed,
-            [], [], [], [], [], [], DateTime.UtcNow, DateTime.UtcNow);
+            [], [], [], [], [], [], DateTime.UtcNow, DateTime.UtcNow, null);
         return new PlanFile(metadata, "", folderPath, "");
     }
 

--- a/src/tendril/Ivy.Tendril.Test/PlanDatabaseServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/PlanDatabaseServiceTests.cs
@@ -39,7 +39,8 @@ public class PlanDatabaseServiceTests : IDisposable
             new List<string>(),
             new List<string>(),
             DateTime.UtcNow.AddDays(-1),
-            DateTime.UtcNow
+            DateTime.UtcNow,
+            null
         );
 
         return new PlanFile(

--- a/src/tendril/Ivy.Tendril.Test/PlanDownloadHelperTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/PlanDownloadHelperTests.cs
@@ -57,7 +57,7 @@ public class PlanDownloadHelperTests
             await Task.Delay(100);
 
             ctx.Reset();
-            var metadata = new PlanMetadata(1, "Test", "Test", "Test Plan", PlanStatus.Draft, [], [], [], [], [], [], DateTime.UtcNow, DateTime.UtcNow);
+            var metadata = new PlanMetadata(1, "Test", "Test", "Test Plan", PlanStatus.Draft, [], [], [], [], [], [], DateTime.UtcNow, DateTime.UtcNow, null);
             var testPlan = new PlanFile(metadata, "", Path.Combine(tempDir, "00001-TestPlan"), "");
 
             PlanDownloadHelper.UsePlanDownload(ctx, planService, testPlan);
@@ -84,7 +84,7 @@ public class PlanDownloadHelperTests
             var planService = ctx.UseService<PlanReaderService>();
 
             // First render with plan 1
-            var metadata1 = new PlanMetadata(1, "Test", "Test", "Test Plan", PlanStatus.Draft, [], [], [], [], [], [], DateTime.UtcNow, DateTime.UtcNow);
+            var metadata1 = new PlanMetadata(1, "Test", "Test", "Test Plan", PlanStatus.Draft, [], [], [], [], [], [], DateTime.UtcNow, DateTime.UtcNow, null);
             var plan1 = new PlanFile(metadata1, "", Path.Combine(tempDir, "00001-TestPlan"), "");
             PlanDownloadHelper.UsePlanDownload(ctx, planService, plan1);
 
@@ -93,7 +93,7 @@ public class PlanDownloadHelperTests
 
             // Second render with plan 2
             ctx.Reset();
-            var metadata2 = new PlanMetadata(2, "Test", "Test", "Other Plan", PlanStatus.Draft, [], [], [], [], [], [], DateTime.UtcNow, DateTime.UtcNow);
+            var metadata2 = new PlanMetadata(2, "Test", "Test", "Other Plan", PlanStatus.Draft, [], [], [], [], [], [], DateTime.UtcNow, DateTime.UtcNow, null);
             var plan2 = new PlanFile(metadata2, "", Path.Combine(tempDir, "00002-OtherPlan"), "");
             PlanDownloadHelper.UsePlanDownload(ctx, planService, plan2);
 
@@ -140,7 +140,7 @@ public class PlanDownloadHelperTests
         try
         {
             var planService = ctx.UseService<PlanReaderService>();
-            var metadata = new PlanMetadata(1, "Test", "Test", "Test Plan", PlanStatus.Draft, [], [], [], [], [], [], DateTime.UtcNow, DateTime.UtcNow);
+            var metadata = new PlanMetadata(1, "Test", "Test", "Test Plan", PlanStatus.Draft, [], [], [], [], [], [], DateTime.UtcNow, DateTime.UtcNow, null);
             var testPlan = new PlanFile(metadata, "", Path.Combine(tempDir, "00001-TestPlan"), "");
 
             var result = PlanDownloadHelper.UsePlanDownload(ctx, planService, testPlan);

--- a/src/tendril/Ivy.Tendril/Apps/Plans/Models.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Plans/Models.cs
@@ -13,7 +13,7 @@ public enum PlanStatus
     Icebox
 }
 
-public record PlanMetadata(int Id, string Project, string Level, string Title, PlanStatus State, List<string> Repos, List<string> Commits, List<string> Prs, List<PlanVerificationEntry> Verifications, List<string> RelatedPlans, List<string> DependsOn, DateTime Created, DateTime Updated);
+public record PlanMetadata(int Id, string Project, string Level, string Title, PlanStatus State, List<string> Repos, List<string> Commits, List<string> Prs, List<PlanVerificationEntry> Verifications, List<string> RelatedPlans, List<string> DependsOn, DateTime Created, DateTime Updated, string? InitialPrompt);
 
 public record PlanFile(
     PlanMetadata Metadata,
@@ -36,6 +36,7 @@ public record PlanFile(
     public List<string> DependsOn => Metadata.DependsOn;
     public DateTime Created => Metadata.Created;
     public DateTime Updated => Metadata.Updated;
+    public string? InitialPrompt => Metadata.InitialPrompt;
     public string FolderName => Path.GetFileName(FolderPath);
 }
 

--- a/src/tendril/Ivy.Tendril/Apps/Plans/PlanYaml.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Plans/PlanYaml.cs
@@ -20,4 +20,5 @@ public class PlanYaml
     public List<PlanVerificationEntry> Verifications { get; set; } = new();
     public List<string> RelatedPlans { get; set; } = new();
     public List<string> DependsOn { get; set; } = new();
+    public string? InitialPrompt { get; set; }
 }

--- a/src/tendril/Ivy.Tendril/Services/PlanDatabaseService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanDatabaseService.cs
@@ -71,7 +71,7 @@ public class PlanDatabaseService : IPlanDatabaseService, IDisposable
         {
             var sql = """
                 SELECT Id, Title, Project, Level, State, FolderPath, FolderName,
-                       YamlRaw, RevisionCount, LatestRevisionContent, Created, Updated
+                       YamlRaw, RevisionCount, LatestRevisionContent, Created, Updated, InitialPrompt
                 FROM Plans
                 """;
 
@@ -92,7 +92,7 @@ public class PlanDatabaseService : IPlanDatabaseService, IDisposable
             using var reader = cmd.ExecuteReader();
             var rawPlans = new List<(int Id, string Title, string Project, string Level, string State,
                 string FolderPath, string FolderName, string YamlRaw, int RevisionCount,
-                string LatestContent, string Created, string Updated)>();
+                string LatestContent, string Created, string Updated, string? InitialPrompt)>();
 
             while (reader.Read())
             {
@@ -100,7 +100,8 @@ public class PlanDatabaseService : IPlanDatabaseService, IDisposable
                 planIds.Add(planId);
                 rawPlans.Add((planId, reader.GetString(1), reader.GetString(2), reader.GetString(3),
                     reader.GetString(4), reader.GetString(5), reader.GetString(6), reader.GetString(7),
-                    reader.GetInt32(8), reader.GetString(9), reader.GetString(10), reader.GetString(11)));
+                    reader.GetInt32(8), reader.GetString(9), reader.GetString(10), reader.GetString(11),
+                    reader.IsDBNull(12) ? null : reader.GetString(12)));
             }
 
             if (rawPlans.Count == 0)
@@ -117,7 +118,7 @@ public class PlanDatabaseService : IPlanDatabaseService, IDisposable
             {
                 var plan = BuildPlanFileFromRow(row.Id, row.Title, row.Project, row.Level, row.State,
                     row.FolderPath, row.FolderName, row.YamlRaw, row.RevisionCount, row.LatestContent,
-                    row.Created, row.Updated,
+                    row.Created, row.Updated, row.InitialPrompt,
                     allRepos.GetValueOrDefault(row.Id, []),
                     allCommits.GetValueOrDefault(row.Id, []),
                     allPrs.GetValueOrDefault(row.Id, []),
@@ -139,7 +140,7 @@ public class PlanDatabaseService : IPlanDatabaseService, IDisposable
             using var cmd = _connection.CreateCommand();
             cmd.CommandText = """
                 SELECT Id, Title, Project, Level, State, FolderPath, FolderName,
-                       YamlRaw, RevisionCount, LatestRevisionContent, Created, Updated
+                       YamlRaw, RevisionCount, LatestRevisionContent, Created, Updated, InitialPrompt
                 FROM Plans WHERE FolderPath = @folderPath
                 """;
             cmd.Parameters.AddWithValue("@folderPath", folderPath);
@@ -159,7 +160,7 @@ public class PlanDatabaseService : IPlanDatabaseService, IDisposable
             using var cmd = _connection.CreateCommand();
             cmd.CommandText = """
                 SELECT Id, Title, Project, Level, State, FolderPath, FolderName,
-                       YamlRaw, RevisionCount, LatestRevisionContent, Created, Updated
+                       YamlRaw, RevisionCount, LatestRevisionContent, Created, Updated, InitialPrompt
                 FROM Plans WHERE Id = @id
                 """;
             cmd.Parameters.AddWithValue("@id", planId);
@@ -183,6 +184,7 @@ public class PlanDatabaseService : IPlanDatabaseService, IDisposable
             reader.GetString(1), reader.GetString(2), reader.GetString(3), reader.GetString(4),
             reader.GetString(5), reader.GetString(6), reader.GetString(7), reader.GetInt32(8),
             reader.GetString(9), reader.GetString(10), reader.GetString(11),
+            reader.IsDBNull(12) ? null : reader.GetString(12),
             GetListForPlan(planId, "Repos", "RepoPath"),
             GetListForPlan(planId, "Commits", "CommitHash"),
             GetListForPlan(planId, "PullRequests", "PrUrl"),
@@ -193,7 +195,7 @@ public class PlanDatabaseService : IPlanDatabaseService, IDisposable
 
     private static PlanFile? BuildPlanFileFromRow(int planId, string title, string project, string level,
         string state, string folderPath, string folderName, string yamlRaw, int revisionCount,
-        string latestContent, string createdStr, string updatedStr,
+        string latestContent, string createdStr, string updatedStr, string? initialPrompt,
         List<string> repos, List<string> commits, List<string> prs,
         List<PlanVerificationEntry> verifications, List<string> relatedPlans, List<string> dependsOn)
     {
@@ -204,7 +206,7 @@ public class PlanDatabaseService : IPlanDatabaseService, IDisposable
         var updated = DateTime.Parse(updatedStr, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal);
 
         var metadata = new PlanMetadata(planId, project, level, title, status,
-            repos, commits, prs, verifications, relatedPlans, dependsOn, created, updated);
+            repos, commits, prs, verifications, relatedPlans, dependsOn, created, updated, initialPrompt);
 
         return new PlanFile(metadata, latestContent, folderPath, yamlRaw, revisionCount);
     }
@@ -437,7 +439,7 @@ public class PlanDatabaseService : IPlanDatabaseService, IDisposable
             using var ftsCmd = _connection.CreateCommand();
             ftsCmd.CommandText = """
                 SELECT p.Id, p.Title, p.Project, p.Level, p.State, p.FolderPath, p.FolderName,
-                       p.YamlRaw, p.RevisionCount, p.LatestRevisionContent, p.Created, p.Updated
+                       p.YamlRaw, p.RevisionCount, p.LatestRevisionContent, p.Created, p.Updated, p.InitialPrompt
                 FROM Plans p
                 INNER JOIN PlanSearch fts ON fts.rowid = p.Id
                 WHERE PlanSearch MATCH @query
@@ -454,7 +456,7 @@ public class PlanDatabaseService : IPlanDatabaseService, IDisposable
                 using var likeCmd = _connection.CreateCommand();
                 likeCmd.CommandText = """
                     SELECT Id, Title, Project, Level, State, FolderPath, FolderName,
-                           YamlRaw, RevisionCount, LatestRevisionContent, Created, Updated
+                           YamlRaw, RevisionCount, LatestRevisionContent, Created, Updated, InitialPrompt
                     FROM Plans
                     WHERE Title LIKE @search OR LatestRevisionContent LIKE @search
                           OR CAST(Id AS TEXT) LIKE @search OR Project LIKE @search
@@ -473,7 +475,7 @@ public class PlanDatabaseService : IPlanDatabaseService, IDisposable
         var planIds = new List<int>();
         var rawPlans = new List<(int Id, string Title, string Project, string Level, string State,
             string FolderPath, string FolderName, string YamlRaw, int RevisionCount,
-            string LatestContent, string Created, string Updated)>();
+            string LatestContent, string Created, string Updated, string? InitialPrompt)>();
 
         using var reader = cmd.ExecuteReader();
         while (reader.Read())
@@ -482,7 +484,8 @@ public class PlanDatabaseService : IPlanDatabaseService, IDisposable
             planIds.Add(planId);
             rawPlans.Add((planId, reader.GetString(1), reader.GetString(2), reader.GetString(3),
                 reader.GetString(4), reader.GetString(5), reader.GetString(6), reader.GetString(7),
-                reader.GetInt32(8), reader.GetString(9), reader.GetString(10), reader.GetString(11)));
+                reader.GetInt32(8), reader.GetString(9), reader.GetString(10), reader.GetString(11),
+                reader.IsDBNull(12) ? null : reader.GetString(12)));
         }
 
         if (rawPlans.Count == 0)
@@ -500,7 +503,7 @@ public class PlanDatabaseService : IPlanDatabaseService, IDisposable
         {
             var plan = BuildPlanFileFromRow(row.Id, row.Title, row.Project, row.Level, row.State,
                 row.FolderPath, row.FolderName, row.YamlRaw, row.RevisionCount, row.LatestContent,
-                row.Created, row.Updated,
+                row.Created, row.Updated, row.InitialPrompt,
                 allRepos.GetValueOrDefault(row.Id, []),
                 allCommits.GetValueOrDefault(row.Id, []),
                 allPrs.GetValueOrDefault(row.Id, []),
@@ -537,9 +540,9 @@ public class PlanDatabaseService : IPlanDatabaseService, IDisposable
         using var cmd = _connection.CreateCommand();
         cmd.CommandText = """
             INSERT INTO Plans (Id, Title, Project, Level, State, FolderPath, FolderName,
-                               YamlRaw, RevisionCount, LatestRevisionContent, Created, Updated)
+                               YamlRaw, RevisionCount, LatestRevisionContent, Created, Updated, InitialPrompt)
             VALUES (@id, @title, @project, @level, @state, @folderPath, @folderName,
-                    @yamlRaw, @revisionCount, @latestContent, @created, @updated)
+                    @yamlRaw, @revisionCount, @latestContent, @created, @updated, @initialPrompt)
             ON CONFLICT(Id) DO UPDATE SET
                 Title = excluded.Title,
                 Project = excluded.Project,
@@ -551,7 +554,8 @@ public class PlanDatabaseService : IPlanDatabaseService, IDisposable
                 RevisionCount = excluded.RevisionCount,
                 LatestRevisionContent = excluded.LatestRevisionContent,
                 Created = excluded.Created,
-                Updated = excluded.Updated
+                Updated = excluded.Updated,
+                InitialPrompt = excluded.InitialPrompt
             WHERE excluded.Updated >= Plans.Updated
             """;
 
@@ -567,6 +571,7 @@ public class PlanDatabaseService : IPlanDatabaseService, IDisposable
         cmd.Parameters.AddWithValue("@latestContent", plan.LatestRevisionContent);
         cmd.Parameters.AddWithValue("@created", plan.Created.ToString("O", CultureInfo.InvariantCulture));
         cmd.Parameters.AddWithValue("@updated", plan.Updated.ToString("O", CultureInfo.InvariantCulture));
+        cmd.Parameters.AddWithValue("@initialPrompt", plan.InitialPrompt ?? (object)DBNull.Value);
 
         cmd.ExecuteNonQuery();
 

--- a/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
@@ -537,7 +537,7 @@ public class PlanReaderService(IConfigService config, ILogger<PlanReaderService>
             if (!Enum.TryParse<PlanStatus>(planYaml.State, ignoreCase: true, out var status))
                 status = PlanStatus.Draft;
 
-            var metadata = new PlanMetadata(id, planYaml.Project ?? "", planYaml.Level ?? "NiceToHave", planYaml.Title ?? "", status, planYaml.Repos ?? new(), planYaml.Commits ?? new(), planYaml.Prs ?? new(), planYaml.Verifications ?? new(), planYaml.RelatedPlans ?? new(), planYaml.DependsOn ?? new(), planYaml.Created, planYaml.Updated);
+            var metadata = new PlanMetadata(id, planYaml.Project ?? "", planYaml.Level ?? "NiceToHave", planYaml.Title ?? "", status, planYaml.Repos ?? new(), planYaml.Commits ?? new(), planYaml.Prs ?? new(), planYaml.Verifications ?? new(), planYaml.RelatedPlans ?? new(), planYaml.DependsOn ?? new(), planYaml.Created, planYaml.Updated, planYaml.InitialPrompt);
             var latestContent = ReadLatestRevisionFromFileSystem(folderName);
 
             var revisionsDir = Path.Combine(folderPath, "revisions");


### PR DESCRIPTION
# Summary

## Changes

Added `InitialPrompt` to the full plan data flow so that the `initialPrompt` field from `plan.yaml` is stored in the SQLite database and available for FTS5 full-text search indexing. Also resolved pre-existing merge conflict markers in `PlanDatabaseService.SearchPlans`.

## API Changes

- `PlanMetadata` record: added `string? InitialPrompt` as last positional parameter
- `PlanFile` record: added `string? InitialPrompt` computed property
- `PlanYaml` class: added `string? InitialPrompt` property
- `PlanDatabaseService.UpsertPlanInternal`: now includes `InitialPrompt` in INSERT/UPDATE SQL
- `PlanDatabaseService.BuildPlanFileFromRow`: added `string? initialPrompt` parameter
- All SELECT queries (`GetPlans`, `GetPlanByFolder`, `GetPlanById`, `SearchPlans`): now include `InitialPrompt` column

## Files Modified

- **Models**: `src/tendril/Ivy.Tendril/Apps/Plans/Models.cs` — PlanMetadata and PlanFile
- **YAML model**: `src/tendril/Ivy.Tendril/Apps/Plans/PlanYaml.cs` — PlanYaml class
- **Database service**: `src/tendril/Ivy.Tendril/Services/PlanDatabaseService.cs` — Upsert, queries, row builder
- **Reader service**: `src/tendril/Ivy.Tendril/Services/PlanReaderService.cs` — ParsePlanFolder
- **Tests**: `ContentViewTests.cs`, `PlanDatabaseServiceTests.cs`, `PlanDownloadHelperTests.cs` — constructor updates

## Commits

- b80b736d2 [01982] Add InitialPrompt to UpsertPlanInternal and full data flow