### PR TITLE
[03044] Import Issues from Github

### DIFF
--- a/src/tendril/Ivy.Tendril/AppShell/Dialogs/ImportIssuesDialog.cs
+++ b/src/tendril/Ivy.Tendril/AppShell/Dialogs/ImportIssuesDialog.cs
@@ -1,0 +1,224 @@
+using System.Text.RegularExpressions;
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.AppShell.Dialogs;
+
+public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) : ViewBase
+{
+    private readonly IConfigService _config = config;
+    private readonly IState<bool> _dialogOpen = dialogOpen;
+
+    public override object? Build()
+    {
+        var githubService = UseService<IGithubService>();
+        var client = UseService<IClientProvider>();
+
+        var selectedRepo = UseState<string?>(null);
+        var searchQuery = UseState("");
+        var selectedAssignee = UseState<string?>(null);
+        var selectedLabels = UseState(Array.Empty<string>());
+        var fetchedIssues = UseState<List<GitHubIssue>?>(null);
+        var isFetching = UseState(false);
+        var isImporting = UseState(false);
+
+        var assigneesQuery = UseQuery<string[], string>(
+            selectedRepo.Value ?? "",
+            async (repoName, _) =>
+            {
+                if (string.IsNullOrEmpty(repoName)) return Array.Empty<string>();
+                var repos = githubService.GetRepos();
+                var repo = repos.FirstOrDefault(r => r.DisplayName == repoName);
+                if (repo is null) return Array.Empty<string>();
+                return (await githubService.GetAssigneesAsync(repo.Owner, repo.Name)).ToArray();
+            },
+            initialValue: Array.Empty<string>()
+        );
+
+        var labelsQuery = UseQuery<string[], string>(
+            selectedRepo.Value ?? "",
+            async (repoName, _) =>
+            {
+                if (string.IsNullOrEmpty(repoName)) return Array.Empty<string>();
+                var repos = githubService.GetRepos();
+                var repo = repos.FirstOrDefault(r => r.DisplayName == repoName);
+                if (repo is null) return Array.Empty<string>();
+                return (await githubService.GetLabelsAsync(repo.Owner, repo.Name)).ToArray();
+            },
+            initialValue: Array.Empty<string>()
+        );
+
+        UseEffect(() =>
+        {
+            fetchedIssues.Set(null);
+            selectedAssignee.Set(null);
+            selectedLabels.Set(Array.Empty<string>());
+        }, selectedRepo);
+
+        if (!_dialogOpen.Value) return null;
+
+        var repos = githubService.GetRepos();
+        var repositoryOptions = repos.Select(r => r.DisplayName).ToArray();
+
+        async Task FetchIssues()
+        {
+            if (selectedRepo.Value is not { } repoName) return;
+            var repo = repos.FirstOrDefault(r => r.DisplayName == repoName);
+            if (repo is null) return;
+
+            isFetching.Set(true);
+            try
+            {
+                var labels = selectedLabels.Value.Length > 0 ? selectedLabels.Value : null;
+                var issues = await githubService.SearchIssuesAsync(
+                    repo.Owner, repo.Name,
+                    string.IsNullOrWhiteSpace(searchQuery.Value) ? null : searchQuery.Value,
+                    selectedAssignee.Value,
+                    labels);
+                fetchedIssues.Set(issues);
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"[ImportIssuesDialog] Fetch failed: {ex.Message}");
+                fetchedIssues.Set([]);
+            }
+            finally
+            {
+                isFetching.Set(false);
+            }
+        }
+
+        async Task ImportAll()
+        {
+            if (fetchedIssues.Value is not { Count: > 0 } issues) return;
+            if (selectedRepo.Value is not { } repoName) return;
+            var repo = repos.FirstOrDefault(r => r.DisplayName == repoName);
+            if (repo is null) return;
+
+            isImporting.Set(true);
+            try
+            {
+                var inboxPath = Path.Combine(_config.TendrilHome, "Inbox");
+                Directory.CreateDirectory(inboxPath);
+
+                var projectName = GetProjectForRepo(repo.Owner, repo.Name);
+                var importedCount = 0;
+
+                foreach (var issue in issues)
+                {
+                    var safeName = SanitizeFileName(issue.Title);
+                    var fileName = $"{issue.Number}-{safeName}.md";
+                    var filePath = Path.Combine(inboxPath, fileName);
+
+                    if (File.Exists(filePath)) continue;
+
+                    var content = $"""
+                                   ---
+                                   project: {projectName}
+                                   ---
+                                   [GitHub Issue #{issue.Number}](https://github.com/{repo.Owner}/{repo.Name}/issues/{issue.Number})
+
+                                   {issue.Body}
+                                   """;
+
+                    await File.WriteAllTextAsync(filePath, content);
+                    importedCount++;
+                }
+
+                client.Toast($"Imported {importedCount} issue{(importedCount == 1 ? "" : "s")} to Inbox", "Import Complete");
+                _dialogOpen.Set(false);
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"[ImportIssuesDialog] Import failed: {ex.Message}");
+                client.Toast($"Import failed: {ex.Message}", "Error");
+            }
+            finally
+            {
+                isImporting.Set(false);
+            }
+        }
+
+        object? issuesList = null;
+        if (isFetching.Value)
+        {
+            issuesList = Text.Muted("Fetching issues...");
+        }
+        else if (fetchedIssues.Value is { } issues)
+        {
+            if (issues.Count == 0)
+            {
+                issuesList = Text.Muted("No issues found matching the filters.");
+            }
+            else
+            {
+                issuesList = Layout.Vertical().Gap(1)
+                             | Text.Label($"Found {issues.Count} issue{(issues.Count == 1 ? "" : "s")}")
+                             | (Layout.Vertical().Gap(1)
+                                | issues.Select(i =>
+                                    (object)Text.Muted($"#{i.Number} — {i.Title}")
+                                ).ToArray());
+            }
+        }
+
+        return new Dialog(
+            _ =>
+            {
+                fetchedIssues.Set(null);
+                searchQuery.Set("");
+                selectedAssignee.Set(null);
+                selectedLabels.Set(Array.Empty<string>());
+                selectedRepo.Set(null);
+                _dialogOpen.Set(false);
+            },
+            new DialogHeader("Import Issues from GitHub"),
+            new DialogBody(
+                Layout.Vertical().Gap(3)
+                | selectedRepo.ToSelectInput(repositoryOptions.ToOptions())
+                    .AutoFocus().WithField().Label("Repository").Required()
+                | searchQuery.ToTextInput().Placeholder("Search query...").WithField().Label("Search")
+                | selectedAssignee.ToSelectInput(assigneesQuery.Value.ToOptions())
+                    .Nullable().WithField().Label("Assignee")
+                | selectedLabels.ToSelectInput(labelsQuery.Value.ToOptions())
+                    .Placeholder("Select labels...").WithField().Label("Labels")
+                | new Button("Fetch Issues").Outline().Loading(isFetching.Value)
+                    .OnClick(async () => await FetchIssues())
+                | issuesList
+            ),
+            new DialogFooter(
+                new Button("Cancel").Outline().OnClick(() =>
+                {
+                    fetchedIssues.Set(null);
+                    searchQuery.Set("");
+                    selectedAssignee.Set(null);
+                    selectedLabels.Set(Array.Empty<string>());
+                    selectedRepo.Set(null);
+                    _dialogOpen.Set(false);
+                }),
+                new Button("Import All").Primary()
+                    .Loading(isImporting.Value)
+                    .Disabled(fetchedIssues.Value is not { Count: > 0 })
+                    .OnClick(async () => await ImportAll())
+            )
+        ).Width(Size.Rem(36));
+    }
+
+    private string GetProjectForRepo(string owner, string repo)
+    {
+        var repoPath = $"{owner}/{repo}";
+        var matchingProjects = _config.Settings.Projects
+            .Where(p => p.RepoPaths.Any(path =>
+                GithubService.GetRepoConfigFromPath(path)?.FullName
+                    .Equals(repoPath, StringComparison.OrdinalIgnoreCase) ?? false))
+            .ToList();
+
+        return matchingProjects.Count == 1 ? matchingProjects[0].Name : "[Auto]";
+    }
+
+    internal static string SanitizeFileName(string title)
+    {
+        var sanitized = Regex.Replace(title, @"[^a-zA-Z0-9\s-]", "");
+        sanitized = Regex.Replace(sanitized, @"\s+", "-");
+        sanitized = sanitized.Trim('-').ToLowerInvariant();
+        return sanitized.Length > 60 ? sanitized[..60].TrimEnd('-') : sanitized;
+    }
+}

