### PR TITLE
[03035] Store PR Status in SQLite and Create Background Checker Service

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/JobServiceDeletionTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/JobServiceDeletionTests.cs
@@ -134,6 +134,9 @@ public class JobServiceDeletionTests
         public void UpsertJob(JobItem job) { }
         public List<JobItem> GetRecentJobs(int limit = 100) => new();
         public void PurgeOldJobs(int keepCount = 500) { }
+        public Dictionary<string, string> GetAllPrStatuses() => new();
+        public void UpsertPrStatus(string prUrl, string owner, string repo, string status, DateTime lastChecked) { }
+        public List<string> GetNonMergedPrUrls() => new();
         public long GetDatabaseSize() => 0;
         public DateTime GetLastSyncTime() => DateTime.MinValue;
         public void SetLastSyncTime(DateTime time) { }

--- a/src/tendril/Ivy.Tendril.Test/PrStatusSyncServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/PrStatusSyncServiceTests.cs
@@ -1,0 +1,87 @@
+using Ivy.Tendril.Apps.Plans;
+using Ivy.Tendril.Services;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Ivy.Tendril.Test;
+
+public class PrStatusSyncServiceTests : IDisposable
+{
+    private readonly PlanDatabaseService _db;
+    private readonly string _dbPath;
+
+    public PrStatusSyncServiceTests()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"tendril-test-{Guid.NewGuid()}.db");
+        _db = new PlanDatabaseService(_dbPath, NullLogger<PlanDatabaseService>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _db.Dispose();
+        SqliteConnection.ClearAllPools();
+        if (File.Exists(_dbPath))
+            File.Delete(_dbPath);
+        if (File.Exists(_dbPath + "-wal"))
+            File.Delete(_dbPath + "-wal");
+        if (File.Exists(_dbPath + "-shm"))
+            File.Delete(_dbPath + "-shm");
+    }
+
+    [Fact]
+    public void UpsertPrStatus_StoresAndRetrieves()
+    {
+        _db.UpsertPrStatus("https://github.com/owner/repo/pull/1", "owner", "repo", "Open", DateTime.UtcNow);
+        _db.UpsertPrStatus("https://github.com/owner/repo/pull/2", "owner", "repo", "Merged", DateTime.UtcNow);
+
+        var statuses = _db.GetAllPrStatuses();
+        Assert.Equal(2, statuses.Count);
+        Assert.Equal("Open", statuses["https://github.com/owner/repo/pull/1"]);
+        Assert.Equal("Merged", statuses["https://github.com/owner/repo/pull/2"]);
+    }
+
+    [Fact]
+    public void UpsertPrStatus_UpdatesExistingStatus()
+    {
+        var now = DateTime.UtcNow;
+        _db.UpsertPrStatus("https://github.com/owner/repo/pull/1", "owner", "repo", "Open", now);
+        _db.UpsertPrStatus("https://github.com/owner/repo/pull/1", "owner", "repo", "Merged", now.AddMinutes(10));
+
+        var statuses = _db.GetAllPrStatuses();
+        Assert.Single(statuses);
+        Assert.Equal("Merged", statuses["https://github.com/owner/repo/pull/1"]);
+    }
+
+    [Fact]
+    public void GetNonMergedPrUrls_ExcludesMerged()
+    {
+        var now = DateTime.UtcNow;
+        _db.UpsertPrStatus("https://github.com/owner/repo/pull/1", "owner", "repo", "Open", now);
+        _db.UpsertPrStatus("https://github.com/owner/repo/pull/2", "owner", "repo", "Merged", now);
+        _db.UpsertPrStatus("https://github.com/owner/repo/pull/3", "owner", "repo", "Closed", now);
+
+        var nonMerged = _db.GetNonMergedPrUrls();
+        Assert.Equal(2, nonMerged.Count);
+        Assert.Contains("https://github.com/owner/repo/pull/1", nonMerged);
+        Assert.Contains("https://github.com/owner/repo/pull/3", nonMerged);
+        Assert.DoesNotContain("https://github.com/owner/repo/pull/2", nonMerged);
+    }
+
+    [Fact]
+    public void GroupByOwnerRepo_BatchesCorrectly()
+    {
+        var urls = new List<string>
+        {
+            "https://github.com/owner1/repo1/pull/1",
+            "https://github.com/owner1/repo1/pull/2",
+            "https://github.com/owner2/repo2/pull/10",
+            "https://github.com/owner1/repo3/pull/5"
+        };
+
+        var grouped = PrStatusSyncService.GroupByOwnerRepo(urls);
+        Assert.Equal(3, grouped.Count);
+        Assert.Equal(2, grouped["owner1/repo1"].Count);
+        Assert.Single(grouped["owner2/repo2"]);
+        Assert.Single(grouped["owner1/repo3"]);
+    }
+}

