### PR TITLE
[00024] Add Agent Profiles to config.yaml and Fix Codex Support in ExecutePlan

### DIFF
--- a/src/tendril/Ivy.Tendril.TeamIvyConfig/config.yaml
+++ b/src/tendril/Ivy.Tendril.TeamIvyConfig/config.yaml
@@ -1,4 +1,35 @@
 codingAgent: claude
+agents:
+- name: ClaudeCode
+  profiles:
+  - name: deep
+    model: claude-opus-4-6
+    effort: max
+  - name: balanced
+    model: claude-sonnet-4-6
+    effort: high
+  - name: quick
+    model: claude-haiku-4-5
+    effort: low
+- name: Codex
+  profiles:
+  - name: deep
+    model: gpt-5.4
+    effort: high
+  - name: balanced
+    model: gpt-5.4-mini
+    effort: medium
+  - name: quick
+    model: gpt-5.3-codex
+    effort: low
+- name: Gemini
+  profiles:
+  - name: deep
+    model: gemini-3-flash-preview
+  - name: balanced
+    model: gemini-2.5-flash
+  - name: quick
+    model: gemini-2.5-flash-lite
 jobTimeout: 30
 staleOutputTimeout: 10
 maxConcurrentJobs: 10
@@ -253,8 +284,7 @@ llm:
   model: gpt-4o-mini
 promptwares:
   MakePlan:
-    model: sonnet
-    effort: high
+    profile: balanced
     allowedTools:
     - Read
     - Glob
@@ -263,8 +293,7 @@ promptwares:
     - Write
     - Edit
   ExecutePlan:
-    model: opus
-    effort: max
+    profile: deep
     allowedTools:
     - Read
     - Write
@@ -273,8 +302,7 @@ promptwares:
     - Grep
     - Bash
   ExpandPlan:
-    model: sonnet
-    effort: high
+    profile: balanced
     allowedTools:
     - Read
     - Glob
@@ -282,16 +310,14 @@ promptwares:
     - Bash
     - Write
   MakePr:
-    model: sonnet
-    effort: medium
+    profile: balanced
     allowedTools:
     - Read
     - Bash
     - Write
     - Edit
   UpdatePlan:
-    model: sonnet
-    effort: high
+    profile: balanced
     allowedTools:
     - Read
     - Glob
@@ -299,21 +325,18 @@ promptwares:
     - Bash
     - Write
   SplitPlan:
-    model: sonnet
-    effort: medium
+    profile: balanced
     allowedTools:
     - Read
     - Bash
     - Write
   CreateIssue:
-    model: sonnet
-    effort: medium
+    profile: balanced
     allowedTools:
     - Read
     - Bash
   IvyFrameworkVerification:
-    model: sonnet
-    effort: high
+    profile: balanced
     allowedTools:
     - Read
     - Write

--- a/src/tendril/Ivy.Tendril.Test/ConfigServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/ConfigServiceTests.cs
@@ -647,4 +647,128 @@ promptwares:
         var result = PlatformHelper.OpenInEditor("nonexistent-editor-xyz-12345", "somefile.txt");
         Assert.False(result);
     }
