### PR TITLE
[02054] Fix PostHog Events Not Being Sent to Server

### DIFF
--- a/src/tendril/Ivy.Tendril/Program.cs
+++ b/src/tendril/Ivy.Tendril/Program.cs
@@ -87,7 +87,8 @@ server.Services.AddSingleton<PlanDatabaseSyncService>(sp =>
 server.Services.AddSingleton<ITelemetryService>(sp =>
 {
     var config = sp.GetRequiredService<IConfigService>();
-    return new TelemetryService(config.Settings.Telemetry);
+    var logger = sp.GetRequiredService<ILogger<TelemetryService>>();
+    return new TelemetryService(config.Settings.Telemetry, logger);
 });
 server.Services.AddSingleton<TelemetryService>(sp =>
     (TelemetryService)sp.GetRequiredService<ITelemetryService>());
@@ -136,7 +137,9 @@ server.UseWebApplication(app =>
     // Start database sync in background
     var syncService = app.Services.GetRequiredService<PlanDatabaseSyncService>();
     Task.Run(syncService.PerformInitialSync);
-    app.Services.GetRequiredService<TelemetryService>().TrackAppStarted();
+    var telemetryService = app.Services.GetRequiredService<TelemetryService>();
+    telemetryService.TrackAppStarted();
+    _ = Task.Run(async () => await telemetryService.FlushAsync());
     app.UseAssets(server.Args, app.Services.GetRequiredService<ILogger<Server>>(), "Assets", "tendril/assets");
 });
 server.AddAppsFromAssembly();

--- a/src/tendril/Ivy.Tendril/Services/ITelemetryService.cs
+++ b/src/tendril/Ivy.Tendril/Services/ITelemetryService.cs
@@ -8,4 +8,5 @@ public interface ITelemetryService
     void TrackPlanCreated();
     void TrackPrCreated();
     void TrackJobCompleted(string jobType, JobStatus status, int? durationSeconds);
+    Task FlushAsync();
 }

--- a/src/tendril/Ivy.Tendril/Services/JobService.cs
+++ b/src/tendril/Ivy.Tendril/Services/JobService.cs
@@ -532,6 +532,10 @@ public class JobService : IJobService
 
         _telemetryService?.TrackJobCompleted(job.Type, job.Status, job.DurationSeconds);
 
+        // Flush telemetry events to ensure they reach PostHog
+        if (_telemetryService != null)
+            _ = Task.Run(async () => await _telemetryService.FlushAsync());
+
         CleanupInboxFile(job);
         WriteJobLog(job);
 

--- a/src/tendril/Ivy.Tendril/Services/TelemetryService.cs
+++ b/src/tendril/Ivy.Tendril/Services/TelemetryService.cs
@@ -1,5 +1,6 @@
 using Ivy.Tendril.Apps.Jobs;
 using PostHog;
+using Microsoft.Extensions.Logging;
 
 namespace Ivy.Tendril.Services;
 
