### PR TITLE
[02028] Rename lineChartData to barChartData in BarChartBuilder

### DIFF
--- a/src/Ivy/Views/Charts/BarChartView.cs
+++ b/src/Ivy/Views/Charts/BarChartView.cs
@@ -100,7 +100,7 @@ public class BarChartBuilder<TSource>(
             throw new InvalidOperationException("At least one measure is required.");
         }
 
-        var lineChartData = UseState(ImmutableArray.Create<Dictionary<string, object>>);
+        var barChartData = UseState(ImmutableArray.Create<Dictionary<string, object>>);
         var loading = UseState(true);
 
         UseEffect(async () =>
@@ -124,7 +124,7 @@ public class BarChartBuilder<TSource>(
                 }
 
                 var results = await pivotBuilder.ExecuteAsync();
-                lineChartData.Set([.. results]);
+                barChartData.Set([.. results]);
             }
             finally
             {
@@ -140,7 +140,7 @@ public class BarChartBuilder<TSource>(
         var resolvedDesigner = style ?? BarChartStyleHelpers.GetStyle<TSource>(BarChartStyles.Default);
 
         var scaffolded = resolvedDesigner.Design(
-            lineChartData.Value.ToExpando(),
+            barChartData.Value.ToExpando(),
             dimension,
             _measures.ToArray()
         );


### PR DESCRIPTION
# Summary

## Changes

Renamed the local variable `lineChartData` to `barChartData` in `BarChartBuilder<TSource>.Build()` method. This fixes a copy-paste naming issue where the variable name referenced "line chart" in a bar chart context.

## API Changes

None.

## Files Modified

- `src/Ivy/Views/Charts/BarChartView.cs` — renamed variable at declaration (line 103), state update (line 127), and value access (line 143)

## Commits

- f2a97d1e5 [02028] Rename lineChartData to barChartData in BarChartBuilder