### PR TITLE
[02043] Extract cost formatting to FormatHelper.FormatCost

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/DashboardApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/DashboardApp.cs
@@ -55,7 +55,7 @@ public class DashboardApp : ViewBase
             | BuildStatCard(reviewCount.ToString(), "Ready for Review")
             | BuildStatCard(completedCount.ToString(), "Completed")
             | BuildStatCard(failedCount.ToString(), "Failed")
-            | BuildStatCard($"${avgCost:F2}", "Avg Cost/Plan");
+            | BuildStatCard(FormatHelper.FormatCost(avgCost), "Avg Cost/Plan");
 
         var today = DateTime.UtcNow.Date;
         var days = Enumerable.Range(0, 7).Select(i => today.AddDays(-i)).ToList();
@@ -78,7 +78,7 @@ public class DashboardApp : ViewBase
             var dayCost = completedOrFailedPlans.Sum(p => costCache.GetValueOrDefault(p.FolderPath, 0m));
             var dayTokens = completedOrFailedPlans.Sum(p => tokenCache.GetValueOrDefault(p.FolderPath, 0));
             var costPerPlan = dayCompletedCount > 0 && dayCost > 0
-                ? $"${dayCost / dayCompletedCount:F2}"
+                ? FormatHelper.FormatCost(dayCost / dayCompletedCount)
                 : "";
 
             return new DashboardDayRow
@@ -89,7 +89,7 @@ public class DashboardApp : ViewBase
                 Completed = dayCompletedCount,
                 PrsMerged = prsMerged,
                 Failed = dayFailedCount,
-                Cost = dayCost > 0 ? $"${dayCost:F2}" : "",
+                Cost = dayCost > 0 ? FormatHelper.FormatCost(dayCost) : "",
                 CostPerPlan = costPerPlan,
                 Tokens = dayTokens > 0 ? FormatHelper.FormatTokens(dayTokens) : ""
             };

--- a/src/tendril/Ivy.Tendril/Services/FormatHelper.cs
+++ b/src/tendril/Ivy.Tendril/Services/FormatHelper.cs
@@ -15,4 +15,13 @@ public static class FormatHelper
              : tokens >= 1_000 ? $"{tokens / 1_000.0:F0}K"
              : tokens.ToString();
     }
+
+    /// <summary>
+    /// Formats a cost value as a currency string with 2 decimal places.
+    /// Returns "$X.XX" format (e.g. "$12.45" or "$0.00").
+    /// </summary>
+    public static string FormatCost(decimal cost)
+    {
+        return $"${cost:F2}";
+    }
 }


### PR DESCRIPTION
# Summary

## Changes

Added `FormatHelper.FormatCost(decimal cost)` method and replaced all three inline cost formatting expressions (`$"${cost:F2}"`) in `DashboardApp.cs` with calls to this centralized method. This follows the same pattern as the existing `FormatHelper.FormatTokens()` method.

## API Changes

- **New:** `FormatHelper.FormatCost(decimal cost)` — returns `$"$X.XX"` formatted string

## Files Modified

- **Services/FormatHelper.cs** — Added `FormatCost` static method
- **Apps/DashboardApp.cs** — Replaced 3 inline `$"${...:F2}"` expressions with `FormatHelper.FormatCost()` calls

## Commits

- 6af1feabd [02043] Extract cost formatting to FormatHelper.FormatCost