### PR TITLE
[02059] Track plan state transitions in PostHog telemetry

### DIFF
--- a/src/tendril/Ivy.Tendril/Program.cs
+++ b/src/tendril/Ivy.Tendril/Program.cs
@@ -61,7 +61,8 @@ server.Services.AddSingleton<PlanReaderService>(sp =>
 {
     var planService = new PlanReaderService(
         sp.GetRequiredService<IConfigService>(),
-        sp.GetRequiredService<ILogger<PlanReaderService>>());
+        sp.GetRequiredService<ILogger<PlanReaderService>>(),
+        sp.GetRequiredService<ITelemetryService>());
     planService.RepairPlans();
     planService.RecoverStuckPlans();
     return planService;

--- a/src/tendril/Ivy.Tendril/Services/ITelemetryService.cs
+++ b/src/tendril/Ivy.Tendril/Services/ITelemetryService.cs
@@ -8,5 +8,6 @@ public interface ITelemetryService
     void TrackPlanCreated();
     void TrackPrCreated();
     void TrackJobCompleted(string jobType, JobStatus status, int? durationSeconds);
+    void TrackPlanStateTransition(int planId, string fromState, string toState);
     Task FlushAsync();
 }

--- a/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
@@ -5,10 +5,11 @@ using Ivy.Tendril.Apps.Plans;
 
 namespace Ivy.Tendril.Services;
 
-public class PlanReaderService(IConfigService config, ILogger<PlanReaderService> logger) : IPlanReaderService
+public class PlanReaderService(IConfigService config, ILogger<PlanReaderService> logger, ITelemetryService? telemetryService = null) : IPlanReaderService
 {
     private readonly IConfigService _config = config;
     private readonly ILogger<PlanReaderService> _logger = logger;
+    private readonly ITelemetryService? _telemetryService = telemetryService;
 
     private readonly TimeCache<List<HourlyTokenBurn>> _hourlyBurnCache = new(TimeSpan.FromMinutes(2));
 
@@ -223,8 +224,17 @@ public class PlanReaderService(IConfigService config, ILogger<PlanReaderService>
     /// <param name="newState">The target state to transition to.</param>
     public void TransitionState(string folderName, PlanStatus newState)
     {
-        // Update database first for instant UI feedback.
         var planId = ExtractPlanId(folderName);
+
+        // Track state transition in telemetry before making the change.
+        if (planId.HasValue)
+        {
+            var currentPlan = GetPlanByFolder(Path.Combine(PlansDirectory, folderName));
+            var oldState = currentPlan?.Status.ToString() ?? "Unknown";
+            _telemetryService?.TrackPlanStateTransition(planId.Value, oldState, newState.ToString());
+        }
+
+        // Update database first for instant UI feedback.
         if (planId.HasValue && _database != null)
             _database.UpdatePlanState(planId.Value, newState);
 

--- a/src/tendril/Ivy.Tendril/Services/TelemetryService.cs
+++ b/src/tendril/Ivy.Tendril/Services/TelemetryService.cs
@@ -96,6 +96,24 @@ public class TelemetryService : ITelemetryService, IAsyncDisposable
         }
     }
 
+    public void TrackPlanStateTransition(int planId, string fromState, string toState)
+    {
+        try
+        {
+            _client?.Capture(_distinctId, "plan_state_transition", new Dictionary<string, object>
+            {
+                ["plan_id"] = planId,
+                ["from_state"] = fromState,
+                ["to_state"] = toState
+            });
+            _logger?.LogDebug("Tracked plan_state_transition event: {PlanId} {FromState} -> {ToState}", planId, fromState, toState);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Failed to track plan_state_transition event");
+        }
+    }
+
     public async Task FlushAsync()
     {
         if (_client == null) return;


### PR DESCRIPTION
# Summary

## Changes

Added `plan_state_transition` event tracking to PostHog telemetry. When plans transition between states (e.g., Draft -> Executing -> ReadyForReview -> Completed), the event is now captured with plan ID, previous state, and new state as properties.

## API Changes

- `ITelemetryService`: Added `void TrackPlanStateTransition(int planId, string fromState, string toState)`
- `TelemetryService`: Implemented `TrackPlanStateTransition` with PostHog capture and error handling
- `PlanReaderService`: Constructor now accepts optional `ITelemetryService?` parameter
- `PlanReaderService.TransitionState`: Now reads current state before transitioning and calls telemetry

## Files Modified

- `src/tendril/Ivy.Tendril/Services/ITelemetryService.cs` — Added interface method
- `src/tendril/Ivy.Tendril/Services/TelemetryService.cs` — Implemented tracking method
- `src/tendril/Ivy.Tendril/Services/PlanReaderService.cs` — Injected telemetry service and added tracking call
- `src/tendril/Ivy.Tendril/Program.cs` — Wired ITelemetryService into PlanReaderService DI registration

## Commits

- 8fffcf03f [02059] Track plan state transitions in PostHog telemetry