### PR TITLE
[02011] Remove the "All clears"

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/DashboardApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/DashboardApp.cs
@@ -52,7 +52,7 @@ public class DashboardApp : ViewBase
             | BuildStatCard(totalCount, "Total Plans")
             | BuildStatCard(draftCount, "Draft")
             | BuildStatCard(inProgressCount, "In Progress")
-            | BuildStatCard(reviewCount, "Ready for Review", zeroSubtitle: "All clear")
+            | BuildStatCard(reviewCount, "Ready for Review")
             | BuildStatCard(completedCount, "Completed")
             | BuildStatCard(failedCount, "Failed")
             | BuildStatCard($"${avgCost:F2}", "Avg Cost/Plan");
@@ -205,16 +205,8 @@ public class DashboardApp : ViewBase
              : tokens.ToString();
     }
 
-    private static object BuildStatCard(int count, string label, string? zeroSubtitle = null)
+    private static object BuildStatCard(int count, string label)
     {
-        if (count == 0 && zeroSubtitle != null)
-        {
-            return Layout.Vertical().Padding(1)
-                | Text.Block(count.ToString()).Bold()
-                | Text.Muted(label)
-                | Text.Muted(zeroSubtitle).Italic();
-        }
-
         return BuildStatCard(count.ToString(), label);
     }
 


### PR DESCRIPTION
# Summary

## Changes

Removed the `zeroSubtitle` feature from the Dashboard's stat cards. The "All clear" italic text that appeared below "Ready for Review" when the count was zero has been removed. The `BuildStatCard(int, string, string?)` overload was simplified to delegate directly to `BuildStatCard(string, string)`.

## API Changes

- Removed `zeroSubtitle` optional parameter from `BuildStatCard(int count, string label, string? zeroSubtitle = null)` — now `BuildStatCard(int count, string label)`

## Files Modified

- `src/tendril/Ivy.Tendril/Apps/DashboardApp.cs` — Removed zeroSubtitle usage and conditional rendering logic

## Commits

- c1f994087 [02011] Remove zeroSubtitle feature from DashboardApp