### PR TITLE
[03019] Fix YAML parsing errors in recommendations.yaml causing Review flash

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/PlanDatabaseSyncServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/PlanDatabaseSyncServiceTests.cs
@@ -131,6 +131,29 @@ public class PlanDatabaseSyncServiceTests : IDisposable
     }
 
     [Fact]
+    public void PerformInitialSync_HandlesmalformedRecommendationsYaml()
+    {
+        var yaml =
+            "state: Completed\nproject: Tendril\ntitle: Bad Recs Plan\nlevel: NiceToHave\nrepos: []\ncommits: []\nprs: []\nverifications: []\nrelatedPlans: []\ndependsOn: []\ncreated: 2026-01-01T00:00:00Z\nupdated: 2026-01-01T00:00:00Z\n";
+        var dir = Path.Combine(_planReader.PlansDirectory, "01502-BadRecsPlan");
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "plan.yaml"), yaml);
+        var revisionsDir = Path.Combine(dir, "revisions");
+        Directory.CreateDirectory(revisionsDir);
+        File.WriteAllText(Path.Combine(revisionsDir, "001.md"), "# Bad Recs Plan");
+        var artifactsDir = Path.Combine(dir, "artifacts");
+        Directory.CreateDirectory(artifactsDir);
+        File.WriteAllText(Path.Combine(artifactsDir, "recommendations.yaml"),
+            "- title: `Backtick title` causes parse failure\n  description: This breaks\n  state: Pending\n");
+
+        _syncService.PerformInitialSync();
+
+        Assert.True(_syncService.IsInitialSyncComplete);
+        var recs = _database.GetRecommendations();
+        Assert.Empty(recs);
+    }
+
+    [Fact]
     public void PlanWatcher_WatchedFolders_IncludesArtifacts()
     {
         // Verify that PlanWatcherService watches the artifacts folder so that

--- a/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -2,6 +2,7 @@ using Ivy.Core;
 using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Apps.Review.Dialogs;
 using Ivy.Tendril.Services;
+using Microsoft.Extensions.Logging;
 
 namespace Ivy.Tendril.Apps.Review;
 
@@ -27,6 +28,7 @@ public class ContentView(
     public override object Build()
     {
         var client = UseService<IClientProvider>();
+        var logger = UseService<ILogger<ContentView>>();
         var copyToClipboard = UseClipboard();
         var openVerification = UseState<string?>(null);
         var openArtifact = UseState<string?>(null);
@@ -130,9 +132,9 @@ public class ContentView(
                                 FileHelper.ReadAllText(recsPath)) ?? new List<RecommendationYaml>()
                             : new List<RecommendationYaml>();
                     }
-                    catch
+                    catch (Exception ex)
                     {
-                        // Malformed YAML must not crash the process — file may be partially written by a promptware.
+                        logger.LogWarning(ex, "Failed to parse recommendations.yaml for plan {FolderPath}", folderPath);
                         recs = new List<RecommendationYaml>();
                     }
 

--- a/src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
+++ b/src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
@@ -362,6 +362,8 @@ If you identified items in ANY category, write them to `<PlanFolder>/artifacts/r
   state: Pending
 ```
 
+**YAML quoting rules:** Titles containing backticks, colons, brackets, braces, or other YAML special characters MUST be double-quoted. Alternatively, use block scalar style (`>` or `|`) for values with special characters.
+
 Do NOT include items that are part of the current plan's scope.
 
 Do NOT include recommendations about code formatting, linting, or style issues (e.g., line wrapping, indentation, trailing whitespace, import ordering). These are handled automatically by DotnetFormat and FrontendLint verifications.


### PR DESCRIPTION
# Summary

## Changes

Fixed YAML parsing errors caused by unquoted backtick characters in recommendation titles. Added logging to ContentView's silent catch block so malformed YAML is reported instead of swallowed. Updated ExecutePlan documentation with YAML quoting rules and added a test for graceful handling of malformed recommendations.yaml.

## API Changes

None.

## Files Modified

- **ContentView.cs** — Added `ILogger<ContentView>` via `UseService` and replaced bare `catch` with `catch (Exception ex)` that logs warnings
- **Program.md** — Added YAML quoting rules note for recommendation titles
- **PlanDatabaseSyncServiceTests.cs** — Added `PerformInitialSync_HandlesmalformedRecommendationsYaml` test
- **Plan 25 recommendations.yaml** — Quoted title containing backtick characters (direct fix, not in worktree)

## Commits

- cd110f3be [03019] Fix YAML parsing errors in recommendations.yaml