### PR TITLE
[00029] Add Recheck Button to Required Software Screen

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Onboarding/SoftwareCheckStepView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Onboarding/SoftwareCheckStepView.cs
@@ -53,7 +53,15 @@ public class SoftwareCheckStepView(
                    """)
                | (checkResults.Value != null
                    ? Layout.Vertical()
-                     | Text.H3("Results")
+                     | (Layout.Horizontal().AlignContent(Align.Center)
+                        | Text.H3("Results")
+                        | new Button("Recheck")
+                            .Outline()
+                            .Small()
+                            .Icon(Icons.RefreshCw, Align.Right)
+                            .Loading(isChecking.Value)
+                            .Disabled(isChecking.Value)
+                            .OnClick(async () => await CheckSoftware()))
                      | new Table(
                          new TableRow(
                              new TableCell("Software").IsHeader(),
@@ -83,13 +91,8 @@ public class SoftwareCheckStepView(
                            .Large()
                            .Icon(Icons.ArrowRight, Align.Right)
                            .OnClick(() => stepperIndex.Set(stepperIndex.Value + 1))
-                       : Layout.Vertical()
-                         | Text.Warning(
-                             "Please install and authenticate all required software before continuing. GitHub CLI must be logged in, and at least one coding agent must be working.")
-                            | new Button("Check Again")
-                                .Outline()
-                                .Icon(Icons.CheckCheck, Align.Right)
-                                .OnClick(async () => await CheckSoftware())
+                       : Text.Warning(
+                           "Please install and authenticate all required software before continuing. GitHub CLI must be logged in, and at least one coding agent must be working.")
                );
 
         async Task CheckSoftware()


### PR DESCRIPTION
# Summary

## Changes

Added a persistent "Recheck" button inline next to the "Results" H3 heading on the onboarding "Required Software" screen (`SoftwareCheckStepView`). The button is always visible whenever check results are displayed — both pass and fail states — so users can re-verify after installing missing software without scrolling or restarting the wizard. Removed the now-redundant "Check Again" button that previously appeared only under the failure warning.

## API Changes

None. This is a UI-only change to a single view; no public types, methods, or properties were added, removed, or modified.

## Files Modified

- `src/tendril/Ivy.Tendril/Apps/Onboarding/SoftwareCheckStepView.cs` — replaced standalone `Text.H3("Results")` with `Layout.Horizontal().AlignContent(Align.Center) | Text.H3("Results") | new Button("Recheck")…`, and collapsed the failure-path `Layout.Vertical` (warning + "Check Again" button) to just the `Text.Warning` (+11 / -8 lines).

## Commits

- f4b4b4399