### PR TITLE
[01993] Add CodeFixProviders for additional analyzers

### DIFF
--- a/src/Ivy.Analyser.Test/AppConstructorCodeFixProviderTests.cs
+++ b/src/Ivy.Analyser.Test/AppConstructorCodeFixProviderTests.cs
@@ -1,0 +1,163 @@
+using System.Threading.Tasks;
+using Xunit;
+
+using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.CSharpCodeFixVerifier<
+    Ivy.Analyser.Analyzers.AppConstructorAnalyzer,
+    Ivy.Analyser.Analyzers.AppConstructorCodeFixProvider,
+    Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
+
+namespace Ivy.Analyser.Test
+{
+    public class AppConstructorCodeFixProviderTests
+    {
+        [Fact]
+        public async Task CodeFix_AddsParameterlessConstructor_ToAppWithParameterizedConstructor()
+        {
+            const string testCode = @"
+namespace Ivy
+{
+    [System.AttributeUsage(System.AttributeTargets.Class)]
+    public class AppAttribute : System.Attribute { }
+}
+
+namespace TestNamespace
+{
+    [Ivy.App]
+    public class {|#0:MyApp|}
+    {
+        public MyApp(string param) { }
+
+        public object Build() => null;
+    }
+}";
+
+            const string fixedCode = @"
+namespace Ivy
+{
+    [System.AttributeUsage(System.AttributeTargets.Class)]
+    public class AppAttribute : System.Attribute { }
+}
+
+namespace TestNamespace
+{
+    [Ivy.App]
+    public class MyApp
+    {
+        public MyApp()
+        {
+        }
+
+        public MyApp(string param) { }
+
+        public object Build() => null;
+    }
+}";
+
+            var expected = Verifier.Diagnostic(Analyzers.AppConstructorAnalyzer.DiagnosticId)
+                .WithLocation(0)
+                .WithArguments("MyApp");
+
+            await Verifier.VerifyCodeFixAsync(testCode, expected, fixedCode);
+        }
+
+        [Fact]
+        public async Task CodeFix_AddsConstructor_BetweenFieldsAndMethods()
+        {
+            const string testCode = @"
+namespace Ivy
+{
+    [System.AttributeUsage(System.AttributeTargets.Class)]
+    public class AppAttribute : System.Attribute { }
+}
+
+namespace TestNamespace
+{
+    [Ivy.App]
+    public class {|#0:MyApp|}
+    {
+        private int _field = 0;
+
+        public MyApp(int value) { _field = value; }
+
+        public object Build() => null;
+    }
+}";
+
+            const string fixedCode = @"
+namespace Ivy
+{
+    [System.AttributeUsage(System.AttributeTargets.Class)]
+    public class AppAttribute : System.Attribute { }
+}
+
+namespace TestNamespace
+{
+    [Ivy.App]
+    public class MyApp
+    {
+        private int _field = 0;
+
+        public MyApp()
+        {
+        }
+
+        public MyApp(int value) { _field = value; }
+
+        public object Build() => null;
+    }
+}";
+
+            var expected = Verifier.Diagnostic(Analyzers.AppConstructorAnalyzer.DiagnosticId)
+                .WithLocation(0)
+                .WithArguments("MyApp");
+
+            await Verifier.VerifyCodeFixAsync(testCode, expected, fixedCode);
+        }
+
+        [Fact]
+        public async Task CodeFix_HandlesClassWithOnlyConstructor()
+        {
+            const string testCode = @"
+namespace Ivy
+{
+    [System.AttributeUsage(System.AttributeTargets.Class)]
+    public class AppAttribute : System.Attribute { }
+}
+
+namespace TestNamespace
+{
+    [Ivy.App]
+    public class {|#0:MyApp|}
+    {
+        public MyApp(string param) { }
+    }
+}";
+
+            const string fixedCode = @"
+namespace Ivy
+{
+    [System.AttributeUsage(System.AttributeTargets.Class)]
+    public class AppAttribute : System.Attribute { }
+}
+
+namespace TestNamespace
+{
+    [Ivy.App]
+    public class MyApp
+    {
+        public MyApp()
+        {
+        }
+
+        public MyApp(string param) { }
+    }
+}";
+
+            var expected = Verifier.Diagnostic(Analyzers.AppConstructorAnalyzer.DiagnosticId)
+                .WithLocation(0)
+                .WithArguments("MyApp");
+
+            await Verifier.VerifyCodeFixAsync(testCode, expected, fixedCode);
+        }
+    }
+}

--- a/src/Ivy.Analyser.Test/HookUsageAnalyzerTests.cs
+++ b/src/Ivy.Analyser.Test/HookUsageAnalyzerTests.cs
@@ -1,5 +1,4 @@
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.AnalyzerVerifier<
     Ivy.Analyser.Analyzers.HookUsageAnalyzer>;

--- a/src/Ivy.Analyser.Test/HookUsageInlineCodeFixProviderTests.cs
+++ b/src/Ivy.Analyser.Test/HookUsageInlineCodeFixProviderTests.cs
@@ -1,0 +1,140 @@
+using System.Threading.Tasks;
+using Xunit;
+
+using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.CSharpCodeFixVerifier<
+    Ivy.Analyser.Analyzers.HookUsageAnalyzer,
+    Ivy.Analyser.Analyzers.HookUsageInlineCodeFixProvider,
+    Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
+
+namespace Ivy.Analyser.Test
+{
+    public class HookUsageInlineCodeFixProviderTests
+    {
+        [Fact]
+        public async Task CodeFix_ExtractsInlineHook_ToVariable()
+        {
+            const string testCode = @"
+public class TestView
+{
+    public object Build()
+    {
+        return {|#0:UseState(0)|}.Value;
+    }
+
+    private State<T> UseState<T>(T value) => default;
+}
+
+public class State<T>
+{
+    public T Value { get; set; }
+}";
+
+            const string fixedCode = @"
+public class TestView
+{
+    public object Build()
+    {
+        var state = UseState(0);
+        return state.Value;
+    }
+
+    private State<T> UseState<T>(T value) => default;
+}
+
+public class State<T>
+{
+    public T Value { get; set; }
+}";
+
+            var expected = Verifier.Diagnostic("IVYHOOK007")
+                .WithLocation(0)
+                .WithArguments("UseState");
+
+            await Verifier.VerifyCodeFixAsync(testCode, expected, fixedCode);
+        }
+
+        [Fact]
+        public async Task CodeFix_ExtractsHook_FromArgument()
+        {
+            const string testCode = @"
+public class TestView
+{
+    public object Build()
+    {
+        return CreateWidget({|#0:UseEffect(42)|});
+    }
+
+    private object CreateWidget(object widget) => widget;
+    private object UseEffect(int value) => null;
+}";
+
+            const string fixedCode = @"
+public class TestView
+{
+    public object Build()
+    {
+        var effect = UseEffect(42);
+        return CreateWidget(effect);
+    }
+
+    private object CreateWidget(object widget) => widget;
+    private object UseEffect(int value) => null;
+}";
+
+            var expected = Verifier.Diagnostic("IVYHOOK007")
+                .WithLocation(0)
+                .WithArguments("UseEffect");
+
+            await Verifier.VerifyCodeFixAsync(testCode, expected, fixedCode);
+        }
+
+        [Fact]
+        public async Task CodeFix_GeneratesUniqueVariableName_WhenConflict()
+        {
+            const string testCode = @"
+public class TestView
+{
+    public object Build()
+    {
+        var state = UseState(""existing"");
+        return {|#0:UseState(0)|}.Value;
+    }
+
+    private State<T> UseState<T>(T value) => default;
+}
+
+public class State<T>
+{
+    public T Value { get; set; }
+}";
+
+            const string fixedCode = @"
+public class TestView
+{
+    public object Build()
+    {
+        var state2 = UseState(0);
+        var state = UseState(""existing"");
+        return state2.Value;
+    }
+
+    private State<T> UseState<T>(T value) => default;
+}
+
+public class State<T>
+{
+    public T Value { get; set; }
+}";
+
+            // The second UseState call triggers both IVYHOOK005 (not at top) and IVYHOOK007 (inline)
+            var expected = new[]
+            {
+                Verifier.Diagnostic("IVYHOOK007")
+                    .WithLocation(0)
+                    .WithArguments("UseState"),
+            };
+
+            await Verifier.VerifyCodeFixAsync(testCode, expected, fixedCode);
+        }
+    }
+}

--- a/src/Ivy.Analyser/Analyzers/AppConstructorCodeFixProvider.cs
+++ b/src/Ivy.Analyser/Analyzers/AppConstructorCodeFixProvider.cs
@@ -1,0 +1,144 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Ivy.Analyser.Analyzers
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AppConstructorCodeFixProvider)), Shared]
+    public class AppConstructorCodeFixProvider : CodeFixProvider
+    {
+        private const string Title = "Add parameterless constructor";
+
+        public override ImmutableArray<string> FixableDiagnosticIds =>
+            ImmutableArray.Create(AppConstructorAnalyzer.DiagnosticId);
+
+        public override FixAllProvider GetFixAllProvider() =>
+            WellKnownFixAllProviders.BatchFixer;
+
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+            if (root == null)
+                return;
+
+            var diagnostic = context.Diagnostics.First();
+            var diagnosticSpan = diagnostic.Location.SourceSpan;
+
+            var node = root.FindNode(diagnosticSpan);
+            var classDecl = node.FirstAncestorOrSelf<ClassDeclarationSyntax>();
+            if (classDecl == null)
+                return;
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: Title,
+                    createChangedDocument: c => AddParameterlessConstructorAsync(context.Document, classDecl, c),
+                    equivalenceKey: Title),
+                diagnostic);
+        }
+
+        private static async Task<Document> AddParameterlessConstructorAsync(
+            Document document,
+            ClassDeclarationSyntax classDecl,
+            CancellationToken cancellationToken)
+        {
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            if (root == null)
+                return document;
+
+            var className = classDecl.Identifier.Text;
+            var eol = DetectLineEnding(classDecl);
+            var members = classDecl.Members;
+
+            // Find insertion point: before the first existing constructor
+            int insertIndex = 0;
+            for (int i = 0; i < members.Count; i++)
+            {
+                if (members[i] is ConstructorDeclarationSyntax)
+                {
+                    insertIndex = i;
+                    break;
+                }
+                else if (members[i] is FieldDeclarationSyntax || members[i] is PropertyDeclarationSyntax)
+                {
+                    insertIndex = i + 1;
+                }
+            }
+
+            // Determine indent from existing members
+            var indent = "        ";
+            if (members.Count > 0)
+            {
+                var refMember = insertIndex < members.Count ? members[insertIndex] : members[members.Count - 1];
+                indent = GetIndentation(refMember.GetLeadingTrivia());
+            }
+
+            // Parse constructor from string to guarantee consistent line endings
+            var ctorSource = $"public {className}(){eol}{indent}{{{eol}{indent}}}";
+            var parsed = SyntaxFactory.ParseMemberDeclaration(ctorSource);
+            if (parsed is not ConstructorDeclarationSyntax constructor)
+                return document;
+
+            // Get the member we're inserting before
+            var followingMember = insertIndex < members.Count ? members[insertIndex] : null;
+
+            if (followingMember != null)
+            {
+                // Take the leading trivia from the following member for the new constructor
+                constructor = constructor.WithLeadingTrivia(followingMember.GetLeadingTrivia());
+
+                // Give the following member a blank-line-separated leading trivia
+                var newFollowingTrivia = SyntaxFactory.TriviaList(
+                    SyntaxFactory.EndOfLine(eol),
+                    SyntaxFactory.EndOfLine(eol),
+                    SyntaxFactory.Whitespace(indent));
+                var updatedFollowing = followingMember.WithLeadingTrivia(newFollowingTrivia);
+
+                var newMembers = members
+                    .Replace(followingMember, updatedFollowing)
+                    .Insert(insertIndex, constructor);
+
+                var newClassDecl = classDecl.WithMembers(newMembers);
+                return document.WithSyntaxRoot(root.ReplaceNode(classDecl, newClassDecl));
+            }
+            else
+            {
+                constructor = constructor.WithLeadingTrivia(
+                    SyntaxFactory.EndOfLine(eol),
+                    SyntaxFactory.Whitespace(indent));
+
+                var newClassDecl = classDecl.WithMembers(members.Insert(insertIndex, constructor));
+                return document.WithSyntaxRoot(root.ReplaceNode(classDecl, newClassDecl));
+            }
+        }
+
+        private static string DetectLineEnding(SyntaxNode node)
+        {
+            foreach (var trivia in node.DescendantTrivia())
+            {
+                if (trivia.IsKind(SyntaxKind.EndOfLineTrivia))
+                    return trivia.ToString();
+            }
+
+            return "\n";
+        }
+
+        private static string GetIndentation(SyntaxTriviaList trivia)
+        {
+            for (int i = trivia.Count - 1; i >= 0; i--)
+            {
+                if (trivia[i].IsKind(SyntaxKind.WhitespaceTrivia))
+                    return trivia[i].ToString();
+            }
+
+            return "        ";
+        }
+    }
+}