@@ -7,9 +8,12 @@ public class TelemetryService : ITelemetryService, IAsyncDisposable
 {
     private readonly PostHogClient? _client;
     private readonly string _distinctId;
+    private readonly ILogger<TelemetryService>? _logger;
 
-    public TelemetryService(bool enabled)
+    public TelemetryService(bool enabled, ILogger<TelemetryService>? logger = null)
     {
+        _logger = logger;
+
         if (!enabled)
         {
             _client = null;
@@ -17,37 +21,94 @@ public class TelemetryService : ITelemetryService, IAsyncDisposable
             return;
         }
 
-        // Public key — safe to expose (like a website tracking snippet)
-        _client = new PostHogClient(new PostHogOptions
+        try
         {
-            ProjectApiKey = "phc_uHeJHFURzThFPnizzGMzLEimLWnRAuqy8DunK8N3oYcd"
-        });
-        _distinctId = GetOrCreateAnonymousId();
+            // Public key — safe to expose (like a website tracking snippet)
+            _client = new PostHogClient(new PostHogOptions
+            {
+                ProjectApiKey = "phc_uHeJHFURzThFPnizzGMzLEimLWnRAuqy8DunK8N3oYcd"
+            });
+            _distinctId = GetOrCreateAnonymousId();
+            _logger?.LogDebug("TelemetryService initialized with anonymous ID: {DistinctId}", _distinctId);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Failed to initialize PostHog client");
+            _client = null;
+            _distinctId = "";
+        }
     }
 
     public void TrackAppStarted()
     {
-        _client?.Capture(_distinctId, "app_started");
+        try
+        {
+            _client?.Capture(_distinctId, "app_started");
+            _logger?.LogDebug("Tracked app_started event");
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Failed to track app_started event");
+        }
     }
 
     public void TrackPlanCreated()
     {
-        _client?.Capture(_distinctId, "plan_created");
+        try
+        {
+            _client?.Capture(_distinctId, "plan_created");
+            _logger?.LogDebug("Tracked plan_created event");
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Failed to track plan_created event");
+        }
     }
 
     public void TrackPrCreated()
     {
-        _client?.Capture(_distinctId, "pr_created");
+        try
+        {
+            _client?.Capture(_distinctId, "pr_created");
+            _logger?.LogDebug("Tracked pr_created event");
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Failed to track pr_created event");
+        }
     }
 
     public void TrackJobCompleted(string jobType, JobStatus status, int? durationSeconds)
     {
-        _client?.Capture(_distinctId, "job_completed", new Dictionary<string, object>
+        try
         {
-            ["job_type"] = jobType,
-            ["status"] = status.ToString(),
-            ["duration_seconds"] = durationSeconds ?? 0
-        });
+            _client?.Capture(_distinctId, "job_completed", new Dictionary<string, object>
+            {
+                ["job_type"] = jobType,
+                ["status"] = status.ToString(),
+                ["duration_seconds"] = durationSeconds ?? 0
+            });
+            _logger?.LogDebug("Tracked job_completed event: {JobType} - {Status}", jobType, status);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Failed to track job_completed event");
+        }
+    }
+
+    public async Task FlushAsync()
+    {
+        if (_client == null) return;
+
+        try
+        {
+            await _client.FlushAsync();
+            _logger?.LogDebug("Flushed telemetry events to PostHog");
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Failed to flush telemetry events");
+        }
     }
 
     private static string GetOrCreateAnonymousId()
@@ -72,6 +133,16 @@ public class TelemetryService : ITelemetryService, IAsyncDisposable
     public async ValueTask DisposeAsync()
     {
         if (_client != null)
-            await _client.DisposeAsync();
+        {
+            try
+            {
+                await FlushAsync();
+                await _client.DisposeAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError(ex, "Error during telemetry service disposal");
+            }
+        }
     }
 }


### PR DESCRIPTION
# Summary

## Changes

Added explicit event flushing and error handling to TelemetryService to ensure PostHog events reliably reach the server. Previously, events were fire-and-forget with no flush or error logging; now each tracking point is wrapped in try-catch with ILogger diagnostics, and FlushAsync is called after app startup, after every job completion, and during disposal.

## API Changes

- `ITelemetryService` — added `Task FlushAsync()` method
- `TelemetryService` constructor — added optional `ILogger<TelemetryService>? logger` parameter
- `TelemetryService.FlushAsync()` — new public method that explicitly flushes queued events to PostHog

## Files Modified

- **Interface:** `src/tendril/Ivy.Tendril/Services/ITelemetryService.cs` — added FlushAsync declaration
- **Service:** `src/tendril/Ivy.Tendril/Services/TelemetryService.cs` — added logger, error handling, FlushAsync, flush-on-dispose
- **Startup:** `src/tendril/Ivy.Tendril/Program.cs` — pass logger to TelemetryService, flush after TrackAppStarted
- **Jobs:** `src/tendril/Ivy.Tendril/Services/JobService.cs` — flush telemetry after job completion tracking

---

**Commits:**
- 96143f6d3 [02054] Fix PostHog events not reaching server