### PR TITLE
[03028] Update Tendril Apps To Use TextInput Instead Of FolderInput

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Onboarding/ProjectSetupStepView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Onboarding/ProjectSetupStepView.cs
@@ -25,20 +25,7 @@ public class ProjectSetupStepView(IState<int> stepperIndex) : ViewBase
         for (var i = 0; i < currentRepos.Count; i++)
         {
             var ri = i;
-            reposLayout |= Layout.Horizontal().Gap(2).AlignContent(Align.Center)
-                           | new FolderInput
-                           {
-                               Value = currentRepos[ri],
-                               Placeholder = "Select repository folder...",
-                               Mode = FolderInputMode.FullPath,
-                               OnChange = new(e =>
-                               {
-                                   var list = new List<string>(repoPaths.Value);
-                                   list[ri] = e.Value ?? "";
-                                   repoPaths.Set(list);
-                                   return ValueTask.CompletedTask;
-                               })
-                           }.Width(Size.Grow());
+            reposLayout |= new RepoPathInputView(repoPaths, ri);
         }
 
         reposLayout |= new Button("Add").Outline().OnClick(() =>
@@ -158,3 +145,20 @@ public class ProjectSetupStepView(IState<int> stepperIndex) : ViewBase
 }
 
 internal record VerificationEntry(string Name, string Prompt, bool Required);
+
+internal class RepoPathInputView(IState<List<string>> repoPaths, int index) : ViewBase
+{
+    public override object Build()
+    {
+        var repoPath = UseState(repoPaths.Value[index]);
+        UseEffect(() =>
+        {
+            var list = new List<string>(repoPaths.Value);
+            list[index] = repoPath.Value ?? "";
+            repoPaths.Set(list);
+        }, repoPath);
+
+        return repoPath.ToTextInput("Select repository folder...")
+            .Width(Size.Grow());
+    }
+}

--- a/src/tendril/Ivy.Tendril/Apps/Onboarding/TendrilHomeStepView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Onboarding/TendrilHomeStepView.cs
@@ -21,7 +21,7 @@ public class TendrilHomeStepView(IState<int> stepperIndex) : ViewBase
                | Text.H2("Tendril Data Location")
                | Text.Muted("This folder will store your plans, inbox, trash, and other Tendril data.")
                | (error.Value != null ? Text.Danger(error.Value) : null!)
-               | folderPath.ToFolderInput("Select Tendril data folder...", mode: FolderInputMode.FullPath)
+               | folderPath.ToTextInput("Select Tendril data folder...")
                    .WithField().Label("Tendril Home")
                | new Button("Next").Primary().Large().Icon(Icons.ArrowRight, Align.Right)
                    .OnClick(() =>

--- a/src/tendril/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs
@@ -87,7 +87,7 @@ public class EditProjectDialog(
                                            : $"Not a git repository: {expandedPath}")
                                    : new Spacer().Width(Size.Units(4)))
                                | editingRepoPath
-                                   .ToFolderInput("Select repository folder...", mode: FolderInputMode.FullPath)
+                                   .ToTextInput("Select repository folder...")
                                    .Width(Size.Grow())
                                | new Badge(repo.PrRule).Variant(BadgeVariant.Outline)
                                | new Button().Icon(Icons.Check).Ghost().Small().OnClick(() =>
@@ -160,7 +160,7 @@ public class EditProjectDialog(
         if (repoPathError.Value != null) reposLayout |= Text.Danger(repoPathError.Value);
 
         reposLayout |= Layout.Horizontal().Gap(2).AlignContent(Align.Center)
-                       | newRepoPath.ToFolderInput("Select repository folder...", mode: FolderInputMode.FullPath)
+                       | newRepoPath.ToTextInput("Select repository folder...")
                            .Width(Size.Grow())
                        | newRepoPrRule.ToSelectInput(new List<string> { "default", "yolo" }).Width(Size.Units(20))
                        | new Button("Add").Outline().Small().OnClick(() =>


### PR DESCRIPTION
# Summary

## Changes

Replaced all `FolderInput` usages in Tendril onboarding and setup views with `TextInput`. For `ProjectSetupStepView`, extracted a `RepoPathInputView` sub-component since `TextInput` requires `IState` via `.ToTextInput()` and Ivy hooks cannot be called inside loops.

## API Changes

None. Internal UI widget replacement only — no public APIs changed.

## Files Modified

- **src/tendril/Ivy.Tendril/Apps/Onboarding/TendrilHomeStepView.cs** — `.ToFolderInput()` replaced with `.ToTextInput()`
- **src/tendril/Ivy.Tendril/Apps/Onboarding/ProjectSetupStepView.cs** — `new FolderInput {...}` replaced with `RepoPathInputView` sub-component using `.ToTextInput()`; added `RepoPathInputView` class
- **src/tendril/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs** — Two `.ToFolderInput()` calls replaced with `.ToTextInput()`

## Commits

- 0a5df3d03