### PR TITLE
[03027] Fix OnboardingTest to check for codingAgents instead of agents

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/OnboardingSetupServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/OnboardingSetupServiceTests.cs
@@ -138,7 +138,7 @@ public class OnboardingSetupServiceTests : IAsyncLifetime
         var content = await File.ReadAllTextAsync(configPath);
         Assert.Contains("codingAgent: claude", content);
         Assert.Contains("projects: []", content);
-        Assert.Contains("agents:", content);
+        Assert.Contains("codingAgents:", content);
         Assert.Contains("ClaudeCode", content);
         Assert.Contains("Codex", content);
         Assert.Contains("Gemini", content);


### PR DESCRIPTION
# Summary

## Changes

Updated `OnboardingSetupServiceTests.cs` to assert `"codingAgents:"` instead of `"agents:"` in the config validation test. This ensures the test explicitly checks for the correct YAML key after the rename in plan 03013.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril.Test/OnboardingSetupServiceTests.cs` — Changed assertion from `"agents:"` to `"codingAgents:"`

## Commits

- 835cc69eb [03027] Fix OnboardingTest to check for codingAgents instead of agents