### PR TITLE
[01242] Rename VideoPlayer Handle* extension methods to On*

### DIFF
--- a/src/.releases/Refactors/Upcoming/VideoPlayer-Event-Renames.md
+++ b/src/.releases/Refactors/Upcoming/VideoPlayer-Event-Renames.md
@@ -1,0 +1,35 @@
+# VideoPlayer Event Renames
+
+## Summary
+
+The event handler extension methods for the `VideoPlayer` widget have been renamed from `Handle[Event]` to `On[Event]` to align with the standard naming convention used across the Ivy Framework (e.g., `Button.OnClick`, `SelectInput.OnChange`).
+
+## What Changed
+
+### Before
+```csharp
+var video = new VideoPlayer(url)
+    .HandlePlay(() => Console.WriteLine("Playing"))
+    .HandlePause(() => Console.WriteLine("Paused"))
+    .HandleEnded(() => Console.WriteLine("Ended"))
+    .HandleLoaded(() => Console.WriteLine("Loaded"));
+```
+
+### After
+```csharp
+var video = new VideoPlayer(url)
+    .OnPlay(() => Console.WriteLine("Playing"))
+    .OnPause(() => Console.WriteLine("Paused"))
+    .OnEnded(() => Console.WriteLine("Ended"))
+    .OnLoaded(() => Console.WriteLine("Loaded"));
+```
+
+## How to Find Affected Code
+
+Run `dotnet build`. The old methods have been removed, so any code using them will fail to compile.
+
+Or search for:
+- `.HandlePlay(`
+- `.HandlePause(`
+- `.HandleEnded(`
+- `.HandleLoaded(`

--- a/src/.releases/weekly-notes-archive/weekly-notes-2026-03-20.md
+++ b/src/.releases/weekly-notes-archive/weekly-notes-2026-03-20.md
@@ -7,7 +7,7 @@
 
 ### VideoPlayer: time range, events, and playback speed
 
