### PR TITLE
[02002] Add int dimension support to FillDimensionGaps

### DIFF
--- a/src/Ivy.Test/PivotTableTests.cs
+++ b/src/Ivy.Test/PivotTableTests.cs
@@ -101,4 +101,111 @@ public class PivotTableTests
         Assert.Equal(100, results[0]["Value"]);
         Assert.Equal(300, results[1]["Value"]);
     }
+
+    public record IntDimensionData(int Id, int Score);
+
+    [Fact]
+    public async Task PivotTable_FillGaps_FillsIntGaps()
+    {
+        var data = new[]
+        {
+            new IntDimensionData(1, 100),
+            new IntDimensionData(3, 300),
+            new IntDimensionData(5, 500),
+        };
+
+        var results = await data.ToPivotTable()
+            .Dimension("Id", e => e.Id)
+            .Measure("Score", e => e.Sum(f => f.Score))
+            .FillGaps()
+            .ExecuteAsync();
+
+        Assert.Equal(5, results.Length); // 1, 2, 3, 4, 5
+        Assert.Equal(1, results[0]["Id"]);
+        Assert.Equal(100, results[0]["Score"]);
+        Assert.Equal(2, results[1]["Id"]);
+        Assert.Equal(0, results[1]["Score"]); // filled with 0
+        Assert.Equal(3, results[2]["Id"]);
+        Assert.Equal(300, results[2]["Score"]);
+        Assert.Equal(4, results[3]["Id"]);
+        Assert.Equal(0, results[3]["Score"]); // filled with 0
+        Assert.Equal(5, results[4]["Id"]);
+        Assert.Equal(500, results[4]["Score"]);
+    }
+
+    [Fact]
+    public async Task PivotTable_FillGaps_IntWithCustomInterval()
+    {
+        var data = new[]
+        {
+            new IntDimensionData(0, 10),
+            new IntDimensionData(5, 50),
+            new IntDimensionData(10, 100),
+            new IntDimensionData(20, 200),
+        };
+
+        var results = await data.ToPivotTable()
+            .Dimension("Id", e => e.Id)
+            .Measure("Score", e => e.Sum(f => f.Score))
+            .FillGaps(5)
+            .ExecuteAsync();
+
+        Assert.Equal(5, results.Length); // 0, 5, 10, 15, 20
+        Assert.Equal(0, results[0]["Id"]);
+        Assert.Equal(10, results[0]["Score"]);
+        Assert.Equal(5, results[1]["Id"]);
+        Assert.Equal(50, results[1]["Score"]);
+        Assert.Equal(10, results[2]["Id"]);
+        Assert.Equal(100, results[2]["Score"]);
+        Assert.Equal(15, results[3]["Id"]);
+        Assert.Equal(0, results[3]["Score"]); // filled with 0
+        Assert.Equal(20, results[4]["Id"]);
+        Assert.Equal(200, results[4]["Score"]);
+    }
+
+    [Fact]
+    public async Task PivotTable_FillGaps_IntPreservesExistingData()
+    {
+        var data = new[]
+        {
+            new IntDimensionData(1, 100),
+            new IntDimensionData(2, 200),
+            new IntDimensionData(3, 300),
+        };
+
+        var results = await data.ToPivotTable()
+            .Dimension("Id", e => e.Id)
+            .Measure("Score", e => e.Sum(f => f.Score))
+            .FillGaps()
+            .ExecuteAsync();
+
+        Assert.Equal(3, results.Length); // no gaps to fill
+        Assert.Equal(100, results[0]["Score"]);
+        Assert.Equal(200, results[1]["Score"]);
+        Assert.Equal(300, results[2]["Score"]);
+    }
+
+    [Fact]
+    public async Task PivotTable_FillGaps_MixedTypesDontInterfere()
+    {
+        // Verify DateTime gap filling still works after int support was added
+        var data = new[]
+        {
+            new HourlyData(new DateTime(2026, 4, 1, 10, 0, 0), 100),
+            new HourlyData(new DateTime(2026, 4, 1, 12, 0, 0), 200),
+        };
+
+        var results = await data.ToPivotTable()
+            .Dimension("Hour", e => e.Hour)
+            .Measure("Value", e => e.Sum(f => f.Value))
+            .FillGaps(TimeSpan.FromHours(1))
+            .ExecuteAsync();
+
+        Assert.Equal(3, results.Length); // 10, 11, 12
+        Assert.Equal(new DateTime(2026, 4, 1, 10, 0, 0), results[0]["Hour"]);
+        Assert.Equal(100, results[0]["Value"]);
+        Assert.Equal(0, results[1]["Value"]); // 11:00 filled with 0
+        Assert.Equal(new DateTime(2026, 4, 1, 12, 0, 0), results[2]["Hour"]);
+        Assert.Equal(200, results[2]["Value"]);
+    }
 }

--- a/src/Ivy/Views/Charts/PivotTable.cs
+++ b/src/Ivy/Views/Charts/PivotTable.cs
@@ -180,6 +180,36 @@ public class PivotTable<T>
             return filled;
         }
 
+        // Int gap filling
+        if (firstValue is int startInt && lastValue is int endInt)
+        {
+            var step = interval as int? ?? 1;
+            var lookup = result.ToDictionary(r => (int)r[dimensionName]);
+            var filled = new List<Dictionary<string, object>>();
+
+            for (var current = startInt; current <= endInt; current += step)
+            {
+                if (lookup.TryGetValue(current, out var existing))
+                {
+                    filled.Add(existing);
+                }
+                else
+                {
+                    var row = new Dictionary<string, object>
+                    {
+                        [dimensionName] = current
+                    };
+                    foreach (var measure in measures)
+                    {
+                        row[measure.Name] = 0;
+                    }
+                    filled.Add(row);
+                }
+            }
+
+            return filled;
+        }
+
         return result;
     }
 


### PR DESCRIPTION
# Summary

## Changes

Extended the `FillDimensionGaps` method in `PivotTable<T>` to support `int` dimensions alongside the existing `DateTime` support. When gap filling is enabled and the dimension values are integers, missing sequential values are filled with zero-valued rows. The default step is 1, and a custom integer step can be provided via the polymorphic `interval` parameter.

## API Changes

None. The existing `FillGaps(object? interval = null)` method on `PivotTableBuilder<TSource>` now accepts `int` values for the interval parameter (in addition to `TimeSpan`). No new public APIs were added.

## Files Modified

- **src/Ivy/Views/Charts/PivotTable.cs** — Added int gap-filling branch to `FillDimensionGaps` private method
- **src/Ivy.Test/PivotTableTests.cs** — Added 4 new test cases for int gap filling

## Commits

- a8475752a [02002] Add int dimension support to FillDimensionGaps