--- a/src/Ivy.Analyser/Analyzers/HookUsageInlineCodeFixProvider.cs
+++ b/src/Ivy.Analyser/Analyzers/HookUsageInlineCodeFixProvider.cs
@@ -1,0 +1,249 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Ivy.Analyser.Analyzers
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(HookUsageInlineCodeFixProvider)), Shared]
+    public class HookUsageInlineCodeFixProvider : CodeFixProvider
+    {
+        private const string Title = "Extract hook to variable";
+
+        public override ImmutableArray<string> FixableDiagnosticIds =>
+            ImmutableArray.Create(HookUsageAnalyzer.DiagnosticIdInlineExpression);
+
+        public override FixAllProvider GetFixAllProvider() =>
+            WellKnownFixAllProviders.BatchFixer;
+
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+            if (root == null)
+                return;
+
+            var diagnostic = context.Diagnostics.First();
+            var diagnosticSpan = diagnostic.Location.SourceSpan;
+
+            // Find the hook invocation at the diagnostic span
+            // Walk descendants to find the exact hook call (not an outer invocation like CreateWidget(...))
+            var node = root.FindNode(diagnosticSpan, getInnermostNodeForTie: true);
+            InvocationExpressionSyntax? invocation = null;
+
+            if (node is InvocationExpressionSyntax inv && IsHookCall(inv))
+            {
+                invocation = inv;
+            }
+            else
+            {
+                // Search descendants for the hook invocation within the diagnostic span
+                foreach (var descendant in node.DescendantNodesAndSelf())
+                {
+                    if (descendant is InvocationExpressionSyntax candidate &&
+                        candidate.Span == diagnosticSpan &&
+                        IsHookCall(candidate))
+                    {
+                        invocation = candidate;
+                        break;
+                    }
+                }
+
+                // Fallback: walk up from node to find the nearest hook invocation
+                if (invocation == null)
+                {
+                    var current = node;
+                    while (current != null)
+                    {
+                        if (current is InvocationExpressionSyntax ancestor && IsHookCall(ancestor))
+                        {
+                            invocation = ancestor;
+                            break;
+                        }
+
+                        current = current.Parent;
+                    }
+                }
+            }
+
+            if (invocation == null)
+                return;
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: Title,
+                    createChangedDocument: c => ExtractHookToVariableAsync(context.Document, invocation, c),
+                    equivalenceKey: Title),
+                diagnostic);
+        }
+
+        private static async Task<Document> ExtractHookToVariableAsync(
+            Document document,
+            InvocationExpressionSyntax invocation,
+            CancellationToken cancellationToken)
+        {
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            if (root == null)
+                return document;
+
+            var containingBlock = FindContainingBuildBlock(invocation);
+            if (containingBlock == null)
+                return document;
+
+            var hookName = GetHookMethodName(invocation);
+            var baseName = GenerateVariableName(hookName ?? "hook");
+            var variableName = EnsureUniqueName(baseName, containingBlock);
+
+            // Find the statement that contains this invocation
+            var containingStatement = invocation.Ancestors().OfType<StatementSyntax>().First();
+
+            // Create: var {name} = {hookCall};
+            var variableDeclaration = SyntaxFactory.LocalDeclarationStatement(
+                SyntaxFactory.VariableDeclaration(
+                    SyntaxFactory.IdentifierName("var"))
+                .WithVariables(
+                    SyntaxFactory.SingletonSeparatedList(
+                        SyntaxFactory.VariableDeclarator(
+                            SyntaxFactory.Identifier(variableName))
+                        .WithInitializer(
+                            SyntaxFactory.EqualsValueClause(
+                                invocation.WithoutTrivia())))))
+                .WithLeadingTrivia(containingStatement.GetLeadingTrivia())
+                .WithTrailingTrivia(SyntaxFactory.TriviaList(SyntaxFactory.EndOfLine(DetectLineEnding(containingBlock))));
+
+            // Replace the inline hook call with the variable reference
+            var identifierName = SyntaxFactory.IdentifierName(variableName);
+            var newContainingStatement = containingStatement.ReplaceNode(invocation, identifierName);
+
+            // Build new statement list: insert declaration at the TOP of Build(), replace the original
+            var statements = containingBlock.Statements;
+            var newStatements = new List<StatementSyntax>();
+
+            // Insert the declaration at position 0 (top of method)
+            newStatements.Add(variableDeclaration);
+
+            for (int i = 0; i < statements.Count; i++)
+            {
+                if (statements[i] == containingStatement)
+                {
+                    newStatements.Add(newContainingStatement);
+                }
+                else
+                {
+                    newStatements.Add(statements[i]);
+                }
+            }
+
+            var newBlock = containingBlock.WithStatements(SyntaxFactory.List(newStatements));
+            var newRoot = root.ReplaceNode(containingBlock, newBlock);
+            return document.WithSyntaxRoot(newRoot);
+        }
+
+        private static BlockSyntax? FindContainingBuildBlock(SyntaxNode node)
+        {
+            var current = node.Parent;
+            while (current != null)
+            {
+                if (current is MethodDeclarationSyntax method &&
+                    (method.Identifier.Text == "Build" || method.Identifier.Text == "BuildSample"))
+                {
+                    return method.Body;
+                }
+
+                current = current.Parent;
+            }
+
+            return null;
+        }
+
+        private static bool IsHookCall(InvocationExpressionSyntax invocation)
+        {
+            var name = GetHookMethodName(invocation);
+            return name != null && name.Length > 3 && name.StartsWith("Use") && char.IsUpper(name[3]);
+        }
+
+        private static string? GetHookMethodName(InvocationExpressionSyntax invocation)
+        {
+            if (invocation.Expression is IdentifierNameSyntax identifier)
+                return identifier.Identifier.Text;
+
+            if (invocation.Expression is GenericNameSyntax genericName)
+                return genericName.Identifier.Text;
+
+            if (invocation.Expression is MemberAccessExpressionSyntax memberAccess)
+            {
+                if (memberAccess.Name is IdentifierNameSyntax memberIdentifier)
+                    return memberIdentifier.Identifier.Text;
+
+                if (memberAccess.Name is GenericNameSyntax memberGenericName)
+                    return memberGenericName.Identifier.Text;
+            }
+
+            return null;
+        }
+
+        private static string GenerateVariableName(string hookName)
+        {
+            if (hookName.Length > 3 && hookName.StartsWith("Use") && char.IsUpper(hookName[3]))
+            {
+                var name = hookName.Substring(3);
+                return char.ToLowerInvariant(name[0]) + name.Substring(1);
+            }
+
+            return "hook";
+        }
+
+        private static string EnsureUniqueName(string baseName, BlockSyntax block)
+        {
+            var existingNames = new HashSet<string>();
+
+            foreach (var statement in block.Statements)
+            {
+                if (statement is LocalDeclarationStatementSyntax localDecl)
+                {
+                    foreach (var variable in localDecl.Declaration.Variables)
+                    {
+                        existingNames.Add(variable.Identifier.Text);
+                    }
+                }
+            }
+
+            if (block.Parent is MethodDeclarationSyntax method)
+            {
+                foreach (var param in method.ParameterList.Parameters)
+                {
+                    existingNames.Add(param.Identifier.Text);
+                }
+            }
+
+            if (!existingNames.Contains(baseName))
+                return baseName;
+
+            for (int i = 2; i < 100; i++)
+            {
+                var candidate = baseName + i;
+                if (!existingNames.Contains(candidate))
+                    return candidate;
+            }
+
+            return baseName;
+        }
+
+        private static string DetectLineEnding(SyntaxNode node)
+        {
+            foreach (var trivia in node.DescendantTrivia())
+            {
+                if (trivia.IsKind(SyntaxKind.EndOfLineTrivia))
+                    return trivia.ToString();
+            }
+
+            return "\n";
+        }
+    }
+}

