### PR TITLE
[03015] Add Spacer Between Results Header and Table in Onboarding Software Step

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Onboarding/SoftwareCheckStepView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Onboarding/SoftwareCheckStepView.cs
@@ -62,6 +62,7 @@ public class SoftwareCheckStepView(
                             .Loading(isChecking.Value)
                             .Disabled(isChecking.Value)
                             .OnClick(async () => await CheckSoftware()))
+                     | Layout.Spacer()
                      | new Table(
                          new TableRow(
                              new TableCell("Software").IsHeader(),


### PR DESCRIPTION
# Summary

## Changes

Added a `Layout.Spacer()` between the "Results" header row (containing H3 heading and Recheck button) and the software status Table in the onboarding software check step. This provides visual breathing room between the header and table.

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/Apps/Onboarding/SoftwareCheckStepView.cs** — Inserted `Layout.Spacer()` after the horizontal header layout and before the Table widget.

## Commits

- [03015] Add spacer between results header and table in software check step (e41dc96d9)