### PR TITLE
[02020] Remove XUnit Specific Testing Packages From Analyser Tests

### DIFF
--- a/src/Ivy.Analyser.Test/AppConstructorAnalyzerTests.cs
+++ b/src/Ivy.Analyser.Test/AppConstructorAnalyzerTests.cs
@@ -1,7 +1,8 @@
 using System.Threading.Tasks;
 using Xunit;
-using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.AnalyzerVerifier<
-    Ivy.Analyser.Analyzers.AppConstructorAnalyzer>;
+using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerVerifier<
+    Ivy.Analyser.Analyzers.AppConstructorAnalyzer,
+    Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
 
 namespace Ivy.Analyser.Test;
 

--- a/src/Ivy.Analyser.Test/HookUsageAnalyzerTests.cs
+++ b/src/Ivy.Analyser.Test/HookUsageAnalyzerTests.cs
@@ -1,7 +1,8 @@
 using System.Threading.Tasks;
 using Xunit;
-using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.AnalyzerVerifier<
-    Ivy.Analyser.Analyzers.HookUsageAnalyzer>;
+using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerVerifier<
+    Ivy.Analyser.Analyzers.HookUsageAnalyzer,
+    Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
 
 namespace Ivy.Analyser.Test
 {

--- a/src/Ivy.Analyser.Test/Ivy.Analyser.Test.csproj
+++ b/src/Ivy.Analyser.Test/Ivy.Analyser.Test.csproj
@@ -15,8 +15,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/Ivy.Analyser.Test/LeafWidgetAnalyzerTests.cs
+++ b/src/Ivy.Analyser.Test/LeafWidgetAnalyzerTests.cs
@@ -1,7 +1,8 @@
 using System.Threading.Tasks;
 using Xunit;
-using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.AnalyzerVerifier<
-    Ivy.Analyser.Analyzers.LeafWidgetAnalyzer>;
+using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerVerifier<
+    Ivy.Analyser.Analyzers.LeafWidgetAnalyzer,
+    Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
 
 namespace Ivy.Analyser.Test;
 

--- a/src/Ivy.Analyser.Test/UseEffectTaskAnalyzerTests.cs
+++ b/src/Ivy.Analyser.Test/UseEffectTaskAnalyzerTests.cs
@@ -6,8 +6,9 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Xunit;
-using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.AnalyzerVerifier<
-    Ivy.Analyser.Analyzers.UseEffectTaskAnalyzer>;
+using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerVerifier<
+    Ivy.Analyser.Analyzers.UseEffectTaskAnalyzer,
+    Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
 
 namespace Ivy.Analyser.Test;
 


### PR DESCRIPTION
# Summary

## Changes

Removed the XUnit-specific Roslyn testing packages (`Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit` and `Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit`) from `Ivy.Analyser.Test.csproj` and replaced them with the base packages (without `.XUnit` suffix). Migrated all 4 test files that used `XUnit.AnalyzerVerifier` to use `CSharpAnalyzerVerifier` with `DefaultVerifier`, resolving the xunit 2.5+ incompatibility.

## API Changes

None.

## Files Modified

- **Project file:** `src/Ivy.Analyser.Test/Ivy.Analyser.Test.csproj` — swapped XUnit-specific package references for base packages
- **Test files migrated:**
  - `src/Ivy.Analyser.Test/AppConstructorAnalyzerTests.cs`
  - `src/Ivy.Analyser.Test/HookUsageAnalyzerTests.cs`
  - `src/Ivy.Analyser.Test/UseEffectTaskAnalyzerTests.cs`
  - `src/Ivy.Analyser.Test/LeafWidgetAnalyzerTests.cs`

## Commits

- cafc32caa [02020] Remove XUnit-specific testing packages and migrate to DefaultVerifier