### PR TITLE
[01225] Add slim-scrollbar to multiselect and icon input popovers

### DIFF
--- a/src/frontend/src/components/ui/input/icon-input-variant.ts
+++ b/src/frontend/src/components/ui/input/icon-input-variant.ts
@@ -55,7 +55,7 @@ export const iconInputPopoverVariant = cva("p-0", {
   },
 });
 
-export const iconInputPopoverScrollVariant = cva("overflow-auto", {
+export const iconInputPopoverScrollVariant = cva("overflow-auto slim-scrollbar", {
   variants: {
     density: {
       Small: "h-[240px]",

--- a/src/frontend/src/components/ui/multiselect.tsx
+++ b/src/frontend/src/components/ui/multiselect.tsx
@@ -285,7 +285,10 @@ const MultipleSelector = React.forwardRef<
     const handleBulkSelectAll = React.useCallback(() => {
       const merged = computeSelectAllValues(
         selectedValueStrings,
-        visibleEnabledForBulk.map((o) => ({ value: o.value, disabled: !!o.disable })),
+        visibleEnabledForBulk.map((o) => ({
+          value: o.value,
+          disabled: !!o.disable,
+        })),
         maxSelections,
       );
       const newOptions: Option[] = merged.map((v) => {
@@ -503,7 +506,7 @@ const MultipleSelector = React.forwardRef<
             >
               {defaultOptions.length > 0 ? (
                 <>
-                  <CommandGroup className="h-full overflow-auto max-h-[300px]">
+                  <CommandGroup className="h-full overflow-auto max-h-[300px] slim-scrollbar">
                     {defaultOptions.map((option) => {
                       const selected = isSelected(option);
                       return (


### PR DESCRIPTION
## Summary

Added the `slim-scrollbar` CSS class to two compact popup containers: the multiselect dropdown option list in `multiselect.tsx` and the icon picker popover grid in `icon-input-variant.ts`. This completes the slim-scrollbar audit for bounded popup/popover containers.

## API Changes

None.

## Files Modified

- **Frontend components:**
  - `src/frontend/src/components/ui/multiselect.tsx` — Added `slim-scrollbar` to `<CommandGroup>` className
  - `src/frontend/src/components/ui/input/icon-input-variant.ts` — Added `slim-scrollbar` to `iconInputPopoverScrollVariant` cva base class

## Commits

- e0e88510b [01225] Add slim-scrollbar to multiselect and icon input popovers