### PR TITLE
[03013] Rename agents to codingAgents

### DIFF
--- a/src/tendril/Ivy.Tendril.TeamIvyConfig/config.yaml
+++ b/src/tendril/Ivy.Tendril.TeamIvyConfig/config.yaml
@@ -1,5 +1,5 @@
 codingAgent: claude
-agents:
+codingAgents:
 - name: claude
   profiles:
   - name: deep

--- a/src/tendril/Ivy.Tendril.Test/ConfigServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/ConfigServiceTests.cs
@@ -674,8 +674,8 @@ promptwares:
     public void Agents_DefaultsToEmptyList()
     {
         var settings = new TendrilSettings();
-        Assert.NotNull(settings.Agents);
-        Assert.Empty(settings.Agents);
+        Assert.NotNull(settings.CodingAgents);
+        Assert.Empty(settings.CodingAgents);
     }
 
     [Fact]

--- a/src/tendril/Ivy.Tendril.Test/ConfigServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/ConfigServiceTests.cs
@@ -535,7 +535,7 @@ promptwares:
     public void Should_Deserialize_Agents_Section_With_Profiles()
     {
         var yaml = @"
-agents:
+codingAgents:
   - name: ClaudeCode
     profiles:
       - name: deep
@@ -564,10 +564,10 @@ agents:
         {
             service.SetTendrilHome(tempDir);
 
-            Assert.NotNull(service.Settings.Agents);
-            Assert.Equal(2, service.Settings.Agents.Count);
+            Assert.NotNull(service.Settings.CodingAgents);
+            Assert.Equal(2, service.Settings.CodingAgents.Count);
 
-            var claude = service.Settings.Agents[0];
+            var claude = service.Settings.CodingAgents[0];
             Assert.Equal("ClaudeCode", claude.Name);
             Assert.Equal(3, claude.Profiles.Count);
 
@@ -581,7 +581,7 @@ agents:
             Assert.Equal("claude-sonnet-4-6", claudeBalanced.Model);
             Assert.Equal("high", claudeBalanced.Effort);
 
-            var codex = service.Settings.Agents[1];
+            var codex = service.Settings.CodingAgents[1];
             Assert.Equal("Codex", codex.Name);
             Assert.Equal(2, codex.Profiles.Count);
             Assert.Equal("gpt-5.4", codex.Profiles[0].Model);
@@ -598,7 +598,7 @@ agents:
     {
         var yaml = @"
 codingAgent: claude
-agents:
+codingAgents:
   - name: ClaudeCode
     arguments: --global-flag
     profiles:
@@ -615,10 +615,10 @@ agents:
         {
             service.SetTendrilHome(tempDir);
 
-            Assert.NotNull(service.Settings.Agents);
-            Assert.Single(service.Settings.Agents);
+            Assert.NotNull(service.Settings.CodingAgents);
+            Assert.Single(service.Settings.CodingAgents);
 
-            var agent = service.Settings.Agents[0];
+            var agent = service.Settings.CodingAgents[0];
             Assert.Equal("ClaudeCode", agent.Name);
             Assert.Equal("--global-flag", agent.Arguments);
 

--- a/src/tendril/Ivy.Tendril/Commands/DoctorCommand.cs
+++ b/src/tendril/Ivy.Tendril/Commands/DoctorCommand.cs
@@ -200,7 +200,7 @@ public static class DoctorCommand
         }
 
         // 5. Agent model verification
-        if (configService?.Settings.Agents is { Count: > 0 } agents)
+        if (configService?.Settings.CodingAgents is { Count: > 0 } agents)
         {
             PrintHeader("Agent Models");
 
@@ -287,7 +287,7 @@ public static class DoctorCommand
         var codingAgent = configService?.Settings.CodingAgent ?? "claude";
         var clis = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        if (configService?.Settings.Agents is { Count: > 0 } agents)
+        if (configService?.Settings.CodingAgents is { Count: > 0 } agents)
         {
             foreach (var agent in agents)
             {

--- a/src/tendril/Ivy.Tendril/Promptwares/.shared/Utils.ps1
+++ b/src/tendril/Ivy.Tendril/Promptwares/.shared/Utils.ps1
@@ -631,8 +631,8 @@ function GetAgentCommand {
             }
 
             # Resolve model, effort, and arguments from agent profile if profile is specified
-            if ($pwConfig -and $pwConfig.profile -and $config.agents) {
-                $agentEntry = $config.agents | Where-Object {
+            if ($pwConfig -and $pwConfig.profile -and $config.codingAgents) {
+                $agentEntry = $config.codingAgents | Where-Object {
                     ($_.name -eq "ClaudeCode" -and $codingAgent -eq "claude") -or
                     ($_.name -eq "Codex" -and $codingAgent -eq "codex") -or
                     ($_.name -eq "Gemini" -and $codingAgent -eq "gemini") -or

--- a/src/tendril/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/tendril/Ivy.Tendril/Services/ConfigService.cs
@@ -123,7 +123,7 @@ public class TendrilSettings
     public EditorConfig Editor { get; set; } = new();
     public LlmConfig? Llm { get; set; }
     public Dictionary<string, PromptwareConfig> Promptwares { get; set; } = new();
-    public List<AgentConfig> Agents { get; set; } = new();
+    public List<AgentConfig> CodingAgents { get; set; } = new();
     public bool Telemetry { get; set; } = true;
 
     public List<LevelConfig> Levels { get; set; } = new()

--- a/src/tendril/Ivy.Tendril/Services/OnboardingSetupService.cs
+++ b/src/tendril/Ivy.Tendril/Services/OnboardingSetupService.cs
@@ -36,7 +36,7 @@ public class OnboardingSetupService(IConfigService config, IServiceProvider serv
             var basicConfig = "codingAgent: claude\n" +
                               "jobTimeout: 30\n" +
                               "staleOutputTimeout: 10\n" +
-                              "agents:\n" +
+                              "codingAgents:\n" +
                               "- name: ClaudeCode\n" +
                               "  profiles:\n" +
                               "  - name: deep\n" +

--- a/src/tendril/Ivy.Tendril/example.config.yaml
+++ b/src/tendril/Ivy.Tendril/example.config.yaml
@@ -24,7 +24,7 @@ maxConcurrentJobs: 5  # Maximum number of jobs to run concurrently (default: 5)
 # Agent profiles — each agent has three profiles: deep, balanced, quick.
 # Promptwares reference profiles by name so switching codingAgent automatically
 # picks the right model and effort without per-promptware changes.
-agents:
+codingAgents:
 - name: claude
   profiles:
   - name: deep


### PR DESCRIPTION
# Summary

## Changes

Renamed the `agents` configuration field to `codingAgents` across all C# code, YAML config files, PowerShell scripts, and tests. This aligns the list property name with the existing `codingAgent` scalar field for clarity.

## API Changes

- `TendrilConfig.Agents` property renamed to `TendrilConfig.CodingAgents` (type unchanged: `List<AgentConfig>`)
- YAML config key `agents:` renamed to `codingAgents:`

## Files Modified

**C# source:**
- `Services/ConfigService.cs` — property rename
- `Commands/DoctorCommand.cs` — two usages updated
- `Services/OnboardingSetupService.cs` — YAML string literal updated

**Tests:**
- `Ivy.Tendril.Test/ConfigServiceTests.cs` — YAML strings, assertions, and default test updated (fix commit for missed `Agents_DefaultsToEmptyList` reference)

**Configuration:**
- `example.config.yaml` — key renamed
- `Ivy.Tendril.TeamIvyConfig/config.yaml` — key renamed

**PowerShell:**
- `Promptwares/.shared/Utils.ps1` — two `$config.agents` references updated

## Commits

- 0a83bdcb7 [03013] Rename agents to codingAgents
- e7a5a1823 [03013] Fix missed Agents reference in default test