### PR TITLE
[03007] Document --max-turns Risk in Claude Health Check

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Onboarding/SoftwareCheckStepView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Onboarding/SoftwareCheckStepView.cs
@@ -127,6 +127,13 @@ public class SoftwareCheckStepView(
             if (results["gh"])
                 health["gh"] = await CheckHealth("gh", "auth status");
 
+            // --max-turns 1 caps Claude at a single agentic turn so the process exits cleanly.
+            // Without it, `claude -p` still starts an interactive session on some versions and
+            // blocks until the 30 s timeout fires, falsely reporting "not authenticated".
+            // NOTE: --max-turns is undocumented in `claude --help` (Claude Code 2.1.100) and
+            // could be silently removed in a future release — exactly what happened to Gemini CLI
+            // in 0.37.1+ (see plan 00030). If this check starts failing without auth changes,
+            // verify --max-turns is still a recognized flag (`claude --help | grep max-turns`).
             if (results["claude"])
                 health["claude"] = await CheckHealth("claude", "-p \"ping\" --max-turns 1");
 


### PR DESCRIPTION
# Summary

## Changes

Added a seven-line inline comment above the Claude CLI health check in `SoftwareCheckStepView.cs` explaining why `--max-turns 1` is required (caps Claude at a single agentic turn so `claude -p` exits cleanly instead of blocking on stdin until the 30 s timeout fires) and warning that the flag is undocumented in `claude --help` and could be silently removed in a future release — mirroring the Gemini CLI 0.37.1+ regression fixed in plan 00030. Comment-only change; no behavioural impact.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Apps/Onboarding/SoftwareCheckStepView.cs` — added 7-line comment above `CheckHealth("claude", ...)` call.

## Commits

- d597e33f2