### PR TITLE
[01136] Add Ivy Samples app with Iframe and DevTools for testing

### DIFF
--- a/src/Ivy.Samples.Shared/Apps/Demos/IframeDevToolsApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Demos/IframeDevToolsApp.cs
@@ -1,0 +1,51 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Ivy.Samples.Shared.Apps.Demos;
+
+[App(icon: Icons.CodeXml, group: ["Demos"], searchHints: ["devtools", "iframe", "testing", "visual", "edit"])]
+public class IframeDevToolsApp : ViewBase
+{
+    public override object? Build()
+    {
+        var iframeUrl = UseState("/hello");
+        var devToolsEnabled = UseState(false);
+        var messages = UseState(Array.Empty<string>());
+        var outboundToken = UseState<string?>(null);
+
+        async ValueTask HandleToggle(Event<Button> _)
+        {
+            var next = !devToolsEnabled.Value;
+            devToolsEnabled.Set(next);
+            outboundToken.Set(next ? "true" : "false");
+        }
+
+        async ValueTask HandleMessage(Event<Iframe, (string type, JsonNode payload)> e)
+        {
+            if (e.Value.type == "DEVTOOLS_APPLY_CHANGES")
+            {
+                var json = e.Value.payload?.ToJsonString(new JsonSerializerOptions { WriteIndented = true }) ?? "null";
+                messages.Set([.. messages.Value, json]);
+            }
+        }
+
+        var iframe = new Iframe(iframeUrl.Value)
+            .Height(Size.Units(120))
+            .OutboundMessageType("DEVTOOLS_SET_ENABLED")
+            .OutboundMessageToken(outboundToken.Value ?? "false");
+        iframe.OnMessageReceived = HandleMessage;
+
+        return Layout.Vertical()
+            | (Layout.Horizontal()
+                | iframeUrl.ToInput(placeholder: "Iframe URL, e.g. /hello")
+                | new Button(devToolsEnabled.Value ? "DevTools: On" : "DevTools: Off", HandleToggle)
+                    .Icon(devToolsEnabled.Value ? Icons.EyeOff : Icons.Eye)
+                    .Variant(devToolsEnabled.Value ? ButtonVariant.Primary : ButtonVariant.Outline))
+            | iframe
+            | (messages.Value.Length > 0
+                ? Layout.Vertical()
+                    | Text.H4("Received DevTools Messages")
+                    | (Layout.Vertical().Gap(2) | messages.Value.Select(m => Text.Code(m, Languages.Json)))
+                : null);
+    }
+}

--- a/src/Ivy/Widgets/Primitives/Iframe.cs
+++ b/src/Ivy/Widgets/Primitives/Iframe.cs
@@ -33,6 +33,18 @@ public record Iframe : WidgetBase<Iframe>
 
 public static class IframeExtensions
 {
+    public static Iframe OutboundMessageType(this Iframe widget, string? type)
+    {
+        widget.OutboundMessageType = type;
+        return widget;
+    }
+
+    public static Iframe OutboundMessageToken(this Iframe widget, string? token)
+    {
+        widget.OutboundMessageToken = token;
+        return widget;
+    }
+
     public static Iframe OnMessageReceived(
         this Iframe widget,
         Func<Event<Iframe, (string type, JsonNode payload)>, ValueTask> callback)


### PR DESCRIPTION
# Summary

## Changes

Added a new `IframeDevToolsApp` sample app under Demos that embeds an Iframe pointing to a configurable URL (defaulting to `/hello`) and provides a toggle button to enable/disable DevTools in the embedded app via `DEVTOOLS_SET_ENABLED` messages. The app captures and displays `DEVTOOLS_APPLY_CHANGES` messages received from the iframe. Also added missing fluent extension methods `OutboundMessageType()` and `OutboundMessageToken()` on the `Iframe` widget.

## API Changes

- `IframeExtensions.OutboundMessageType(this Iframe, string?)` - new fluent setter
- `IframeExtensions.OutboundMessageToken(this Iframe, string?)` - new fluent setter

## Files Modified

- **Created:** `src/Ivy.Samples.Shared/Apps/Demos/IframeDevToolsApp.cs` - New demo sample app
- **Modified:** `src/Ivy/Widgets/Primitives/Iframe.cs` - Added `OutboundMessageType` and `OutboundMessageToken` fluent extension methods

## Commits

- 0a8eb19d8 [01136] Add IframeDevToolsApp sample and Iframe fluent setters