### PR TITLE
[03053] Add File.Exists Check Before Reading plan.yaml in PlanReaderService

### DIFF
--- a/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
@@ -959,6 +959,13 @@ public class PlanReaderService(
         try
         {
             var planYamlPath = Path.Combine(folderPath, "plan.yaml");
+
+            if (!File.Exists(planYamlPath))
+            {
+                _logger.LogWarning("Plan folder is missing plan.yaml: {FolderPath}", folderPath);
+                return null;
+            }
+
             var yamlContent = FileHelper.ReadAllText(planYamlPath);
             PlanYaml? planYaml;
 


### PR DESCRIPTION
# Summary

## Changes

Added a `File.Exists` check in `PlanReaderService.ParsePlanFolder` before calling `FileHelper.ReadAllText` on `plan.yaml`. When the file is missing, the method now logs a clean warning and returns `null` without throwing a `FileNotFoundException`.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Services/PlanReaderService.cs` — Added `File.Exists` guard in `ParsePlanFolder`

## Commits

- 69efb4827 [03053] Add File.Exists check before reading plan.yaml in PlanReaderService