### PR TITLE
[02023] Replace dynamic with generic math interfaces in FillGaps

### DIFF
--- a/src/Ivy/Views/Charts/PivotTable.cs
+++ b/src/Ivy/Views/Charts/PivotTable.cs
@@ -1,4 +1,5 @@
 using System.Linq.Expressions;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 
 // ReSharper disable once CheckNamespace
@@ -154,7 +155,7 @@ public class PivotTable<T>
         return firstValue switch
         {
             DateTime startTime when lastValue is DateTime endTime =>
-                FillGaps(result, dimensionName, measures, startTime, endTime,
+                FillDateTimeGaps(result, dimensionName, measures, startTime, endTime,
                     interval as TimeSpan? ?? TimeSpan.FromHours(1)),
 
             int startInt when lastValue is int endInt =>
@@ -165,20 +166,54 @@ public class PivotTable<T>
         };
     }
 
+    private static List<Dictionary<string, object>> FillDateTimeGaps(
+        List<Dictionary<string, object>> result,
+        string dimensionName,
+        IList<Measure<T>> measures,
+        DateTime start,
+        DateTime end,
+        TimeSpan step)
+    {
+        var lookup = result.ToDictionary(r => (DateTime)r[dimensionName]);
+        var filled = new List<Dictionary<string, object>>();
+
+        for (var current = start; current <= end; current += step)
+        {
+            if (lookup.TryGetValue(current, out var existing))
+            {
+                filled.Add(existing);
+            }
+            else
+            {
+                var row = new Dictionary<string, object>
+                {
+                    [dimensionName] = current
+                };
+                foreach (var measure in measures)
+                {
+                    row[measure.Name] = 0;
+                }
+                filled.Add(row);
+            }
+        }
+
+        return filled;
+    }
+
     private static List<Dictionary<string, object>> FillGaps<TValue>(
         List<Dictionary<string, object>> result,
         string dimensionName,
         IList<Measure<T>> measures,
         TValue start,
         TValue end,
-        dynamic step) where TValue : struct
+        TValue step) where TValue : struct, INumber<TValue>
     {
         var lookup = result.ToDictionary(r => (TValue)r[dimensionName]);
         var filled = new List<Dictionary<string, object>>();
 
-        for (dynamic current = start; current <= end; current += step)
+        for (var current = start; current <= end; current += step)
         {
-            if (lookup.TryGetValue((TValue)current, out var existing))
+            if (lookup.TryGetValue(current, out var existing))
             {
                 filled.Add(existing);
             }


### PR DESCRIPTION
# Summary

## Changes

Replaced the single `FillGaps<TValue>` method that used `dynamic` for arithmetic with two type-safe methods: `FillDateTimeGaps` (handling `DateTime + TimeSpan`) and `FillGaps<TValue>` (constrained to `INumber<TValue>` for numeric types). Added `using System.Numerics` import.

## API Changes

None. Both methods are `private static` — no public API surface changed.

## Files Modified

- **src/Ivy/Views/Charts/PivotTable.cs** — Split `FillGaps<TValue>` into `FillDateTimeGaps` and `FillGaps<TValue>` with `INumber<TValue>` constraint; updated `FillDimensionGaps` to call `FillDateTimeGaps` for the DateTime case.

## Commits

- a4ff8f9a2 [02023] Replace dynamic with generic math interfaces in FillGaps