### PR TITLE
[02030] Remove two RowActions from Jobs table

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/JobsApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/JobsApp.cs
@@ -27,8 +27,6 @@ public class JobsApp : ViewBase
         var planService = UseService<IPlanReaderService>();
         var client = UseService<IClientProvider>();
         var refreshToken = UseRefreshToken();
-        var showCommand = UseState<string?>(null);
-        var showOutput = UseState<string?>(null);
         var showPlan = UseState<string?>(null);
         var openFile = UseState<string?>(null);
         var config = UseService<IConfigService>();
@@ -146,8 +144,6 @@ public class JobsApp : ViewBase
                 return ValueTask.CompletedTask;
             })
             .RowActions(
-                new MenuItem(Label: "Show Command", Icon: Icons.Terminal, Tag: "show-command").Tooltip("Show the PowerShell command"),
-                new MenuItem(Label: "View Output", Icon: Icons.ScrollText, Tag: "view-output").Tooltip("View full job output"),
                 new MenuItem(Label: "View Plan", Icon: Icons.FileText, Tag: "view-plan").Tooltip("Open the associated plan"),
                 new MenuItem(Label: "Stop", Icon: Icons.Square, Tag: "stop-job").Tooltip("Stop this running job"),
                 new MenuItem(Label: "Rerun", Icon: Icons.RotateCw, Tag: "rerun-job").Tooltip("Rerun this job"),
@@ -176,18 +172,6 @@ public class JobsApp : ViewBase
                         {
                             jobService.StopJob(job.Id);
                             refreshToken.Refresh();
-                        }
-                    }
-                    else if (tag == "show-command")
-                    {
-                        var command = $"pwsh -NoProfile -File \"{job.ScriptPath}\" {string.Join(" ", job.Args.Select(a => $"\"{a}\""))}";
-                        showCommand.Set(command);
-                    }
-                    else if (tag == "view-output")
-                    {
-                        if (job.Status != "Running" && job.OutputLines.Count > 0)
-                        {
-                            showOutput.Set(string.Join("\n", job.OutputLines));
                         }
                     }
                     else if (tag == "rerun-job")
@@ -235,30 +219,6 @@ public class JobsApp : ViewBase
                 ));
 
         var layout = Layout.Vertical().Height(Size.Full());
-
-        if (showCommand.Value is { } cmd)
-        {
-            return layout | new Fragment(
-                dataTable,
-                new Sheet(
-                    onClose: () => showCommand.Set(null),
-                    content: new Markdown($"```\n{cmd}\n```"),
-                    title: "Promptware Command"
-                ).Width(Size.Half()).Resizable()
-            );
-        }
-
-        if (showOutput.Value is { } output)
-        {
-            return layout | new Fragment(
-                dataTable,
-                new Sheet(
-                    onClose: () => showOutput.Set(null),
-                    content: new Markdown($"```\n{output}\n```"),
-                    title: "Job Output"
-                ).Width(Size.Half()).Resizable()
-            );
-        }
 
         if (showPlan.Value is { } planPath)
         {


### PR DESCRIPTION
# Summary

## Changes

Removed the "Show Command" and "View Output" RowActions from the Jobs table in JobsApp.cs. This includes removing the MenuItem definitions, their OnRowAction handler blocks, the associated `showCommand` and `showOutput` state variables, and the Sheet rendering blocks that displayed the command/output content.

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/Apps/JobsApp.cs** — Removed 2 RowActions, 2 state variables, 2 handler blocks, and 2 Sheet rendering blocks (40 lines deleted)

---

## Commits

- bda5268a4 [02030] Remove Show Command and View Output RowActions from Jobs table