### PR TITLE
[02013] Keyboard shortcuts trigger multiple times causing duplicate plan acceptance

### DIFF
--- a/src/frontend/src/widgets/button/ButtonWidget.tsx
+++ b/src/frontend/src/widgets/button/ButtonWidget.tsx
@@ -21,6 +21,10 @@ import { parseShortcut, formatShortcutForDisplay, keyToCode } from "@/lib/shortc
 
 const ButtonWithTooltip = withTooltip(Button);
 
+// Debounce state for keyboard shortcuts to prevent duplicate triggers during UI transitions
+const recentShortcuts = new Map<string, number>();
+const DEBOUNCE_MS = 300;
+
 interface ButtonWidgetProps {
   id: string;
   title: string;
@@ -209,6 +213,14 @@ export const ButtonWidget: React.FC<ButtonWidgetProps> = ({
         event.code === expectedCode;
 
       if (isShortcutPressed) {
+        const now = Date.now();
+        const lastTrigger = recentShortcuts.get(id) || 0;
+
+        if (now - lastTrigger < DEBOUNCE_MS) {
+          return; // Ignore rapid-fire triggers
+        }
+
+        recentShortcuts.set(id, now);
         event.preventDefault();
         if (!effectiveUrl) {
           eventHandler("OnClick", id, []);


### PR DESCRIPTION
# Summary

## Changes

Added debounce logic to the keyboard shortcut handler in `ButtonWidget.tsx` to prevent duplicate triggers when multiple Button components with the same shortcut key are mounted during UI transitions. A module-level `Map` tracks the last trigger time per button ID, and subsequent triggers within 300ms are ignored.

## API Changes

None.

## Files Modified

- **Frontend:**
  - `src/frontend/src/widgets/button/ButtonWidget.tsx` — Added module-level debounce state (`recentShortcuts` Map, `DEBOUNCE_MS` constant) and debounce check in the `handleKeyDown` function

## Commits

- [02013] Add debounce to keyboard shortcut handlers to prevent duplicate triggers (c2c68d0b4)