### PR TITLE
[02017] Refactor GetHourlyTokenBurn to read columns by name for consistency

### DIFF
--- a/src/tendril/Ivy.Tendril/Services/PlanDatabaseService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanDatabaseService.cs
@@ -387,15 +387,15 @@ public class PlanDatabaseService : IPlanDatabaseService, IDisposable
             using var reader = cmd.ExecuteReader();
             while (reader.Read())
             {
-                var hourStr = reader.GetString(0);
+                var hourStr = reader.GetString(reader.GetOrdinal("Hour"));
                 if (DateTime.TryParse(hourStr, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal, out var hour))
                 {
                     result.Add(new HourlyTokenBurn
                     {
                         Hour = DateTime.SpecifyKind(hour, DateTimeKind.Utc),
-                        Project = reader.GetString(1),
-                        Cost = Convert.ToDecimal(reader.GetDouble(2), CultureInfo.InvariantCulture),
-                        Tokens = reader.GetInt32(3)
+                        Project = reader.GetString(reader.GetOrdinal("Project")),
+                        Cost = Convert.ToDecimal(reader.GetDouble(reader.GetOrdinal("TotalCost")), CultureInfo.InvariantCulture),
+                        Tokens = reader.GetInt32(reader.GetOrdinal("TotalTokens"))
                     });
                 }
             }


### PR DESCRIPTION
# Summary

## Changes

Refactored `GetHourlyTokenBurn()` in `PlanDatabaseService.cs` to read SQL result columns by name (`reader.GetOrdinal("ColumnName")`) instead of ordinal position (`reader.GetString(0)`, etc.). This aligns with the name-based reading pattern established in plan 01999.

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/Services/PlanDatabaseService.cs** — Changed 4 column reads from ordinal to name-based in `GetHourlyTokenBurn()` method

## Commits

- [02017] Refactor GetHourlyTokenBurn to read columns by name (1f4c53abb)