### PR TITLE
[03017] Remove emojis from project configuration UI

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs
@@ -21,7 +21,6 @@ public class EditProjectDialog(
     {
         var editName = UseState("");
         var editColor = UseState<Colors?>(null);
-        var editSlackEmoji = UseState("");
         var editContext = UseState("");
         var editRepos = UseState(new List<RepoRef>());
         var editVerifications = UseState(new List<ProjectVerificationRef>());
@@ -38,7 +37,6 @@ public class EditProjectDialog(
             {
                 editName.Set("");
                 editColor.Set(null);
-                editSlackEmoji.Set("");
                 editContext.Set("");
                 editRepos.Set(new List<RepoRef>());
                 editVerifications.Set(new List<ProjectVerificationRef>());
@@ -48,7 +46,6 @@ public class EditProjectDialog(
                 var project = _projects[_editIndex.Value.Value];
                 editName.Set(project.Name);
                 editColor.Set(Enum.TryParse<Colors>(project.Color, out var c) ? c : null);
-                editSlackEmoji.Set(project.GetMeta("slackEmoji") ?? "");
                 editContext.Set(project.Context);
                 editRepos.Set(
                     new List<RepoRef>(project.Repos.Select(r => new RepoRef { Path = r.Path, PrRule = r.PrRule })));
@@ -243,7 +240,6 @@ public class EditProjectDialog(
                 Layout.Vertical().Gap(4)
                 | editName.ToTextInput("Project name...").WithField().Label("Name")
                 | editColor.ToSelectInput().WithField().Label("Color")
-                | editSlackEmoji.ToTextInput(":emoji:").WithField().Label("Slack Emoji")
                 | editContext.ToTextareaInput("Project context or prompt for AI agents (optional)...").Rows(4)
                     .WithField().Label("Context / Prompt (Optional)")
                 | (Layout.Vertical().Gap(2)
@@ -266,7 +262,6 @@ public class EditProjectDialog(
                     var project = isNew ? new ProjectConfig() : _projects[_editIndex.Value!.Value];
                     project.Name = editName.Value;
                     project.Color = editColor.Value?.ToString() ?? "";
-                    project.Meta["slackEmoji"] = editSlackEmoji.Value;
                     project.Context = editContext.Value;
                     project.Repos = new List<RepoRef>(editRepos.Value);
                     project.Verifications = new List<ProjectVerificationRef>(editVerifications.Value);

--- a/src/tendril/Ivy.Tendril/Apps/Setup/ProjectsSetupView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Setup/ProjectsSetupView.cs
@@ -16,7 +16,7 @@ public class ProjectsSetupView : ViewBase
         var projects = config.Settings.Projects;
         var allVerifications = config.Settings.Verifications.Select(v => v.Name).ToList();
 
-        var rows = projects.Select((p, i) => new ProjectRow(p.Name, p.Color, p.GetMeta("slackEmoji"), p.Repos.Count, p.Verifications.Count, i)).ToList();
+        var rows = projects.Select((p, i) => new ProjectRow(p.Name, p.Color, p.Repos.Count, p.Verifications.Count, i)).ToList();
 
         var table = new TableBuilder<ProjectRow>(rows)
             .Header(t => t.Index, "Actions")
@@ -27,12 +27,6 @@ public class ProjectsSetupView : ViewBase
                     editIndex.Set(idx);
                 })
                 | new Button().Icon(Icons.Trash).Outline().Small().OnClick(() => { deleteIndex.Set(idx); })
-            ))
-            .Header(t => t.Icon, "Icon")
-            .Builder(t => t.Icon, f => f.Func<ProjectRow, string?>(emoji =>
-                !string.IsNullOrEmpty(emoji)
-                    ? Text.Block(emoji)
-                    : new Spacer()
             ));
 
         return Layout.Vertical().Gap(4).Padding(4).Width(Size.Auto().Max(Size.Units(120)))
@@ -46,5 +40,5 @@ public class ProjectsSetupView : ViewBase
                | new DeleteProjectDialog(deleteIndex, projects, config, client, refreshToken);
     }
 
-    private record ProjectRow(string Name, string Color, string? Icon, int RepoCount, int VerificationCount, int Index);
+    private record ProjectRow(string Name, string Color, int RepoCount, int VerificationCount, int Index);
 }


### PR DESCRIPTION
# Summary

## Changes

Removed all emoji-related UI elements from the Tendril Setup interface. The Icon column was removed from the Projects table in `ProjectsSetupView.cs`, and the Slack Emoji input field plus all associated state management was removed from `EditProjectDialog.cs`. Existing `slackEmoji` values in project metadata remain untouched for use by the NotifySlack hook.

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/Apps/Setup/ProjectsSetupView.cs** — Removed `slackEmoji` from ProjectRow construction, removed Icon column from table, removed Icon parameter from ProjectRow record
- **src/tendril/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs** — Removed `editSlackEmoji` state variable, removed initialization/loading of emoji state, removed Slack Emoji input field from dialog, removed saving emoji to project metadata

## Commits

- 7f6757cfd [03017] Remove emoji fields from project configuration UI