### PR TITLE
[03037] Prevent Gemini health check from opening browser window

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Onboarding/SoftwareCheckStepView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Onboarding/SoftwareCheckStepView.cs
@@ -13,7 +13,7 @@ public class SoftwareCheckStepView(
         ["gh"] = "Run `gh auth login` to authenticate",
         ["claude"] = "Run `claude` to log in, or check your plan/credits",
         ["codex"] = "Run `codex login` to authenticate",
-        ["gemini"] = "Run `gemini` to log in, or check your API key"
+        ["gemini"] = "Run `gemini` to authenticate (opens browser). Verify auth before selecting Gemini as your coding agent."
     };
 
     public override object Build()
@@ -133,9 +133,8 @@ public class SoftwareCheckStepView(
             // verify --max-turns is still a recognized flag (`claude --help | grep max-turns`).
             var claudeHealthTask = results["claude"] ? CheckHealth("claude", "-p \"ping\" --max-turns 1") : null;
             var codexHealthTask = results["codex"] ? CheckHealth("codex", "login status") : null;
-            var geminiHealthTask = results["gemini"] ? CheckHealth("gemini", "-p \"Reply OK\"") : null;
 
-            var activeHealthTasks = new[] { ghHealthTask, claudeHealthTask, codexHealthTask, geminiHealthTask }
+            var activeHealthTasks = new[] { ghHealthTask, claudeHealthTask, codexHealthTask }
                 .OfType<Task<HealthCheckStatus>>()
                 .ToArray();
             if (activeHealthTasks.Length > 0)
@@ -145,7 +144,6 @@ public class SoftwareCheckStepView(
             if (ghHealthTask != null) health["gh"] = ghHealthTask.Result;
             if (claudeHealthTask != null) health["claude"] = claudeHealthTask.Result;
             if (codexHealthTask != null) health["codex"] = codexHealthTask.Result;
-            if (geminiHealthTask != null) health["gemini"] = geminiHealthTask.Result;
 
             healthResults.Set(health);
             isChecking.Set(false);

--- a/src/tendril/Ivy.Tendril/Commands/DoctorCommand.cs
+++ b/src/tendril/Ivy.Tendril/Commands/DoctorCommand.cs
@@ -25,8 +25,7 @@ public static class DoctorCommand
     {
         ["gh"] = "auth status",
         ["claude"] = "-p \"ping\" --max-turns 1",
-        ["codex"] = "login status",
-        ["gemini"] = "-p \"Reply OK\""
+        ["codex"] = "login status"
     };
 
     public static int Handle(string[] args)


### PR DESCRIPTION
# Summary

## Changes

Removed the Gemini CLI authentication health check from both the `doctor` command and the onboarding software check wizard. The Gemini CLI has no non-interactive way to verify auth status — `gemini -p "Reply OK"` opens a browser window when unauthenticated, which is disruptive during automated health checks. Gemini's version/installation check is preserved; only the auth health check is skipped. The hint text now guides users to authenticate separately.

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/Commands/DoctorCommand.cs** — Removed `["gemini"]` entry from `HealthArgs` dictionary
- **src/tendril/Ivy.Tendril/Apps/Onboarding/SoftwareCheckStepView.cs** — Removed gemini health check task, updated `activeHealthTasks` array, updated hint text

## Commits

- e4acd92ac [03037] Remove Gemini health check to prevent browser window on auth