-The [**VideoPlayer**](https://docs.ivy.app/widgets/primitives/video-player) widget now supports **time range** (`StartTime` / `EndTime` in seconds), **playback events** (`OnPlay`, `OnPause`, `OnEnded`, `OnLoaded`—each with async, sync-with-event, and parameterless overloads), and **playback speed** (`PlaybackRate`, minimum 0.25×).
+The [**VideoPlayer**](https://docs.ivy.app/widgets/primitives/video-player) widget now supports **time range** (`StartTime` / `EndTime` in seconds), **playback events** (`HandlePlay`, `HandlePause`, `HandleEnded`, `HandleLoaded`—each with async, sync-with-event, and parameterless overloads), and **playback speed** (`PlaybackRate`, minimum 0.25×).
 
 **Note:** Time ranges use Media Fragments (HTML5) and embed parameters (YouTube). `PlaybackRate` applies to native HTML5 video only; YouTube embeds do not change speed.
 
@@ -19,10 +19,10 @@ var video = new VideoPlayer("https://www.w3schools.com/html/mov_bbb.mp4")
     .StartTime(2)  // time range
     .EndTime(6)  // time range
     .PlaybackRate(1.5)  // playback speed
-    .OnPlay(_ => playCount.Set(playCount.Value + 1))  // event: play
-    .OnPause(_ => Console.WriteLine("Video paused"))  // event: pause
-    .OnEnded(_ => completed.Set(true))  // event: ended
-    .OnLoaded(_ => Console.WriteLine("Video ready"))  // event: metadata loaded
+    .HandlePlay(_ => playCount.Set(playCount.Value + 1))  // event: play
+    .HandlePause(_ => Console.WriteLine("Video paused"))  // event: pause
+    .HandleEnded(_ => completed.Set(true))  // event: ended
+    .HandleLoaded(_ => Console.WriteLine("Video ready"))  // event: metadata loaded
     .Height(Size.Units(50));  // layout
 ```
 

--- a/src/.releases/weekly-notes-archive/weekly-notes-2026-03-20.md
+++ b/src/.releases/weekly-notes-archive/weekly-notes-2026-03-20.md
@@ -7,7 +7,7 @@
 
 ### VideoPlayer: time range, events, and playback speed
 
-The [**VideoPlayer**](https://docs.ivy.app/widgets/primitives/video-player) widget now supports **time range** (`StartTime` / `EndTime` in seconds), **playback events** (`HandlePlay`, `HandlePause`, `HandleEnded`, `HandleLoaded`—each with async, sync-with-event, and parameterless overloads), and **playback speed** (`PlaybackRate`, minimum 0.25×).
+The [**VideoPlayer**](https://docs.ivy.app/widgets/primitives/video-player) widget now supports **time range** (`StartTime` / `EndTime` in seconds), **playback events** (`OnPlay`, `OnPause`, `OnEnded`, `OnLoaded`—each with async, sync-with-event, and parameterless overloads), and **playback speed** (`PlaybackRate`, minimum 0.25×).
 
 **Note:** Time ranges use Media Fragments (HTML5) and embed parameters (YouTube). `PlaybackRate` applies to native HTML5 video only; YouTube embeds do not change speed.
 
@@ -19,10 +19,10 @@ var video = new VideoPlayer("https://www.w3schools.com/html/mov_bbb.mp4")
     .StartTime(2)  // time range
     .EndTime(6)  // time range
     .PlaybackRate(1.5)  // playback speed
-    .HandlePlay(_ => playCount.Set(playCount.Value + 1))  // event: play
-    .HandlePause(_ => Console.WriteLine("Video paused"))  // event: pause
-    .HandleEnded(_ => completed.Set(true))  // event: ended
-    .HandleLoaded(_ => Console.WriteLine("Video ready"))  // event: metadata loaded
+    .OnPlay(_ => playCount.Set(playCount.Value + 1))  // event: play
+    .OnPause(_ => Console.WriteLine("Video paused"))  // event: pause
+    .OnEnded(_ => completed.Set(true))  // event: ended
+    .OnLoaded(_ => Console.WriteLine("Video ready"))  // event: metadata loaded
     .Height(Size.Units(50));  // layout
 ```
 

--- a/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/VideoPlayerApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/VideoPlayerApp.cs
@@ -15,10 +15,10 @@ public class VideoPlayerApp : SampleBase
         var loadedState = UseState(false);
 
         var eventVideo = new VideoPlayer("https://www.w3schools.com/html/mov_bbb.mp4")
-            .HandlePlay(_ => playCount.Set(playCount.Value + 1))
-            .HandlePause(_ => pauseCount.Set(pauseCount.Value + 1))
-            .HandleEnded(_ => completedState.Set(true))
-            .HandleLoaded(_ => loadedState.Set(true))
+            .OnPlay(_ => playCount.Set(playCount.Value + 1))
+            .OnPause(_ => pauseCount.Set(pauseCount.Value + 1))
+            .OnEnded(_ => completedState.Set(true))
+            .OnLoaded(_ => loadedState.Set(true))
             .Height(Size.Units(50));
 
         // Basic video player

--- a/src/Ivy/Widgets/Primitives/VideoPlayer.cs
+++ b/src/Ivy/Widgets/Primitives/VideoPlayer.cs
@@ -106,27 +106,27 @@ public static class VideoPlayerExtensions
 
     public static VideoPlayer Id(this VideoPlayer widget, string id) => widget with { Id = id };
 
-    public static VideoPlayer HandlePlay(this VideoPlayer widget, Func<Event<VideoPlayer>, ValueTask> onPlay) => widget with { OnPlay = new(onPlay) };
+    public static VideoPlayer OnPlay(this VideoPlayer widget, Func<Event<VideoPlayer>, ValueTask> onPlay) => widget with { OnPlay = new(onPlay) };
 
-    public static VideoPlayer HandlePlay(this VideoPlayer widget, Action<Event<VideoPlayer>> onPlay) => widget with { OnPlay = new(onPlay.ToValueTask()) };
+    public static VideoPlayer OnPlay(this VideoPlayer widget, Action<Event<VideoPlayer>> onPlay) => widget with { OnPlay = new(onPlay.ToValueTask()) };
 
-    public static VideoPlayer HandlePlay(this VideoPlayer widget, Action onPlay) => widget with { OnPlay = new(_ => { onPlay(); return ValueTask.CompletedTask; }) };
+    public static VideoPlayer OnPlay(this VideoPlayer widget, Action onPlay) => widget with { OnPlay = new(_ => { onPlay(); return ValueTask.CompletedTask; }) };
 
-    public static VideoPlayer HandlePause(this VideoPlayer widget, Func<Event<VideoPlayer>, ValueTask> onPause) => widget with { OnPause = new(onPause) };
+    public static VideoPlayer OnPause(this VideoPlayer widget, Func<Event<VideoPlayer>, ValueTask> onPause) => widget with { OnPause = new(onPause) };
 
-    public static VideoPlayer HandlePause(this VideoPlayer widget, Action<Event<VideoPlayer>> onPause) => widget with { OnPause = new(onPause.ToValueTask()) };
+    public static VideoPlayer OnPause(this VideoPlayer widget, Action<Event<VideoPlayer>> onPause) => widget with { OnPause = new(onPause.ToValueTask()) };
 
-    public static VideoPlayer HandlePause(this VideoPlayer widget, Action onPause) => widget with { OnPause = new(_ => { onPause(); return ValueTask.CompletedTask; }) };
+    public static VideoPlayer OnPause(this VideoPlayer widget, Action onPause) => widget with { OnPause = new(_ => { onPause(); return ValueTask.CompletedTask; }) };
 
-    public static VideoPlayer HandleEnded(this VideoPlayer widget, Func<Event<VideoPlayer>, ValueTask> onEnded) => widget with { OnEnded = new(onEnded) };
+    public static VideoPlayer OnEnded(this VideoPlayer widget, Func<Event<VideoPlayer>, ValueTask> onEnded) => widget with { OnEnded = new(onEnded) };
 
-    public static VideoPlayer HandleEnded(this VideoPlayer widget, Action<Event<VideoPlayer>> onEnded) => widget with { OnEnded = new(onEnded.ToValueTask()) };
+    public static VideoPlayer OnEnded(this VideoPlayer widget, Action<Event<VideoPlayer>> onEnded) => widget with { OnEnded = new(onEnded.ToValueTask()) };
 
-    public static VideoPlayer HandleEnded(this VideoPlayer widget, Action onEnded) => widget with { OnEnded = new(_ => { onEnded(); return ValueTask.CompletedTask; }) };
+    public static VideoPlayer OnEnded(this VideoPlayer widget, Action onEnded) => widget with { OnEnded = new(_ => { onEnded(); return ValueTask.CompletedTask; }) };
 
-    public static VideoPlayer HandleLoaded(this VideoPlayer widget, Func<Event<VideoPlayer>, ValueTask> onLoaded) => widget with { OnLoaded = new(onLoaded) };
+    public static VideoPlayer OnLoaded(this VideoPlayer widget, Func<Event<VideoPlayer>, ValueTask> onLoaded) => widget with { OnLoaded = new(onLoaded) };
 
-    public static VideoPlayer HandleLoaded(this VideoPlayer widget, Action<Event<VideoPlayer>> onLoaded) => widget with { OnLoaded = new(onLoaded.ToValueTask()) };
+    public static VideoPlayer OnLoaded(this VideoPlayer widget, Action<Event<VideoPlayer>> onLoaded) => widget with { OnLoaded = new(onLoaded.ToValueTask()) };
 
-    public static VideoPlayer HandleLoaded(this VideoPlayer widget, Action onLoaded) => widget with { OnLoaded = new(_ => { onLoaded(); return ValueTask.CompletedTask; }) };
+    public static VideoPlayer OnLoaded(this VideoPlayer widget, Action onLoaded) => widget with { OnLoaded = new(_ => { onLoaded(); return ValueTask.CompletedTask; }) };
 }


### PR DESCRIPTION
## Summary

Renamed all 12 `Handle*` fluent extension method overloads on `VideoPlayer` to `On*` (`HandlePlay` -> `OnPlay`, `HandlePause` -> `OnPause`, `HandleEnded` -> `OnEnded`, `HandleLoaded` -> `OnLoaded`) to match the framework-wide `On*` event naming convention. Updated all callsites in the sample app and release notes.

## API Changes

- `VideoPlayer.HandlePlay(...)` renamed to `VideoPlayer.OnPlay(...)` (3 overloads)
- `VideoPlayer.HandlePause(...)` renamed to `VideoPlayer.OnPause(...)` (3 overloads)
- `VideoPlayer.HandleEnded(...)` renamed to `VideoPlayer.OnEnded(...)` (3 overloads)
- `VideoPlayer.HandleLoaded(...)` renamed to `VideoPlayer.OnLoaded(...)` (3 overloads)

## Files Modified

- **Widget definition:** `src/Ivy/Widgets/Primitives/VideoPlayer.cs` — renamed 12 extension methods
- **Sample app:** `src/Ivy.Samples.Shared/Apps/Widgets/Primitives/VideoPlayerApp.cs` — updated 4 callsites
- **Release notes:** `src/.releases/weekly-notes-archive/weekly-notes-2026-03-20.md` — updated prose and code examples

## Commits

- 8f3e5edbd

Closes #2634