### PR TITLE
[00006] Add ss fallback for Unix KillProcessUsingPort

### DIFF
--- a/src/Ivy/Helpers/ProcessHelper.cs
+++ b/src/Ivy/Helpers/ProcessHelper.cs
@@ -86,29 +86,14 @@ public static class ProcessHelper
 
     private static void KillProcessUsingPortUnix(int port)
     {
-        using var lsof = new Process
-        {
-            StartInfo = new ProcessStartInfo
-            {
-                FileName = "lsof",
-                Arguments = $"-ti tcp:{port}",
-                RedirectStandardOutput = true,
-                UseShellExecute = false,
-                CreateNoWindow = true
-            }
-        };
-        lsof.Start();
-        string output = lsof.StandardOutput.ReadToEnd();
-        lsof.WaitForExitOrKill(10000);
+        var pids = GetPidsOnPort("lsof", $"-ti tcp:{port}", ParseLsofOutput)
+                   ?? GetPidsOnPort("ss", $"-tlnp sport = :{port}", ParseSsOutput);
 
-        if (lsof.ExitCode != 0 || string.IsNullOrWhiteSpace(output))
-            return;
+        if (pids == null) return;
 
-        var pids = output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries);
-        foreach (var pidStr in pids)
+        foreach (var pid in pids)
         {
-            if (!int.TryParse(pidStr.Trim(), out int pid) || pid == 0)
-                continue;
+            if (pid == 0) continue;
             try
             {
                 using var proc = Process.GetProcessById(pid);
@@ -119,6 +104,51 @@ public static class ProcessHelper
                 // ignore - process may have already exited
             }
         }
+    }
+
+    private static List<int>? GetPidsOnPort(string fileName, string arguments, Func<string, IEnumerable<int>> parser)
+    {
+        try
+        {
+            using var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = fileName,
+                    Arguments = arguments,
+                    RedirectStandardOutput = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                }
+            };
+            process.Start();
+            var output = process.StandardOutput.ReadToEnd();
+            process.WaitForExitOrKill(10000);
+
+            if (process.ExitCode != 0 || string.IsNullOrWhiteSpace(output))
+                return null;
+
+            return parser(output).ToList();
+        }
+        catch (System.ComponentModel.Win32Exception)
+        {
+            return null;
+        }
+    }
+
+    private static IEnumerable<int> ParseLsofOutput(string output)
+    {
+        return output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries)
+            .Select(line => int.TryParse(line.Trim(), out var pid) ? pid : 0)
+            .Where(pid => pid != 0);
+    }
+
+    private static IEnumerable<int> ParseSsOutput(string output)
+    {
+        return Regex.Matches(output, @"pid=(\d+)")
+            .Select(m => int.TryParse(m.Groups[1].Value, out var pid) ? pid : 0)
+            .Where(pid => pid != 0)
+            .Distinct();
     }
 
     public static void OpenBrowser(string localUrl)


### PR DESCRIPTION
## Summary

Refactored `KillProcessUsingPortUnix` in `ProcessHelper.cs` to try `lsof` first and fall back to `ss` (from `iproute2`) when `lsof` is not available. Extracted a reusable `GetPidsOnPort` helper that catches `System.ComponentModel.Win32Exception` (command not found) and returns `null` to enable the fallback chain. Added dedicated `ParseLsofOutput` and `ParseSsOutput` parser methods.

## API Changes

None. All changes are to private methods — the public `KillProcessUsingPort(int port)` signature is unchanged.

## Files Modified

- **src/Ivy/Helpers/ProcessHelper.cs** — Added `GetPidsOnPort`, `ParseLsofOutput`, `ParseSsOutput` private methods; refactored `KillProcessUsingPortUnix` to use lsof->ss fallback.

## Commits

- 84cc640a0 [00006] Add ss fallback for Unix KillProcessUsingPort