### PR TITLE
[00023] Fix WorktreeCleanupService UnauthorizedAccessException on Windows

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/WorktreeCleanupServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/WorktreeCleanupServiceTests.cs
@@ -240,6 +240,67 @@ public class WorktreeCleanupServiceTests : IDisposable
         Assert.Contains("TestRepo", logEntries[0]);
     }
 
+    [Fact]
+    public void CleanupPlanWorktrees_ForceDeletes_DeepNodeModulesPath()
+    {
+        // Simulates the real-world failure: cleanup must succeed over a deeply nested
+        // node_modules tree like the one that crashed on 'helper-string-parser'.
+        var dir = CreatePlan("11000-DeepNodeModules", "Completed", DateTime.UtcNow.AddHours(-2));
+        var worktreeDir = Path.Combine(dir, "worktrees", "TestRepo");
+
+        var deep = Path.Combine(
+            worktreeDir,
+            "frontend", "node_modules", "some-pkg", "node_modules",
+            "helper-string-parser", "lib", "esm", "helpers");
+        Directory.CreateDirectory(deep);
+
+        // Spread several files at different depths.
+        File.WriteAllText(Path.Combine(worktreeDir, "package.json"), "{}");
+        File.WriteAllText(
+            Path.Combine(worktreeDir, "frontend", "node_modules", "some-pkg", "index.js"),
+            "module.exports = {};");
+        File.WriteAllText(Path.Combine(deep, "parse-array.js"), "exports.parseArray = () => [];");
+        File.WriteAllText(Path.Combine(deep, "parse-object.js"), "exports.parseObject = () => ({});");
+
+        WorktreeCleanupService.CleanupPlanWorktrees(dir);
+
+        Assert.False(Directory.Exists(worktreeDir),
+            "Deeply nested node_modules worktree should be force-deleted");
+        Assert.False(Directory.Exists(Path.Combine(dir, "worktrees")),
+            "Worktrees directory should be removed");
+    }
+
+    [Fact]
+    public void ForceDeleteDirectory_Logs_Fallback_When_Initial_Delete_Fails()
+    {
+        // Windows-only: holding a file handle open forces Directory.Delete to throw,
+        // which should trigger the rmdir fallback and produce a log entry.
+        if (!OperatingSystem.IsWindows()) return;
+
+        var testDir = Path.Combine(_tempDir, "force-delete-fallback");
+        Directory.CreateDirectory(testDir);
+        var lockedFile = Path.Combine(testDir, "locked.txt");
+        File.WriteAllText(lockedFile, "content");
+
+        var logEntries = new List<string>();
+        var logger = new CapturingLogger(logEntries);
+
+        // Open the file with exclusive access to force Directory.Delete to fail.
+        using (var stream = new FileStream(lockedFile, FileMode.Open, FileAccess.Read, FileShare.None))
+        {
+            // Expect IOException: Directory.Delete fails because of the lock, and
+            // rmdir /s /q also can't delete the file while it's held open.
+            Assert.Throws<IOException>(() =>
+                WorktreeCleanupService.ForceDeleteDirectory(testDir, logger));
+        }
+
+        Assert.Contains(logEntries, e => e.Contains("falling back to rmdir"));
+
+        // Cleanup after the stream is released.
+        if (Directory.Exists(testDir))
+            Directory.Delete(testDir, true);
+    }
+
     private class CapturingLogger(List<string> entries) : ILogger
     {
         public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;

--- a/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
@@ -328,8 +328,7 @@ public class PlanReaderService(
         {
             if (!Directory.Exists(folderPath)) return;
             RemoveWorktrees(folderPath, _logger);
-            ClearReadOnlyAttributes(folderPath);
-            Directory.Delete(folderPath, true);
+            WorktreeCleanupService.ForceDeleteDirectory(folderPath, _logger);
         });
     }
 

--- a/src/tendril/Ivy.Tendril/Services/WorktreeCleanupService.cs
+++ b/src/tendril/Ivy.Tendril/Services/WorktreeCleanupService.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Globalization;
 using Ivy.Tendril.Apps.Plans;
 using Microsoft.Extensions.Logging;
