### PR TITLE
[01233] Update formatBytes JSDoc for non-finite values

### DIFF
--- a/src/frontend/src/lib/formatters.ts
+++ b/src/frontend/src/lib/formatters.ts
@@ -1,5 +1,5 @@
 /** Formats a byte count into a human-readable string (e.g. 1536 → "1.50 KB").
- *  Non-positive values return "0 B". */
+ *  Non-positive and non-finite values return "0 B". */
 export const formatBytes = (bytes: number, precision?: number): string => {
   if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
 


### PR DESCRIPTION
## Summary

Updated the JSDoc comment on `formatBytes` in `src/frontend/src/lib/formatters.ts` to accurately document that non-finite values (NaN, Infinity, -Infinity) also return "0 B", matching the guard added in plan 01223.

## API Changes

None.

## Files Modified

- `src/frontend/src/lib/formatters.ts` — JSDoc comment update (line 2)

## Commits

- b6968632a