### PR TITLE
[02055] Use Colors enum for project color selection

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/OnboardingApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/OnboardingApp.cs
@@ -290,7 +290,7 @@ public class ProjectSetupStepView(IState<int> stepperIndex) : ViewBase
     {
         var config = UseService<IConfigService>();
         var projectName = UseState("");
-        var projectColor = UseState("");
+        var projectColor = UseState<Colors?>(null);
         var repoPaths = UseState(new List<string>());
         var newRepoPath = UseState("");
         var error = UseState<string?>(null);
@@ -327,7 +327,7 @@ public class ProjectSetupStepView(IState<int> stepperIndex) : ViewBase
                | Text.Muted("Set up your first project. You can add more projects later in Settings.")
                | (error.Value != null ? Text.Danger(error.Value) : null!)
                | projectName.ToTextInput("Project name...").WithField().Label("Project Name")
-               | projectColor.ToColorInput().Variant(ColorInputVariant.TextAndPicker).Nullable().WithField().Label("Color")
+               | projectColor.ToSelectInput().WithField().Label("Color")
                | (Layout.Vertical().Gap(2)
                    | Text.Block("Repositories").Bold()
                    | Text.Muted("Add at least one repository path for this project.")
@@ -352,7 +352,7 @@ public class ProjectSetupStepView(IState<int> stepperIndex) : ViewBase
                            var project = new ProjectConfig
                            {
                                Name = projectName.Value.Trim(),
-                               Color = projectColor.Value,
+                               Color = projectColor.Value?.ToString() ?? "",
                                Repos = repoPaths.Value.Select(p => new RepoRef { Path = p, PrRule = "default" }).ToList()
                            };
                            config.SetPendingProject(project);

--- a/src/tendril/Ivy.Tendril/Apps/Settings/ProjectsSettingsView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Settings/ProjectsSettingsView.cs
@@ -14,7 +14,7 @@ public class ProjectsSettingsView : ViewBase
 
         // Edit form state — must be declared unconditionally (Ivy hook rules)
         var editName = UseState("");
-        var editColor = UseState("");
+        var editColor = UseState<Colors?>(null);
         var editSlackEmoji = UseState("");
         var editContext = UseState("");
         var editRepos = UseState(new List<RepoRef>());
@@ -60,7 +60,7 @@ public class ProjectsSettingsView : ViewBase
             {
                 editIndex.Set(null);
                 editName.Set("");
-                editColor.Set("");
+                editColor.Set(null);
                 editSlackEmoji.Set("");
                 editContext.Set("");
                 editRepos.Set(new List<RepoRef>());
@@ -225,7 +225,7 @@ public class ProjectsSettingsView : ViewBase
                 new DialogBody(
                     Layout.Vertical().Gap(4)
                         | editName.ToTextInput("Project name...").WithField().Label("Name")
-                        | editColor.ToColorInput().Variant(ColorInputVariant.TextAndPicker).Nullable().WithField().Label("Color")
+                        | editColor.ToSelectInput().WithField().Label("Color")
                         | editSlackEmoji.ToTextInput(":emoji:").WithField().Label("Slack Emoji")
                         | editContext.ToTextareaInput("Project context...").Rows(4).WithField().Label("Context")
                         | (Layout.Vertical().Gap(2)
@@ -242,7 +242,7 @@ public class ProjectsSettingsView : ViewBase
                         if (string.IsNullOrWhiteSpace(editName.Value)) return;
                         var project = isNew ? new ProjectConfig() : projects[editIndex.Value!.Value];
                         project.Name = editName.Value;
-                        project.Color = editColor.Value;
+                        project.Color = editColor.Value?.ToString() ?? "";
                         project.Meta["slackEmoji"] = editSlackEmoji.Value;
                         project.Context = editContext.Value;
                         project.Repos = new List<RepoRef>(editRepos.Value);
@@ -289,7 +289,7 @@ public class ProjectsSettingsView : ViewBase
         {
             editIndex.Set(idx);
             editName.Set(project.Name);
-            editColor.Set(project.Color);
+            editColor.Set(Enum.TryParse<Colors>(project.Color, out var c) ? c : null);
             editSlackEmoji.Set(project.GetMeta("slackEmoji") ?? "");
             editContext.Set(project.Context);
             editRepos.Set(new List<RepoRef>(project.Repos.Select(r => new RepoRef { Path = r.Path, PrRule = r.PrRule })));


### PR DESCRIPTION
# Summary

## Changes

Replaced `ColorInput` with `SelectInput` for project color selection in both `OnboardingApp` (onboarding wizard) and `ProjectsSettingsView` (settings dialog). The state type changed from `IState<string>` to `IState<Colors?>`, and string-to-enum conversion is handled when loading/saving project configs.

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/Apps/OnboardingApp.cs** — Changed `projectColor` state to `Colors?`, replaced `ToColorInput()` with `ToSelectInput()`, added `?.ToString() ?? ""` for config serialization
- **src/tendril/Ivy.Tendril/Apps/Settings/ProjectsSettingsView.cs** — Changed `editColor` state to `Colors?`, replaced `ToColorInput()` with `ToSelectInput()`, added `Enum.TryParse` when loading project color, updated reset to `null`

## Commits

- 3e0e29bd3 [02055] Use Colors enum for project color selection