### PR TITLE
[01232] Add convertToHex test for non-hex theme color fallback path

### DIFF
--- a/src/frontend/src/widgets/inputs/__tests__/colorUtils.test.ts
+++ b/src/frontend/src/widgets/inputs/__tests__/colorUtils.test.ts
@@ -68,6 +68,26 @@ describe("convertToHex", () => {
 
     vi.restoreAllMocks();
   });
+
+  it("falls back to raw color name when theme returns rgb instead of hex", () => {
+    vi.spyOn(globalThis, "getComputedStyle").mockReturnValue({
+      getPropertyValue: () => "rgb(255, 0, 0)",
+    } as unknown as CSSStyleDeclaration);
+
+    expect(convertToHex("red")).toBe("red");
+
+    vi.restoreAllMocks();
+  });
+
+  it("falls back to raw color name when theme returns empty string", () => {
+    vi.spyOn(globalThis, "getComputedStyle").mockReturnValue({
+      getPropertyValue: () => "",
+    } as unknown as CSSStyleDeclaration);
+
+    expect(convertToHex("red")).toBe("red");
+
+    vi.restoreAllMocks();
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
# Summary

## Changes

Added two unit tests to `colorUtils.test.ts` covering the `convertToHex` fallback path when `getThemeColorHex` returns `undefined` due to non-hex computed style values. One test mocks `getComputedStyle` returning `rgb(255, 0, 0)`, the other mocks it returning an empty string — both verify `convertToHex("red")` falls through to returning the raw color name `"red"`.

## API Changes

None.

## Files Modified

- `src/frontend/src/widgets/inputs/__tests__/colorUtils.test.ts` — added 2 test cases in `describe("convertToHex")` block

## Commits

- 9012e58c2