--- a/src/tendril/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/tendril/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -2,6 +2,7 @@ using System.Collections.Immutable;
 using System.Reactive.Disposables;
 using Ivy.Core;
 using Ivy.Core.Apps;
+using Ivy.Tendril.AppShell.Dialogs;
 using Ivy.Tendril.Apps;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Views;
@@ -57,6 +58,7 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
         var serverArgs = UseService<ServerArgs>();
         var navigate = Context.UseSignal<NavigateSignal, NavigateArgs, Unit>();
         var navigator = UseNavigation();
+        var importIssuesDialogOpen = UseState(false);
         UseEffect(() =>
         {
             void OnChanged()
@@ -358,6 +360,10 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
 
         var commonMenuItems = new[]
         {
+            MenuItem.Default("Import Issues from GitHub")
+                .Tag("$import-issues")
+                .Icon(Icons.Download)
+                .OnSelect(() => importIssuesDialogOpen.Set(true)),
             MenuItem.Default("Setup")
                 .Tag("$setup")
                 .Icon(Icons.Construction)
@@ -453,20 +459,22 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
 
         if (config.NeedsOnboarding) return new OnboardingApp();
 
-        return new SidebarLayout(
-            body ?? null!,
-            sidebarMenu,
-            Layout.Vertical().Gap(2)
-            | settings.Header
-            | new NewPlanButton()
-            ,
-            Layout.Vertical(
-                new SidebarNews("https://ivy.app/news.json"),
-                settings.Footer,
-                footer
-            ),
-            settings.Width
-        ).Open(sidebarOpen.Value).MainAppSidebar();
+        return Layout.Vertical()
+               | new SidebarLayout(
+                   body ?? null!,
+                   sidebarMenu,
+                   Layout.Vertical().Gap(2)
+                   | settings.Header
+                   | new NewPlanButton()
+                   ,
+                   Layout.Vertical(
+                       new SidebarNews("https://ivy.app/news.json"),
+                       settings.Footer,
+                       footer
+                   ),
+                   settings.Width
+               ).Open(sidebarOpen.Value).MainAppSidebar()
+               | new ImportIssuesDialog(importIssuesDialogOpen, config);
     }
 
     private record TabState(string Id, string AppId, string Title, AppHost AppHost, Icons? Icon, string RefreshToken)

--- a/src/tendril/Ivy.Tendril/Services/GithubService.cs
+++ b/src/tendril/Ivy.Tendril/Services/GithubService.cs
@@ -70,6 +70,67 @@ public class GithubService(IConfigService config) : IGithubService
         return statuses;
     }
 
+    public async Task<List<GitHubIssue>> SearchIssuesAsync(string owner, string repo, string? query, string? assignee,
+        string[]? labels)
+    {
+        try
+        {
+            var args = $"issue list --repo {owner}/{repo} --state open --limit 100 --json number,title,body,labels,assignees";
+            if (!string.IsNullOrWhiteSpace(query))
+                args += $" --search \"{query}\"";
+            if (!string.IsNullOrWhiteSpace(assignee))
+                args += $" --assignee {assignee}";
+            if (labels is { Length: > 0 })
+                args += $" --label \"{string.Join(",", labels)}\"";
+
+            var psi = new ProcessStartInfo("gh", args)
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                StandardOutputEncoding = Encoding.UTF8,
+                StandardErrorEncoding = Encoding.UTF8
+            };
+
+            using var process = Process.Start(psi);
+            if (process is null) return [];
+
+            var output = await process.StandardOutput.ReadToEndAsync();
+            var stderr = await process.StandardError.ReadToEndAsync();
+            await process.WaitForExitOrKillAsync(60000);
+
+            if (process.ExitCode != 0)
+            {
+                Console.Error.WriteLine($"[GithubService] gh issue list failed for {owner}/{repo}: {stderr}");
+                return [];
+            }
+
+            var issues = new List<GitHubIssue>();
+            using var doc = JsonDocument.Parse(output);
+            foreach (var element in doc.RootElement.EnumerateArray())
+            {
+                var number = element.GetProperty("number").GetInt32();
+                var title = element.GetProperty("title").GetString() ?? "";
+                var body = element.TryGetProperty("body", out var bodyProp) ? bodyProp.GetString() : null;
+                var issueLabels = element.GetProperty("labels").EnumerateArray()
+                    .Select(l => l.GetProperty("name").GetString() ?? "")
+                    .ToArray();
+                var issueAssignees = element.GetProperty("assignees").EnumerateArray()
+                    .Select(a => a.GetProperty("login").GetString() ?? "")
+                    .ToArray();
+                issues.Add(new GitHubIssue(number, title, body, issueLabels, issueAssignees));
+            }
+
+            return issues;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[GithubService] Failed to search issues for {owner}/{repo}: {ex.Message}");
+            return [];
+        }
+    }
+
     internal static RepoConfig? GetRepoConfigFromPath(string repoPath)
     {
         try

--- a/src/tendril/Ivy.Tendril/Services/IGithubService.cs
+++ b/src/tendril/Ivy.Tendril/Services/IGithubService.cs
@@ -1,9 +1,18 @@
 namespace Ivy.Tendril.Services;
 
+public record GitHubIssue(
+    int Number,
+    string Title,
+    string? Body,
+    string[] Labels,
+    string[] Assignees
+);
+
 public interface IGithubService
 {
     List<RepoConfig> GetRepos();
     Task<List<string>> GetAssigneesAsync(string owner, string repo);
     Task<List<string>> GetLabelsAsync(string owner, string repo);
     Task<Dictionary<string, string>> GetPrStatusesAsync(string owner, string repo);
+    Task<List<GitHubIssue>> SearchIssuesAsync(string owner, string repo, string? query, string? assignee, string[]? labels);
 }


### PR DESCRIPTION
# Summary

## Changes

Added a new "Import Issues from GitHub" feature to Tendril. Users can now bulk-import open GitHub issues as inbox files through a dialog accessible from the sidebar footer menu. The dialog supports filtering by search query, assignee, and labels, with a preview before import.

## API Changes

- `GitHubIssue` record added to `Ivy.Tendril.Services` namespace with `Number`, `Title`, `Body`, `Labels`, `Assignees` properties
- `IGithubService.SearchIssuesAsync(string owner, string repo, string? query, string? assignee, string[]? labels)` — new method for searching open issues with filters
- `GithubService.SearchIssuesAsync` — implementation using `gh issue list` CLI command with JSON parsing
- `ImportIssuesDialog` — new dialog class in `Ivy.Tendril.AppShell.Dialogs`
- `ImportIssuesDialog.SanitizeFileName(string title)` — internal static helper for creating safe inbox file names

## Files Modified

- **Services/IGithubService.cs** — Added `GitHubIssue` record and `SearchIssuesAsync` method to interface
- **Services/GithubService.cs** — Implemented `SearchIssuesAsync` with `gh issue list` CLI integration and JSON parsing
- **AppShell/Dialogs/ImportIssuesDialog.cs** — New dialog with repo selection, search/filter controls, issue preview, and bulk inbox import
- **AppShell/TendrilAppShell.cs** — Added "Import Issues from GitHub" menu item to footer and dialog rendering

## Commits

- f9679ce2b [03044] Add Import Issues from GitHub feature