### PR TITLE
[01997] Prevent merge conflict markers from reaching main

### DIFF
--- a/.github/workflows/backend-checks-linux.yml
+++ b/.github/workflows/backend-checks-linux.yml
@@ -15,6 +15,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Check for merge conflict markers (fail fast before expensive build steps)
+      - name: Check for merge conflicts
+        run: |
+          if git grep -n -E '^(<<<<<<<|=======|>>>>>>>)' -- '*.cs'; then
+            echo "ERROR: Merge conflict markers found!"
+            exit 1
+          fi
+
       # Install required packages
       - name: Install required packages
         run: sudo apt-get update && sudo apt-get install -y attr

--- a/.github/workflows/backend-checks-windows.yml
+++ b/.github/workflows/backend-checks-windows.yml
@@ -15,6 +15,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Check for merge conflict markers (fail fast before expensive build steps)
+      - name: Check for merge conflicts
+        run: |
+          if git grep -n -E '^(<<<<<<<|=======|>>>>>>>)' -- '*.cs'; then
+            echo "ERROR: Merge conflict markers found!"
+            exit 1
+          fi
+
       # Setup Node.js (needed for integrated frontend build in dotnet build)
       - uses: voidzero-dev/setup-vp@v1
 

--- a/.github/workflows/check-conflicts.yml
+++ b/.github/workflows/check-conflicts.yml
@@ -1,0 +1,19 @@
+name: Check for Conflict Markers
+permissions:
+  contents: read
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+jobs:
+  check-conflicts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check for merge conflict markers
+        run: |
+          if git grep -n -E '^(<<<<<<<|=======|>>>>>>>)' -- '*.cs' '*.ts' '*.tsx' '*.js' '*.jsx' '*.yml' '*.yaml' '*.json' '*.md'; then
+            echo "ERROR: Merge conflict markers found in source files!"
+            exit 1
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -207,6 +207,20 @@ Before submitting your widget PR, ensure you have:
 - [ ] Code follows project style guidelines
 - [ ] All existing tests still pass
 
+## Merge Conflict Resolution
+
+When resolving merge conflicts:
+
+1. Ensure all conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) are removed
+2. Test that code builds and passes tests after resolution
+3. Use `git diff --check` to verify no conflict markers remain
+4. Prefer PR workflow over direct pushes to main
+
+The repository has automated protections against unresolved conflict markers:
+
+- **Pre-commit hook** — blocks commits containing conflict markers
+- **CI check** — a dedicated workflow scans all source files for conflict markers on every push and PR to main
+
 ## Pull Request Process
 
 1. **Create a descriptive branch name:**

--- a/src/frontend/.husky/pre-commit
+++ b/src/frontend/.husky/pre-commit
@@ -1,5 +1,16 @@
 #!/bin/sh
 
+# Check for merge conflict markers in staged files
+CONFLICT_FILES=$(git diff --cached --name-only | xargs grep -l -E '^(<<<<<<<|=======|>>>>>>>)' 2>/dev/null || true)
+if [ -n "$CONFLICT_FILES" ]; then
+  echo "ERROR: Merge conflict markers detected in staged files!"
+  echo ""
+  git diff --cached --name-only | xargs grep -n -E '^(<<<<<<<|=======|>>>>>>>)' 2>/dev/null
+  echo ""
+  echo "Please resolve all conflicts before committing."
+  exit 1
+fi
+
 # Check if any frontend files are staged
 FRONTEND_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep "^src/frontend/" || true)
 


### PR DESCRIPTION
# Summary

## Changes

Added multi-layered protection against merge conflict markers reaching the main branch. Updated the existing pre-commit hook to detect conflict markers before any commit, created a dedicated CI workflow that scans all source files, and added fail-fast conflict checks to both backend CI workflows.

## API Changes

None.

## Files Modified

- **Pre-commit hook:** `src/frontend/.husky/pre-commit` — added conflict marker detection as the first check
- **New CI workflow:** `.github/workflows/check-conflicts.yml` — scans `.cs`, `.ts`, `.tsx`, `.js`, `.jsx`, `.yml`, `.yaml`, `.json`, `.md` files
- **Backend CI (Windows):** `.github/workflows/backend-checks-windows.yml` — added conflict check as first step
- **Backend CI (Linux):** `.github/workflows/backend-checks-linux.yml` — added conflict check as first step
- **Documentation:** `CONTRIBUTING.md` — added "Merge Conflict Resolution" section

## Commits

- 195281599 [01997] Add merge conflict marker detection to pre-commit hook and CI