### PR TITLE
[03033] Make the font in Graphviz diagrams smaller

### DIFF
--- a/src/frontend/src/components/GraphvizRenderer.tsx
+++ b/src/frontend/src/components/GraphvizRenderer.tsx
@@ -106,6 +106,17 @@ const applyFontToSvg = (svgString: string): string => {
   const textElements = svgElement.querySelectorAll("text");
   textElements.forEach((el) => {
     el.setAttribute("font-family", fontSans);
+
+    const fontSize = el.getAttribute("font-size");
+    if (fontSize) {
+      const match = fontSize.match(/^([\d.]+)(.*)$/);
+      if (match) {
+        const value = parseFloat(match[1]);
+        const unit = match[2] || "";
+        const scaledValue = (value * 0.8).toFixed(2);
+        el.setAttribute("font-size", `${scaledValue}${unit}`);
+      }
+    }
   });
 
   return new XMLSerializer().serializeToString(svgElement);


### PR DESCRIPTION
# Summary

## Changes

Modified the `applyFontToSvg` function in `GraphvizRenderer.tsx` to scale down font sizes by 20% (multiply by 0.8) on all `<text>` elements in Graphviz-rendered SVGs. Text elements without an explicit `font-size` attribute are left unchanged. Units (px, pt, etc.) are preserved.

## API Changes

None.

## Files Modified

- `src/frontend/src/components/GraphvizRenderer.tsx` — Added font-size scaling logic to the existing `applyFontToSvg` function

## Commits

- 86fbd081a [03033] Scale down Graphviz diagram font sizes by 20%