### PR TITLE
(docs): fix appearing of screenshots in markdowns

### DIFF
--- a/src/Ivy/Server.cs
+++ b/src/Ivy/Server.cs
@@ -732,7 +732,7 @@ public class Server
         app.MapGrpcService<DataTableService>().EnableGrpcWeb();
 
         app.UseFrontend(_args, logger2);
-        app.UseAssets(_args, logger2, "Assets", "ivy-assets");
+        app.UseAssets(_args, logger2, "Assets", "ivy/assets");
 
         return app;
     }


### PR DESCRIPTION
Had a problem:
<img width="1073" height="540" alt="image" src="https://github.com/user-attachments/assets/e1a03df3-fb4f-4d92-a46b-e8ae04d79395" />

The bug was in Server.cs: embedded assets were registered with request path ivy-assets (one segment, hyphen), so the real URLs looked like:

/ivy-assets/auth0_applications.webp

Nothing was served at /ivy/assets/..., so every doc image that still pointed at /ivy/assets/ returned 404 and showed as broken. That likely regressed when the path was changed from the documented /ivy/assets/* layout (see the [weekly notes](https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/.releases/weekly-notes-archive/weekly-notes-2025-11-21.md) mention).
<img width="1499" height="1276" alt="image" src="https://github.com/user-attachments/assets/b50ce627-8b75-4f45-a843-11cf672dde6d" />