@@ -98,8 +99,7 @@ public class WorktreeCleanupService : IStartable, IDisposable
         {
             try
             {
-                PlanReaderService.ClearReadOnlyAttributes(wtDir);
-                Directory.Delete(wtDir, true);
+                ForceDeleteDirectory(wtDir, logger);
             }
             catch (Exception ex)
             {
@@ -111,11 +111,50 @@ public class WorktreeCleanupService : IStartable, IDisposable
         try
         {
             if (Directory.Exists(worktreesDir))
-                Directory.Delete(worktreesDir, true);
+                ForceDeleteDirectory(worktreesDir, logger);
         }
-        catch
+        catch (Exception ex)
         {
-            // Best-effort: directory may be locked
+            logger?.LogWarning(ex, "Failed to force-delete worktrees directory {Dir}", worktreesDir);
+        }
+    }
+
+    /// <summary>
+    ///     Recursively deletes a directory, falling back to <c>cmd /c rmdir /s /q</c> on
+    ///     Windows when <see cref="Directory.Delete(string, bool)"/> fails with
+    ///     <see cref="UnauthorizedAccessException"/> or <see cref="IOException"/>.
+    /// </summary>
+    /// <remarks>
+    ///     Windows <c>Directory.Delete</c> can fail on deeply nested paths (such as
+    ///     <c>node_modules</c>) due to long-path limits, transient file locks, or
+    ///     NTFS permission quirks. <c>rmdir /s /q</c> handles these cases more robustly.
+    /// </remarks>
+    internal static void ForceDeleteDirectory(string path, ILogger? logger = null)
+    {
+        PlanReaderService.ClearReadOnlyAttributes(path);
+        try
+        {
+            Directory.Delete(path, true);
+        }
+        catch (Exception ex) when (ex is UnauthorizedAccessException or IOException)
+        {
+            if (!OperatingSystem.IsWindows()) throw;
+
+            logger?.LogInformation("Directory.Delete failed for {Dir}, falling back to rmdir /s /q",
+                Path.GetFileName(path));
+
+            var psi = new ProcessStartInfo("cmd.exe", $"/c rmdir /s /q \"{path}\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+            using var process = Process.Start(psi);
+            process?.WaitForExit(30000);
+
+            if (Directory.Exists(path))
+                throw new IOException($"rmdir /s /q also failed to delete '{Path.GetFileName(path)}'", ex);
         }
     }
 


### PR DESCRIPTION
# Summary

## Changes

Added a Windows-specific `rmdir /s /q` fallback to the worktree cleanup path so `WorktreeCleanupService.CleanupPlanWorktrees` can delete deeply nested `node_modules` trees (like `helper-string-parser`) that previously threw `UnauthorizedAccessException` from `Directory.Delete`. The same fallback now backs `PlanReaderService.DeletePlan` for consistency.

## API Changes

- `WorktreeCleanupService.ForceDeleteDirectory(string path, ILogger? logger = null)` — new `internal static` helper. Clears read-only attributes, calls `Directory.Delete(path, true)`, and on Windows falls back to `cmd /c rmdir /s /q "<path>"` when the delete throws `UnauthorizedAccessException` or `IOException`. Throws `IOException` if the fallback also leaves the directory in place.

No public API changes.

## Files Modified

- `src/tendril/Ivy.Tendril/Services/WorktreeCleanupService.cs` — added `using System.Diagnostics`, replaced both inline force-delete blocks with calls to the new `ForceDeleteDirectory` helper, and introduced that helper.
- `src/tendril/Ivy.Tendril/Services/PlanReaderService.cs` — `DeletePlan` now delegates to `WorktreeCleanupService.ForceDeleteDirectory` instead of duplicating the `ClearReadOnlyAttributes` + `Directory.Delete` pair.
- `src/tendril/Ivy.Tendril.Test/WorktreeCleanupServiceTests.cs` — added `CleanupPlanWorktrees_ForceDeletes_DeepNodeModulesPath` (cross-platform, reproduces the deep-path scenario) and `ForceDeleteDirectory_Logs_Fallback_When_Initial_Delete_Fails` (Windows-only, exercises and asserts on the fallback log path).

## Commits

- cf4aa49c7