### PR TITLE
[02386] Add deep-merge support for promptware _default config

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/ConfigServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/ConfigServiceTests.cs
@@ -589,6 +589,44 @@ promptwares:
     }
 
     [Fact]
+    public void Should_Parse_Partial_Promptware_Entry_Alongside_Default()
+    {
+        var yaml = @"
+promptwares:
+  _default:
+    model: sonnet
+    effort: high
+    allowedTools:
+      - Read
+      - Glob
+  ExecutePlan:
+    model: opus
+";
+
+        var tempDir = CreateTempConfigFile(yaml);
+        var service = new ConfigService(new TendrilSettings());
+
+        try
+        {
+            service.SetTendrilHome(tempDir);
+
+            var defaultConfig = service.Settings.Promptwares["_default"];
+            Assert.Equal("sonnet", defaultConfig.Model);
+            Assert.Equal("high", defaultConfig.Effort);
+            Assert.Equal(2, defaultConfig.AllowedTools.Count);
+
+            var execConfig = service.Settings.Promptwares["ExecutePlan"];
+            Assert.Equal("opus", execConfig.Model);
+            Assert.Equal("", execConfig.Effort); // Not specified — PowerShell merge will inherit from _default
+            Assert.Empty(execConfig.AllowedTools); // Not specified — PowerShell merge will inherit from _default
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
     public void EditorConfig_IsAvailable_WhenCommandExists()
     {
         // "dotnet" should be available on any machine running these tests

--- a/src/tendril/Ivy.Tendril/Promptwares/.shared/Utils.ps1
+++ b/src/tendril/Ivy.Tendril/Promptwares/.shared/Utils.ps1
@@ -595,11 +595,27 @@ function GetAgentCommand {
                 $codingAgent = $config.codingAgent.ToLower()
             }
 
+            # Start with _default as base, then overlay specific promptware entry
             $pwConfig = $null
-            if ($Promptware -and $config.promptwares.$Promptware) {
-                $pwConfig = $config.promptwares.$Promptware
-            } elseif ($config.promptwares._default) {
-                $pwConfig = $config.promptwares._default
+            $defaultConfig = $config.promptwares._default
+            $specificConfig = if ($Promptware) { $config.promptwares.$Promptware } else { $null }
+
+            if ($defaultConfig -or $specificConfig) {
+                $pwConfig = @{}
+
+                # Layer 1: _default values
+                if ($defaultConfig) {
+                    if ($defaultConfig.model) { $pwConfig.model = $defaultConfig.model }
+                    if ($defaultConfig.effort) { $pwConfig.effort = $defaultConfig.effort }
+                    if ($defaultConfig.allowedTools) { $pwConfig.allowedTools = $defaultConfig.allowedTools }
+                }
+
+                # Layer 2: specific promptware values override
+                if ($specificConfig) {
+                    if ($specificConfig.model) { $pwConfig.model = $specificConfig.model }
+                    if ($specificConfig.effort) { $pwConfig.effort = $specificConfig.effort }
+                    if ($specificConfig.allowedTools) { $pwConfig.allowedTools = $specificConfig.allowedTools }
+                }
             }
 
             if ($pwConfig) {

--- a/src/tendril/Ivy.Tendril/example.config.yaml
+++ b/src/tendril/Ivy.Tendril/example.config.yaml
@@ -22,7 +22,8 @@ defaultEffort: high    # Default effort level for promptwares (low/medium/high/m
 
 # Default promptware configuration — controls model, effort, and tool permissions per promptware.
 # Without these, promptwares inherit global permissions from codingAgent.
-# Use _default as a fallback for any promptware not explicitly listed.
+# _default provides base values. Specific entries override only the fields they define;
+# unspecified fields are inherited from _default.
 promptwares:
   MakePlan:
     model: sonnet


### PR DESCRIPTION
# Summary

## Changes

Changed `GetAgentCommand` in `Utils.ps1` to deep-merge promptware config entries on top of `_default`, so specific entries inherit unspecified fields (model, effort, allowedTools) from `_default` instead of completely replacing it. Updated the `example.config.yaml` comment to reflect the new inheritance behavior. Added a C# test verifying the data model supports partial promptware entries alongside `_default`.

## API Changes

None. The PowerShell function `GetAgentCommand` behavior changed (now merges instead of replaces), but its signature and return values are unchanged.

## Files Modified

- **PowerShell:** `src/tendril/Ivy.Tendril/Promptwares/.shared/Utils.ps1` — replaced if/elseif with two-layer merge logic
- **Config:** `src/tendril/Ivy.Tendril/example.config.yaml` — updated `_default` comment to describe inheritance
- **Tests:** `src/tendril/Ivy.Tendril.Test/ConfigServiceTests.cs` — added `Should_Parse_Partial_Promptware_Entry_Alongside_Default` test

## Commits

- 01a160861 [02386] Add deep-merge support for promptware _default config