### PR TITLE
[02050] Fix Dashboard FillGaps not working due to string dimension

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/DashboardApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/DashboardApp.cs
@@ -170,7 +170,7 @@ public class DashboardApp : ViewBase
                     ],
                     XAxis =
                     [
-                        new XAxis().Hide()
+                        new XAxis().TickFormatter("MM/dd HH").Hide()
                     ],
                     YAxis =
                     [
@@ -179,7 +179,7 @@ public class DashboardApp : ViewBase
                     ]
                 })
             .FillGaps(TimeSpan.FromHours(1))
-            .Dimension("Hour", e => e.Hour.ToString("MM/dd HH"))
+            .Dimension("Hour", e => e.Hour)
             .Measure("Cost ($)", e => e.Sum(f => (double)f.Cost))
             .Measure("Tokens", e => e.Sum(f => (double)f.Tokens))
             .Height(Size.Px(350))


### PR DESCRIPTION
# Summary

## Changes

Changed the Dashboard hourly cost & tokens chart dimension from a formatted string (`e.Hour.ToString("MM/dd HH")`) to the raw `DateTime` value (`e.Hour`). Moved the date formatting to `XAxis.TickFormatter("MM/dd HH")` so the chart still displays dates in the same format while allowing `FillDimensionGaps` to correctly identify and fill DateTime gaps.

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/Apps/DashboardApp.cs** — Changed `.Dimension()` lambda and added `.TickFormatter()` to XAxis

---

## Commits

- d30c65842 [02050] Fix Dashboard FillGaps by using DateTime dimension instead of string