### PR TITLE
[03045] Select multiple projects with Select UI

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Plans/Dialogs/CreatePlanDialog.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Plans/Dialogs/CreatePlanDialog.cs
@@ -2,19 +2,19 @@ namespace Ivy.Tendril.Apps.Plans.Dialogs;
 
 public class CreatePlanDialog(
     List<string> projectNames,
-    Action<string, string> onCreatePlan,
+    Action<string, string[]> onCreatePlan,
     Action onClose,
-    string defaultProject = "[Auto]") : ViewBase
+    string[]? defaultProjects = null) : ViewBase
 {
-    private readonly string _defaultProject = defaultProject;
+    private readonly string[] _defaultProjects = defaultProjects ?? ["[Auto]"];
     private readonly Action _onClose = onClose;
-    private readonly Action<string, string> _onCreatePlan = onCreatePlan;
+    private readonly Action<string, string[]> _onCreatePlan = onCreatePlan;
     private readonly List<string> _projectNames = projectNames;
 
     public override object Build()
     {
         var createPlanText = UseState("");
-        var selectedProject = UseState(_defaultProject);
+        var selectedProjects = UseState(_defaultProjects);
 
         var options = new List<string> { "[Auto]" };
         options.AddRange(_projectNames);
@@ -24,7 +24,7 @@ public class CreatePlanDialog(
             new DialogHeader("Create New Plan"),
             new DialogBody(
                 Layout.Vertical()
-                | selectedProject.ToSelectInput(options).Variant(SelectInputVariant.Toggle).WithLabel("Select project")
+                | selectedProjects.ToSelectInput(options).Variant(SelectInputVariant.Toggle).WithLabel("Select project(s)")
                 | createPlanText.ToTextareaInput("Enter task description...").Rows(6).AutoFocus().WithField()
                     .Label("Describe the task for the new plan")
             ),
@@ -34,7 +34,11 @@ public class CreatePlanDialog(
                 {
                     if (!string.IsNullOrWhiteSpace(createPlanText.Value))
                     {
-                        _onCreatePlan(createPlanText.Value, selectedProject.Value);
+                        var projects = selectedProjects.Value
+                            .Where(p => p != "[Auto]")
+                            .ToArray();
+                        if (projects.Length == 0) projects = ["[Auto]"];
+                        _onCreatePlan(createPlanText.Value, projects);
                         _onClose();
                     }
                 })

--- a/src/tendril/Ivy.Tendril/Apps/WallpaperApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/WallpaperApp.cs
@@ -12,7 +12,7 @@ public class WallpaperApp : ViewBase
         var configService = UseService<IConfigService>();
         var countsService = UseService<IPlanCountsService>();
         var dialogOpen = UseState(false);
-        var lastSelectedProject = UseState("[Auto]");
+        var lastSelectedProjects = UseState<string[]>(["[Auto]"]);
 
         var counts = countsService.Current;
         var projectNames = configService.Projects.Select(p => p.Name).ToList();
@@ -39,13 +39,14 @@ public class WallpaperApp : ViewBase
         if (dialogOpen.Value)
             elements.Add(new CreatePlanDialog(
                 projectNames,
-                (description, project) =>
+                (description, projects) =>
                 {
-                    lastSelectedProject.Set(project);
+                    lastSelectedProjects.Set(projects);
+                    var project = string.Join(",", projects);
                     jobService.StartJob("MakePlan", "-Description", $"{description} [FORCE]", "-Project", project);
                 },
                 () => dialogOpen.Set(false),
-                lastSelectedProject.Value
+                lastSelectedProjects.Value
             ));
 
         return new Fragment(elements.ToArray());

--- a/src/tendril/Ivy.Tendril/Views/NewPlanButton.cs
+++ b/src/tendril/Ivy.Tendril/Views/NewPlanButton.cs
@@ -10,7 +10,7 @@ public class NewPlanButton : ViewBase
         var jobService = UseService<IJobService>();
         var configService = UseService<IConfigService>();
         var dialogOpen = UseState(false);
-        var lastSelectedProject = UseState("[Auto]");
+        var lastSelectedProjects = UseState<string[]>(["[Auto]"]);
 
         var projectNames = configService.Projects.Select(p => p.Name).ToList();
 
@@ -27,13 +27,14 @@ public class NewPlanButton : ViewBase
         if (dialogOpen.Value)
             elements.Add(new CreatePlanDialog(
                 projectNames,
-                (description, project) =>
+                (description, projects) =>
                 {
-                    lastSelectedProject.Set(project);
+                    lastSelectedProjects.Set(projects);
+                    var project = string.Join(",", projects);
                     jobService.StartJob("MakePlan", "-Description", $"{description} [FORCE]", "-Project", project);
                 },
                 () => dialogOpen.Set(false),
-                lastSelectedProject.Value
+                lastSelectedProjects.Value
             ));
 
         return new Fragment(elements.ToArray());


### PR DESCRIPTION
# Summary

## Changes

Changed the CreatePlanDialog from single-project selection (`IState<string>`) to multi-project selection (`IState<string[]>`) using the existing SelectInput Toggle variant with `SelectMany` support. When the user selects specific projects, `[Auto]` is filtered out at submission time; selecting no specific projects defaults to `[Auto]`. Callers (NewPlanButton, WallpaperApp) join selected projects with comma for the `-Project` parameter.

## API Changes

- `CreatePlanDialog` constructor: `Action<string, string> onCreatePlan` changed to `Action<string, string[]> onCreatePlan`
- `CreatePlanDialog` constructor: `string defaultProject = "[Auto]"` changed to `string[]? defaultProjects = null`

## Files Modified

- **src/tendril/Ivy.Tendril/Apps/Plans/Dialogs/CreatePlanDialog.cs** — Multi-select state, updated callback signature, [Auto] filtering logic
- **src/tendril/Ivy.Tendril/Views/NewPlanButton.cs** — Updated to string[] state and callback, comma-joined project parameter
- **src/tendril/Ivy.Tendril/Apps/WallpaperApp.cs** — Same updates as NewPlanButton

## Commits

- d317c9f7c [03045] Enable multi-project selection in CreatePlanDialog