### PR TITLE
[00031] Increase Jobs Prompt Display Cap and Strip Newlines

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/JobsApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/JobsApp.cs
@@ -378,13 +378,24 @@ public class JobsApp : ViewBase
         return $"{span.Minutes}m {span.Seconds:D2}s";
     }
 
+    private const int PromptDisplayMaxLength = 150;
+
+    private static string CleanPromptText(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+            return text;
+        var replaced = text.Replace("\r\n", " ").Replace("\n", " ").Replace("\r", " ");
+        var collapsed = Regex.Replace(replaced, @"\s+", " ");
+        return collapsed.Trim();
+    }
+
     private static string GetPromptDisplay(JobItem j, IPlanReaderService planService)
     {
         // MakePlan jobs: use the -Description arg for display (PlanFile may now hold the folder name)
         if (j.Type == "MakePlan")
         {
-            var desc = GetFullPrompt(j) ?? j.PlanFile;
-            return desc.Length > 50 ? desc[..50] + "..." : desc;
+            var desc = CleanPromptText(GetFullPrompt(j) ?? j.PlanFile);
+            return desc.Length > PromptDisplayMaxLength ? desc[..PromptDisplayMaxLength] + "..." : desc;
         }
 
         // For other jobs, try to read the plan title
@@ -394,14 +405,14 @@ public class JobsApp : ViewBase
             var plan = planService.GetPlanByFolder(fullPath);
             if (plan != null && !string.IsNullOrEmpty(plan.Title))
             {
-                var title = plan.Title;
-                return title.Length > 50 ? title[..50] + "..." : title;
+                var title = CleanPromptText(plan.Title);
+                return title.Length > PromptDisplayMaxLength ? title[..PromptDisplayMaxLength] + "..." : title;
             }
         }
 
         // Fallback to folder name
-        var pf = j.PlanFile;
-        return pf.Length > 50 ? pf[..50] + "..." : pf;
+        var pf = CleanPromptText(j.PlanFile);
+        return pf.Length > PromptDisplayMaxLength ? pf[..PromptDisplayMaxLength] + "..." : pf;
     }
 
     private static string GetStatusMessage(JobItem job)


### PR DESCRIPTION
# Summary

## Changes

Increased the Jobs table "Prompt/Title" column truncation cap from 50 to 150 characters and added newline/whitespace cleaning. Multi-line prompts now render on a single row instead of breaking the table layout, and meaningful content past the previous 50-char cutoff is now visible.

## API Changes

- Added private constant `JobsApp.PromptDisplayMaxLength = 150`
- Added private static helper `JobsApp.CleanPromptText(string text)` — replaces CR/LF with spaces, collapses consecutive whitespace, and trims
- Modified `JobsApp.GetPromptDisplay` to apply `CleanPromptText` and use the new cap in all three branches (MakePlan description, plan title, PlanFile fallback)

No public API changes.

## Files Modified

- `src/tendril/Ivy.Tendril/Apps/JobsApp.cs` — added `CleanPromptText`, `PromptDisplayMaxLength` constant, updated `GetPromptDisplay`

## Commits

- 32d505be6