### PR TITLE
[01991] Apply StackedProgress colors to JobsApp status badges

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/JobsApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/JobsApp.cs
@@ -91,7 +91,20 @@ public class JobsApp : ViewBase
             .Width(t => t.LastOutput, Size.Px(90))
             .Width(t => t.Cost, Size.Px(80))
             .Width(t => t.StatusMessage, Size.Auto())
-            .Renderer(t => t.Status, new LabelsDisplayRenderer())
+            .Renderer(t => t.Status, new LabelsDisplayRenderer
+            {
+                BadgeColorMapping = new Dictionary<string, string>
+                {
+                    ["Running"] = "Blue",
+                    ["Completed"] = "Green",
+                    ["Failed"] = "Red",
+                    ["Timeout"] = "Red",
+                    ["Queued"] = "Amber",
+                    ["Pending"] = "Amber",
+                    ["Stopped"] = "Gray",
+                    ["Blocked"] = "Orange"
+                }
+            })
             .Renderer(t => t.PlanId, new LinkDisplayRenderer())
             .Hidden(t => t.Id)
             .Hidden(t => t.LastOutputTimestamp)


### PR DESCRIPTION
# Summary

## Changes

Added `BadgeColorMapping` to the JobsApp DataTable's Status column renderer, so status badges now display with the same colors as the StackedProgress bar (Running=Blue, Completed=Green, Failed/Timeout=Red, Queued/Pending=Amber, Stopped=Gray, Blocked=Orange).

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/Apps/JobsApp.cs** — Updated `LabelsDisplayRenderer` initialization for the Status column to include `BadgeColorMapping` dictionary

---

## Commits

- 5764fff1e [01991] Apply StackedProgress colors to JobsApp status badges