### PR TITLE
[02381] Parallelize CheckSoftware health checks in onboarding

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Onboarding/SoftwareCheckStepView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Onboarding/SoftwareCheckStepView.cs
@@ -96,16 +96,25 @@ public class SoftwareCheckStepView(
         {
             isChecking.Set(true);
 
+            var ghTask = CheckCommand("gh", "--version");
+            var claudeTask = CheckCommand("claude", "--version");
+            var codexTask = CheckCommand("codex", "--version");
+            var geminiTask = CheckCommand("gemini", "--version");
+            var gitTask = CheckCommand("git", "--version");
+            var powershellTask = CheckPowerShell();
+            var pandocTask = CheckCommand("pandoc", "--version");
+
+            await Task.WhenAll(ghTask, claudeTask, codexTask, geminiTask, gitTask, powershellTask, pandocTask);
+
             var results = new Dictionary<string, bool>
             {
-                ["gh"] = await CheckCommand("gh", "--version"),
-                ["claude"] = await CheckCommand("claude", "--version"),
-                ["codex"] = await CheckCommand("codex", "--version"),
-                ["gemini"] = await CheckCommand("gemini", "--version"),
-                ["git"] = await CheckCommand("git", "--version"),
-                ["powershell"] = await CheckCommand("pwsh", "-Version")
-                                 || await CheckCommand("powershell", "-Version"),
-                ["pandoc"] = await CheckCommand("pandoc", "--version")
+                ["gh"] = ghTask.Result,
+                ["claude"] = claudeTask.Result,
+                ["codex"] = codexTask.Result,
+                ["gemini"] = geminiTask.Result,
+                ["git"] = gitTask.Result,
+                ["powershell"] = powershellTask.Result,
+                ["pandoc"] = pandocTask.Result
             };
 
             checkResults.Set(results);
@@ -163,6 +172,11 @@ public class SoftwareCheckStepView(
             new TableCell(statusText),
             notesCell
         );
+    }
+
+    private static async Task<bool> CheckPowerShell()
+    {
+        return await CheckCommand("pwsh", "-Version") || await CheckCommand("powershell", "-Version");
     }
 
     private static Task<bool> CheckCommand(string fileName, string arguments)


### PR DESCRIPTION
# Summary

## Changes

Refactored `CheckSoftware()` in `SoftwareCheckStepView.cs` to fire all 7 software version checks concurrently using `Task.WhenAll` instead of awaiting each sequentially. Extracted a `CheckPowerShell()` static helper method to encapsulate the `pwsh`/`powershell` fallback logic (which must remain sequential). This reduces worst-case wall-clock time from ~60s to ~15s.

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/Apps/Onboarding/SoftwareCheckStepView.cs** — Parallelized `CheckCommand` calls in `CheckSoftware()` local function; added `CheckPowerShell()` static helper method

## Commits

- cde07cba0 [02381] Parallelize CheckSoftware health checks in onboarding