### PR TITLE
[02018] Cache LevelNames in ConfigService

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/IConfigServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/IConfigServiceTests.cs
@@ -57,4 +57,68 @@ public class IConfigServiceTests
         config.SetPendingProject(project);
         Assert.Equal("Test", config.GetPendingProject()?.Name);
     }
+
+    [Fact]
+    public void LevelNames_ReturnsSameArrayOnSubsequentCalls()
+    {
+        var config = new ConfigService(new TendrilSettings
+        {
+            Levels = new List<LevelConfig>
+            {
+                new() { Name = "Bug" },
+                new() { Name = "Critical" }
+            }
+        }, "");
+
+        var first = config.LevelNames;
+        var second = config.LevelNames;
+
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void LevelNames_InvalidatedAfterSaveSettings()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"tendril-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var config = new ConfigService(new TendrilSettings
+            {
+                Levels = new List<LevelConfig>
+                {
+                    new() { Name = "Bug" },
+                    new() { Name = "Critical" }
+                }
+            }, tempDir);
+
+            var first = config.LevelNames;
+            config.SaveSettings();
+            var second = config.LevelNames;
+
+            Assert.NotSame(first, second);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void LevelNames_ReturnsCorrectNames()
+    {
+        var config = new ConfigService(new TendrilSettings
+        {
+            Levels = new List<LevelConfig>
+            {
+                new() { Name = "Bug", Badge = "Destructive" },
+                new() { Name = "Critical", Badge = "Warning" },
+                new() { Name = "NiceToHave", Badge = "Outline" }
+            }
+        }, "");
+
+        var names = config.LevelNames;
+
+        Assert.Equal(new[] { "Bug", "Critical", "NiceToHave" }, names);
+    }
 }

--- a/src/tendril/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/tendril/Ivy.Tendril/Services/ConfigService.cs
@@ -110,6 +110,7 @@ public class ConfigService : IConfigService
     private string _tendrilHome;
     private string? _pendingTendrilHome;
     private ProjectConfig? _pendingProject;
+    private string[]? _levelNamesCache;
 
     internal ConfigService(TendrilSettings settings, string tendrilHome = "")
     {
@@ -204,7 +205,17 @@ public class ConfigService : IConfigService
     // Levels are returned in the order defined in config.yaml (not sorted).
     // Users can reorder levels in the Settings UI, and the order is preserved.
     public List<LevelConfig> Levels => _settings.Levels;
-    public string[] LevelNames => _settings.Levels.Select(l => l.Name).ToArray();
+    public string[] LevelNames
+    {
+        get
+        {
+            if (_levelNamesCache == null)
+            {
+                _levelNamesCache = _settings.Levels.Select(l => l.Name).ToArray();
+            }
+            return _levelNamesCache;
+        }
+    }
     public EditorConfig Editor => _settings.Editor;
     public ProjectConfig? GetProject(string name) => _settings.Projects.FirstOrDefault(p => p.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
 
@@ -219,6 +230,7 @@ public class ConfigService : IConfigService
 
     public void SaveSettings()
     {
+        _levelNamesCache = null;
         var yaml = YamlHelper.SerializerCompact.Serialize(_settings);
         File.WriteAllText(_configPath, yaml);
     }
@@ -261,6 +273,7 @@ public class ConfigService : IConfigService
             }
         }
 
+        _levelNamesCache = null;
         VariableExpansion.InitializeUserSecrets(_tendrilHome);
         ExpandSettingsVariables();
     }


### PR DESCRIPTION
# Summary

## Changes

Added caching for the `LevelNames` property in `ConfigService` to avoid creating a new `string[]` on every access. The cache is stored in a `_levelNamesCache` field and invalidated when settings are saved or reloaded. Three new tests verify cache hit behavior, invalidation after `SaveSettings()`, and correct name values.

## API Changes

None. The return type remains `string[]` and the `IConfigService` interface is unchanged.

## Files Modified

- **ConfigService.cs** — Added `_levelNamesCache` field, converted `LevelNames` from expression-bodied to cached property, added cache invalidation in `SaveSettings()` and `SetTendrilHome()`
- **IConfigServiceTests.cs** — Added three new test methods: `LevelNames_ReturnsSameArrayOnSubsequentCalls`, `LevelNames_InvalidatedAfterSaveSettings`, `LevelNames_ReturnsCorrectNames`

## Commits

- ff04289f1 [02018] Cache LevelNames in ConfigService