### PR TITLE
[02001] Add FillGaps to LineChart and AreaChart builders

### DIFF
--- a/src/Ivy/Views/Charts/AreaChartView.cs
+++ b/src/Ivy/Views/Charts/AreaChartView.cs
@@ -73,6 +73,8 @@ public class AreaChartBuilder<TSource>(
     private Func<Toolbox, Toolbox>? _toolboxFactory;
     private Expression<Func<TSource, object>>? _sortSelector;
     private SortOrder _sortOrder = SortOrder.None;
+    private bool _fillGaps;
+    private object? _gapFillInterval;
     private Size? _height;
     private Size? _width;
 
@@ -98,6 +100,11 @@ public class AreaChartBuilder<TSource>(
                 var pivotBuilder = data
                     .ToPivotTable()
                     .Dimension(dimension).Measures(_measures);
+
+                if (_fillGaps)
+                {
+                    pivotBuilder = pivotBuilder.FillGaps(_gapFillInterval);
+                }
 
                 if (_sortOrder != SortOrder.None)
                 {
@@ -206,6 +213,13 @@ public class AreaChartBuilder<TSource>(
     {
         _sortOrder = order;
         _sortSelector = null;
+        return this;
+    }
+
+    public AreaChartBuilder<TSource> FillGaps(object? interval = null)
+    {
+        _fillGaps = true;
+        _gapFillInterval = interval;
         return this;
     }
 }

--- a/src/Ivy/Views/Charts/LineChartView.cs
+++ b/src/Ivy/Views/Charts/LineChartView.cs
@@ -104,6 +104,8 @@ public class LineChartBuilder<TSource>(
     private Func<Toolbox, Toolbox>? _toolboxFactory;
     private Expression<Func<TSource, object>>? _sortSelector;
     private SortOrder _sortOrder = SortOrder.None;
+    private bool _fillGaps;
+    private object? _gapFillInterval;
     private Size? _height;
     private Size? _width;
 
@@ -129,6 +131,11 @@ public class LineChartBuilder<TSource>(
                 var pivotBuilder = data
                     .ToPivotTable()
                     .Dimension(dimension).Measures(_measures).TableCalculations(_calculations);
+
+                if (_fillGaps)
+                {
+                    pivotBuilder = pivotBuilder.FillGaps(_gapFillInterval);
+                }
 
                 if (_sortOrder != SortOrder.None)
                 {
@@ -244,6 +251,13 @@ public class LineChartBuilder<TSource>(
     {
         _sortOrder = order;
         _sortSelector = null;
+        return this;
+    }
+
+    public LineChartBuilder<TSource> FillGaps(object? interval = null)
+    {
+        _fillGaps = true;
+        _gapFillInterval = interval;
         return this;
     }
 }


### PR DESCRIPTION
# Summary

## Changes

Added `FillGaps(object? interval = null)` method to both `LineChartBuilder<TSource>` and `AreaChartBuilder<TSource>`, matching the existing pattern in `BarChartBuilder<TSource>`. This enables gap-filling for time-series data in line and area chart visualizations.

## API Changes

- `LineChartBuilder<TSource>.FillGaps(object? interval = null)` — new public method
- `AreaChartBuilder<TSource>.FillGaps(object? interval = null)` — new public method

## Files Modified

- `src/Ivy/Views/Charts/LineChartView.cs` — added `_fillGaps`/`_gapFillInterval` fields, FillGaps logic in Build(), and public FillGaps() method
- `src/Ivy/Views/Charts/AreaChartView.cs` — added `_fillGaps`/`_gapFillInterval` fields, FillGaps logic in Build(), and public FillGaps() method

## Commits

- f69eadd6c [02001] Add FillGaps to LineChartBuilder and AreaChartBuilder