### PR TITLE
[02027] Move status badge mappings to shared class

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Plans/SidebarView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Plans/SidebarView.cs
@@ -17,19 +17,6 @@ public class SidebarView(
     private readonly IState<string?> _textFilter = textFilter;
     private readonly IConfigService _config = config;
 
-    private static readonly Dictionary<PlanStatus, BadgeVariant> PlanStatusBadgeVariants = new()
-    {
-        [PlanStatus.Building] = BadgeVariant.Info,
-        [PlanStatus.Updating] = BadgeVariant.Info,
-        [PlanStatus.Executing] = BadgeVariant.Info,
-        [PlanStatus.ReadyForReview] = BadgeVariant.Success,
-        [PlanStatus.Failed] = BadgeVariant.Destructive,
-        [PlanStatus.Draft] = BadgeVariant.Outline,
-        [PlanStatus.Completed] = BadgeVariant.Success,
-        [PlanStatus.Skipped] = BadgeVariant.Outline,
-        [PlanStatus.Icebox] = BadgeVariant.Outline
-    };
-
     public override object Build()
     {
         var filteredPlans = PlanFilters.ApplyFilters(_plans, _projectFilter.Value, _levelFilter.Value, _textFilter.Value);
@@ -58,7 +45,7 @@ public class SidebarView(
         var content = new List(filteredPlans.Select(plan =>
         {
             var clickablePlan = plan;
-            var stateBadgeVariant = PlanStatusBadgeVariants.TryGetValue(plan.Status, out var variant)
+            var stateBadgeVariant = StatusMappings.PlanStatusBadgeVariants.TryGetValue(plan.Status, out var variant)
                 ? variant
                 : BadgeVariant.Outline;
 

--- a/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -27,14 +27,6 @@ public class ContentView(
     private readonly IConfigService _config = config;
     private readonly IGitService _gitService = gitService;
 
-    private static readonly Dictionary<string, BadgeVariant> VerificationStatusBadgeVariants = new()
-    {
-        ["Pass"] = BadgeVariant.Success,
-        ["Fail"] = BadgeVariant.Destructive,
-        ["Pending"] = BadgeVariant.Outline,
-        ["Skipped"] = BadgeVariant.Outline
-    };
-
     public override object? Build()
     {
         var client = UseService<IClientProvider>();
@@ -147,7 +139,7 @@ public class ContentView(
 
             verificationsTable |= new TableRow(
                 new TableCell(new Badge(v.Status).Variant(
-                    VerificationStatusBadgeVariants.TryGetValue(v.Status, out var variant)
+                    StatusMappings.VerificationStatusBadgeVariants.TryGetValue(v.Status, out var variant)
                         ? variant
                         : BadgeVariant.Outline)),
                 new TableCell(nameCell)

--- a/src/tendril/Ivy.Tendril/Apps/StatusMappings.cs
+++ b/src/tendril/Ivy.Tendril/Apps/StatusMappings.cs
@@ -1,0 +1,36 @@
+using Ivy.Tendril.Apps.Plans;
+
+namespace Ivy.Tendril.Apps;
+
+/// <summary>
+/// Shared mappings for status to badge variant styling across Tendril views.
+/// </summary>
+internal static class StatusMappings
+{
+    /// <summary>
+    /// Maps plan status to badge variant for consistent styling.
+    /// </summary>
+    public static readonly Dictionary<PlanStatus, BadgeVariant> PlanStatusBadgeVariants = new()
+    {
+        [PlanStatus.Building] = BadgeVariant.Info,
+        [PlanStatus.Updating] = BadgeVariant.Info,
+        [PlanStatus.Executing] = BadgeVariant.Info,
+        [PlanStatus.ReadyForReview] = BadgeVariant.Success,
+        [PlanStatus.Failed] = BadgeVariant.Destructive,
+        [PlanStatus.Draft] = BadgeVariant.Outline,
+        [PlanStatus.Completed] = BadgeVariant.Success,
+        [PlanStatus.Skipped] = BadgeVariant.Outline,
+        [PlanStatus.Icebox] = BadgeVariant.Outline
+    };
+
+    /// <summary>
+    /// Maps verification status strings to badge variants for consistent styling.
+    /// </summary>
+    public static readonly Dictionary<string, BadgeVariant> VerificationStatusBadgeVariants = new()
+    {
+        ["Pass"] = BadgeVariant.Success,
+        ["Fail"] = BadgeVariant.Destructive,
+        ["Pending"] = BadgeVariant.Outline,
+        ["Skipped"] = BadgeVariant.Outline
+    };
+}


### PR DESCRIPTION
# Summary

## Changes

Extracted `PlanStatusBadgeVariants` and `VerificationStatusBadgeVariants` dictionaries from their respective private view classes into a new shared `StatusMappings` static class in the `Ivy.Tendril.Apps` namespace. Both consuming views now reference the shared class instead of maintaining their own copies.

## API Changes

- **New class:** `Ivy.Tendril.Apps.StatusMappings` (`internal static`)
  - `public static readonly Dictionary<PlanStatus, BadgeVariant> PlanStatusBadgeVariants`
  - `public static readonly Dictionary<string, BadgeVariant> VerificationStatusBadgeVariants`
- **Removed:** `SidebarView.PlanStatusBadgeVariants` (private static)
- **Removed:** `ContentView.VerificationStatusBadgeVariants` (private static)

## Files Modified

- **New:** `src/tendril/Ivy.Tendril/Apps/StatusMappings.cs` — shared status-to-badge-variant mappings
- **Modified:** `src/tendril/Ivy.Tendril/Apps/Plans/SidebarView.cs` — removed local dictionary, uses `StatusMappings`
- **Modified:** `src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs` — removed local dictionary, uses `StatusMappings`

## Commits

- 34b0d21f7 [02027] Move status badge mappings to shared StatusMappings class