### PR TITLE
[00011] Refactor FileLinkHelper to use IConfigService instead of individual editor string parameters

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/Services/FileLinkHelperTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/Services/FileLinkHelperTests.cs
@@ -4,6 +4,8 @@ namespace Ivy.Tendril.Test.Services;
 
 public class FileLinkHelperTests
 {
+    private static readonly IConfigService TestConfig = new TestConfigService();
+
     [Fact]
     public void CreateFileLinkClickHandler_CapturesFilePath_WhenFileUrlProvided()
     {
@@ -40,7 +42,7 @@ public class FileLinkHelperTests
     [Fact]
     public void BuildFileLinkSheet_ReturnsNull_WhenFilePathIsNull()
     {
-        var result = FileLinkHelper.BuildFileLinkSheet(null, () => { }, []);
+        var result = FileLinkHelper.BuildFileLinkSheet(null, () => { }, [], TestConfig);
         Assert.Null(result);
     }
 
@@ -51,7 +53,7 @@ public class FileLinkHelperTests
         File.WriteAllBytes(tempFile, [0x89, 0x50, 0x4E, 0x47]); // PNG header
         try
         {
-            var result = FileLinkHelper.BuildFileLinkSheet(tempFile, () => { }, []);
+            var result = FileLinkHelper.BuildFileLinkSheet(tempFile, () => { }, [], TestConfig);
             Assert.NotNull(result);
             Assert.IsType<Sheet>(result);
         }
@@ -68,7 +70,7 @@ public class FileLinkHelperTests
         File.WriteAllText(tempFile, "public class Foo { }");
         try
         {
-            var result = FileLinkHelper.BuildFileLinkSheet(tempFile, () => { }, []);
+            var result = FileLinkHelper.BuildFileLinkSheet(tempFile, () => { }, [], TestConfig);
             Assert.NotNull(result);
             Assert.IsType<Sheet>(result);
         }
@@ -82,7 +84,7 @@ public class FileLinkHelperTests
     public void BuildFileLinkSheet_ShowsSuggestions_WhenFileNotFound()
     {
         var result = FileLinkHelper.BuildFileLinkSheet(
-            "/nonexistent/path/foo.cs", () => { }, []);
+            "/nonexistent/path/foo.cs", () => { }, [], TestConfig);
         Assert.NotNull(result);
         Assert.IsType<Sheet>(result);
     }
@@ -91,9 +93,35 @@ public class FileLinkHelperTests
     public void BuildFileLinkSheet_ReturnsSheet_WhenFileNotFound()
     {
         var result = FileLinkHelper.BuildFileLinkSheet(
-            "/nonexistent/file.txt", () => { }, []);
+            "/nonexistent/file.txt", () => { }, [], TestConfig);
         Assert.NotNull(result);
         Assert.IsType<Sheet>(result);
+    }
+
+    private class TestConfigService : IConfigService
+    {
+        public TendrilSettings Settings => new();
+        public string TendrilHome => "";
+        public string ConfigPath => "";
+        public string PlanFolder => "";
+        public List<ProjectConfig> Projects => [];
+        public List<LevelConfig> Levels => [];
+        public string[] LevelNames => [];
+        public EditorConfig Editor => new() { Command = "code", Label = "VS Code" };
+        public bool NeedsOnboarding => false;
+
+        public ProjectConfig? GetProject(string name) => null;
+        public BadgeVariant GetBadgeVariant(string level) => BadgeVariant.Outline;
+        public Colors? GetProjectColor(string projectName) => null;
+        public void SaveSettings() { }
+        public void SetPendingTendrilHome(string path) { }
+        public string? GetPendingTendrilHome() => null;
+        public void SetPendingProject(ProjectConfig project) { }
+        public ProjectConfig? GetPendingProject() => null;
+        public void SetPendingVerificationDefinitions(List<VerificationConfig> definitions) { }
+        public List<VerificationConfig>? GetPendingVerificationDefinitions() => null;
+        public void CompleteOnboarding(string tendrilHome) { }
+        public void OpenInEditor(string path) { }
     }
 
     private class TestState<T> : IState<T>

--- a/src/tendril/Ivy.Tendril/Apps/Icebox/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Icebox/ContentView.cs
@@ -168,7 +168,7 @@ public class ContentView(
 
         var repoPaths = _selectedPlan.GetEffectiveRepoPaths(_config);
         var fileLinkSheet = FileLinkHelper.BuildFileLinkSheet(
-            openFile.Value, () => openFile.Set(null), repoPaths, _config.Editor.Command, _config.Editor.Label);
+            openFile.Value, () => openFile.Set(null), repoPaths, _config);
         if (fileLinkSheet is not null)
             elements.Add(fileLinkSheet);
 

