### PR TITLE
[00015] Log warning in RemoveWorktrees for missing .git file

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/WorktreeCleanupServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/WorktreeCleanupServiceTests.cs
@@ -1,4 +1,5 @@
 using Ivy.Tendril.Services;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Ivy.Tendril.Test;
@@ -219,5 +220,35 @@ public class WorktreeCleanupServiceTests : IDisposable
 
         Assert.False(Directory.Exists(worktreeDir), "Directory with read-only files should be force-deleted");
         Assert.False(Directory.Exists(Path.Combine(dir, "worktrees")), "Worktrees directory should be removed");
+    }
+
+    [Fact]
+    public void RemoveWorktrees_Logs_Warning_When_GitFile_Missing()
+    {
+        var dir = CreatePlan("10000-LogWarningTest", "Failed", DateTime.UtcNow.AddHours(-2));
+        var worktreeDir = Path.Combine(dir, "worktrees", "TestRepo");
+        Directory.CreateDirectory(worktreeDir);
+        File.WriteAllText(Path.Combine(worktreeDir, "file.txt"), "test");
+
+        var logEntries = new List<string>();
+        var logger = new CapturingLogger(logEntries);
+
+        PlanReaderService.RemoveWorktrees(dir, logger);
+
+        Assert.Single(logEntries);
+        Assert.Contains("has no .git file", logEntries[0]);
+        Assert.Contains("TestRepo", logEntries[0]);
+    }
+
+    private class CapturingLogger(List<string> entries) : ILogger
+    {
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            entries.Add(formatter(state, exception));
+        }
     }
 }

--- a/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
@@ -327,7 +327,7 @@ public class PlanReaderService(
         WriteFileInBackground(() =>
         {
             if (!Directory.Exists(folderPath)) return;
-            RemoveWorktrees(folderPath);
+            RemoveWorktrees(folderPath, _logger);
             ClearReadOnlyAttributes(folderPath);
             Directory.Delete(folderPath, true);
         });
@@ -883,7 +883,7 @@ public class PlanReaderService(
         return latestFile != null ? FileHelper.ReadAllText(latestFile) : string.Empty;
     }
 
-    internal static void RemoveWorktrees(string planFolderPath)
+    internal static void RemoveWorktrees(string planFolderPath, ILogger? logger = null)
     {
         var worktreesDir = Path.Combine(planFolderPath, "worktrees");
         if (!Directory.Exists(worktreesDir)) return;
@@ -891,7 +891,11 @@ public class PlanReaderService(
         foreach (var wtDir in Directory.GetDirectories(worktreesDir))
         {
             var gitFile = Path.Combine(wtDir, ".git");
-            if (!File.Exists(gitFile)) continue;
+            if (!File.Exists(gitFile))
+            {
+                logger?.LogWarning("Worktree directory has no .git file, skipping git removal: {Path}", wtDir);
+                continue;
+            }
 
             // Read the .git file to find which repo this worktree belongs to.
             // Format: "gitdir: <path-to-repo>/.git/worktrees/<name>"

--- a/src/tendril/Ivy.Tendril/Services/WorktreeCleanupService.cs
+++ b/src/tendril/Ivy.Tendril/Services/WorktreeCleanupService.cs
@@ -90,7 +90,7 @@ public class WorktreeCleanupService : IStartable, IDisposable
         logger?.LogInformation("Cleaning up worktrees for plan {PlanFolder} (state: {State}, updated: {Updated})",
             Path.GetFileName(planFolderPath), planYaml.State, planYaml.Updated.ToString("o", CultureInfo.InvariantCulture));
 
-        PlanReaderService.RemoveWorktrees(planFolderPath);
+        PlanReaderService.RemoveWorktrees(planFolderPath, logger);
 
         // Force-delete any remaining worktree directories that git couldn't remove
         // (orphaned .git files, missing entries, Windows file locks, etc.)


### PR DESCRIPTION
## Changes

Added an optional `ILogger? logger` parameter to `PlanReaderService.RemoveWorktrees` and a warning log when a worktree directory lacks a `.git` file. Updated callers (`DeletePlan` and `WorktreeCleanupService.CleanupPlanWorktrees`) to pass their loggers. Added a test verifying the warning is emitted.

## API Changes

- `PlanReaderService.RemoveWorktrees(string planFolderPath, ILogger? logger = null)` — added optional `logger` parameter (backward compatible)

## Files Modified

- **Services/PlanReaderService.cs** — Added `ILogger?` parameter and warning log in `RemoveWorktrees`; passed `_logger` from `DeletePlan`
- **Services/WorktreeCleanupService.cs** — Passed `logger` parameter through to `RemoveWorktrees` in `CleanupPlanWorktrees`
- **Ivy.Tendril.Test/WorktreeCleanupServiceTests.cs** — Added `RemoveWorktrees_Logs_Warning_When_GitFile_Missing` test with inline `CapturingLogger`

## Commits

- f2930452b