### PR TITLE
[02051] Pre-populate Tendril Home input if TENDRIL_HOME is already set

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/OnboardingApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/OnboardingApp.cs
@@ -199,10 +199,11 @@ public class TendrilHomeStepView(IState<int> stepperIndex) : ViewBase
     {
         var details = UseState(new TendrilHomeDetails
         {
-            TendrilHome = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-            ".tendril"
-        )
+            TendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME")
+                ?? Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                    ".tendril"
+                )
         });
         var error = UseState<string?>(null);
         var config = UseService<IConfigService>();


### PR DESCRIPTION
# Summary

## Changes

Modified the Tendril onboarding flow to check for an existing `TENDRIL_HOME` environment variable before defaulting to `~/.tendril`. This pre-populates the data location input field with the user's configured value when available.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Apps/OnboardingApp.cs` — Updated `TendrilHomeStepView.Build()` to use `Environment.GetEnvironmentVariable("TENDRIL_HOME")` with null-coalescing fallback

---

## Commits

- 4eba98575 [02051] Pre-populate Tendril Home from TENDRIL_HOME env var