### PR TITLE
[03048] Exclude promptware log files from dotnet watch

### DIFF
--- a/src/tendril/Ivy.Tendril/Ivy.Tendril.csproj
+++ b/src/tendril/Ivy.Tendril/Ivy.Tendril.csproj
@@ -9,6 +9,7 @@
     <UserSecretsId>a8f3c2e1-4b7d-4e9f-a1c3-8d6e2f5b9a7c</UserSecretsId>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>tendril</ToolCommandName>
+    <DefaultItemExcludes>$(DefaultItemExcludes);Promptwares\**</DefaultItemExcludes>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>Ivy.Tendril</PackageId>


### PR DESCRIPTION
# Summary

## Changes

Added `Promptwares\**` to the `DefaultItemExcludes` MSBuild property in `Ivy.Tendril.csproj`. The existing `<Watch Remove="Promptwares\**" />` only affects the `Watch` item group, but `dotnet watch` also monitors files picked up by default SDK globbing (e.g., `None` items for newly created files). `DefaultItemExcludes` prevents Promptwares files from being included in any default item group, stopping dotnet watch from triggering evaluations when log files are created or updated during plan execution.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Ivy.Tendril.csproj` — Added `DefaultItemExcludes` property to exclude `Promptwares\**`

## Commits

- 5d6e4f6ed