### PR TITLE
[02025] Clean up button shortcut debounce map to prevent memory leak

### DIFF
--- a/src/frontend/src/widgets/button/ButtonWidget.tsx
+++ b/src/frontend/src/widgets/button/ButtonWidget.tsx
@@ -239,6 +239,7 @@ export const ButtonWidget: React.FC<ButtonWidgetProps> = ({
     window.addEventListener("keydown", handleKeyDown);
     return () => {
       window.removeEventListener("keydown", handleKeyDown);
+      recentShortcuts.delete(id);
     };
   }, [shortcutKey, disabled, id, effectiveUrl, eventHandler]);
 


### PR DESCRIPTION
# Summary

## Changes

Added cleanup logic to the ButtonWidget's keyboard shortcut `useEffect` to remove the button's entry from the module-level `recentShortcuts` Map when the component unmounts. This prevents unbounded growth of the Map during long-running sessions.

## API Changes

None.

## Files Modified

- `src/frontend/src/widgets/button/ButtonWidget.tsx` — Added `recentShortcuts.delete(id)` to the useEffect cleanup function

## Commits

- 3ca2060ad [02025] Clean up recentShortcuts map entry on button unmount