### PR TITLE
[02006] Deduplicate status-to-color mapping in JobsApp

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/JobsApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/JobsApp.cs
@@ -9,6 +9,18 @@ namespace Ivy.Tendril.Apps;
 [App(title: "Jobs", icon: Icons.Activity, group: new[] { "Tools" }, order: MenuOrder.Jobs)]
 public class JobsApp : ViewBase
 {
+    private static readonly Dictionary<string, Colors> StatusColors = new()
+    {
+        ["Running"] = Colors.Blue,
+        ["Completed"] = Colors.Green,
+        ["Failed"] = Colors.Red,
+        ["Timeout"] = Colors.Red,
+        ["Queued"] = Colors.Amber,
+        ["Pending"] = Colors.Amber,
+        ["Stopped"] = Colors.Gray,
+        ["Blocked"] = Colors.Orange
+    };
+
     public override object? Build()
     {
         var jobService = UseService<IJobService>();
@@ -93,17 +105,10 @@ public class JobsApp : ViewBase
             .Width(t => t.StatusMessage, Size.Auto())
             .Renderer(t => t.Status, new LabelsDisplayRenderer
             {
-                BadgeColorMapping = new Dictionary<string, string>
-                {
-                    ["Running"] = "Blue",
-                    ["Completed"] = "Green",
-                    ["Failed"] = "Red",
-                    ["Timeout"] = "Red",
-                    ["Queued"] = "Amber",
-                    ["Pending"] = "Amber",
-                    ["Stopped"] = "Gray",
-                    ["Blocked"] = "Orange"
-                }
+                BadgeColorMapping = StatusColors.ToDictionary(
+                    kvp => kvp.Key,
+                    kvp => kvp.Value.ToString()
+                )
             })
             .Renderer(t => t.PlanId, new LinkDisplayRenderer())
             .Hidden(t => t.Id)
@@ -328,16 +333,6 @@ public class JobsApp : ViewBase
         return $"{span.Minutes}m {span.Seconds:D2}s";
     }
 
-    private static Colors GetStatusColor(string status) => status switch
-    {
-        "Running" => Colors.Blue,
-        "Completed" => Colors.Green,
-        "Failed" => Colors.Red,
-        "Timeout" => Colors.Red,
-        "Queued" => Colors.Amber,
-        "Pending" => Colors.Amber,
-        "Stopped" => Colors.Gray,
-        "Blocked" => Colors.Orange,
-        _ => Colors.Slate
-    };
+    private static Colors GetStatusColor(string status) =>
+        StatusColors.TryGetValue(status, out var color) ? color : Colors.Slate;
 }


### PR DESCRIPTION
# Summary

## Changes

Extracted a single `StatusColors` dictionary as the source of truth for status-to-color mapping in `JobsApp.cs`. The `GetStatusColor` method and the `BadgeColorMapping` for DataTable badges now both derive from this dictionary, eliminating duplication.

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/Apps/JobsApp.cs** — Added `StatusColors` static field, simplified `GetStatusColor` method, derived `BadgeColorMapping` from `StatusColors`

## Commits

- 2b5f051be [02006] Deduplicate status-to-color mapping in JobsApp