### PR TITLE
[02033] Fix Jobs DataTable not auto-refreshing Timer and Last Output columns

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/JobServiceJobsChangedTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/JobServiceJobsChangedTests.cs
@@ -1,0 +1,51 @@
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Test;
+
+public class JobServiceJobsChangedTests
+{
+    private static JobService CreateService()
+    {
+        SynchronizationContext.SetSynchronizationContext(null);
+        return new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
+    }
+
+    [Fact]
+    public void CompleteJob_RaisesJobsChangedEvent()
+    {
+        var service = CreateService();
+        var id = service.CreateTestJob("ExecutePlan", "test-plan");
+
+        var fired = false;
+        service.JobsChanged += () => fired = true;
+        service.CompleteJob(id, exitCode: 0);
+
+        Assert.True(fired);
+    }
+
+    [Fact]
+    public void CompleteJob_Failure_RaisesJobsChangedEvent()
+    {
+        var service = CreateService();
+        var id = service.CreateTestJob("ExecutePlan", "test-plan");
+
+        var fired = false;
+        service.JobsChanged += () => fired = true;
+        service.CompleteJob(id, exitCode: 1);
+
+        Assert.True(fired);
+    }
+
+    [Fact]
+    public void StopJob_RaisesJobsChangedEvent()
+    {
+        var service = CreateService();
+        var id = service.CreateTestJob("ExecutePlan", "test-plan");
+
+        var fired = false;
+        service.JobsChanged += () => fired = true;
+        service.StopJob(id);
+
+        Assert.True(fired);
+    }
+}

--- a/src/tendril/Ivy.Tendril/Apps/JobsApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/JobsApp.cs
@@ -46,6 +46,21 @@ public class JobsApp : ViewBase
             return Disposable.Create(() => jobService.NotificationReady -= OnNotification);
         });
 
+        UseEffect(() =>
+        {
+            void OnJobsChanged() => refreshToken.Refresh();
+            jobService.JobsChanged += OnJobsChanged;
+            return Disposable.Create(() => jobService.JobsChanged -= OnJobsChanged);
+        });
+
+        UseInterval(() =>
+        {
+            if (jobService.GetJobs().Any(j => j.Status == "Running"))
+            {
+                refreshToken.Refresh();
+            }
+        }, TimeSpan.FromSeconds(5));
+
         var jobs = jobService.GetJobs();
         var rows = jobs.Select(j => new JobItemRow
         {


### PR DESCRIPTION
# Summary

## Changes

Added two refresh mechanisms to `JobsApp.cs` that were lost during the plan 01922 migration from polling to event-based notifications: a `JobsChanged` event subscription for immediate UI updates on job state changes, and a `UseInterval` that refreshes every 5 seconds when running jobs exist to keep Timer and Last Output columns current.

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/Apps/JobsApp.cs** — Added `UseEffect` for `JobsChanged` event subscription and `UseInterval` for periodic refresh of time-based columns
- **src/tendril/Ivy.Tendril.Test/JobServiceJobsChangedTests.cs** — New test class verifying `JobsChanged` event fires on complete, fail, and stop operations

## Commits

- 63e36f9a8 [02033] Fix Jobs DataTable not auto-refreshing