### PR TITLE
[02003] Priority levels do not need to be sorted

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Settings/LevelsSettingsView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Settings/LevelsSettingsView.cs
@@ -15,6 +15,8 @@ public class LevelsSettingsView : ViewBase
 
         var badgeOptions = Enum.GetNames<BadgeVariant>().ToList();
 
+        // Use levels in config.yaml order (not alphabetically sorted).
+        // The order is controlled by the user via up/down arrows in the UI.
         var levels = config.Settings.Levels;
 
         var rows = levels.Select((level, i) => new LevelRow(i, level.Name, level.Badge)).ToList();

--- a/src/tendril/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/tendril/Ivy.Tendril/Services/ConfigService.cs
@@ -201,6 +201,8 @@ public class ConfigService : IConfigService
     public string ConfigPath => _configPath;
     public string PlanFolder => string.IsNullOrEmpty(_tendrilHome) ? "" : Path.Combine(_tendrilHome, "Plans");
     public List<ProjectConfig> Projects => _settings.Projects;
+    // Levels are returned in the order defined in config.yaml (not sorted).
+    // Users can reorder levels in the Settings UI, and the order is preserved.
     public List<LevelConfig> Levels => _settings.Levels;
     public string[] LevelNames => _settings.Levels.Select(l => l.Name).ToArray();
     public EditorConfig Editor => _settings.Editor;

--- a/src/tendril/Ivy.Tendril/Services/YamlHelper.cs
+++ b/src/tendril/Ivy.Tendril/Services/YamlHelper.cs
@@ -28,6 +28,7 @@ public static class YamlHelper
     /// <summary>
     /// Compact serializer that omits default values for cleaner output.
     /// Use this for writing config files where brevity is desired.
+    /// Note: Does not sort collections - order is preserved as-is (important for levels).
     /// </summary>
     public static readonly ISerializer SerializerCompact = new SerializerBuilder()
         .WithNamingConvention(CamelCaseNamingConvention.Instance)


### PR DESCRIPTION
# Summary

## Changes

Added clarifying comments to three files explaining that priority levels are intentionally kept in config.yaml order (not sorted alphabetically), and that this order is user-controlled via the Settings UI.

## API Changes

None.

## Files Modified

- **ConfigService.cs** — Added comment above `Levels` property explaining order preservation
- **LevelsSettingsView.cs** — Added comment above levels usage explaining config.yaml ordering
- **YamlHelper.cs** — Extended XML doc on `SerializerCompact` noting collection order is preserved

## Commits

- c93d93d1b [02003] Add comments clarifying that priority levels preserve config.yaml order