### PR TITLE
[02015] Extract status-to-badge mappings in PlansApp

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Plans/SidebarView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Plans/SidebarView.cs
@@ -17,6 +17,19 @@ public class SidebarView(
     private readonly IState<string?> _textFilter = textFilter;
     private readonly IConfigService _config = config;
 
+    private static readonly Dictionary<PlanStatus, BadgeVariant> PlanStatusBadgeVariants = new()
+    {
+        [PlanStatus.Building] = BadgeVariant.Info,
+        [PlanStatus.Updating] = BadgeVariant.Info,
+        [PlanStatus.Executing] = BadgeVariant.Info,
+        [PlanStatus.ReadyForReview] = BadgeVariant.Success,
+        [PlanStatus.Failed] = BadgeVariant.Destructive,
+        [PlanStatus.Draft] = BadgeVariant.Outline,
+        [PlanStatus.Completed] = BadgeVariant.Success,
+        [PlanStatus.Skipped] = BadgeVariant.Outline,
+        [PlanStatus.Icebox] = BadgeVariant.Outline
+    };
+
     public override object Build()
     {
         var filteredPlans = PlanFilters.ApplyFilters(_plans, _projectFilter.Value, _levelFilter.Value, _textFilter.Value);
@@ -45,12 +58,9 @@ public class SidebarView(
         var content = new List(filteredPlans.Select(plan =>
         {
             var clickablePlan = plan;
-            var stateBadgeVariant = plan.Status switch
-            {
-                PlanStatus.Building or PlanStatus.Updating => BadgeVariant.Info,
-                PlanStatus.ReadyForReview => BadgeVariant.Success,
-                _ => BadgeVariant.Outline
-            };
+            var stateBadgeVariant = PlanStatusBadgeVariants.TryGetValue(plan.Status, out var variant)
+                ? variant
+                : BadgeVariant.Outline;
 
             var badges = Layout.Horizontal().Gap(1);
             if (plan.Status != PlanStatus.Draft)

--- a/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -27,6 +27,14 @@ public class ContentView(
     private readonly IConfigService _config = config;
     private readonly IGitService _gitService = gitService;
 
+    private static readonly Dictionary<string, BadgeVariant> VerificationStatusBadgeVariants = new()
+    {
+        ["Pass"] = BadgeVariant.Success,
+        ["Fail"] = BadgeVariant.Destructive,
+        ["Pending"] = BadgeVariant.Outline,
+        ["Skipped"] = BadgeVariant.Outline
+    };
+
     public override object? Build()
     {
         var client = UseService<IClientProvider>();
@@ -139,9 +147,9 @@ public class ContentView(
 
             verificationsTable |= new TableRow(
                 new TableCell(new Badge(v.Status).Variant(
-                    v.Status == "Pass" ? BadgeVariant.Success
-                    : v.Status == "Fail" ? BadgeVariant.Destructive
-                    : BadgeVariant.Outline)),
+                    VerificationStatusBadgeVariants.TryGetValue(v.Status, out var variant)
+                        ? variant
+                        : BadgeVariant.Outline)),
                 new TableCell(nameCell)
             );
         }


### PR DESCRIPTION
# Summary

## Changes

Extracted inline status-to-badge variant mappings into static dictionaries in both `SidebarView` and `ContentView`. The plan status switch expression in `SidebarView` was replaced with a `PlanStatusBadgeVariants` dictionary lookup covering all `PlanStatus` enum values. The verification status ternary chain in `ContentView` was replaced with a `VerificationStatusBadgeVariants` dictionary lookup.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Apps/Plans/SidebarView.cs` — Added `PlanStatusBadgeVariants` static dictionary, replaced switch expression with dictionary lookup
- `src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs` — Added `VerificationStatusBadgeVariants` static dictionary, replaced ternary chain with dictionary lookup

## Commits

- 871ec48c9 [02015] Extract status-to-badge mappings into static dictionaries