### PR TITLE
[03021] Fix auto-commit to exclude backup files from git staging

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -419,6 +419,9 @@ Ivy.Samples/.claude/settings.local.json
 .ivy/
 **/tmp_out/
 
+# Tendril backup files
+*.bak_*
+
 # Claude Code worktrees
 .worktrees/
 

--- a/src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
+++ b/src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
@@ -155,6 +155,7 @@ if [[ -n $(git status --porcelain) ]]; then
   # After resolving stale files, check if there are still changes to commit
   if [[ -n $(git status --porcelain) ]]; then
     git add -A
+    git reset -- '*.bak_*' 2>/dev/null || true
     git commit -m "WIP: Auto-commit before plan execution [$(date -u +%Y-%m-%dT%H:%M:%SZ)]"
     git push origin $(git branch --show-current)
     echo "Changes committed and pushed successfully"


### PR DESCRIPTION
# Summary

## Changes

Added `*.bak_*` pattern to the repo's `.gitignore` to globally exclude Tendril backup files (both `*.bak_verify` and `*.bak_<planId>` variants). Added a defensive `git reset -- '*.bak_*'` after `git add -A` in ExecutePlan's auto-commit step (Step 1.8) to unstage any backup files that might bypass `.gitignore`.

## API Changes

None.

## Files Modified

- **src/.gitignore** — Added `*.bak_*` exclusion pattern
- **src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/Program.md** — Added `git reset` after `git add -A` in auto-commit code block

## Commits

- [03021] Fix auto-commit to exclude backup files from git staging