--- a/src/Ivy.Analyser/README.md
+++ b/src/Ivy.Analyser/README.md
@@ -234,6 +234,84 @@ This means any custom hooks you create following the `UseX` pattern will be auto
 **Message:** `Ivy hook '{hookName}' must be called at the top of the Build() method, before any other statements.`  
 **Description:** All hooks must be called at the very top of the Build() method, before any other non-hook statements. This ensures hooks are called in a consistent order on every render.
 
+### IVYHOOK007 - Hook Called Inline in Expression (Warning)
+
+**Severity:** Warning  
+**Message:** `'{hookName}' should be assigned to a local variable at the top of the Build method, not called inline in an expression.`  
+**Description:** Hooks must be assigned to a top-level local variable or called as a standalone expression statement. Do not call hooks inline within widget construction expressions, pipe chains, constructor arguments, or return statements.
+
+#### Quick Fix
+
+The analyzer includes a CodeFixProvider that can automatically extract inline hook calls to variables.
+
+**How to use:**
+1. Place your cursor on the warning (yellow squiggle on the hook call)
+2. Trigger the quick action menu:
+   - **Visual Studio:** Press `Ctrl+.` or click the lightbulb icon
+   - **VS Code:** Press `Ctrl+.` or click the lightbulb icon
+   - **Rider:** Press `Alt+Enter` or click the lightbulb icon
+3. Select **"Extract hook to variable"** from the menu
+4. The hook call will be moved to the top of the Build() method and assigned to a variable
+
+**Example:**
+```csharp
+// Before fix:
+public override object Build()
+{
+    return new Text(UseState(0).Value.ToString());  // ⚠️ Warning IVYHOOK007
+}
+
+// After applying quick fix:
+public override object Build()
+{
+    var state = UseState(0);  // ✅ Extracted
+    return new Text(state.Value.ToString());
+}
+```
+
+**Note:** The quick fix generates variable names automatically (UseState -> state, UseEffect -> effect, etc.). If a variable with that name already exists, it will append a number (state2, state3, etc.).
+
+### IVYAPP001 - App Missing Parameterless Constructor (Error)
+
+**Severity:** Error  
+**Message:** `App '{AppName}' must have a parameterless constructor, use UseService<T>() inside Build() instead of constructor injection.`  
+**Description:** App classes are instantiated via Activator.CreateInstance and require a parameterless constructor. Use UseService<T>() inside Build() for dependency injection.
+
+#### Quick Fix
+
+The analyzer includes a CodeFixProvider that can automatically add a parameterless constructor.
+
+**How to use:**
+1. Place your cursor on the error (red squiggle on the class name)
+2. Trigger the quick action menu:
+   - **Visual Studio:** Press `Ctrl+.` or click the lightbulb/screwdriver icon
+   - **VS Code:** Press `Ctrl+.` or click the lightbulb icon
+   - **Rider:** Press `Alt+Enter` or click the lightbulb icon
+3. Select **"Add parameterless constructor"** from the menu
+4. An empty `public ClassName() { }` constructor will be added to your class
+
+**Example:**
+```csharp
+// Before fix:
+[App]
+public class MyApp  // ❌ Error IVYAPP001
+{
+    public MyApp(IConfigService config) { }
+    public override object Build() => new Text("Hello");
+}
+
+// After applying quick fix:
+[App]
+public class MyApp  // ✅ Fixed
+{
+    public MyApp() { }  // Added automatically
+    public MyApp(IConfigService config) { }
+    public override object Build() => new Text("Hello");
+}
+```
+
+**Note:** The quick fix adds an empty parameterless constructor. You'll need to manually update your code to use `UseService<T>()` inside the `Build()` method instead of constructor injection.
+
 ### IVYSERVICE001 - UseService Should Use Interface (Warning)
 
 **Severity:** Warning  


