### PR TITLE
[03020] Add Advanced Settings Tab to SetupApp

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/ConfigServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/ConfigServiceTests.cs
@@ -694,4 +694,45 @@ promptwares:
         Assert.Equal("", profile.Effort);
         Assert.Equal("", profile.Arguments);
     }
+
+    [Fact]
+    public void SaveSettings_PersistsAdvancedSettings()
+    {
+        var yaml = @"
+jobTimeout: 30
+staleOutputTimeout: 10
+maxConcurrentJobs: 5
+editor:
+  command: code
+  label: VS Code
+";
+
+        var tempDir = CreateTempConfigFile(yaml);
+        var service = new ConfigService(new TendrilSettings());
+
+        try
+        {
+            service.SetTendrilHome(tempDir);
+
+            service.Settings.JobTimeout = 45;
+            service.Settings.StaleOutputTimeout = 15;
+            service.Settings.MaxConcurrentJobs = 8;
+            service.Settings.Editor.Command = "vim";
+            service.Settings.Editor.Label = "Vim";
+            service.SaveSettings();
+
+            var reloaded = new ConfigService(new TendrilSettings());
+            reloaded.SetTendrilHome(tempDir);
+
+            Assert.Equal(45, reloaded.Settings.JobTimeout);
+            Assert.Equal(15, reloaded.Settings.StaleOutputTimeout);
+            Assert.Equal(8, reloaded.Settings.MaxConcurrentJobs);
+            Assert.Equal("vim", reloaded.Settings.Editor.Command);
+            Assert.Equal("Vim", reloaded.Settings.Editor.Label);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
 }

--- a/src/tendril/Ivy.Tendril/Apps/Setup/AdvancedSetupView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Setup/AdvancedSetupView.cs
@@ -1,0 +1,52 @@
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Apps.Setup;
+
+public class AdvancedSetupView : ViewBase
+{
+    public override object Build()
+    {
+        var config = UseService<IConfigService>();
+        var client = UseService<IClientProvider>();
+
+        var jobTimeout = UseState(config.Settings.JobTimeout);
+        var staleOutputTimeout = UseState(config.Settings.StaleOutputTimeout);
+        var maxConcurrentJobs = UseState(config.Settings.MaxConcurrentJobs);
+        var editorCommand = UseState(config.Settings.Editor.Command);
+        var editorLabel = UseState(config.Settings.Editor.Label);
+
+        var hasChanges = jobTimeout.Value != config.Settings.JobTimeout
+                         || staleOutputTimeout.Value != config.Settings.StaleOutputTimeout
+                         || maxConcurrentJobs.Value != config.Settings.MaxConcurrentJobs
+                         || editorCommand.Value != config.Settings.Editor.Command
+                         || editorLabel.Value != config.Settings.Editor.Label;
+
+        var form = Layout.Vertical().Gap(4).Padding(4).Width(Size.Auto().Max(Size.Units(120)))
+                   | Text.Block("Timeouts").Bold()
+                   | jobTimeout.ToNumberInput().Min(1).Max(120).Suffix("min")
+                       .WithField().Label("Job Timeout")
+                   | staleOutputTimeout.ToNumberInput().Min(1).Max(60).Suffix("min")
+                       .WithField().Label("Stale Output Timeout")
+                   | maxConcurrentJobs.ToNumberInput().Min(1).Max(50)
+                       .WithField().Label("Max Concurrent Jobs")
+                   | Text.Block("Editor").Bold()
+                   | editorCommand.ToTextInput("e.g. code, vim")
+                       .WithField().Label("Command")
+                   | editorLabel.ToTextInput("e.g. VS Code, Vim")
+                       .WithField().Label("Label")
+                   | new Button("Save").Primary()
+                       .Disabled(!hasChanges)
+                       .OnClick(() =>
+                       {
+                           config.Settings.JobTimeout = jobTimeout.Value;
+                           config.Settings.StaleOutputTimeout = staleOutputTimeout.Value;
+                           config.Settings.MaxConcurrentJobs = maxConcurrentJobs.Value;
+                           config.Settings.Editor.Command = editorCommand.Value;
+                           config.Settings.Editor.Label = editorLabel.Value;
+                           config.SaveSettings();
+                           client.Toast("Settings saved successfully", "Saved");
+                       });
+
+        return form;
+    }
+}

--- a/src/tendril/Ivy.Tendril/Apps/SetupApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/SetupApp.cs
@@ -19,7 +19,8 @@ public class SetupApp : ViewBase
             new Tab("Levels", new LevelsSetupView()),
             new Tab("Verifications", new VerificationsSetupView()),
             new Tab("Promptwares", new PromptwaresSetupView()),
-            new Tab("Projects", new ProjectsSetupView())
+            new Tab("Projects", new ProjectsSetupView()),
+            new Tab("Advanced", new AdvancedSetupView())
         ).Variant(TabsVariant.Content);
     }
 }


### PR DESCRIPTION
# Summary

## Changes

Added a new "Advanced" tab to SetupApp that exposes timeout settings (JobTimeout, StaleOutputTimeout, MaxConcurrentJobs) and editor configuration (Command, Label) through the UI. Added a test verifying that saving these settings persists correctly to config.yaml.

## API Changes

- New class `AdvancedSetupView` in `Ivy.Tendril.Apps.Setup` namespace
- New "Advanced" tab added to `SetupApp` tab layout

## Files Modified

- **New:** `src/tendril/Ivy.Tendril/Apps/Setup/AdvancedSetupView.cs` — Advanced settings view with NumberInput fields for timeouts and TextInput fields for editor config
- **Modified:** `src/tendril/Ivy.Tendril/Apps/SetupApp.cs` — Added Advanced tab to TabsLayout
- **Modified:** `src/tendril/Ivy.Tendril.Test/ConfigServiceTests.cs` — Added `SaveSettings_PersistsAdvancedSettings` test

## Commits

- 1d899e94b [03020] Add Advanced Settings tab to SetupApp