### PR TITLE
[03024] Remove Stack-Specific References From Tendril Promptwares And Config

### DIFF
--- a/src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
+++ b/src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
@@ -1,5 +1,7 @@
 # ExecutePlan
 
+**Note:** This promptware is stack-agnostic. Stack-specific operations (build, format, test) are defined in `config.yaml` under `verifications`. Examples in this document use multiple tech stacks for illustration.
+
 Execute an approved plan in isolated git worktrees.
 
 ## Context
@@ -208,7 +210,9 @@ git worktree add "<PlanFolder>/worktrees/<RepoName>" -b "plan-<PlanId>-<RepoName
 
 **Important:** Always branch from `origin/<default-branch>`, not local HEAD. This ensures the PR only contains the plan's commits, not any unpushed local work.
 
-### 2.5. Setup Frontend Dependencies
+### 2.5. Setup Frontend Dependencies (JavaScript/TypeScript Projects Only)
+
+**Note:** This section applies only to projects using npm/pnpm. Skip if not applicable.
 
 **!CRITICAL: Frontend builds in worktrees have known issues with npm package module resolution that cause 15-25 minute timeouts. Follow this workaround to avoid them.**
 
@@ -267,7 +271,7 @@ If the plan **modifies frontend code** (adding/editing `.tsx`, `.ts`, `.css` fil
 
 ### 3. Handle Cross-Repo References
 
-Projects may reference other repos via absolute paths in `.csproj` files (e.g. `<ProjectReference Include="/path/to/other-repo/src/Project.csproj" />`).
+Projects may reference other repos via absolute paths in project files (e.g. `.csproj`, `go.mod`, `package.json`).
 
 These paths point to the original repos, not the worktree copies. Since we only modify files in the worktree, this is usually fine — the build references the original (stable) code.
 
@@ -285,25 +289,22 @@ Work exclusively in the worktree directories. Follow the plan's latest revision:
 
 Make logically grouped commits in the worktree(s). Each commit should be a coherent unit of work.
 
-Before each commit, run formatting/linting as defined by the project's verifications in `config.yaml`. Common patterns:
+Before each commit, run formatting/linting as defined by the project's verifications in `config.yaml`. The exact commands depend on your stack's verification definitions.
 
-**Frontend files** (in directories containing `package.json`):
-
-```bash
-cd <frontend-dir> && npm run format && npm run lint:fix && cd <back-to-root>
-```
-
-**C# files**:
+**Example patterns** (actual commands come from config.yaml verifications):
 
 ```bash
-# Get changed .cs files from this execution's commits
-CHANGED_CS=$(git diff --name-only --diff-filter=ACM HEAD~1 -- '*.cs' | tr '\n' ' ')
-if [ -n "$CHANGED_CS" ]; then
-  dotnet format --include $CHANGED_CS
-fi
+# Get changed files from this execution's commits
+CHANGED_FILES=$(git diff --name-only --diff-filter=ACM HEAD~1)
+
+# Run your formatter on changed files (examples):
+# - .NET: dotnet format --include <files>
+# - JavaScript: npm run format <files>
+# - Python: black <files>
+# - Go: gofmt -w <files>
 ```
 
-If `dotnet format` fails with `Could not find a MSBuild project file or solution file`, the current working directory doesn't contain a discoverable `.slnx`/`.sln`. Pass the solution that contains the changed files as an explicit first positional argument (`dotnet format <path/to/solution.slnx> --include <files>`). Repos without a top-level solution file are common — check `Memory/` for repo-specific workspace paths.
+If your formatter requires a workspace/solution file that isn't in the current directory, pass it as an explicit argument. Check `Memory/` for repo-specific workspace paths.
 
 Commit messages should reference the plan ID:
 

--- a/src/tendril/Ivy.Tendril/Promptwares/MakePlan/Program.md
+++ b/src/tendril/Ivy.Tendril/Promptwares/MakePlan/Program.md
@@ -1,5 +1,7 @@
 # MakePlan
 
+**Note:** This promptware is stack-agnostic. Stack-specific operations (build, format, test) are defined in `config.yaml` under `verifications`. Examples in this document use multiple tech stacks for illustration.
+
 **🚫 FORBIDDEN: Do NOT modify, create, or delete any source code files (.cs, .ts, .ps1, etc.). Do NOT implement the plan. You are a PLANNER, not an executor. Your ONLY output is plan files (plan.yaml, revisions/*.md) inside PlansDirectory. If you catch yourself writing code to a repo, STOP IMMEDIATELY.**
 
 Create an implementation plan for a task described in args.
@@ -193,18 +195,18 @@ Only include `## Questions` if you have genuine questions for the user that bloc
 The `## Tests` section MUST include two parts:
 
 1. **New tests to write** — describe any new test cases needed for the feature/fix
-2. **Test scope** — specify a `dotnet test --filter` expression that limits DotnetTest to relevant tests only. 
+2. **Test scope** — specify which tests to run using your test framework's filter/selector syntax.
    
    To determine scope:
-   - Identify the namespaces/classes being modified
+   - Identify the modules/classes being modified
    - Search for existing test classes that cover those areas
-   - **Filters MUST target specific test classes, not broad namespaces.** 
-     - Good: `FullyQualifiedName~MyApp.Tests.CommandParserTests`
-     - Good: `FullyQualifiedName~MyApp.Tests.StringHelperTests|FullyQualifiedName~MyApp.Tests.ValidationHelperTests`
-     - Bad: `FullyQualifiedName~MyApp` (matches entire project including E2E)
-     - Bad: `FullyQualifiedName~MyApp.Tests` (matches hundreds of unrelated tests)
+   - **Filters MUST target specific test classes, not broad namespaces/directories.** 
+     Examples:
+     - .NET: `dotnet test --filter "FullyQualifiedName~MyApp.Tests.CommandParserTests"`
+     - JavaScript: `jest --testPathPattern=CommandParser.test.ts`
+     - Python: `pytest tests/test_command_parser.py`
+     - Go: `go test ./pkg/parser/...`
    - **Exclude E2E/integration test classes** unless the plan specifically changes E2E-level behavior. E2E tests are environment-dependent and should only run when explicitly needed.
-   - When multiple test classes are relevant, combine with `|` operator: `FullyQualifiedName~ClassA|FullyQualifiedName~ClassB`
    - If no existing tests cover the changed code, state: "No existing test coverage for this area."
    - If the change is so broad that all tests are genuinely needed, explicitly state: "Run all tests (broad cross-cutting change)." and justify why.
    

--- a/src/tendril/Ivy.Tendril/Promptwares/MakePr/Program.md
+++ b/src/tendril/Ivy.Tendril/Promptwares/MakePr/Program.md
@@ -1,5 +1,7 @@
 # MakePr
 
+**Note:** This promptware is stack-agnostic. Stack-specific operations (build, format, test) are defined in `config.yaml` under `verifications`. Examples in this document use multiple tech stacks for illustration.
+
 Create GitHub pull requests and apply PR rules.
 
 **!CRITICAL: ALL steps are mandatory. Do not skip PR rule application.**
@@ -152,9 +154,13 @@ When the PR status is `CONFLICTING`, resolve the conflict locally before retryin
    git commit -m "[<planId>] Resolve merge conflicts with <default-branch>"
    ```
 
-6. **Quick build check** (if C# files were involved in conflicts):
+6. **Quick build check** (if build-critical files were involved in conflicts):
    ```bash
-   dotnet build --warnaserror
+   # Run your project's build command from config.yaml verifications
+   # Examples:
+   # - .NET: dotnet build --warnaserror
+   # - JavaScript: npm run build
+   # - Go: go build ./...
    ```
    If the build fails, fix the issue and amend the merge commit.
 

--- a/src/tendril/Ivy.Tendril/example.config.yaml
+++ b/src/tendril/Ivy.Tendril/example.config.yaml
@@ -149,7 +149,9 @@ verifications:
     3. Compare the plan's Problem and Solution sections against the actual changes
     4. Write the verification report to `<PlanFolder>/verification/CheckResult.md`
 
-# Example .NET verifications (uncomment and customize):
+# Stack-specific verification examples (uncomment and customize for your stack):
+
+# .NET:
 # - name: DotnetBuild
 #   prompt: Run `dotnet build --warnaserror` in the plan's worktree directory and verify it succeeds.
 # - name: DotnetFormat
@@ -160,6 +162,26 @@ verifications:
 #   prompt: >
 #     Run dotnet tests using the filter from the plan's **## Tests** section.
 #     If plan specifies `dotnet test --filter <expression>`, run it. Verify all tests pass.
+
+# JavaScript/TypeScript:
+# - name: NpmBuild
+#   prompt: Run `npm run build` in the plan's worktree directory and verify it succeeds.
+# - name: NpmLint
+#   prompt: Run `npm run lint` on changed files and fix any errors.
+# - name: NpmTest
+#   prompt: Run `npm test` with the filter from the plan's **## Tests** section.
+
+# Python:
+# - name: PythonLint
+#   prompt: Run `black --check .` and `flake8` on changed .py files.
+# - name: PythonTest
+#   prompt: Run `pytest <files>` with the filter from the plan's **## Tests** section.
+
+# Go:
+# - name: GoBuild
+#   prompt: Run `go build ./...` and verify it succeeds.
+# - name: GoTest
+#   prompt: Run `go test <packages>` with the filter from the plan's **## Tests** section.
 
 levels:
   - name: Bug
@@ -202,6 +224,6 @@ planTemplate: >
 
   **Test scope:**
 
-  Specify which tests to run (e.g., test file patterns, test names, or "No existing test coverage" / "Run all tests — <justification>")
+  Specify which tests to run using your test framework's syntax (e.g., `dotnet test --filter "..."`, `jest --testPathPattern=...`, `pytest tests/specific/`, or "No existing test coverage" / "Run all tests — <justification>")
 
   ## Verification


### PR DESCRIPTION
# Summary

## Changes

Replaced stack-specific (.NET, npm/pnpm) hardcoded references in Tendril core promptware documentation with stack-agnostic patterns and multi-stack examples. Added a stack-agnostic note header to each updated Program.md file.

## API Changes

None.

## Files Modified

- **MakePlan/Program.md** — Replaced dotnet-only test scope section with multi-stack examples (.NET, JS, Python, Go); added stack-agnostic header note
- **ExecutePlan/Program.md** — Added "(JavaScript/TypeScript Projects Only)" qualifier and skip note to frontend deps section; generalized cross-repo references from `.csproj` to project files; replaced hardcoded format commands with config-driven pattern; added stack-agnostic header note
- **MakePr/Program.md** — Generalized quick build check from "C# files" to "build-critical files" with multi-stack examples; added stack-agnostic header note
- **example.config.yaml** — Expanded commented verification examples from .NET-only to include JavaScript/TypeScript, Python, and Go stacks; updated planTemplate test scope with multi-framework syntax examples

## Commits

- 9afb68ed2 [03024] Remove stack-specific references from Tendril promptwares