--- a/src/tendril/Ivy.Tendril/Apps/PullRequestApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/PullRequestApp.cs
@@ -15,52 +15,13 @@ public class PullRequestApp : ViewBase
         var showPlan = UseState<string?>(null);
         var openFile = UseState<string?>(null);
         var config = UseService<IConfigService>();
-        var githubService = UseService<IGithubService>();
-        var statusQuery = UseQuery<Dictionary<string, string>, string>(
-            "pr-statuses",
-            async (_, ct) =>
-            {
-                var allPlans = planService.GetPlans()
-                    .Where(p => p.Prs.Count > 0)
-                    .ToList();
-
-                var keys = allPlans
-                    .SelectMany(p => p.Prs.Where(IsValidUrl))
-                    .Select(ExtractRepo)
-                    .Distinct()
-                    .ToList();
-
-                var tasks = keys.Select(async repoKey =>
-                {
-                    var parts = repoKey.Split('/');
-                    if (parts.Length != 2) return new Dictionary<string, string>();
-                    try
-                    {
-                        return await githubService.GetPrStatusesAsync(parts[0], parts[1]);
-                    }
-                    catch
-                    {
-                        return new Dictionary<string, string>();
-                    }
-                }).ToList();
-
-                var results = await Task.WhenAll(tasks);
-                var allStatuses = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-                foreach (var statuses in results)
-                    foreach (var kvp in statuses)
-                        allStatuses[kvp.Key] = kvp.Value;
-
-                return allStatuses;
-            },
-            initialValue: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-        );
+        var databaseService = UseService<IPlanDatabaseService>();
+        var prStatuses = databaseService.GetAllPrStatuses();
 
         var plans = planService.GetPlans()
             .Where(p => p.Prs.Count > 0)
             .OrderByDescending(p => p.Id)
             .ToList();
-
-        var prStatuses = statusQuery.Value ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
         var rows = plans.SelectMany(plan =>
         {

--- a/src/tendril/Ivy.Tendril/Database/Migrations/Migration_008_PrStatusTable.cs
+++ b/src/tendril/Ivy.Tendril/Database/Migrations/Migration_008_PrStatusTable.cs
@@ -1,0 +1,30 @@
+using Microsoft.Data.Sqlite;
+
+namespace Ivy.Tendril.Database.Migrations;
+
+public class Migration_008_PrStatusTable : IMigration
+{
+    public int Version => 8;
+    public string Description => "Add PR status cache table";
+
+    public void Apply(SqliteConnection connection)
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = """
+            CREATE TABLE IF NOT EXISTS PrStatuses (
+                PrUrl TEXT PRIMARY KEY,
+                Owner TEXT NOT NULL,
+                Repo TEXT NOT NULL,
+                Status TEXT NOT NULL,
+                LastChecked TEXT NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_pr_statuses_owner_repo ON PrStatuses(Owner, Repo);
+            CREATE INDEX IF NOT EXISTS idx_pr_statuses_status ON PrStatuses(Status);
+            """;
+        cmd.ExecuteNonQuery();
+
+        using var setVersionCmd = connection.CreateCommand();
+        setVersionCmd.CommandText = "PRAGMA user_version = 8;";
+        setVersionCmd.ExecuteNonQuery();
+    }
+}

--- a/src/tendril/Ivy.Tendril/Services/IPlanDatabaseService.cs
+++ b/src/tendril/Ivy.Tendril/Services/IPlanDatabaseService.cs
@@ -48,6 +48,11 @@ public interface IPlanDatabaseService : IDisposable
     void PurgeOldJobs(int keepCount = 500);
     void DeleteJob(string id);
 
+    // PR statuses
+    Dictionary<string, string> GetAllPrStatuses();
+    void UpsertPrStatus(string prUrl, string owner, string repo, string status, DateTime lastChecked);
+    List<string> GetNonMergedPrUrls();
+
     // Diagnostics
     long GetDatabaseSize();
     DateTime GetLastSyncTime();

--- a/src/tendril/Ivy.Tendril/Services/PlanDatabaseService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanDatabaseService.cs
@@ -1044,6 +1044,70 @@ public class PlanDatabaseService : IPlanDatabaseService
         }
     }
 
