### PR TITLE
[02022] Inline BuildStatCard int overload to reduce method count

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/DashboardApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/DashboardApp.cs
@@ -49,12 +49,12 @@ public class DashboardApp : ViewBase
             : 0;
 
         var statsRow = Layout.Horizontal().Gap(2).Padding(2)
-            | BuildStatCard(totalCount, "Total Plans")
-            | BuildStatCard(draftCount, "Draft")
-            | BuildStatCard(inProgressCount, "In Progress")
-            | BuildStatCard(reviewCount, "Ready for Review")
-            | BuildStatCard(completedCount, "Completed")
-            | BuildStatCard(failedCount, "Failed")
+            | BuildStatCard(totalCount.ToString(), "Total Plans")
+            | BuildStatCard(draftCount.ToString(), "Draft")
+            | BuildStatCard(inProgressCount.ToString(), "In Progress")
+            | BuildStatCard(reviewCount.ToString(), "Ready for Review")
+            | BuildStatCard(completedCount.ToString(), "Completed")
+            | BuildStatCard(failedCount.ToString(), "Failed")
             | BuildStatCard($"${avgCost:F2}", "Avg Cost/Plan");
 
         var today = DateTime.UtcNow.Date;
@@ -203,11 +203,6 @@ public class DashboardApp : ViewBase
         return tokens >= 1_000_000 ? $"{tokens / 1_000_000.0:F1}M"
              : tokens >= 1_000 ? $"{tokens / 1_000.0:F0}K"
              : tokens.ToString();
-    }
-
-    private static object BuildStatCard(int count, string label)
-    {
-        return BuildStatCard(count.ToString(), label);
     }
 
     private static object BuildStatCard(string value, string label)


### PR DESCRIPTION
# Summary

## Changes

Inlined the `BuildStatCard(int count, string label)` overload by adding `.ToString()` at all 6 call sites and removing the now-unnecessary int overload method, reducing the class method count by 1.

## API Changes

None. Both methods were `private static` — no public API surface affected.

## Files Modified

- `src/tendril/Ivy.Tendril/Apps/DashboardApp.cs` — Removed int overload of `BuildStatCard`, updated 6 call sites to use `.ToString()`

## Commits

- 19ce569a2 [02022] Inline BuildStatCard int overload to reduce method count