+
+    [Fact]
+    public void Should_Deserialize_Agents_Section_With_Profiles()
+    {
+        var yaml = @"
+agents:
+  - name: ClaudeCode
+    profiles:
+      - name: deep
+        model: claude-opus-4-6
+        effort: max
+      - name: balanced
+        model: claude-sonnet-4-6
+        effort: high
+      - name: quick
+        model: claude-haiku-4-5
+        effort: low
+  - name: Codex
+    profiles:
+      - name: deep
+        model: gpt-5.4
+        effort: high
+      - name: balanced
+        model: gpt-5.4-mini
+        effort: medium
+";
+
+        var tempDir = CreateTempConfigFile(yaml);
+        var service = new ConfigService(new TendrilSettings());
+
+        try
+        {
+            service.SetTendrilHome(tempDir);
+
+            Assert.NotNull(service.Settings.Agents);
+            Assert.Equal(2, service.Settings.Agents.Count);
+
+            var claude = service.Settings.Agents[0];
+            Assert.Equal("ClaudeCode", claude.Name);
+            Assert.Equal(3, claude.Profiles.Count);
+
+            var claudeDeep = claude.Profiles[0];
+            Assert.Equal("deep", claudeDeep.Name);
+            Assert.Equal("claude-opus-4-6", claudeDeep.Model);
+            Assert.Equal("max", claudeDeep.Effort);
+
+            var claudeBalanced = claude.Profiles[1];
+            Assert.Equal("balanced", claudeBalanced.Name);
+            Assert.Equal("claude-sonnet-4-6", claudeBalanced.Model);
+            Assert.Equal("high", claudeBalanced.Effort);
+
+            var codex = service.Settings.Agents[1];
+            Assert.Equal("Codex", codex.Name);
+            Assert.Equal(2, codex.Profiles.Count);
+            Assert.Equal("gpt-5.4", codex.Profiles[0].Model);
+            Assert.Equal("high", codex.Profiles[0].Effort);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void Should_Deserialize_PromptwareConfig_Profile_Field()
+    {
+        var yaml = @"
+promptwares:
+  ExecutePlan:
+    profile: deep
+    allowedTools:
+      - Read
+      - Bash
+  MakePlan:
+    profile: balanced
+    allowedTools:
+      - Read
+";
+
+        var tempDir = CreateTempConfigFile(yaml);
+        var service = new ConfigService(new TendrilSettings());
+
+        try
+        {
+            service.SetTendrilHome(tempDir);
+
+            var execute = service.Settings.Promptwares["ExecutePlan"];
+            Assert.Equal("deep", execute.Profile);
+            Assert.Equal("", execute.Model);
+            Assert.Equal("", execute.Effort);
+
+            var make = service.Settings.Promptwares["MakePlan"];
+            Assert.Equal("balanced", make.Profile);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void Agents_DefaultsToEmptyList()
+    {
+        var settings = new TendrilSettings();
+        Assert.NotNull(settings.Agents);
+        Assert.Empty(settings.Agents);
+    }
+
+    [Fact]
+    public void PromptwareConfig_Profile_DefaultsToEmpty()
+    {
+        var config = new PromptwareConfig();
+        Assert.Equal("", config.Profile);
+    }
+
+    [Fact]
+    public void AgentProfileConfig_Fields_DefaultsToEmpty()
+    {
+        var profile = new AgentProfileConfig();
+        Assert.Equal("", profile.Name);
+        Assert.Equal("", profile.Model);
+        Assert.Equal("", profile.Effort);
+        Assert.Equal("", profile.Arguments);
+    }
 }

--- a/src/tendril/Ivy.Tendril/Promptwares/.shared/Utils.ps1
+++ b/src/tendril/Ivy.Tendril/Promptwares/.shared/Utils.ps1
@@ -607,6 +607,7 @@ function GetAgentCommand {
                 if ($defaultConfig) {
                     if ($defaultConfig.model) { $pwConfig.model = $defaultConfig.model }
                     if ($defaultConfig.effort) { $pwConfig.effort = $defaultConfig.effort }
+                    if ($defaultConfig.profile) { $pwConfig.profile = $defaultConfig.profile }
                     if ($defaultConfig.allowedTools) { $pwConfig.allowedTools = $defaultConfig.allowedTools }
                 }
 
@@ -614,6 +615,7 @@ function GetAgentCommand {
                 if ($specificConfig) {
                     if ($specificConfig.model) { $pwConfig.model = $specificConfig.model }
                     if ($specificConfig.effort) { $pwConfig.effort = $specificConfig.effort }
+                    if ($specificConfig.profile) { $pwConfig.profile = $specificConfig.profile }
                     if ($specificConfig.allowedTools) { $pwConfig.allowedTools = $specificConfig.allowedTools }
                 }
             }
@@ -640,6 +642,23 @@ function GetAgentCommand {
                 }
             }
 
+            # Resolve model and effort from agent profile if profile is specified
+            if ($pwConfig -and $pwConfig.profile -and $config.agents) {
+                $agentEntry = $config.agents | Where-Object {
+                    ($_.name -eq "ClaudeCode" -and $codingAgent -eq "claude") -or
+                    ($_.name -eq "Codex" -and $codingAgent -eq "codex") -or
+                    ($_.name -eq "Gemini" -and $codingAgent -eq "gemini") -or
+                    ($_.name.ToLower() -eq $codingAgent)
+                } | Select-Object -First 1
+                if ($agentEntry) {
+                    $profile = $agentEntry.profiles | Where-Object { $_.name -eq $pwConfig.profile } | Select-Object -First 1
+                    if ($profile) {
+                        if ($profile.model) { $model = $profile.model }
+                        if ($profile.effort) { $effort = $profile.effort }
+                    }
+                }
+            }
+
             # Fall back to defaultEffort if no per-promptware effort set
             if (-not $effort -and $config.defaultEffort) {
                 $effort = $config.defaultEffort
@@ -653,8 +672,8 @@ function GetAgentCommand {
     # Build command from codingAgent
     $raw = switch ($codingAgent) {
         "claude"  { "claude --print --verbose --output-format stream-json --dangerously-skip-permissions" }
-        "codex"   { "codex --print --verbose" }
-        "gemini"  { "gemini --print --verbose" }
+        "codex"   { "codex --full-auto" }
+        "gemini"  { "gemini --sandbox" }
         default   { "claude --print --verbose --output-format stream-json --dangerously-skip-permissions" }
     }
 
@@ -664,9 +683,12 @@ function GetAgentCommand {
         $raw += " --model $model"
     }
 
-    # Apply effort level if set (claude only)
-    if ($effort -and $codingAgent -eq "claude") {
-        $raw += " --effort $effort"
+    # Apply effort level with agent-specific flag name
+    if ($effort) {
+        switch ($codingAgent) {
+            "claude" { $raw += " --effort $effort" }
+            "codex"  { $raw += " --reasoning-effort $effort" }
+        }
     }
 
     # Build args with quote-aware parsing
@@ -686,8 +708,9 @@ function GetAgentCommand {
 
     # Append allowedTools as a single comma-separated argument
     # Note: avoid using $args as it's an automatic variable in PowerShell
+    # Only pass --allowedTools to Claude; Codex/Gemini handle tool permissions differently
     $cmdArgs = @($parts[1..($parts.Length - 1)])
-    if ($allowedTools.Count -gt 0) {
+    if ($allowedTools.Count -gt 0 -and $codingAgent -eq "claude") {
         $cmdArgs += "--allowedTools"
         $cmdArgs += ($allowedTools -join ",")
     }

--- a/src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/ExecutePlan.ps1
+++ b/src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/ExecutePlan.ps1
@@ -63,7 +63,15 @@ try {
     Add-Content -Path $rawLogFile -Value "[tendril] Claude invocation started at $startTs" -Encoding UTF8
     Add-Content -Path $rawLogFile -Value "[tendril] Command: $($agent.Executable) $($agent.Args -join ' ') $($extraArgs -join ' ')" -Encoding UTF8
 
-    $output = & $agent.Executable @($agent.Args) @extraArgs -- (Get-Content $promptFile -Raw) 2>&1 |
+    # Claude uses -- separator; Codex/Gemini take prompt as positional argument
+    $promptContent = Get-Content $promptFile -Raw
+    $agentArgs = if ($agent.CodingAgent -eq "claude") {
+        @($agent.Args) + $extraArgs + @("--", $promptContent)
+    }
+    else {
+        @($agent.Args) + $extraArgs + @($promptContent)
+    }
+    $output = & $agent.Executable @agentArgs 2>&1 |
     ForEach-Object {
         $line = if ($_ -is [System.Management.Automation.ErrorRecord]) {
             "[stderr] $_"
@@ -87,6 +95,10 @@ try {
                 $summary = $resultJson.result
             }
             catch { }
+        }
+        elseif ($agent.CodingAgent -ne "claude") {
+            # Non-Claude agents don't emit stream-json; use last non-empty line as summary
+            $summary = ($output | Where-Object { "$_".Trim() } | Select-Object -Last 1) -as [string]
         }
     }
 

--- a/src/tendril/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/tendril/Ivy.Tendril/Services/ConfigService.cs
@@ -87,7 +87,23 @@ public record PromptwareConfig
 {
     public string Model { get; set; } = "";
     public string Effort { get; set; } = "";
+    public string Profile { get; set; } = "";
     public List<string> AllowedTools { get; set; } = new();
+}
+
+public record AgentProfileConfig
+{
+    public string Name { get; set; } = "";
+    public string Model { get; set; } = "";
+    public string Effort { get; set; } = "";
+    public string Arguments { get; set; } = "";
+}
+
+public record AgentConfig
+{
+    public string Name { get; set; } = "";
+    public string Arguments { get; set; } = "";
+    public List<AgentProfileConfig> Profiles { get; set; } = new();
 }
 
 public record LlmConfig
@@ -110,6 +126,7 @@ public class TendrilSettings
     public EditorConfig Editor { get; set; } = new();
     public LlmConfig? Llm { get; set; }
     public Dictionary<string, PromptwareConfig> Promptwares { get; set; } = new();
+    public List<AgentConfig> Agents { get; set; } = new();
     public bool Telemetry { get; set; } = true;
 
     public List<LevelConfig> Levels { get; set; } = new()


### PR DESCRIPTION
# Summary

## Changes

Added agent profiles to Tendril's config schema so model+effort can travel together as a named tuple (deep/balanced/quick) per provider (ClaudeCode/Codex/Gemini), and fixed `ExecutePlan` so it correctly invokes Codex and Gemini CLIs (right base flags, prompt-passing convention, output parsing). Promptware entries now reference `profile:` instead of raw `model:`/`effort:` so swapping the active coding agent automatically picks the provider-appropriate model.

## API Changes

- `Ivy.Tendril.Services.AgentProfileConfig` (new record): `Name`, `Model`, `Effort`, `Arguments`
- `Ivy.Tendril.Services.AgentConfig` (new record): `Name`, `Arguments`, `Profiles`
- `TendrilSettings.Agents` (new property): `List<AgentConfig>`
- `PromptwareConfig.Profile` (new property): `string` — references an agent profile name
- `config.yaml` schema additions:
  - new top-level `agents:` section with three agent entries (`ClaudeCode`, `Codex`, `Gemini`), each with `profiles:` list (`deep`/`balanced`/`quick`, with `model` and `effort`)
  - `promptwares.<Name>.profile:` field replaces per-promptware `model:`/`effort:` in TeamIvyConfig

## Files Modified

- `src/tendril/Ivy.Tendril/Services/ConfigService.cs` — added `AgentProfileConfig`, `AgentConfig`, `Profile`, `Agents`
- `src/tendril/Ivy.Tendril/Promptwares/.shared/Utils.ps1` — `GetAgentCommand` now resolves model/effort from agent profiles, uses correct base commands and per-agent effort flags, and only sends `--allowedTools` to Claude
- `src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/ExecutePlan.ps1` — agent-aware prompt invocation (`--` separator for Claude, positional for Codex/Gemini) and fallback summary parser for non-Claude agents
- `src/tendril/Ivy.Tendril.TeamIvyConfig/config.yaml` — populated `agents:` section, switched all 8 promptware entries to use `profile:`
- `src/tendril/Ivy.Tendril.Test/ConfigServiceTests.cs` — 4 new tests covering agents/profile deserialization and defaults

## Commits

- 5ac37db0d [00024] Add agent profiles to config schema
- 0c4cef6e6 [00024] Fix Codex/Gemini support in ExecutePlan and GetAgentCommand