### PR TITLE
[01286] Add toast feedback to handleDrop when uploadUrl is missing

### DIFF
--- a/src/frontend/src/widgets/inputs/ContentInputWidget/useFileAttachments.test.ts
+++ b/src/frontend/src/widgets/inputs/ContentInputWidget/useFileAttachments.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * Tests for useFileAttachments toast feedback when uploadUrl is missing.
+ *
+ * Since @testing-library/react is not available in this project,
+ * we verify the source code contains the correct patterns.
+ */
+describe("useFileAttachments - handleDrop uploadUrl guard", () => {
+  const hookSource = fs.readFileSync(path.resolve(__dirname, "./useFileAttachments.ts"), "utf-8");
+
+  it("should show a toast when uploadUrl is missing on drop", () => {
+    // Find the handleDrop function
+    const handleDropIndex = hookSource.indexOf("const handleDrop = useCallback");
+    expect(handleDropIndex).toBeGreaterThan(-1);
+
+    const handleDropBlock = hookSource.slice(
+      handleDropIndex,
+      hookSource.indexOf("[disabled, uploadUrl, uploadFiles],", handleDropIndex) + 50,
+    );
+
+    expect(handleDropBlock).toContain("if (!uploadUrl)");
+    expect(handleDropBlock).toContain("toast(");
+    expect(handleDropBlock).toContain('"Upload not available"');
+  });
+
+  it("should not call uploadFiles when uploadUrl is undefined in handleDrop", () => {
+    const handleDropIndex = hookSource.indexOf("const handleDrop = useCallback");
+    const handleDropBlock = hookSource.slice(
+      handleDropIndex,
+      hookSource.indexOf("[disabled, uploadUrl, uploadFiles],", handleDropIndex) + 50,
+    );
+
+    // The !uploadUrl check should come before uploadFiles call and return early
+    const uploadUrlCheckIndex = handleDropBlock.indexOf("if (!uploadUrl)");
+    const returnAfterCheck = handleDropBlock.indexOf("return;", uploadUrlCheckIndex);
+    const uploadFilesCallIndex = handleDropBlock.indexOf("await uploadFiles(files)");
+
+    expect(uploadUrlCheckIndex).toBeGreaterThan(-1);
+    expect(returnAfterCheck).toBeGreaterThan(-1);
+    expect(returnAfterCheck).toBeLessThan(uploadFilesCallIndex);
+  });
+
+  it("should include uploadUrl in handleDrop dependency array", () => {
+    const handleDropIndex = hookSource.indexOf("const handleDrop = useCallback");
+    const handleDropBlock = hookSource.slice(
+      handleDropIndex,
+      hookSource.indexOf(
+        ");",
+        hookSource.indexOf("[disabled, uploadUrl, uploadFiles],", handleDropIndex),
+      ) + 5,
+    );
+
+    expect(handleDropBlock).toContain("[disabled, uploadUrl, uploadFiles],");
+  });
+});
+
+describe("useFileAttachments - handlePaste uploadUrl guard with toast", () => {
+  const hookSource = fs.readFileSync(path.resolve(__dirname, "./useFileAttachments.ts"), "utf-8");
+
+  it("should show a toast when uploadUrl is missing and clipboard contains files", () => {
+    const handlePasteIndex = hookSource.indexOf("const handlePaste = useCallback");
+    expect(handlePasteIndex).toBeGreaterThan(-1);
+
+    const handlePasteBlock = hookSource.slice(
+      handlePasteIndex,
+      hookSource.indexOf("[disabled, uploadUrl, uploadFiles],", handlePasteIndex) + 50,
+    );
+
+    expect(handlePasteBlock).toContain("if (!uploadUrl)");
+    expect(handlePasteBlock).toContain("toast(");
+    expect(handlePasteBlock).toContain('"Upload not available"');
+  });
+
+  it("should only show toast for file pastes, not text-only pastes", () => {
+    const handlePasteIndex = hookSource.indexOf("const handlePaste = useCallback");
+    const handlePasteBlock = hookSource.slice(
+      handlePasteIndex,
+      hookSource.indexOf("[disabled, uploadUrl, uploadFiles],", handlePasteIndex) + 50,
+    );
+
+    // Should check for file items before showing toast
+    expect(handlePasteBlock).toContain('item.kind === "file"');
+    expect(handlePasteBlock).toContain("hasFiles");
+  });
+
+  it("should check disabled separately from uploadUrl in handlePaste", () => {
+    const handlePasteIndex = hookSource.indexOf("const handlePaste = useCallback");
+    const handlePasteBlock = hookSource.slice(
+      handlePasteIndex,
+      hookSource.indexOf("[disabled, uploadUrl, uploadFiles],", handlePasteIndex) + 50,
+    );
+
+    // disabled check should be separate from uploadUrl check
+    expect(handlePasteBlock).toContain("if (disabled) return;");
+    // Should NOT have the combined check anymore
+    expect(handlePasteBlock).not.toContain("if (disabled || !uploadUrl) return;");
+  });
+});

--- a/src/frontend/src/widgets/inputs/ContentInputWidget/useFileAttachments.ts
+++ b/src/frontend/src/widgets/inputs/ContentInputWidget/useFileAttachments.ts
@@ -50,7 +50,20 @@ export function useFileAttachments(options: UseFileAttachmentsOptions) {
 
   const handlePaste = useCallback(
     (e: React.ClipboardEvent) => {
-      if (disabled || !uploadUrl) return;
+      if (disabled) return;
+      if (!uploadUrl) {
+        // Only show toast if there are actually file items being pasted
+        const items = e.clipboardData?.items;
+        const hasFiles = items && Array.from(items).some((item) => item.kind === "file");
+        if (hasFiles) {
+          toast({
+            title: "Upload not available",
+            description: "File uploads are not configured for this input.",
+            variant: "destructive",
+          });
+        }
+        return;
+      }
       const items = e.clipboardData?.items;
       if (!items) return;
 
@@ -101,11 +114,19 @@ export function useFileAttachments(options: UseFileAttachmentsOptions) {
       e.stopPropagation();
       setIsDragging(false);
       if (disabled) return;
+      if (!uploadUrl) {
+        toast({
+          title: "Upload not available",
+          description: "File uploads are not configured for this input.",
+          variant: "destructive",
+        });
+        return;
+      }
 
       const files = Array.from(e.dataTransfer.files);
       await uploadFiles(files);
     },
-    [disabled, uploadFiles],
+    [disabled, uploadUrl, uploadFiles],
   );
 
   const openFilePicker = useCallback(() => {


### PR DESCRIPTION
## Summary

Added toast feedback to `handleDrop` and `handlePaste` in `useFileAttachments.ts` when `uploadUrl` is not configured. Previously, drag-and-drop file uploads silently failed; now users see a destructive toast with "Upload not available". The `handlePaste` handler was also updated to show the same toast for file pastes while still allowing normal text pastes to proceed silently.

## Files Modified

- **Modified:** `src/frontend/src/widgets/inputs/ContentInputWidget/useFileAttachments.ts` — Added `!uploadUrl` guard with toast to `handleDrop`, split `disabled`/`!uploadUrl` checks in `handlePaste` with file-only toast feedback, updated dependency arrays
- **Added:** `src/frontend/src/widgets/inputs/ContentInputWidget/useFileAttachments.test.ts` — 6 source-code assertion tests verifying toast guards, dependency arrays, and conditional behavior

## Commits

- `5243dac85`