### PR TITLE
[03001] Add Files Column to Commits Table

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Plans/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Plans/ContentView.cs
@@ -270,14 +270,16 @@ public class ContentView(
             var commitsTable = new Table(
                 new TableRow(
                         new TableCell("Commit").IsHeader(),
-                        new TableCell("Message").IsHeader()
+                        new TableCell("Message").IsHeader(),
+                        new TableCell("Files").IsHeader()
                     )
                 { IsHeader = true }
             );
             foreach (var row in planData.CommitRows)
                 commitsTable |= new TableRow(
                     new TableCell(new Button(row.ShortHash).Inline().OnClick(() => openCommit.Set(row.Hash))),
-                    new TableCell(row.Title)
+                    new TableCell(row.Title),
+                    new TableCell(row.FileCount?.ToString() ?? "–")
                 );
 
             var commitWarning = PlanContentHelpers.BuildCommitWarningCallout(planData.CommitRows);

--- a/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -300,14 +300,16 @@ public class ContentView(
             var commitsTable = new Table(
                 new TableRow(
                         new TableCell("Commit").IsHeader(),
-                        new TableCell("Message").IsHeader()
+                        new TableCell("Message").IsHeader(),
+                        new TableCell("Files").IsHeader()
                     )
                 { IsHeader = true }
             );
             foreach (var row in planData.CommitRows)
                 commitsTable |= new TableRow(
                     new TableCell(new Button(row.ShortHash).Inline().OnClick(() => openCommit.Set(row.Hash))),
-                    new TableCell(row.Title)
+                    new TableCell(row.Title),
+                    new TableCell(row.FileCount?.ToString() ?? "–")
                 );
 
             commitsLayout |= commitsTable;


### PR DESCRIPTION
# Summary

## Changes

Added a "Files" column to the commits table in both the Review and Plans apps, displaying the `CommitRow.FileCount` value (or `"–"` when `null`). Gives reviewers quick visibility into commit size without opening each commit's detail sheet.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs` — added Files header and cell
- `src/tendril/Ivy.Tendril/Apps/Plans/ContentView.cs` — added Files header and cell

## Commits

- da708bd14