### PR TITLE
[03036] Add spacing below onboarding content to prevent button from sticking to bottom edge

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
@@ -36,7 +36,7 @@ public class CodingAgentStepView(
                 : _installedOptions.First().Label;
         });
 
-        return Layout.Vertical()
+        return Layout.Vertical().Margin(0, 0, 0, 20)
                 | Text.H2("Choose Your Coding Agent")
                 | Text.Muted("You can change this later under Settings.")
                 | selectedAgent.ToSelectInput(_installedOptions.Select(a => a.Label).ToArray())

--- a/src/tendril/Ivy.Tendril/Apps/Onboarding/CompleteStepView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Onboarding/CompleteStepView.cs
@@ -39,7 +39,7 @@ public class CompleteStepView(IState<int> stepperIndex) : ViewBase
             }
         }
 
-        return Layout.Vertical()
+        return Layout.Vertical().Margin(0, 0, 0, 20)
                | Text.H2("Ready to Go!")
                | Text.Markdown(
                    "We'll now:\n" +

--- a/src/tendril/Ivy.Tendril/Apps/Onboarding/ProjectSetupStepView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Onboarding/ProjectSetupStepView.cs
@@ -56,7 +56,7 @@ public class ProjectSetupStepView(IState<int> stepperIndex) : ViewBase
                                    });
         }
 
-        return Layout.Vertical().Gap(4)
+        return Layout.Vertical().Gap(4).Margin(0, 0, 0, 20)
                | Text.H2("Project Setup")
                | Text.Muted("Set up your first project. You can add more projects later in Settings.")
                | (error.Value != null ? Text.Danger(error.Value) : null!)

--- a/src/tendril/Ivy.Tendril/Apps/Onboarding/SoftwareCheckStepView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Onboarding/SoftwareCheckStepView.cs
@@ -36,7 +36,7 @@ public class SoftwareCheckStepView(
                                 && checkResults.Value["git"]
                                 && checkResults.Value["powershell"];
 
-        return Layout.Vertical()
+        return Layout.Vertical().Margin(0, 0, 0, 20)
                | Text.H2("Required Software")
                | Text.Markdown(
                    """

--- a/src/tendril/Ivy.Tendril/Apps/Onboarding/TendrilHomeStepView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Onboarding/TendrilHomeStepView.cs
@@ -17,7 +17,7 @@ public class TendrilHomeStepView(IState<int> stepperIndex) : ViewBase
         var error = UseState<string?>(null);
         var config = UseService<IConfigService>();
 
-        return Layout.Vertical()
+        return Layout.Vertical().Margin(0, 0, 0, 20)
                | Text.H2("Tendril Data Location")
                | Text.Muted("This folder will store your plans, inbox, trash, and other Tendril data.")
                | (error.Value != null ? Text.Danger(error.Value) : null!)

--- a/src/tendril/Ivy.Tendril/Apps/Onboarding/WelcomeStepView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Onboarding/WelcomeStepView.cs
@@ -4,7 +4,7 @@ public class WelcomeStepView(IState<int> stepperIndex) : ViewBase
 {
     public override object Build()
     {
-        return Layout.Vertical()
+        return Layout.Vertical().Margin(0, 0, 0, 20)
                | Text.H1("Welcome to Ivy Tendril")
                | Text.Markdown(
                    """


### PR DESCRIPTION
# Summary

## Changes

Added 20-unit bottom margin to all 6 onboarding wizard step views to prevent the action buttons from sticking to the bottom window edge in small viewports.

## API Changes

None.

## Files Modified

- **Onboarding step views** (all in `src/tendril/Ivy.Tendril/Apps/Onboarding/`):
  - `WelcomeStepView.cs`
  - `SoftwareCheckStepView.cs`
  - `CodingAgentStepView.cs`
  - `TendrilHomeStepView.cs`
  - `ProjectSetupStepView.cs`
  - `CompleteStepView.cs`

## Commits

- 59a2237c0 [03036] Add bottom margin to onboarding step views