### PR TITLE
[00022] Fix PlanDatabaseService crash on fresh install

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/BackgroundServiceActivatorTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/BackgroundServiceActivatorTests.cs
@@ -104,6 +104,91 @@ public class BackgroundServiceActivatorTests : IAsyncLifetime
     }
 
     [Fact]
+    public void JobService_Resolves_WhenTendrilHomeEmpty_WithoutTouchingPlanDatabaseService()
+    {
+        // Simulates fresh-install DI resolution: TendrilHome is empty,
+        // so IPlanDatabaseService registration would throw if resolved.
+        // The JobService factory in TendrilServer must avoid that resolution
+        // when TendrilHome is empty, and pass null for the database dependency.
+
+        var settings = new TendrilSettings();
+        var config = new FreshInstallConfigService(settings);
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfigService>(config);
+        services.AddSingleton(new ModelPricingService());
+        services.AddSingleton<IPlanReaderService>(sp =>
+            new PlanReaderService(sp.GetRequiredService<IConfigService>(), NullLogger<PlanReaderService>.Instance));
+        services.AddSingleton<ITelemetryService>(sp => new TelemetryService(false));
+        services.AddSingleton<IPlanWatcherService>(new PlanWatcherService(config));
+
+        // Mirrors TendrilServer line 63-71: factory throws when TendrilHome is empty.
+        services.AddSingleton<IPlanDatabaseService>(sp =>
+        {
+            var cfg = sp.GetRequiredService<IConfigService>();
+            if (string.IsNullOrEmpty(cfg.TendrilHome))
+                throw new InvalidOperationException("Cannot create PlanDatabaseService: TendrilHome is not configured. Complete onboarding first.");
+            throw new InvalidOperationException("Test should not reach database construction.");
+        });
+
+        // Mirrors TendrilServer line 89-99: fixed factory that conditionally resolves the database.
+        services.AddSingleton<JobService>(sp =>
+        {
+            var cfg = sp.GetRequiredService<IConfigService>();
+            return new JobService(
+                cfg,
+                sp.GetRequiredService<ModelPricingService>(),
+                sp.GetRequiredService<IPlanReaderService>(),
+                sp.GetRequiredService<ITelemetryService>(),
+                sp.GetRequiredService<IPlanWatcherService>(),
+                string.IsNullOrEmpty(cfg.TendrilHome) ? null : sp.GetRequiredService<IPlanDatabaseService>());
+        });
+
+        _serviceProvider = services.BuildServiceProvider();
+
+        // Resolution must NOT throw — this is the crash we're fixing.
+        var jobService = _serviceProvider.GetRequiredService<JobService>();
+        Assert.NotNull(jobService);
+
+        // Verify the database field is null so JobService won't crash at runtime.
+        var databaseField = typeof(JobService).GetField("_database",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        Assert.NotNull(databaseField);
+        Assert.Null(databaseField!.GetValue(jobService));
+    }
+
+    private sealed class FreshInstallConfigService : IConfigService
+    {
+        public FreshInstallConfigService(TendrilSettings settings)
+        {
+            Settings = settings;
+        }
+
+        public TendrilSettings Settings { get; }
+        public string TendrilHome => "";
+        public string ConfigPath => "";
+        public string PlanFolder => "";
+        public List<ProjectConfig> Projects => Settings.Projects;
+        public List<LevelConfig> Levels => Settings.Levels;
+        public string[] LevelNames => Array.Empty<string>();
+        public EditorConfig Editor => Settings.Editor ?? new EditorConfig();
+        public bool NeedsOnboarding => true;
+
+        public ProjectConfig? GetProject(string name) => null;
+        public BadgeVariant GetBadgeVariant(string level) => BadgeVariant.Outline;
+        public Colors? GetProjectColor(string projectName) => null;
+        public void SaveSettings() { }
+        public void SetPendingTendrilHome(string path) { }
+        public string? GetPendingTendrilHome() => null;
+        public void SetPendingProject(ProjectConfig project) { }
+        public ProjectConfig? GetPendingProject() => null;
+        public void SetPendingVerificationDefinitions(List<VerificationConfig> definitions) { }
+        public List<VerificationConfig>? GetPendingVerificationDefinitions() => null;
+        public void CompleteOnboarding(string tendrilHome) { }
+        public void OpenInEditor(string path) { }
+    }
+
+    [Fact]
     public void Start_CallsStartOnAllRegisteredIStartables()
     {
         var startable1 = new MockStartable();

--- a/src/tendril/Ivy.Tendril/TendrilServer.cs
+++ b/src/tendril/Ivy.Tendril/TendrilServer.cs
@@ -88,13 +88,14 @@ public static class TendrilServer
             (TelemetryService)sp.GetRequiredService<ITelemetryService>());
         server.Services.AddSingleton<JobService>(sp =>
         {
+            var cfg = sp.GetRequiredService<IConfigService>();
             return new JobService(
-                sp.GetRequiredService<IConfigService>(),
+                cfg,
                 sp.GetRequiredService<ModelPricingService>(),
                 sp.GetRequiredService<IPlanReaderService>(),
                 sp.GetRequiredService<ITelemetryService>(),
                 sp.GetRequiredService<IPlanWatcherService>(),
-                sp.GetRequiredService<IPlanDatabaseService>());
+                string.IsNullOrEmpty(cfg.TendrilHome) ? null : sp.GetRequiredService<IPlanDatabaseService>());
         });
         server.Services.AddSingleton<IJobService>(sp => sp.GetRequiredService<JobService>());
         server.Services.AddSingleton<PlanWatcherService>(sp =>


### PR DESCRIPTION
# Summary

## Changes

Fixed a fresh-install crash in Tendril where `JobService` resolution unconditionally pulled `IPlanDatabaseService`, which throws when `TendrilHome` is unset. The `JobService` singleton factory in `TendrilServer.ConfigureServices` now passes `null` for the database when `TendrilHome` is empty, matching the existing nullable contract.

## API Changes

None. The fix is internal to the DI factory wiring; `JobService`'s public constructor signature already accepts `IPlanDatabaseService? database = null`.

## Files Modified

- `src/tendril/Ivy.Tendril/TendrilServer.cs` — `JobService` singleton factory now extracts `IConfigService cfg` once and passes `string.IsNullOrEmpty(cfg.TendrilHome) ? null : sp.GetRequiredService<IPlanDatabaseService>()` for the database parameter (3 inserted, 2 deleted).
- `src/tendril/Ivy.Tendril.Test/BackgroundServiceActivatorTests.cs` — Added `JobService_Resolves_WhenTendrilHomeEmpty_WithoutTouchingPlanDatabaseService` test plus a private `FreshInstallConfigService` fake that simulates a fresh-install `IConfigService` (TendrilHome="", NeedsOnboarding=true).

## Commits

- 376a41fd1