### PR TITLE
[01285] Add unit tests for useFileAttachments paste and drag-drop logic

### DIFF
--- a/src/frontend/src/widgets/inputs/ContentInputWidget/useFileAttachments.test.ts
+++ b/src/frontend/src/widgets/inputs/ContentInputWidget/useFileAttachments.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * Tests for useFileAttachments hook.
+ *
+ * Since @testing-library/react is not available in this project,
+ * we verify the source code contains the correct patterns for:
+ * - Paste event handling with guard conditions
+ * - Drop event handling with guard conditions
+ * - Drag state management
+ * - File picker interaction
+ * - Upload pipeline with validation
+ */
+describe("useFileAttachments", () => {
+  const source = fs.readFileSync(path.resolve(__dirname, "./useFileAttachments.ts"), "utf-8");
+
+  describe("imports and dependencies", () => {
+    it("should import useUploadWithProgress from shared", () => {
+      expect(source).toContain(
+        'import { useUploadWithProgress } from "../shared/useUploadWithProgress"',
+      );
+    });
+
+    it("should import validateFileWithToast and validateFileCount from file-input-validation", () => {
+      expect(source).toContain(
+        'import { validateFileWithToast, validateFileCount } from "../file-input-validation"',
+      );
+    });
+
+    it("should not import uploadFileWithProgress directly", () => {
+      expect(source).not.toContain("import { uploadFileWithProgress }");
+    });
+  });
+
+  describe("handlePaste guards", () => {
+    it("should contain disabled || !uploadUrl guard for early return", () => {
+      expect(source).toContain("disabled || !uploadUrl");
+    });
+
+    it("should access e.clipboardData.items", () => {
+      expect(source).toContain("e.clipboardData");
+    });
+
+    it("should check kind === 'file' on clipboard items", () => {
+      expect(source).toContain('kind === "file"');
+    });
+
+    it("should call e.preventDefault() when files are found", () => {
+      const handlePasteIndex = source.indexOf("const handlePaste");
+      expect(handlePasteIndex).toBeGreaterThan(-1);
+
+      const handlePasteBlock = source.slice(
+        handlePasteIndex,
+        source.indexOf("\n  const", handlePasteIndex + 1),
+      );
+      expect(handlePasteBlock).toContain("e.preventDefault()");
+    });
+  });
+
+  describe("handleDrop guards", () => {
+    it("should contain e.preventDefault() and e.stopPropagation()", () => {
+      const handleDropIndex = source.indexOf("const handleDrop");
+      expect(handleDropIndex).toBeGreaterThan(-1);
+
+      const handleDropBlock = source.slice(
+        handleDropIndex,
+        source.indexOf("\n  const", handleDropIndex + 1),
+      );
+      expect(handleDropBlock).toContain("e.preventDefault()");
+      expect(handleDropBlock).toContain("e.stopPropagation()");
+    });
+
+    it("should contain setIsDragging(false)", () => {
+      const handleDropIndex = source.indexOf("const handleDrop");
+      expect(handleDropIndex).toBeGreaterThan(-1);
+
+      const handleDropBlock = source.slice(
+        handleDropIndex,
+        source.indexOf("\n  const", handleDropIndex + 1),
+      );
+      expect(handleDropBlock).toContain("setIsDragging(false)");
+    });
+
+    it("should contain disabled guard for early return", () => {
+      const handleDropIndex = source.indexOf("const handleDrop");
+      expect(handleDropIndex).toBeGreaterThan(-1);
+
+      const handleDropBlock = source.slice(
+        handleDropIndex,
+        source.indexOf("\n  const", handleDropIndex + 1),
+      );
+      expect(handleDropBlock).toContain("disabled");
+    });
+
+    it("should access e.dataTransfer.files", () => {
+      expect(source).toContain("e.dataTransfer.files");
+    });
+  });
+
+  describe("drag handlers", () => {
+    it("onDragEnter should check !disabled before setIsDragging(true)", () => {
+      const dragEnterIndex = source.indexOf("const handleDragEnter");
+      expect(dragEnterIndex).toBeGreaterThan(-1);
+
+      const dragEnterBlock = source.slice(
+        dragEnterIndex,
+        source.indexOf("\n  const", dragEnterIndex + 1),
+      );
+      expect(dragEnterBlock).toContain("!disabled");
+      expect(dragEnterBlock).toContain("setIsDragging(true)");
+    });
+
+    it("onDragOver should check !disabled", () => {
+      const dragOverIndex = source.indexOf("const handleDragOver");
+      expect(dragOverIndex).toBeGreaterThan(-1);
+
+      const dragOverBlock = source.slice(
+        dragOverIndex,
+        source.indexOf("\n  const", dragOverIndex + 1),
+      );
+      expect(dragOverBlock).toContain("!disabled");
+    });
+
+    it("onDragLeave should set isDragging to false", () => {
+      const dragLeaveIndex = source.indexOf("const handleDragLeave");
+      expect(dragLeaveIndex).toBeGreaterThan(-1);
+
+      const dragLeaveBlock = source.slice(
+        dragLeaveIndex,
+        source.indexOf("\n  const", dragLeaveIndex + 1),
+      );
+      expect(dragLeaveBlock).toContain("setIsDragging(false)");
+    });
+  });
+
+  describe("openFilePicker guard", () => {
+    it("should contain !disabled && fileInputRef.current guard", () => {
+      expect(source).toContain("!disabled && fileInputRef.current");
+    });
+  });
+
+  describe("upload pipeline", () => {
+    it("uploadFiles should call validateFileCount before processing", () => {
+      const uploadFilesIndex = source.indexOf("const uploadFiles");
+      expect(uploadFilesIndex).toBeGreaterThan(-1);
+
+      const uploadFilesBlock = source.slice(
+        uploadFilesIndex,
+        source.indexOf("\n  const", uploadFilesIndex + 1),
+      );
+      expect(uploadFilesBlock).toContain("validateFileCount");
+    });
+
+    it("handleUploadFile should contain !uploadUrl guard for early return", () => {
+      const handleUploadIndex = source.indexOf("const handleUploadFile");
+      expect(handleUploadIndex).toBeGreaterThan(-1);
+
+      const handleUploadBlock = source.slice(
+        handleUploadIndex,
+        source.indexOf("\n  const", handleUploadIndex + 1),
+      );
+      expect(handleUploadBlock).toContain("!uploadUrl");
+    });
+
+    it("handleUploadFile should call validateFileWithToast", () => {
+      const handleUploadIndex = source.indexOf("const handleUploadFile");
+      expect(handleUploadIndex).toBeGreaterThan(-1);
+
+      const handleUploadBlock = source.slice(
+        handleUploadIndex,
+        source.indexOf("\n  const", handleUploadIndex + 1),
+      );
+      expect(handleUploadBlock).toContain("validateFileWithToast");
+    });
+
+    it("handleUploadFile should call uploadSingleFile", () => {
+      const handleUploadIndex = source.indexOf("const handleUploadFile");
+      expect(handleUploadIndex).toBeGreaterThan(-1);
+
+      const handleUploadBlock = source.slice(
+        handleUploadIndex,
+        source.indexOf("\n  const", handleUploadIndex + 1),
+      );
+      expect(handleUploadBlock).toContain("uploadSingleFile");
+    });
+  });
+
+  describe("return shape", () => {
+    it("should return isDragging", () => {
+      expect(source).toContain("isDragging,");
+    });
+
+    it("should return dragHandlers", () => {
+      expect(source).toContain("dragHandlers,");
+    });
+
+    it("should return handlePaste", () => {
+      expect(source).toContain("handlePaste,");
+    });
+
+    it("should return openFilePicker", () => {
+      expect(source).toContain("openFilePicker,");
+    });
+
+    it("should return handleFileInputChange", () => {
+      expect(source).toContain("handleFileInputChange,");
+    });
+
+    it("should return fileInputRef", () => {
+      expect(source).toContain("fileInputRef,");
+    });
+
+    it("should return uploadProgress", () => {
+      expect(source).toContain("uploadProgress,");
+    });
+
+    it("should return cancelUpload", () => {
+      expect(source).toContain("cancelUpload,");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Added a comprehensive test file for the `useFileAttachments` hook covering paste event handling, drag-and-drop event handling, file picker interaction, upload pipeline validation, and return shape verification. The tests follow the existing source-code pattern-matching approach used by `useUploadWithProgress.test.ts`, reading the source file and asserting that key code patterns exist.

## API Changes

None.

## Files Modified

- **New:** `src/frontend/src/widgets/inputs/ContentInputWidget/useFileAttachments.test.ts` — 27 test cases across 7 describe blocks covering imports, handlePaste guards, handleDrop guards, drag handlers, openFilePicker guard, upload pipeline, and return shape.

## Commits

- bc36ca022 [01285] Add unit tests for useFileAttachments paste and drag-drop logic