### PR TITLE
[00030] Fix Gemini Auth Health Check in Onboarding Software Screen

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Onboarding/SoftwareCheckStepView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Onboarding/SoftwareCheckStepView.cs
@@ -131,7 +131,7 @@ public class SoftwareCheckStepView(
                 health["codex"] = await CheckHealth("codex", "login status");
 
             if (results["gemini"])
-                health["gemini"] = await CheckHealth("gemini", "-p \"Reply OK\" --max-turns 0");
+                health["gemini"] = await CheckHealth("gemini", "-p \"Reply OK\"");
 
             healthResults.Set(health);
             isChecking.Set(false);
@@ -183,7 +183,7 @@ public class SoftwareCheckStepView(
         => CheckProcess(fileName, arguments, 10000);
 
     private static Task<bool> CheckHealth(string fileName, string arguments)
-        => CheckProcess(fileName, arguments, 15000);
+        => CheckProcess(fileName, arguments, 30000);
 
     private static async Task<bool> CheckProcess(string fileName, string arguments, int timeoutMs)
     {


### PR DESCRIPTION
# Summary

## Changes

Fixed the Gemini CLI health check in `SoftwareCheckStepView` so it no longer passes the unsupported `--max-turns 0` flag (Gemini CLI 0.37.1+ rejects it with exit code 1, which made every authenticated Gemini install report as "Installed but not authenticated"). Also increased the `CheckHealth` timeout from 15s to 30s so Claude/Codex health probes don't spuriously fail on a loaded system.

## API Changes

None. Both changes are internal to `SoftwareCheckStepView`.

## Files Modified

- `src/tendril/Ivy.Tendril/Apps/Onboarding/SoftwareCheckStepView.cs`
  - Removed `--max-turns 0` from the `gemini` health-check arguments (now `-p "Reply OK"`)
  - `CheckHealth` timeout bumped from `15000` ms to `30000` ms

## Commits

- 68d3417bb808eb7a86bef0b7bc7c04c4ff3ef2e9