--- a/src/tendril/Ivy.Tendril/Apps/JobsApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/JobsApp.cs
@@ -284,7 +284,7 @@ public class JobsApp : ViewBase
 
             var repoPaths = plan?.GetEffectiveRepoPaths(config) ?? [];
             var fileLinkSheet = FileLinkHelper.BuildFileLinkSheet(
-                openFile.Value, () => openFile.Set(null), repoPaths);
+                openFile.Value, () => openFile.Set(null), repoPaths, config);
 
             var planSheet = new Sheet(
                 () => showPlan.Set(null),

--- a/src/tendril/Ivy.Tendril/Apps/Plans/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Plans/ContentView.cs
@@ -428,7 +428,7 @@ public class ContentView(
 
         var repoPaths = _selectedPlan.GetEffectiveRepoPaths(_config);
         var fileLinkSheet = FileLinkHelper.BuildFileLinkSheet(
-            openFile.Value, () => openFile.Set(null), repoPaths, _config.Editor.Command, _config.Editor.Label);
+            openFile.Value, () => openFile.Set(null), repoPaths, _config);
         if (fileLinkSheet is not null)
             elements.Add(fileLinkSheet);
 

--- a/src/tendril/Ivy.Tendril/Apps/PullRequestApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/PullRequestApp.cs
@@ -177,7 +177,7 @@ public class PullRequestApp : ViewBase
 
             var repoPaths = plan?.GetEffectiveRepoPaths(config) ?? [];
             var fileLinkSheet = FileLinkHelper.BuildFileLinkSheet(
-                openFile.Value, () => openFile.Set(null), repoPaths);
+                openFile.Value, () => openFile.Set(null), repoPaths, config);
 
             var planSheet = new Sheet(
                 () => showPlan.Set(null),

--- a/src/tendril/Ivy.Tendril/Apps/Recommendations/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Recommendations/ContentView.cs
@@ -163,8 +163,7 @@ public class ContentView(
                 openFile.Value,
                 () => openFile.Set(null),
                 repoPaths,
-                config.Editor.Command,
-                config.Editor.Label);
+                config);
 
             if (fileLinkSheet is not null)
                 return new Fragment(

--- a/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -449,7 +449,7 @@ public class ContentView(
         {
             var fileRepoPaths = _selectedPlan.GetEffectiveRepoPaths(_config);
             var fileLinkSheet =
-                FileLinkHelper.BuildFileLinkSheet(openFile.Value, () => openFile.Set(null), fileRepoPaths);
+                FileLinkHelper.BuildFileLinkSheet(openFile.Value, () => openFile.Set(null), fileRepoPaths, _config);
             if (fileLinkSheet != null) content |= fileLinkSheet;
         }
 

--- a/src/tendril/Ivy.Tendril/Apps/TrashApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/TrashApp.cs
@@ -119,8 +119,7 @@ public class TrashApp : ViewBase
                 filePath,
                 () => openFile.Set(null),
                 [],
-                configService.Editor.Command,
-                configService.Editor.Label);
+                configService);
             if (fileLinkSheet is not null)
                 elements.Add(fileLinkSheet);
         }

--- a/src/tendril/Ivy.Tendril/Services/FileLinkHelper.cs
+++ b/src/tendril/Ivy.Tendril/Services/FileLinkHelper.cs
@@ -22,8 +22,7 @@ public static class FileLinkHelper
         string? filePath,
         Action onClose,
         IEnumerable<string> repoPaths,
-        string editorCommand = "code",
-        string editorLabel = "VS Code")
+        IConfigService config)
     {
         if (filePath is null)
             return null;
@@ -57,9 +56,9 @@ public static class FileLinkHelper
 
         var finalContent = File.Exists(filePath)
             ? new HeaderLayout(
-                new Button($"Open in {editorLabel}").Icon(Icons.ExternalLink).Outline().OnClick(() =>
+                new Button($"Open in {config.Editor.Label}").Icon(Icons.ExternalLink).Outline().OnClick(() =>
                 {
-                    PlatformHelper.OpenInEditor(editorCommand, filePath);
+                    config.OpenInEditor(filePath);
                 }),
                 sheetContent
             )


### PR DESCRIPTION
# Summary

## Changes

Replaced `editorCommand` and `editorLabel` string parameters in `FileLinkHelper.BuildFileLinkSheet` with a single `IConfigService` parameter. Updated all 7 callers and 5 test call sites to pass the config service instead of individual editor strings. The 3 callers that previously used default values ("code"/"VS Code") now correctly use the configured editor.

## API Changes

- `FileLinkHelper.BuildFileLinkSheet` — removed `string editorCommand = "code"` and `string editorLabel = "VS Code"` parameters, added `IConfigService config` (required, no default)
- Internal call changed from `PlatformHelper.OpenInEditor(editorCommand, filePath)` to `config.OpenInEditor(filePath)`
- Button label changed from `$"Open in {editorLabel}"` to `$"Open in {config.Editor.Label}"`

## Files Modified

- **Core:** `Services/FileLinkHelper.cs` — signature and internal usage refactored
- **Callers (passing config properties before):** `Apps/Plans/ContentView.cs`, `Apps/Icebox/ContentView.cs`, `Apps/Recommendations/ContentView.cs`, `Apps/TrashApp.cs`
- **Callers (using defaults before):** `Apps/Review/ContentView.cs`, `Apps/PullRequestApp.cs`, `Apps/JobsApp.cs`
- **Tests:** `Ivy.Tendril.Test/Services/FileLinkHelperTests.cs` — added `TestConfigService`, updated all `BuildFileLinkSheet` calls

## Commits

- 4c9561d19 [00011] Refactor FileLinkHelper to use IConfigService instead of string parameters