### PR TITLE
[01244] Limit Playwright Test Worker Concurrency

### DIFF
--- a/src/frontend/playwright.config.ts
+++ b/src/frontend/playwright.config.ts
@@ -19,8 +19,9 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
+  // Limit workers to prevent CPU saturation when multiple test suites run concurrently.
+  // Override via PLAYWRIGHT_WORKERS env var (number or percentage string like '50%').
+  workers: process.env.CI ? 1 : (process.env.PLAYWRIGHT_WORKERS || '25%'),
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [["html"], ["list"], ["json", { outputFile: "test-results/results.json" }]],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/src/frontend/playwright.config.ts
+++ b/src/frontend/playwright.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   // Limit workers to prevent CPU saturation when multiple test suites run concurrently.
   // Override via PLAYWRIGHT_WORKERS env var (number or percentage string like '50%').
-  workers: process.env.CI ? 1 : (process.env.PLAYWRIGHT_WORKERS || '25%'),
+  workers: process.env.CI ? 1 : process.env.PLAYWRIGHT_WORKERS || "25%",
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [["html"], ["list"], ["json", { outputFile: "test-results/results.json" }]],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */


### PR DESCRIPTION
# Summary

## Changes

Updated the Playwright test configuration to limit worker concurrency for local (non-CI) runs. Workers now default to 25% of CPU cores instead of unlimited, preventing CPU saturation when multiple Tendril jobs run Playwright test suites concurrently. Added support for a `PLAYWRIGHT_WORKERS` environment variable to allow per-environment overrides.

## API Changes

- New environment variable: `PLAYWRIGHT_WORKERS` — accepts a number (`'2'`) or percentage string (`'50%'`) to override the default 25% worker limit for local Playwright runs.

## Files Modified

- **src/frontend/playwright.config.ts** — Changed `workers` setting from `undefined` (half of cores) to `'25%'` for non-CI runs, with `PLAYWRIGHT_WORKERS` env var override support.

## Commits

- fcad9f515