### PR DESCRIPTION
# Summary

## Changes

Added two new Roslyn CodeFixProviders to the Ivy.Analyser project: `AppConstructorCodeFixProvider` for IVYAPP001 (adds a parameterless constructor to App classes) and `HookUsageInlineCodeFixProvider` for IVYHOOK007 (extracts inline hook calls to local variables at the top of the Build method). Both providers include FixAll support and follow the existing `UseServiceInterfaceCodeFixProvider` pattern.

## API Changes

- **New class:** `Ivy.Analyser.Analyzers.AppConstructorCodeFixProvider` - CodeFixProvider for IVYAPP001
- **New class:** `Ivy.Analyser.Analyzers.HookUsageInlineCodeFixProvider` - CodeFixProvider for IVYHOOK007

## Files Modified

**New files:**
- `src/Ivy.Analyser/Analyzers/AppConstructorCodeFixProvider.cs` - IVYAPP001 code fix
- `src/Ivy.Analyser/Analyzers/HookUsageInlineCodeFixProvider.cs` - IVYHOOK007 code fix
- `src/Ivy.Analyser.Test/AppConstructorCodeFixProviderTests.cs` - 3 tests
- `src/Ivy.Analyser.Test/HookUsageInlineCodeFixProviderTests.cs` - 3 tests

**Modified files:**
- `src/Ivy.Analyser/README.md` - Added documentation for IVYAPP001 and IVYHOOK007 quick fixes

## Commits

- c6d9149db Add CodeFixProviders for IVYAPP001 and IVYHOOK007