### PR TITLE
[02031] Extract FormatTokens to shared formatter utility

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/DashboardApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/DashboardApp.cs
@@ -91,7 +91,7 @@ public class DashboardApp : ViewBase
                 Failed = dayFailedCount,
                 Cost = dayCost > 0 ? $"${dayCost:F2}" : "",
                 CostPerPlan = costPerPlan,
-                Tokens = dayTokens > 0 ? FormatTokens(dayTokens) : ""
+                Tokens = dayTokens > 0 ? FormatHelper.FormatTokens(dayTokens) : ""
             };
         }).ToList();
 
@@ -196,13 +196,6 @@ public class DashboardApp : ViewBase
             header: statsRow,
             content: content
         );
-    }
-
-    private static string FormatTokens(int tokens)
-    {
-        return tokens >= 1_000_000 ? $"{tokens / 1_000_000.0:F1}M"
-             : tokens >= 1_000 ? $"{tokens / 1_000.0:F0}K"
-             : tokens.ToString();
     }
 
     private static object BuildStatCard(string value, string label)

--- a/src/tendril/Ivy.Tendril/Services/FormatHelper.cs
+++ b/src/tendril/Ivy.Tendril/Services/FormatHelper.cs
@@ -1,0 +1,18 @@
+namespace Ivy.Tendril.Services;
+
+/// <summary>
+/// Shared formatting utilities for human-readable display values.
+/// </summary>
+public static class FormatHelper
+{
+    /// <summary>
+    /// Formats a token count as a human-readable string.
+    /// Values >= 1M are formatted as "X.XM", >= 1K as "XK", otherwise as the raw number.
+    /// </summary>
+    public static string FormatTokens(int tokens)
+    {
+        return tokens >= 1_000_000 ? $"{tokens / 1_000_000.0:F1}M"
+             : tokens >= 1_000 ? $"{tokens / 1_000.0:F0}K"
+             : tokens.ToString();
+    }
+}


### PR DESCRIPTION
# Summary

## Changes

Extracted the `FormatTokens(int)` method from `DashboardApp.cs` into a new shared `FormatHelper` static class in `Services/`. The `DashboardApp` now calls `FormatHelper.FormatTokens()` instead of its own private method.

## API Changes

- **New class:** `Ivy.Tendril.Services.FormatHelper` (public static)
- **New method:** `FormatHelper.FormatTokens(int tokens)` — formats token counts as "1.2M", "45K", or raw number

## Files Modified

- **New:** `Services/FormatHelper.cs` — shared formatter utility
- **Modified:** `Apps/DashboardApp.cs` — removed private `FormatTokens`, updated call to use `FormatHelper.FormatTokens`

## Commits

- 26b160f72 [02031] Extract FormatTokens to shared FormatHelper utility