### PR TITLE
[03005] Warn on silently dropped Gemini effort in GetAgentCommand

### DIFF
--- a/src/tendril/Ivy.Tendril/Promptwares/.shared/Utils.ps1
+++ b/src/tendril/Ivy.Tendril/Promptwares/.shared/Utils.ps1
@@ -688,6 +688,7 @@ function GetAgentCommand {
         switch ($codingAgent) {
             "claude" { $raw += " --effort $effort" }
             "codex"  { $raw += " --reasoning-effort $effort" }
+            "gemini" { Write-Warning "Effort '$effort' is configured but the Gemini CLI does not support an effort flag — ignoring." }
         }
     }
 


### PR DESCRIPTION
# Summary

## Changes

Added a `"gemini"` case to the per-agent effort flag switch in `GetAgentCommand` (Utils.ps1). The Gemini CLI has no effort flag, so instead of silently dropping the value, the function now emits a `Write-Warning` diagnostic that names the dropped effort level. Claude and Codex behavior is unchanged.

## API Changes

None. Internal PowerShell helper behavior only — no public API, config schema, or CLI surface changes.

## Files Modified

- `src/tendril/Ivy.Tendril/Promptwares/.shared/Utils.ps1` — added `"gemini"` switch case emitting `Write-Warning` in the effort-flag block of `GetAgentCommand`

## Commits

- ad5b2478c