### PR TITLE
[02005] Use icons in Projects table

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Settings/ProjectsSettingsView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Settings/ProjectsSettingsView.cs
@@ -37,7 +37,7 @@ public class ProjectsSettingsView : ViewBase
         };
 
         var rows = projects.Select((p, i) => new ProjectRow(
-            i, p.Name, p.Color, p.Repos.Count, p.Verifications.Count
+            i, p.Name, p.Color, p.GetMeta("slackEmoji"), p.Repos.Count, p.Verifications.Count
         )).ToList();
 
         var table = new TableBuilder<ProjectRow>(rows)
@@ -52,6 +52,12 @@ public class ProjectsSettingsView : ViewBase
                     {
                         deleteIndex.Set(idx);
                     })
+            ))
+            .Header(t => t.Icon, "Icon")
+            .Builder(t => t.Icon, f => f.Func<ProjectRow, string?>(emoji =>
+                !string.IsNullOrEmpty(emoji)
+                    ? (object)Text.Block(emoji)
+                    : new Spacer()
             ));
 
         var content = Layout.Vertical().Gap(4).Padding(4)
@@ -299,5 +305,5 @@ public class ProjectsSettingsView : ViewBase
         }
     }
 
-    private record ProjectRow(int Index, string Name, string Color, int RepoCount, int VerificationCount);
+    private record ProjectRow(int Index, string Name, string Color, string? Icon, int RepoCount, int VerificationCount);
 }


### PR DESCRIPTION
# Summary

## Changes

Added an Icon column to the Projects settings table in Tendril that displays each project's Slack emoji from the `meta.slackEmoji` config field. The column appears after the Actions column and shows the emoji text or an empty spacer if no emoji is configured.

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/Apps/Settings/ProjectsSettingsView.cs** — Added `Icon` field to `ProjectRow` record, populated it from `GetMeta("slackEmoji")`, and added Icon column with Header/Builder to the table.

## Commits

- 1f163e8fc [02005] Add Icon column to Projects settings table