### PR TITLE
[03003] Add Retry-with-Backoff to ForceDeleteDirectory and Log Handle Holders

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/WorktreeCleanupServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/WorktreeCleanupServiceTests.cs
@@ -343,13 +343,45 @@ public class WorktreeCleanupServiceTests : IDisposable
         {
             // Expect IOException: Directory.Delete fails because of the lock, and
             // rmdir /s /q also can't delete the file while it's held open.
-            Assert.Throws<IOException>(() =>
+            var ex = Assert.Throws<IOException>(() =>
                 WorktreeCleanupService.ForceDeleteDirectory(testDir, logger));
+            Assert.Contains("after 3 retries", ex.Message);
         }
 
         Assert.Contains(logEntries, e => e.Contains("falling back to rmdir"));
 
         // Cleanup after the stream is released.
+        if (Directory.Exists(testDir))
+            Directory.Delete(testDir, true);
+    }
+
+    [Fact]
+    public void ForceDeleteDirectory_Retries_Before_Throwing()
+    {
+        // Windows-only: keep a file locked for the entire call so every retry
+        // attempt fails. Verify retry log entries appear and the final message
+        // mentions "after 3 retries". Slow test (~3s back-off).
+        if (!OperatingSystem.IsWindows()) return;
+
+        var testDir = Path.Combine(_tempDir, "force-delete-retry");
+        Directory.CreateDirectory(testDir);
+        var lockedFile = Path.Combine(testDir, "locked.txt");
+        File.WriteAllText(lockedFile, "content");
+
+        var logEntries = new List<string>();
+        var logger = new CapturingLogger(logEntries);
+
+        using (var stream = new FileStream(lockedFile, FileMode.Open, FileAccess.Read, FileShare.None))
+        {
+            var ex = Assert.Throws<IOException>(() =>
+                WorktreeCleanupService.ForceDeleteDirectory(testDir, logger));
+            Assert.Contains("after 3 retries", ex.Message);
+        }
+
+        Assert.Contains(logEntries, e => e.Contains("retry 1/3"));
+        Assert.Contains(logEntries, e => e.Contains("retry 2/3"));
+        Assert.Contains(logEntries, e => e.Contains("retry 3/3"));
+
         if (Directory.Exists(testDir))
             Directory.Delete(testDir, true);
     }

--- a/src/tendril/Ivy.Tendril/Services/WorktreeCleanupService.cs
+++ b/src/tendril/Ivy.Tendril/Services/WorktreeCleanupService.cs
@@ -131,30 +131,75 @@ public class WorktreeCleanupService : IStartable, IDisposable
     /// </remarks>
     internal static void ForceDeleteDirectory(string path, ILogger? logger = null)
     {
-        PlanReaderService.ClearReadOnlyAttributes(path);
+        const int maxRetries = 3;
+        int[] delaysMs = [500, 1000, 1500];
+
+        for (int attempt = 0; attempt <= maxRetries; attempt++)
+        {
+            if (attempt > 0)
+            {
+                logger?.LogDebug("ForceDeleteDirectory retry {Attempt}/{Max} for {Dir}",
+                    attempt, maxRetries, Path.GetFileName(path));
+                Thread.Sleep(delaysMs[attempt - 1]);
+            }
+
+            PlanReaderService.ClearReadOnlyAttributes(path);
+            try
+            {
+                Directory.Delete(path, true);
+                return;
+            }
+            catch (Exception ex) when (ex is UnauthorizedAccessException or IOException)
+            {
+                if (!OperatingSystem.IsWindows()) throw;
+
+                logger?.LogInformation("Directory.Delete failed for {Dir}, falling back to rmdir /s /q",
+                    Path.GetFileName(path));
+
+                var psi = new ProcessStartInfo("cmd.exe", $"/c rmdir /s /q \"{path}\"")
+                {
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                };
+                using var process = Process.Start(psi);
+                process?.WaitForExit(30000);
+
+                if (!Directory.Exists(path))
+                    return;
+
+                if (attempt < maxRetries)
+                    continue;
+
+                TryLogHandleHolders(path, logger);
+                throw new IOException($"rmdir /s /q also failed to delete '{Path.GetFileName(path)}' after {maxRetries} retries", ex);
+            }
+        }
+    }
+
+    private static void TryLogHandleHolders(string path, ILogger? logger)
+    {
+        if (logger == null || !OperatingSystem.IsWindows()) return;
         try
         {
-            Directory.Delete(path, true);
-        }
-        catch (Exception ex) when (ex is UnauthorizedAccessException or IOException)
-        {
-            if (!OperatingSystem.IsWindows()) throw;
-
-            logger?.LogInformation("Directory.Delete failed for {Dir}, falling back to rmdir /s /q",
-                Path.GetFileName(path));
-
-            var psi = new ProcessStartInfo("cmd.exe", $"/c rmdir /s /q \"{path}\"")
+            var psi = new ProcessStartInfo("handle.exe", $"-accepteula -nobanner \"{path}\"")
             {
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 UseShellExecute = false,
                 CreateNoWindow = true
             };
-            using var process = Process.Start(psi);
-            process?.WaitForExit(30000);
-
-            if (Directory.Exists(path))
-                throw new IOException($"rmdir /s /q also failed to delete '{Path.GetFileName(path)}'", ex);
+            using var proc = Process.Start(psi);
+            if (proc == null) return;
+            var output = proc.StandardOutput.ReadToEnd();
+            proc.WaitForExit(5000);
+            if (!string.IsNullOrWhiteSpace(output))
+                logger.LogWarning("Processes holding handles on {Dir}:\n{Output}", Path.GetFileName(path), output);
+        }
+        catch
+        {
+            // handle.exe not installed or failed — silently skip
         }
     }
 


### PR DESCRIPTION
# Summary

## Changes

Added a 3-attempt retry-with-backoff loop (500/1000/1500 ms) to `ForceDeleteDirectory` in `WorktreeCleanupService`, so transient file handles (AV scanners, file watchers, lingering node processes) have time to clear before the final throw. On final failure the method now invokes Sysinternals `handle.exe` (best-effort, silent if missing) and logs the processes still holding handles on the target path.

## API Changes

- `WorktreeCleanupService.ForceDeleteDirectory(string path, ILogger? logger = null)` — public surface unchanged, but the final `IOException` message now reads `"rmdir /s /q also failed to delete '<name>' after 3 retries"`.
- New `private static void TryLogHandleHolders(string path, ILogger? logger)` — internal helper, not part of the public surface.

## Files Modified

- `src/tendril/Ivy.Tendril/Services/WorktreeCleanupService.cs` — retry loop + `TryLogHandleHolders`.
- `src/tendril/Ivy.Tendril.Test/WorktreeCleanupServiceTests.cs` — updated `ForceDeleteDirectory_Logs_Fallback_When_Initial_Delete_Fails` to assert the new `"after 3 retries"` message; added `ForceDeleteDirectory_Retries_Before_Throwing` covering the retry log entries.

## Commits

- b5fde6b0c005ecf383e485b47b5768dc05f1a9fa