### PR TITLE
Refactor: Move merge conflict check to Linux workflow

### DIFF
--- a/.github/workflows/backend-checks-windows.yml
+++ b/.github/workflows/backend-checks-windows.yml
@@ -15,14 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Check for merge conflict markers (fail fast before expensive build steps)
-      - name: Check for merge conflicts
-        run: |
-          if git grep -n -E '^(<<<<<<<|=======|>>>>>>>)' -- '*.cs'; then
-            echo "ERROR: Merge conflict markers found!"
-            exit 1
-          fi
-
       # Setup Node.js (needed for integrated frontend build in dotnet build)
       - uses: voidzero-dev/setup-vp@v1
 


### PR DESCRIPTION
Removing the merge conflict check from the Windows workflow to avoid PowerShell parser errors. The check is already performed in the Linux workflow and the dedicated conflict check workflow.