### PR TITLE
[00005] Reduce containerWidth ResizeObserver re-renders in DataTable

### DIFF
--- a/src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx
+++ b/src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx
@@ -202,7 +202,6 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
     columns,
     columnOrder,
     columnWidths,
-    containerWidth,
     showGroups: showGroups ?? false,
     showColumnTypeIcons: showColumnTypeIcons ?? true,
   });

--- a/src/frontend/src/widgets/dataTables/dataTableEditor/hooks/useGridColumns.ts
+++ b/src/frontend/src/widgets/dataTables/dataTableEditor/hooks/useGridColumns.ts
@@ -8,7 +8,6 @@ interface UseGridColumnsProps {
   columns: DataColumn[];
   columnOrder: number[];
   columnWidths: Record<string, number>;
-  containerWidth: number;
   showGroups?: boolean;
   showColumnTypeIcons?: boolean;
 }
@@ -20,7 +19,6 @@ export const useGridColumns = ({
   columns,
   columnOrder,
   columnWidths,
-  containerWidth,
   showGroups = false,
   showColumnTypeIcons = true,
 }: UseGridColumnsProps) => {
@@ -37,20 +35,11 @@ export const useGridColumns = ({
         columns,
         columnOrder,
         columnWidths,
-        containerWidth,
         showGroups,
         showColumnTypeIcons,
         headerFont,
       ),
-    [
-      columns,
-      columnOrder,
-      columnWidths,
-      containerWidth,
-      showGroups,
-      showColumnTypeIcons,
-      headerFont,
-    ],
+    [columns, columnOrder, columnWidths, showGroups, showColumnTypeIcons, headerFont],
   );
 
   // Use column groups hook when showGroups is enabled

--- a/src/frontend/src/widgets/dataTables/utils/columnHelpers.test.ts
+++ b/src/frontend/src/widgets/dataTables/utils/columnHelpers.test.ts
@@ -49,7 +49,7 @@ describe("columnHelpers", () => {
 
     it("should convert columns to grid columns without reordering", () => {
       const columnWidths = {};
-      const result = convertToGridColumns(mockColumns, [], columnWidths, 0, false);
+      const result = convertToGridColumns(mockColumns, [], columnWidths, false);
 
       expect(result).toEqual([
         { title: "ID", width: 80, group: undefined, icon: "headerNumber" },
@@ -60,14 +60,14 @@ describe("columnHelpers", () => {
           group: undefined,
           icon: "headerBoolean",
         },
-        { title: "Created", width: 120, group: undefined, icon: "headerDate" },
+        { title: "Created", width: 120, grow: 1, group: undefined, icon: "headerDate" },
       ]);
     });
 
     it("should apply column ordering", () => {
       const columnOrder = [2, 0, 1, 3]; // Status, ID, Name, Created
       const columnWidths = {};
-      const result = convertToGridColumns(mockColumns, columnOrder, columnWidths, 0, false);
+      const result = convertToGridColumns(mockColumns, columnOrder, columnWidths, false);
 
       expect(result.map((col) => col.title)).toEqual(["Status", "ID", "Name", "Created"]);
     });
@@ -77,7 +77,7 @@ describe("columnHelpers", () => {
         "0": 100, // ID: 80 -> 100
         "1": 200, // Name: 150 -> 200
       };
-      const result = convertToGridColumns(mockColumns, [], columnWidths, 0, false);
+      const result = convertToGridColumns(mockColumns, [], columnWidths, false);
 
       expect("width" in result[0] && result[0].width).toBe(100);
       expect("width" in result[1] && result[1].width).toBe(200);
@@ -87,19 +87,11 @@ describe("columnHelpers", () => {
 
     it("should make last column fill remaining width with grow", () => {
       const columnWidths = {};
-      const containerWidth = 600;
-      const result = convertToGridColumns(mockColumns, [], columnWidths, containerWidth, false);
+      const result = convertToGridColumns(mockColumns, [], columnWidths, false);
 
       // Last column uses grow: 1 to fill remaining space (avoids scrollbar gap)
       expect("width" in result[3] && result[3].width).toBe(120);
       expect("grow" in result[3] && result[3].grow).toBe(1);
-    });
-
-    it("should not expand last column if containerWidth is 0", () => {
-      const columnWidths = {};
-      const result = convertToGridColumns(mockColumns, [], columnWidths, 0, false);
-
-      expect("width" in result[3] && result[3].width).toBe(120);
     });
 
     it("should include groups when showGroups is true", () => {
@@ -114,7 +106,7 @@ describe("columnHelpers", () => {
         },
       ];
 
-      const result = convertToGridColumns(columnsWithGroups, [], {}, 0, true);
+      const result = convertToGridColumns(columnsWithGroups, [], {}, true);
 
       expect(result[0].group).toBe("Identity");
       expect(result[1].group).toBe("Identity");
@@ -127,7 +119,7 @@ describe("columnHelpers", () => {
         { name: "Name", type: ColType.Text, width: 150, group: "Identity" },
       ];
 
-      const result = convertToGridColumns(columnsWithGroups, [], {}, 0, false);
+      const result = convertToGridColumns(columnsWithGroups, [], {}, false);
 
       expect(result[0].group).toBeUndefined();
       expect(result[1].group).toBeUndefined();
@@ -140,7 +132,7 @@ describe("columnHelpers", () => {
         "1": 200, // Name
       };
 
-      const result = convertToGridColumns(mockColumns, columnOrder, columnWidths, 0, false);
+      const result = convertToGridColumns(mockColumns, columnOrder, columnWidths, false);
 
       // After reordering: Name, ID, Status, Created
       expect(result[0].title).toBe("Name");
@@ -152,14 +144,14 @@ describe("columnHelpers", () => {
     });
 
     it("should handle empty columns array", () => {
-      const result = convertToGridColumns([], [], {}, 0, false);
+      const result = convertToGridColumns([], [], {}, false);
       expect(result).toEqual([]);
     });
 
     it("should handle single column", () => {
       const singleColumn: DataColumn[] = [{ name: "Only", type: ColType.Text, width: 100 }];
 
-      const result = convertToGridColumns(singleColumn, [], {}, 500, false);
+      const result = convertToGridColumns(singleColumn, [], {}, false);
 
       // Last (and only) column uses grow: 1 to fill remaining space
       expect("width" in result[0] && result[0].width).toBe(100);
@@ -174,7 +166,7 @@ describe("columnHelpers", () => {
         { name: "Hidden2", type: ColType.Boolean, width: 100, hidden: true },
       ];
 
-      const result = convertToGridColumns(columns, [], {}, 0, false);
+      const result = convertToGridColumns(columns, [], {}, false);
 
       expect(result).toHaveLength(2);
       expect(result[0].title).toBe("Visible1");
@@ -192,7 +184,7 @@ describe("columnHelpers", () => {
         { name: "col2", type: ColType.Number, width: 100 },
       ];
 
-      const result = convertToGridColumns(columns, [], {}, 0, false);
+      const result = convertToGridColumns(columns, [], {}, false);
 
       expect(result[0].title).toBe("Custom Header 1");
       expect(result[1].title).toBe("col2");
@@ -205,7 +197,7 @@ describe("columnHelpers", () => {
         { name: "Second", type: ColType.Boolean, width: 100, order: 1 },
       ];
 
-      const result = convertToGridColumns(columns, [], {}, 0, false);
+      const result = convertToGridColumns(columns, [], {}, false);
 
       expect(result[0].title).toBe("First");
       expect(result[1].title).toBe("Second");
@@ -218,7 +210,7 @@ describe("columnHelpers", () => {
         { name: "B", type: ColType.Number, width: 100 },
       ];
 
-      const result = convertToGridColumns(columns, [], {}, 0, false);
+      const result = convertToGridColumns(columns, [], {}, false);
 
       expect(result[0].title).toBe("A");
       expect(result[1].title).toBe("B");
@@ -232,7 +224,7 @@ describe("columnHelpers", () => {
       ];
 
       // columnOrder would suggest B, C, A but order property should win
-      const result = convertToGridColumns(columns, [1, 2, 0], {}, 0, false);
+      const result = convertToGridColumns(columns, [1, 2, 0], {}, false);
 
       expect(result[0].title).toBe("A");
       expect(result[1].title).toBe("B");
@@ -247,7 +239,7 @@ describe("columnHelpers", () => {
         { name: "C", type: ColType.Date, width: 100, order: 2 },
       ];
 
-      const result = convertToGridColumns(columns, [], {}, 0, false);
+      const result = convertToGridColumns(columns, [], {}, false);
 
       expect(result).toHaveLength(3);
       expect(result[0].title).toBe("A");
@@ -262,7 +254,7 @@ describe("columnHelpers", () => {
         { name: "NoOrder2", type: ColType.Boolean, width: 100 },
       ];
 
-      const result = convertToGridColumns(columns, [], {}, 0, false);
+      const result = convertToGridColumns(columns, [], {}, false);
 
       // Columns with order come first, then columns without order
       expect(result[0].title).toBe("First");
@@ -276,7 +268,7 @@ describe("columnHelpers", () => {
         { name: "Fixed", type: ColType.Text, width: 200 },
         { name: "Frac", type: ColType.Text, width: 60, originalWidth: "Fraction:0.5" },
       ];
-      const result = convertToGridColumns(columns, [], {}, 600, false);
+      const result = convertToGridColumns(columns, [], {}, false);
       expect(result[1].grow).toBe(0.5);
     });
 
@@ -285,7 +277,7 @@ describe("columnHelpers", () => {
         { name: "Fixed", type: ColType.Text, width: 200 },
         { name: "AutoCol", type: ColType.Text, width: 60, originalWidth: "Auto" },
       ];
-      const result = convertToGridColumns(columns, [], {}, 600, false);
+      const result = convertToGridColumns(columns, [], {}, false);
       expect(result[1].grow).toBe(1);
     });
 
@@ -294,7 +286,7 @@ describe("columnHelpers", () => {
         { name: "Fixed", type: ColType.Text, width: 200 },
         { name: "GrowCol", type: ColType.Text, width: 60, originalWidth: "Grow:2" },
       ];
-      const result = convertToGridColumns(columns, [], {}, 600, false);
+      const result = convertToGridColumns(columns, [], {}, false);
       expect(result[1].grow).toBe(2);
     });
 
@@ -303,7 +295,7 @@ describe("columnHelpers", () => {
         { name: "Fixed", type: ColType.Text, width: 200 },
         { name: "FullCol", type: ColType.Text, width: 60, originalWidth: "Full" },
       ];
-      const result = convertToGridColumns(columns, [], {}, 600, false);
+      const result = convertToGridColumns(columns, [], {}, false);
       expect(result[1].grow).toBe(1);
     });
 
@@ -312,7 +304,7 @@ describe("columnHelpers", () => {
         { name: "Fixed", type: ColType.Text, width: 200 },
         { name: "ScreenCol", type: ColType.Text, width: 60, originalWidth: "Screen" },
       ];
-      const result = convertToGridColumns(columns, [], {}, 600, false);
+      const result = convertToGridColumns(columns, [], {}, false);
       expect(result[1].grow).toBe(1);
     });
 
@@ -321,7 +313,7 @@ describe("columnHelpers", () => {
         { name: "PxCol", type: ColType.Text, width: 200, originalWidth: "Px:200" },
         { name: "Other", type: ColType.Text, width: 100 },
       ];
-      const result = convertToGridColumns(columns, [], {}, 600, false);
+      const result = convertToGridColumns(columns, [], {}, false);
       expect(result[0].grow).toBeUndefined();
     });
 
@@ -330,7 +322,7 @@ describe("columnHelpers", () => {
         { name: "FitCol", type: ColType.Text, width: 60, originalWidth: "Fit" },
         { name: "Other", type: ColType.Text, width: 100 },
       ];
-      const result = convertToGridColumns(columns, [], {}, 600, false);
+      const result = convertToGridColumns(columns, [], {}, false);
       expect(result[0].grow).toBeUndefined();
     });
 
@@ -339,7 +331,7 @@ describe("columnHelpers", () => {
         { name: "MinCol", type: ColType.Text, width: 60, originalWidth: "MinContent" },
         { name: "Other", type: ColType.Text, width: 100 },
       ];
-      const result = convertToGridColumns(columns, [], {}, 600, false);
+      const result = convertToGridColumns(columns, [], {}, false);
       expect(result[0].grow).toBeUndefined();
     });
 
@@ -353,7 +345,7 @@ describe("columnHelpers", () => {
           originalWidth: "Fraction:0.5,Px:100,Px:500",
         },
       ];
-      const result = convertToGridColumns(columns, [], {}, 600, false);
+      const result = convertToGridColumns(columns, [], {}, false);
       expect(result[1].grow).toBe(0.5);
       expect("width" in result[1] && result[1].width).toBeGreaterThanOrEqual(100);
     });
@@ -364,7 +356,7 @@ describe("columnHelpers", () => {
         { name: "Auto", type: ColType.Text, width: 60, originalWidth: "Auto" },
         { name: "Frac", type: ColType.Text, width: 60, originalWidth: "Fraction:0.3" },
       ];
-      const result = convertToGridColumns(columns, [], {}, 600, false);
+      const result = convertToGridColumns(columns, [], {}, false);
       expect(result[0].grow).toBeUndefined(); // Px: no grow
       expect(result[1].grow).toBe(1); // Auto: grow 1
       expect(result[2].grow).toBe(0.3); // Fraction: grow 0.3
@@ -375,7 +367,7 @@ describe("columnHelpers", () => {
         { name: "A", type: ColType.Text, width: 100 },
         { name: "B", type: ColType.Text, width: 100 },
       ];
-      const result = convertToGridColumns(columns, [], {}, 600, false);
+      const result = convertToGridColumns(columns, [], {}, false);
       expect(result[0].grow).toBeUndefined();
       expect(result[1].grow).toBe(1);
     });
@@ -387,7 +379,7 @@ describe("columnHelpers", () => {
         { name: "C", type: ColType.Text, width: 60, originalWidth: "Fraction:0.25" },
         { name: "D", type: ColType.Text, width: 60, originalWidth: "Fraction:0.25" },
       ];
-      const result = convertToGridColumns(columns, [], {}, 600, false);
+      const result = convertToGridColumns(columns, [], {}, false);
       expect(result[0].grow).toBe(0.25);
       expect(result[1].grow).toBe(0.25);
       expect(result[2].grow).toBe(0.25);
@@ -399,7 +391,7 @@ describe("columnHelpers", () => {
         { name: "Wide", type: ColType.Text, width: 60, originalWidth: "Grow:2" },
         { name: "Narrow", type: ColType.Text, width: 60, originalWidth: "Grow:1" },
       ];
-      const result = convertToGridColumns(columns, [], {}, 600, false);
+      const result = convertToGridColumns(columns, [], {}, false);
       expect(result[0].grow).toBe(2);
       expect(result[1].grow).toBe(1);
     });

--- a/src/frontend/src/widgets/dataTables/utils/columnHelpers.ts
+++ b/src/frontend/src/widgets/dataTables/utils/columnHelpers.ts
@@ -114,7 +114,6 @@ export function convertToGridColumns(
   columns: DataColumn[],
   columnOrder: number[],
   columnWidths: Record<string, number>,
-  containerWidth: number,
   showGroups: boolean,
   showColumnTypeIcons: boolean = true,
   headerFont?: string,
@@ -137,7 +136,7 @@ export function convertToGridColumns(
     }
 
     const grow = parseSizeGrow(col.originalWidth);
-    const isLastColumn = index === orderedColumns.length - 1 && containerWidth > 0;
+    const isLastColumn = index === orderedColumns.length - 1;
 
     // Determine effective grow: explicit Size-based grow, or default last column to 1
     const effectiveGrow = grow !== undefined ? grow : isLastColumn ? 1 : undefined;


### PR DESCRIPTION
# Summary

## Changes

Removed `containerWidth` from the column calculation pipeline in DataTable. The `convertToGridColumns` function no longer accepts a `containerWidth` parameter, and the last column always gets `grow: 1` to fill remaining space — previously this only happened when `containerWidth > 0`. This eliminates an unnecessary re-render cycle where ResizeObserver width changes triggered full column recalculation.

## API Changes

- `convertToGridColumns()` — removed 4th parameter `containerWidth: number`. Callers now pass `(columns, columnOrder, columnWidths, showGroups, ...)` instead of `(columns, columnOrder, columnWidths, containerWidth, showGroups, ...)`.
- `UseGridColumnsProps` interface — removed `containerWidth: number` property.
- `useGridColumns` hook — no longer accepts or passes `containerWidth`.

## Files Modified

- **columnHelpers.ts** — Removed `containerWidth` parameter and `containerWidth > 0` guard from `convertToGridColumns`
- **useGridColumns.ts** — Removed `containerWidth` from interface, destructuring, function call, and `useMemo` dependency array
- **DataTableEditor.tsx** — Removed `containerWidth` from `useGridColumns` call props
- **columnHelpers.test.ts** — Removed `containerWidth` arg from all 29 test calls, deleted obsolete "should not expand last column if containerWidth is 0" test, updated expected results for last column to include `grow: 1`

## Commits

- 517714d06