### PR TITLE
[03004] Fix hardcoded 'Claude' log label in ExecutePlan

### DIFF
--- a/src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/ExecutePlan.ps1
+++ b/src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/ExecutePlan.ps1
@@ -60,7 +60,7 @@ try {
     }
 
     $startTs = (Get-Date).ToUniversalTime().ToString("o")
-    Add-Content -Path $rawLogFile -Value "[tendril] Claude invocation started at $startTs" -Encoding UTF8
+    Add-Content -Path $rawLogFile -Value "[tendril] Agent invocation started at $startTs (provider: $($agent.CodingAgent))" -Encoding UTF8
     Add-Content -Path $rawLogFile -Value "[tendril] Command: $($agent.Executable) $($agent.Args -join ' ') $($extraArgs -join ' ')" -Encoding UTF8
 
     # Claude uses -- separator; Codex/Gemini take prompt as positional argument


### PR DESCRIPTION
# Summary

## Changes

Replaced the hardcoded `"Claude"` label in `ExecutePlan.ps1`'s raw log output with a provider-aware line that reads `[tendril] Agent invocation started at <ts> (provider: <codingAgent>)`. This matches the existing pattern in `Utils.ps1` and correctly reflects Codex/Gemini invocations.

## API Changes

None. Internal log string only — no PowerShell function signatures, exported symbols, or behavior change.

## Files Modified

- `src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/ExecutePlan.ps1` — line 63 log line

## Commits

- 19c6b96e1 [03004] Replace hardcoded Claude label with provider-aware log line