### PR TITLE
[02019] Rename lineChartData to areaChartData in AreaChartBuilder

### DIFF
--- a/src/Ivy/Views/Charts/AreaChartView.cs
+++ b/src/Ivy/Views/Charts/AreaChartView.cs
@@ -90,7 +90,7 @@ public class AreaChartBuilder<TSource>(
             throw new InvalidOperationException("At least one measure is required.");
         }
 
-        var lineChartData = UseState(ImmutableArray.Create<Dictionary<string, object>>);
+        var areaChartData = UseState(ImmutableArray.Create<Dictionary<string, object>>);
         var loading = UseState(true);
 
         UseEffect(async () =>
@@ -114,7 +114,7 @@ public class AreaChartBuilder<TSource>(
                 }
 
                 var results = await pivotBuilder.ExecuteAsync();
-                lineChartData.Set([.. results]);
+                areaChartData.Set([.. results]);
             }
             finally
             {
@@ -130,7 +130,7 @@ public class AreaChartBuilder<TSource>(
         var resolvedDesigner = style ?? AreaChartStyleHelpers.GetStyle<TSource>(AreaChartStyles.Default);
 
         var scaffolded = resolvedDesigner.Design(
-            lineChartData.Value.ToExpando(),
+            areaChartData.Value.ToExpando(),
             dimension,
             _measures.ToArray()
         );


### PR DESCRIPTION
# Summary

## Changes

Renamed the `lineChartData` variable to `areaChartData` in `AreaChartBuilder<TSource>.Build()` method in `AreaChartView.cs`. This is a pure rename affecting 3 occurrences (declaration, state update, value access) with no functional changes.

## API Changes

None.

## Files Modified

- `src/Ivy/Views/Charts/AreaChartView.cs` — renamed local variable `lineChartData` to `areaChartData`

## Commits

- 548f88c11 [02019] Rename lineChartData to areaChartData in AreaChartBuilder