### PR TITLE
[02355] Suppress host terminal console noise leaking into Ivy Tendril output

### DIFF
--- a/src/Ivy/Helpers/ProcessHelper.cs
+++ b/src/Ivy/Helpers/ProcessHelper.cs
@@ -156,17 +156,6 @@ public static class ProcessHelper
         if (string.IsNullOrWhiteSpace(localUrl))
             throw new ArgumentNullException(nameof(localUrl));
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            Process.Start(new ProcessStartInfo("cmd", $"/c start {localUrl}") { CreateNoWindow = true });
-        }
-        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-        {
-            Process.Start("xdg-open", localUrl);
-        }
-        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-        {
-            Process.Start("open", localUrl);
-        }
+        Process.Start(new ProcessStartInfo(localUrl) { UseShellExecute = true });
     }
 }


### PR DESCRIPTION
# Summary

## Changes

Simplified `ProcessHelper.OpenBrowser` by replacing the platform-specific if/else block (Windows `cmd /c start`, Linux `xdg-open`, macOS `open`) with a single cross-platform `Process.Start(new ProcessStartInfo(localUrl) { UseShellExecute = true })` call. This delegates to the OS shell handler on all platforms and avoids inheriting parent console handles on Windows, which is a defensive hygiene improvement against future child process noise leaking into Ivy's console output.

## API Changes

None. The public API signature of `ProcessHelper.OpenBrowser(string localUrl)` is unchanged. Behavior is functionally identical — the method opens a URL in the default browser on all platforms.

## Files Modified

- **src/Ivy/Helpers/ProcessHelper.cs** — Replaced platform-specific browser launch code with cross-platform `UseShellExecute = true` approach (1 insertion, 12 deletions)

## Commits

- c560e8501 [02355] Replace platform-specific browser launch with cross-platform UseShellExecute