### PR TITLE
[00013] Rename Settings to Setup

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Setup/Dialogs/DeleteProjectDialog.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Setup/Dialogs/DeleteProjectDialog.cs
@@ -1,6 +1,6 @@
 using Ivy.Tendril.Services;
 
-namespace Ivy.Tendril.Apps.Settings.Dialogs;
+namespace Ivy.Tendril.Apps.Setup.Dialogs;
 
 public class DeleteProjectDialog(
     IState<int?> deleteIndex,

--- a/src/tendril/Ivy.Tendril/Apps/Setup/Dialogs/EditLevelDialog.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Setup/Dialogs/EditLevelDialog.cs
@@ -1,16 +1,16 @@
 using Ivy.Tendril.Services;
 
-namespace Ivy.Tendril.Apps.Settings.Dialogs;
+namespace Ivy.Tendril.Apps.Setup.Dialogs;
 
-public class EditVerificationDialog(
+public class EditLevelDialog(
     IState<int?> editIndex,
-    List<VerificationConfig> verifications,
+    List<LevelConfig> levels,
     IConfigService config,
     IClientProvider client,
     RefreshToken refreshToken) : ViewBase
 {
     private readonly IState<int?> _editIndex = editIndex;
-    private readonly List<VerificationConfig> _verifications = verifications;
+    private readonly List<LevelConfig> _levels = levels;
     private readonly IConfigService _config = config;
     private readonly IClientProvider _client = client;
     private readonly RefreshToken _refreshToken = refreshToken;
@@ -18,33 +18,34 @@ public class EditVerificationDialog(
     public override object? Build()
     {
         var editName = UseState("");
-        var editPrompt = UseState("");
+        var editBadge = UseState("Outline");
 
         UseEffect(() =>
         {
             if (_editIndex.Value == null)
             {
                 editName.Set("");
-                editPrompt.Set("");
+                editBadge.Set("Outline");
             }
             else if (_editIndex.Value >= 0)
             {
-                editName.Set(_verifications[_editIndex.Value.Value].Name);
-                editPrompt.Set(_verifications[_editIndex.Value.Value].Prompt);
+                editName.Set(_levels[_editIndex.Value.Value].Name);
+                editBadge.Set(_levels[_editIndex.Value.Value].Badge);
             }
         }, _editIndex);
 
         if (_editIndex.Value == -1) return null;
 
+        var badgeOptions = Enum.GetNames<BadgeVariant>().ToList();
         var isNew = _editIndex.Value == null;
 
         return new Dialog(
-            _ => _editIndex.Set(-1),
-            new DialogHeader(isNew ? "Add Verification" : "Edit Verification"),
+            _ => { _editIndex.Set(-1); },
+            new DialogHeader(isNew ? "Add Level" : "Edit Level"),
             new DialogBody(
                 Layout.Vertical().Gap(2)
-                | editName.ToTextInput("Verification name...").WithField().Label("Name")
-                | editPrompt.ToTextareaInput("Verification prompt...").Rows(8).WithField().Label("Prompt")
+                | editName.ToTextInput("Level name...").WithField().Label("Name")
+                | editBadge.ToSelectInput(badgeOptions).WithField().Label("Badge Variant")
             ),
             new DialogFooter(
                 new Button("Cancel").Outline().OnClick(() => _editIndex.Set(-1)),
@@ -53,24 +54,21 @@ public class EditVerificationDialog(
                     if (string.IsNullOrWhiteSpace(editName.Value)) return;
                     if (isNew)
                     {
-                        _verifications.Add(new VerificationConfig
-                        {
-                            Name = editName.Value,
-                            Prompt = editPrompt.Value
-                        });
+                        _levels.Add(new LevelConfig { Name = editName.Value, Badge = editBadge.Value });
                     }
                     else
                     {
-                        _verifications[_editIndex.Value!.Value].Name = editName.Value;
-                        _verifications[_editIndex.Value!.Value].Prompt = editPrompt.Value;
+                        var level = _levels[_editIndex.Value!.Value];
+                        level.Name = editName.Value;
+                        level.Badge = editBadge.Value;
                     }
 
                     _config.SaveSettings();
                     _editIndex.Set(-1);
                     _refreshToken.Refresh();
-                    _client.Toast("Verification saved", "Saved");
+                    _client.Toast("Level saved", "Saved");
                 })
             )
-        ).Width(Size.Rem(35));
+        ).Width(Size.Rem(25));
     }
 }

--- a/src/tendril/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs
@@ -1,6 +1,6 @@
 using Ivy.Tendril.Services;
 
-namespace Ivy.Tendril.Apps.Settings.Dialogs;
+namespace Ivy.Tendril.Apps.Setup.Dialogs;
 
 public class EditProjectDialog(
     IState<int?> editIndex,

--- a/src/tendril/Ivy.Tendril/Apps/Setup/Dialogs/EditPromptwareDialog.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Setup/Dialogs/EditPromptwareDialog.cs
@@ -1,6 +1,6 @@
 using Ivy.Tendril.Services;
 
-namespace Ivy.Tendril.Apps.Settings.Dialogs;
+namespace Ivy.Tendril.Apps.Setup.Dialogs;
 
 public class EditPromptwareDialog(
     IState<string?> editKey,

--- a/src/tendril/Ivy.Tendril/Apps/Setup/Dialogs/EditVerificationDialog.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Setup/Dialogs/EditVerificationDialog.cs
@@ -1,16 +1,16 @@
 using Ivy.Tendril.Services;
 
-namespace Ivy.Tendril.Apps.Settings.Dialogs;
+namespace Ivy.Tendril.Apps.Setup.Dialogs;
 
-public class EditLevelDialog(
+public class EditVerificationDialog(
     IState<int?> editIndex,
-    List<LevelConfig> levels,
+    List<VerificationConfig> verifications,
     IConfigService config,
     IClientProvider client,
     RefreshToken refreshToken) : ViewBase
 {
     private readonly IState<int?> _editIndex = editIndex;
-    private readonly List<LevelConfig> _levels = levels;
+    private readonly List<VerificationConfig> _verifications = verifications;
     private readonly IConfigService _config = config;
     private readonly IClientProvider _client = client;
     private readonly RefreshToken _refreshToken = refreshToken;
@@ -18,34 +18,33 @@ public class EditLevelDialog(
     public override object? Build()
     {
         var editName = UseState("");
-        var editBadge = UseState("Outline");
+        var editPrompt = UseState("");
 
         UseEffect(() =>
         {
             if (_editIndex.Value == null)
             {
                 editName.Set("");
-                editBadge.Set("Outline");
+                editPrompt.Set("");
             }
             else if (_editIndex.Value >= 0)
             {
-                editName.Set(_levels[_editIndex.Value.Value].Name);
-                editBadge.Set(_levels[_editIndex.Value.Value].Badge);
+                editName.Set(_verifications[_editIndex.Value.Value].Name);
+                editPrompt.Set(_verifications[_editIndex.Value.Value].Prompt);
             }
         }, _editIndex);
 
         if (_editIndex.Value == -1) return null;
 
-        var badgeOptions = Enum.GetNames<BadgeVariant>().ToList();
         var isNew = _editIndex.Value == null;
 
         return new Dialog(
-            _ => { _editIndex.Set(-1); },
-            new DialogHeader(isNew ? "Add Level" : "Edit Level"),
+            _ => _editIndex.Set(-1),
+            new DialogHeader(isNew ? "Add Verification" : "Edit Verification"),
             new DialogBody(
                 Layout.Vertical().Gap(2)
-                | editName.ToTextInput("Level name...").WithField().Label("Name")
-                | editBadge.ToSelectInput(badgeOptions).WithField().Label("Badge Variant")
+                | editName.ToTextInput("Verification name...").WithField().Label("Name")
+                | editPrompt.ToTextareaInput("Verification prompt...").Rows(8).WithField().Label("Prompt")
             ),
             new DialogFooter(
                 new Button("Cancel").Outline().OnClick(() => _editIndex.Set(-1)),
@@ -54,21 +53,24 @@ public class EditLevelDialog(
                     if (string.IsNullOrWhiteSpace(editName.Value)) return;
                     if (isNew)
                     {
-                        _levels.Add(new LevelConfig { Name = editName.Value, Badge = editBadge.Value });
+                        _verifications.Add(new VerificationConfig
+                        {
+                            Name = editName.Value,
+                            Prompt = editPrompt.Value
+                        });
                     }
                     else
                     {
-                        var level = _levels[_editIndex.Value!.Value];
-                        level.Name = editName.Value;
-                        level.Badge = editBadge.Value;
+                        _verifications[_editIndex.Value!.Value].Name = editName.Value;
+                        _verifications[_editIndex.Value!.Value].Prompt = editPrompt.Value;
                     }
 
                     _config.SaveSettings();
                     _editIndex.Set(-1);
                     _refreshToken.Refresh();
-                    _client.Toast("Level saved", "Saved");
+                    _client.Toast("Verification saved", "Saved");
                 })
             )
-        ).Width(Size.Rem(25));
+        ).Width(Size.Rem(35));
     }
 }

--- a/src/tendril/Ivy.Tendril/Apps/Setup/GeneralSetupView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Setup/GeneralSetupView.cs
@@ -1,8 +1,8 @@
 using Ivy.Tendril.Services;
 
-namespace Ivy.Tendril.Apps.Settings;
+namespace Ivy.Tendril.Apps.Setup;
 
-public class GeneralSettingsView : ViewBase
+public class GeneralSetupView : ViewBase
 {
     private static readonly string[] CodingAgentOptions = ["claude", "codex", "gemini"];
     private static readonly string[] EffortOptions = ["low", "medium", "high", "max"];

--- a/src/tendril/Ivy.Tendril/Apps/Setup/LevelsSetupView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Setup/LevelsSetupView.cs
@@ -1,9 +1,9 @@
-using Ivy.Tendril.Apps.Settings.Dialogs;
+using Ivy.Tendril.Apps.Setup.Dialogs;
 using Ivy.Tendril.Services;
 
-namespace Ivy.Tendril.Apps.Settings;
+namespace Ivy.Tendril.Apps.Setup;
 
-public class LevelsSettingsView : ViewBase
+public class LevelsSetupView : ViewBase
 {
     public override object Build()
     {

--- a/src/tendril/Ivy.Tendril/Apps/Setup/ProjectsSetupView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Setup/ProjectsSetupView.cs
@@ -1,9 +1,9 @@
-using Ivy.Tendril.Apps.Settings.Dialogs;
+using Ivy.Tendril.Apps.Setup.Dialogs;
 using Ivy.Tendril.Services;
 
-namespace Ivy.Tendril.Apps.Settings;
+namespace Ivy.Tendril.Apps.Setup;
 
-public class ProjectsSettingsView : ViewBase
+public class ProjectsSetupView : ViewBase
 {
     public override object Build()
     {

--- a/src/tendril/Ivy.Tendril/Apps/Setup/PromptwaresSetupView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Setup/PromptwaresSetupView.cs
@@ -1,9 +1,9 @@
-using Ivy.Tendril.Apps.Settings.Dialogs;
+using Ivy.Tendril.Apps.Setup.Dialogs;
 using Ivy.Tendril.Services;
 
-namespace Ivy.Tendril.Apps.Settings;
+namespace Ivy.Tendril.Apps.Setup;
 
-public class PromptwaresSettingsView : ViewBase
+public class PromptwaresSetupView : ViewBase
 {
     public override object Build()
     {

--- a/src/tendril/Ivy.Tendril/Apps/Setup/VerificationsSetupView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Setup/VerificationsSetupView.cs
@@ -1,9 +1,9 @@
-using Ivy.Tendril.Apps.Settings.Dialogs;
+using Ivy.Tendril.Apps.Setup.Dialogs;
 using Ivy.Tendril.Services;
 
-namespace Ivy.Tendril.Apps.Settings;
+namespace Ivy.Tendril.Apps.Setup;
 
-public class VerificationsSettingsView : ViewBase
+public class VerificationsSetupView : ViewBase
 {
     public override object Build()
     {

--- a/src/tendril/Ivy.Tendril/Apps/SetupApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/SetupApp.cs
@@ -1,4 +1,4 @@
-using Ivy.Tendril.Apps.Settings;
+using Ivy.Tendril.Apps.Setup;
 
 namespace Ivy.Tendril.Apps;
 
@@ -15,11 +15,11 @@ public class SetupApp : ViewBase
             null,
             null,
             selectedTab.Value,
-            new Tab("General", new GeneralSettingsView()),
-            new Tab("Levels", new LevelsSettingsView()),
-            new Tab("Verifications", new VerificationsSettingsView()),
-            new Tab("Promptwares", new PromptwaresSettingsView()),
-            new Tab("Projects", new ProjectsSettingsView())
+            new Tab("General", new GeneralSetupView()),
+            new Tab("Levels", new LevelsSetupView()),
+            new Tab("Verifications", new VerificationsSetupView()),
+            new Tab("Promptwares", new PromptwaresSetupView()),
+            new Tab("Projects", new ProjectsSetupView())
         ).Variant(TabsVariant.Content);
     }
 }


### PR DESCRIPTION
# Summary

## Changes

Renamed the `Apps/Settings/` directory to `Apps/Setup/` and all five view classes from `*SettingsView` to `*SetupView` to match the existing `SetupApp` naming convention. Updated all namespaces from `Ivy.Tendril.Apps.Settings` to `Ivy.Tendril.Apps.Setup` and updated the `using` directive and class instantiations in `SetupApp.cs`.

## API Changes

- `GeneralSettingsView` -> `GeneralSetupView`
- `LevelsSettingsView` -> `LevelsSetupView`
- `ProjectsSettingsView` -> `ProjectsSetupView`
- `PromptwaresSettingsView` -> `PromptwaresSetupView`
- `VerificationsSettingsView` -> `VerificationsSetupView`
- Namespace `Ivy.Tendril.Apps.Settings` -> `Ivy.Tendril.Apps.Setup`
- Namespace `Ivy.Tendril.Apps.Settings.Dialogs` -> `Ivy.Tendril.Apps.Setup.Dialogs`

## Files Modified

- **Views (renamed):** `GeneralSetupView.cs`, `LevelsSetupView.cs`, `ProjectsSetupView.cs`, `PromptwaresSetupView.cs`, `VerificationsSetupView.cs`
- **Dialogs (namespace updated):** `DeleteProjectDialog.cs`, `EditLevelDialog.cs`, `EditProjectDialog.cs`, `EditPromptwareDialog.cs`, `EditVerificationDialog.cs`
- **Caller updated:** `SetupApp.cs`

## Commits

- `1f0104115` [00013] Rename Settings folder and views to Setup