### PR TITLE
[03031] Filters chevron in SearchInput Suffix

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Icebox/SidebarView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Icebox/SidebarView.cs
@@ -20,6 +20,8 @@ public class SidebarView(
 
     public override object Build()
     {
+        var filtersOpen = UseState(false);
+
         var filteredPlans =
             PlanFilters.ApplyFilters(_plans, _projectFilter.Value, _levelFilter.Value, _textFilter.Value);
 
@@ -34,8 +36,6 @@ public class SidebarView(
             .OrderByDescending(g => g.Count())
             .Select(g => new Option<string>($"{g.Key} ({g.Count()})", g.Key))
             .ToArray<IAnyOption>();
-
-        var filtersOpen = UseState(false);
 
         var searchInput = _textFilter.ToSearchInput()
             .Placeholder("Search plans...")

--- a/src/tendril/Ivy.Tendril/Apps/Icebox/SidebarView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Icebox/SidebarView.cs
@@ -35,16 +35,28 @@ public class SidebarView(
             .Select(g => new Option<string>($"{g.Key} ({g.Count()})", g.Key))
             .ToArray<IAnyOption>();
 
-        var header = Layout.Vertical()
-                     | _textFilter.ToSearchInput().Placeholder("Search plans...")
-                     | new Expandable(
-                         "Filters",
-                         Layout.Vertical()
-                         | _projectFilter.ToSelectInput(projectCounts).Placeholder("All Projects").Nullable()
-                             .WithField().Label("Project")
-                         | _levelFilter.ToSelectInput(levelOptions.ToOptions()).Placeholder("All Levels").Nullable()
-                             .WithField().Label("Level")
-                     ).Open(false).Ghost();
+        var filtersOpen = UseState(false);
+
+        var searchInput = _textFilter.ToSearchInput()
+            .Placeholder("Search plans...")
+            .Suffix(
+                new Button()
+                    .Icon(filtersOpen.Value ? Icons.ChevronUp : Icons.ChevronDown)
+                    .Ghost()
+                    .Small()
+                    .OnClick(() => filtersOpen.Set(!filtersOpen.Value))
+            );
+
+        var header = Layout.Vertical() | searchInput;
+
+        if (filtersOpen.Value)
+        {
+            header |= Layout.Vertical()
+                      | _projectFilter.ToSelectInput(projectCounts).Placeholder("All Projects").Nullable()
+                          .WithField().Label("Project")
+                      | _levelFilter.ToSelectInput(levelOptions.ToOptions()).Placeholder("All Levels").Nullable()
+                          .WithField().Label("Level");
+        }
 
         var content = new List(filteredPlans.Select(plan =>
         {

--- a/src/tendril/Ivy.Tendril/Apps/Plans/SidebarView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Plans/SidebarView.cs
@@ -34,16 +34,28 @@ public class SidebarView(
             .Select(g => new Option<string>($"{g.Key} ({g.Count()})", g.Key))
             .ToArray<IAnyOption>();
 
-        var header = Layout.Vertical()
-                     | _textFilter.ToSearchInput().Placeholder("Search plans...")
-                     | new Expandable(
-                         "Filters",
-                         Layout.Vertical()
-                         | _projectFilter.ToSelectInput(projectCounts).Placeholder("All Projects").Nullable()
-                             .WithField().Label("Project")
-                         | _levelFilter.ToSelectInput(levelOptions.ToOptions()).Placeholder("All Levels").Nullable()
-                             .WithField().Label("Level")
-                     ).Open(false).Ghost();
+        var filtersOpen = UseState(false);
+
+        var searchInput = _textFilter.ToSearchInput()
+            .Placeholder("Search plans...")
+            .Suffix(
+                new Button()
+                    .Icon(filtersOpen.Value ? Icons.ChevronUp : Icons.ChevronDown)
+                    .Ghost()
+                    .Small()
+                    .OnClick(() => filtersOpen.Set(!filtersOpen.Value))
+            );
+
+        var header = Layout.Vertical() | searchInput;
+
+        if (filtersOpen.Value)
+        {
+            header |= Layout.Vertical()
+                      | _projectFilter.ToSelectInput(projectCounts).Placeholder("All Projects").Nullable()
+                          .WithField().Label("Project")
+                      | _levelFilter.ToSelectInput(levelOptions.ToOptions()).Placeholder("All Levels").Nullable()
+                          .WithField().Label("Level");
+        }
 
         var content = new List(filteredPlans.Select(plan =>
         {

--- a/src/tendril/Ivy.Tendril/Apps/Plans/SidebarView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Plans/SidebarView.cs
@@ -19,6 +19,8 @@ public class SidebarView(
 
     public override object Build()
     {
+        var filtersOpen = UseState(false);
+
         var filteredPlans =
             PlanFilters.ApplyFilters(_plans, _projectFilter.Value, _levelFilter.Value, _textFilter.Value);
 
@@ -33,8 +35,6 @@ public class SidebarView(
             .OrderByDescending(g => g.Count())
             .Select(g => new Option<string>($"{g.Key} ({g.Count()})", g.Key))
             .ToArray<IAnyOption>();
-
-        var filtersOpen = UseState(false);
 
         var searchInput = _textFilter.ToSearchInput()
             .Placeholder("Search plans...")

--- a/src/tendril/Ivy.Tendril/Apps/Recommendations/SidebarView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Recommendations/SidebarView.cs
@@ -19,7 +19,7 @@ public class SidebarView(
     private readonly IState<string?> _textFilter = textFilter;
     private readonly int _totalCount = totalCount;
 
-    private object BuildHeader()
+    private object BuildHeader(IState<bool> filtersOpen)
     {
         var projectOptions = _recommendations
             .GroupBy(r => r.Project)
@@ -33,8 +33,6 @@ public class SidebarView(
             .OrderBy(s => s)
             .Select(s => new Option<string>(s.ToString(), s.ToString()))
             .ToArray<IAnyOption>();
-
-        var filtersOpen = UseState(false);
 
         var searchInput = _textFilter.ToSearchInput()
             .Placeholder("Search recommendations...")
@@ -97,6 +95,8 @@ public class SidebarView(
 
     public override object Build()
     {
-        return new HeaderLayout(BuildHeader(), BuildContent());
+        var filtersOpen = UseState(false);
+
+        return new HeaderLayout(BuildHeader(filtersOpen), BuildContent());
     }
 }

--- a/src/tendril/Ivy.Tendril/Apps/Recommendations/SidebarView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Recommendations/SidebarView.cs
@@ -34,16 +34,30 @@ public class SidebarView(
             .Select(s => new Option<string>(s.ToString(), s.ToString()))
             .ToArray<IAnyOption>();
 
-        return Layout.Vertical()
-               | _textFilter.ToSearchInput().Placeholder("Search recommendations...")
-               | new Expandable(
-                   "Filters",
-                   Layout.Vertical()
-                   | _projectFilter.ToSelectInput(projectOptions).Placeholder("All Projects").Nullable().WithField()
-                       .Label("Project")
-                   | _planStatusFilter.ToSelectInput(statusOptions).Placeholder("All Statuses").Nullable().WithField()
-                       .Label("Plan Status")
-               ).Open(false).Ghost();
+        var filtersOpen = UseState(false);
+
+        var searchInput = _textFilter.ToSearchInput()
+            .Placeholder("Search recommendations...")
+            .Suffix(
+                new Button()
+                    .Icon(filtersOpen.Value ? Icons.ChevronUp : Icons.ChevronDown)
+                    .Ghost()
+                    .Small()
+                    .OnClick(() => filtersOpen.Set(!filtersOpen.Value))
+            );
+
+        var header = Layout.Vertical() | searchInput;
+
+        if (filtersOpen.Value)
+        {
+            header |= Layout.Vertical()
+                      | _projectFilter.ToSelectInput(projectOptions).Placeholder("All Projects").Nullable()
+                          .WithField().Label("Project")
+                      | _planStatusFilter.ToSelectInput(statusOptions).Placeholder("All Statuses").Nullable()
+                          .WithField().Label("Plan Status");
+        }
+
+        return header;
     }
 
     private object BuildContent()


### PR DESCRIPTION
# Summary

## Changes

Replaced the separate `Expandable` "Filters" widget with a chevron toggle button in the SearchInput's Suffix slot across three Tendril sidebar views (Plans, Icebox, Recommendations). Filters now expand/collapse inline via `UseState<bool>` instead of occupying a dedicated row.

## API Changes

None.

## Files Modified

- **Plans sidebar:** `src/tendril/Ivy.Tendril/Apps/Plans/SidebarView.cs` — replaced Expandable with Suffix chevron button + conditional filter rendering
- **Icebox sidebar:** `src/tendril/Ivy.Tendril/Apps/Icebox/SidebarView.cs` — same pattern
- **Recommendations sidebar:** `src/tendril/Ivy.Tendril/Apps/Recommendations/SidebarView.cs` — same pattern (Project + Plan Status filters)

## Commits

- 504de2559 [03031] Replace Expandable filters with SearchInput Suffix chevron button
- fa6419ba6 [03031] Move UseState to top of Build() for IVYHOOK005 compliance