### PR TITLE
[02048] Simplify UseEffect stubs in analyzer tests

### DIFF
--- a/src/Ivy.Analyser.Test/UseEffectTaskAnalyzerTests.cs
+++ b/src/Ivy.Analyser.Test/UseEffectTaskAnalyzerTests.cs
@@ -23,7 +23,6 @@ namespace Ivy
 static class UseEffectExtensions
 {
     public static void UseEffect(this Ivy.ViewBase view, Func<IDisposable> callback, params object[] deps) { }
-    public static void UseEffect(this Ivy.ViewBase view, Func<IAsyncDisposable> callback, params object[] deps) { }
 }
 ";
 
@@ -37,7 +36,7 @@ public class MyView : Ivy.ViewBase
     {
         this.UseEffect(() => {
             {|IVYEFFECT001:Task.Delay(300).ContinueWith(_ => { })|};
-            return (IDisposable)null;
+            return null;
         });
         return null;
     }
@@ -110,7 +109,7 @@ public class MyView : Ivy.ViewBase
         var x = 1;
         this.UseEffect(() => {
             {|IVYEFFECT001:Task.Delay(300).ContinueWith(_ => { })|};
-            return (IDisposable)null;
+            return null;
         }, x);
         return null;
     }


### PR DESCRIPTION
# Summary

## Changes

Removed the `Func<IAsyncDisposable>` overload from the `Stubs` constant in `UseEffectTaskAnalyzerTests.cs` and replaced explicit `(IDisposable)null` casts with plain `return null;` in two test methods.

## API Changes

None.

## Files Modified

- `src/Ivy.Analyser.Test/UseEffectTaskAnalyzerTests.cs` — Removed redundant stub overload, simplified return statements

---

**Commits:**
- 5449fcb57 [02048] Simplify UseEffect stubs in analyzer tests