### PR TITLE
[02004] Use icon buttons in Verification Definitions table and move Actions column to right

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Settings/VerificationsSettingsView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Settings/VerificationsSettingsView.cs
@@ -15,19 +15,19 @@ public class VerificationsSettingsView : ViewBase
 
         var verifications = config.Settings.Verifications;
 
-        var rows = verifications.Select((v, i) => new VerificationRow(i, v.Name, v.Prompt)).ToList();
+        var rows = verifications.Select((v, i) => new VerificationRow(v.Name, v.Prompt, i)).ToList();
 
         var table = new TableBuilder<VerificationRow>(rows)
-            .Header(t => t.Index, "Actions")
+            .Header(t => t.Index, "")
             .Builder(t => t.Index, f => f.Func<VerificationRow, int>(idx =>
                 Layout.Horizontal().Gap(1)
-                    | new Button("Edit").Outline().Small().OnClick(() =>
+                    | new Button().Icon(Icons.Pencil).Outline().Small().Tooltip("Edit this verification").OnClick(() =>
                     {
                         editIndex.Set(idx);
                         editName.Set(verifications[idx].Name);
                         editPrompt.Set(verifications[idx].Prompt);
                     })
-                    | new Button("Delete").Outline().Small().OnClick(() =>
+                    | new Button().Icon(Icons.Trash).Outline().Small().Tooltip("Delete this verification").OnClick(() =>
                     {
                         var name = verifications[idx].Name;
                         verifications.RemoveAt(idx);
@@ -88,5 +88,5 @@ public class VerificationsSettingsView : ViewBase
         return content;
     }
 
-    private record VerificationRow(int Index, string Name, string Prompt);
+    private record VerificationRow(string Name, string Prompt, int Index);
 }


### PR DESCRIPTION
# Summary

## Changes

Replaced text-based "Edit" and "Delete" buttons with icon-only buttons (Pencil/Trash icons with tooltips) in the Verification Definitions table, matching the existing LevelsSettingsView pattern. Moved the Actions column from the left side to the right side by reordering the record fields.

## API Changes

None.

## Files Modified

- **Settings UI:** `src/tendril/Ivy.Tendril/Apps/Settings/VerificationsSettingsView.cs` — icon buttons, column reorder

## Commits

- 28ef1faab [02004] Use icon buttons in Verification Definitions table and move Actions column to right