### PR TITLE
[01272] Fix ContentInput clipboard screenshot paste not working

### DIFF
--- a/src/frontend/src/widgets/inputs/ContentInputWidget/useFileAttachments.ts
+++ b/src/frontend/src/widgets/inputs/ContentInputWidget/useFileAttachments.ts
@@ -50,7 +50,6 @@ export function useFileAttachments(options: UseFileAttachmentsOptions) {
 
   const handlePaste = useCallback(
     (e: React.ClipboardEvent) => {
-      if (disabled || !uploadUrl) return;
       const items = e.clipboardData?.items;
       if (!items) return;
 
@@ -62,11 +61,22 @@ export function useFileAttachments(options: UseFileAttachmentsOptions) {
         }
       }
 
-      if (files.length > 0) {
-        e.preventDefault();
-        uploadFiles(files);
+      if (files.length === 0) return; // No files — let normal text paste proceed
+
+      e.preventDefault(); // Prevent binary garbage in textarea
+
+      if (disabled) return;
+
+      if (!uploadUrl) {
+        toast({
+          title: "Upload not available",
+          description: "File attachments require an upload URL to be configured.",
+          variant: "destructive",
+        });
+        return;
       }
-      // If no file items, allow normal text paste to proceed
+
+      uploadFiles(files);
     },
     [disabled, uploadUrl, uploadFiles],
   );


### PR DESCRIPTION
## Summary

Fixed `ContentInput` clipboard paste behavior when `uploadUrl` is not configured. Previously, pasting a screenshot or file was silently ignored. Now the component shows a destructive toast notification explaining that file attachments require an upload URL. Additionally, `e.preventDefault()` is always called when clipboard contains files to prevent binary data from being inserted into the textarea.

## API Changes

None.

## Files Modified

- `src/frontend/src/widgets/inputs/ContentInputWidget/useFileAttachments.ts` — Restructured `handlePaste` to detect files before checking `uploadUrl`, show toast feedback, and always prevent default for file pastes.

## Commits

- `330f3f367` — [01272] Fix ContentInput clipboard screenshot paste showing no feedback