+    public Dictionary<string, string> GetAllPrStatuses()
+    {
+        _lock.EnterReadLock();
+        try
+        {
+            using var cmd = _connection.CreateCommand();
+            cmd.CommandText = "SELECT PrUrl, Status FROM PrStatuses";
+            var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            using var reader = cmd.ExecuteReader();
+            while (reader.Read())
+                result[reader.GetString(0)] = reader.GetString(1);
+            return result;
+        }
+        finally
+        {
+            _lock.ExitReadLock();
+        }
+    }
+
+    public void UpsertPrStatus(string prUrl, string owner, string repo, string status, DateTime lastChecked)
+    {
+        _lock.EnterWriteLock();
+        try
+        {
+            using var cmd = _connection.CreateCommand();
+            cmd.CommandText = """
+                              INSERT INTO PrStatuses (PrUrl, Owner, Repo, Status, LastChecked)
+                              VALUES (@url, @owner, @repo, @status, @checked)
+                              ON CONFLICT(PrUrl) DO UPDATE SET
+                                  Status = excluded.Status,
+                                  LastChecked = excluded.LastChecked
+                              """;
+            cmd.Parameters.AddWithValue("@url", prUrl);
+            cmd.Parameters.AddWithValue("@owner", owner);
+            cmd.Parameters.AddWithValue("@repo", repo);
+            cmd.Parameters.AddWithValue("@status", status);
+            cmd.Parameters.AddWithValue("@checked", lastChecked.ToString("O", CultureInfo.InvariantCulture));
+            cmd.ExecuteNonQuery();
+        }
+        finally
+        {
+            _lock.ExitWriteLock();
+        }
+    }
+
+    public List<string> GetNonMergedPrUrls()
+    {
+        _lock.EnterReadLock();
+        try
+        {
+            using var cmd = _connection.CreateCommand();
+            cmd.CommandText = "SELECT PrUrl FROM PrStatuses WHERE Status != 'Merged'";
+            var result = new List<string>();
+            using var reader = cmd.ExecuteReader();
+            while (reader.Read())
+                result.Add(reader.GetString(0));
+            return result;
+        }
+        finally
+        {
+            _lock.ExitReadLock();
+        }
+    }
+
     public void RebuildFtsIndex()
     {
         _lock.EnterWriteLock();

--- a/src/tendril/Ivy.Tendril/Services/PrStatusSyncService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PrStatusSyncService.cs
@@ -1,0 +1,140 @@
+using System.Globalization;
+using Microsoft.Extensions.Logging;
+
+namespace Ivy.Tendril.Services;
+
+public class PrStatusSyncService : IStartable, IDisposable
+{
+    private static readonly TimeSpan CheckInterval = TimeSpan.FromMinutes(10);
+
+    private readonly IPlanDatabaseService _database;
+    private readonly IGithubService _githubService;
+    private readonly IPlanReaderService _planReader;
+    private readonly ILogger<PrStatusSyncService> _logger;
+    private Timer? _timer;
+
+    public PrStatusSyncService(
+        IPlanDatabaseService database,
+        IGithubService githubService,
+        IPlanReaderService planReader,
+        ILogger<PrStatusSyncService> logger)
+    {
+        _database = database;
+        _githubService = githubService;
+        _planReader = planReader;
+        _logger = logger;
+    }
+
+    public void Start()
+    {
+        _timer = new Timer(_ => _ = RunSyncAsync(), null, TimeSpan.FromSeconds(5), CheckInterval);
+    }
+
+    public void Dispose()
+    {
+        _timer?.Dispose();
+    }
+
+    internal async Task RunSyncAsync()
+    {
+        try
+        {
+            var prUrls = CollectPrUrlsFromPlans();
+            if (prUrls.Count == 0) return;
+
+            var existingStatuses = _database.GetAllPrStatuses();
+            var urlsToCheck = new List<string>();
+
+            foreach (var url in prUrls)
+            {
+                if (existingStatuses.TryGetValue(url, out var status) &&
+                    string.Equals(status, "Merged", StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                urlsToCheck.Add(url);
+            }
+
+            // Also add any new PRs not yet in the database
+            foreach (var url in prUrls)
+            {
+                if (!existingStatuses.ContainsKey(url) && !urlsToCheck.Contains(url))
+                    urlsToCheck.Add(url);
+            }
+
+            if (urlsToCheck.Count == 0)
+            {
+                _logger.LogDebug("All {Total} PRs are merged, nothing to check", prUrls.Count);
+                return;
+            }
+
+            var grouped = GroupByOwnerRepo(urlsToCheck);
+            var now = DateTime.UtcNow;
+
+            foreach (var (ownerRepo, urls) in grouped)
+            {
+                var parts = ownerRepo.Split('/');
+                if (parts.Length != 2) continue;
+
+                try
+                {
+                    var statuses = await _githubService.GetPrStatusesAsync(parts[0], parts[1]);
+                    foreach (var url in urls)
+                    {
+                        var resolvedStatus = statuses.GetValueOrDefault(url, "Open");
+                        _database.UpsertPrStatus(url, parts[0], parts[1], resolvedStatus, now);
+                    }
+
+                    _logger.LogDebug("Synced {Count} PR statuses for {Repo}", urls.Count, ownerRepo);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to fetch PR statuses for {Repo}", ownerRepo);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "PR status sync failed");
+        }
+    }
+
+    private List<string> CollectPrUrlsFromPlans()
+    {
+        var plans = _planReader.GetPlans();
+        return plans
+            .Where(p => p.Prs.Count > 0)
+            .SelectMany(p => p.Prs)
+            .Where(url => Uri.TryCreate(url, UriKind.Absolute, out var uri) &&
+                          (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    internal static Dictionary<string, List<string>> GroupByOwnerRepo(List<string> prUrls)
+    {
+        var result = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+        foreach (var url in prUrls)
+        {
+            try
+            {
+                var uri = new Uri(url);
+                var segments = uri.AbsolutePath.Trim('/').Split('/');
+                if (segments.Length < 2) continue;
+                var key = $"{segments[0]}/{segments[1]}";
+                if (!result.TryGetValue(key, out var list))
+                {
+                    list = new List<string>();
+                    result[key] = list;
+                }
+
+                list.Add(url);
+            }
+            catch (UriFormatException)
+            {
+                // skip malformed URLs
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/tendril/Ivy.Tendril/TendrilServer.cs
+++ b/src/tendril/Ivy.Tendril/TendrilServer.cs
@@ -126,6 +126,15 @@ public static class TendrilServer
             return new WorktreeCleanupService(config.PlanFolder, logger);
         });
         server.Services.AddSingleton<IStartable>(sp => sp.GetRequiredService<WorktreeCleanupService>());
+        server.Services.AddSingleton<PrStatusSyncService>(sp =>
+        {
+            var database = sp.GetRequiredService<IPlanDatabaseService>();
+            var githubService = sp.GetRequiredService<IGithubService>();
+            var planReader = sp.GetRequiredService<IPlanReaderService>();
+            var logger = sp.GetRequiredService<ILogger<PrStatusSyncService>>();
+            return new PrStatusSyncService(database, githubService, planReader, logger);
+        });
+        server.Services.AddSingleton<IStartable>(sp => sp.GetRequiredService<PrStatusSyncService>());
 
         server.UseWebApplication(app =>
         {


### PR DESCRIPTION
# Summary

## Changes

Added persistent PR status caching in SQLite with a background sync service. The PullRequestApp now reads cached statuses from the database instead of making live GitHub API calls on every load, making the app load instantly. A background service (`PrStatusSyncService`) periodically checks non-merged PRs every 10 minutes and stops re-checking merged PRs permanently.

## API Changes

- `IPlanDatabaseService.GetAllPrStatuses()` — returns `Dictionary<string, string>` of PR URL to status
- `IPlanDatabaseService.UpsertPrStatus(string prUrl, string owner, string repo, string status, DateTime lastChecked)` — stores/updates a PR status
- `IPlanDatabaseService.GetNonMergedPrUrls()` — returns list of PR URLs that are not merged
- `PrStatusSyncService` — new `IStartable` background service registered in DI
- `Migration_008_PrStatusTable` — new migration adding `PrStatuses` table

## Files Modified

- **New files:**
  - `Database/Migrations/Migration_008_PrStatusTable.cs` — SQLite migration
  - `Services/PrStatusSyncService.cs` — background sync service
  - `Ivy.Tendril.Test/PrStatusSyncServiceTests.cs` — unit tests

- **Modified files:**
  - `Services/IPlanDatabaseService.cs` — added 3 PR status methods to interface
  - `Services/PlanDatabaseService.cs` — implemented PR status methods
  - `Apps/PullRequestApp.cs` — replaced UseQuery/GitHub API with SQLite read
  - `TendrilServer.cs` — registered PrStatusSyncService as IStartable
  - `Ivy.Tendril.Test/JobServiceDeletionTests.cs` — updated FakeDatabaseService with new interface members

## Commits

- a4eda54d9 [03035] Store PR status in SQLite with background sync service