### PR TITLE
[01234] Add tag trigger to publish-tendril workflow

### DIFF
--- a/.github/workflows/publish-tendril.yml
+++ b/.github/workflows/publish-tendril.yml
@@ -5,7 +5,13 @@ permissions:
   id-token: write
 
 on:
+  push:
+    tags: ['tendril/v*']
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g. 1.0.2). Leave empty to use Directory.Build.props version.'
+        required: false
 
 jobs:
   publish:
@@ -37,8 +43,23 @@ jobs:
       - name: Build
         run: dotnet build tendril/Ivy.Tendril/Ivy.Tendril.csproj --configuration Release --no-restore
 
+      - name: Determine version
+        id: version
+        run: |
+          if [ -n "${{ github.event.inputs.version }}" ]; then
+            echo "version=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
+          elif [[ "$GITHUB_REF" == refs/tags/tendril/v* ]]; then
+            TAG_VERSION="${GITHUB_REF#refs/tags/tendril/v}"
+            echo "version=$TAG_VERSION" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Pack
-        run: dotnet pack tendril/Ivy.Tendril/Ivy.Tendril.csproj --configuration Release --no-build --output ./nupkg
+        run: |
+          VERSION_ARG=""
+          if [ -n "${{ steps.version.outputs.version }}" ]; then
+            VERSION_ARG="/p:Version=${{ steps.version.outputs.version }}"
+          fi
+          dotnet pack tendril/Ivy.Tendril/Ivy.Tendril.csproj --configuration Release --no-build --output ./nupkg $VERSION_ARG
 
       - name: NuGet login (trusted publishing)
         uses: NuGet/login@v1


### PR DESCRIPTION
# Summary

## Changes

Added a `push.tags` trigger for `tendril/v*` tags to the `publish-tendril.yml` GitHub Actions workflow. The workflow now automatically triggers when a tag matching `tendril/v*` is pushed, extracting the version from the tag name for NuGet packaging. The existing `workflow_dispatch` trigger was enhanced with an optional `version` input parameter.

## API Changes

None.

## Files Modified

- `.github/workflows/publish-tendril.yml` — Added tag trigger, version extraction step, and updated Pack step to use resolved version

## Commits

- ad86597bf — [01234] Add tag trigger to publish-tendril workflow