### PR TITLE
[01280] Fix error sheet scrolling for large content

### DIFF
--- a/src/frontend/src/components/ErrorDisplay.tsx
+++ b/src/frontend/src/components/ErrorDisplay.tsx
@@ -28,25 +28,27 @@ export const ErrorDisplay: React.FC<ErrorDisplayProps> = ({ title, message, stac
   };
 
   return (
-    <div className="space-y-4">
-      {title && (
-        <div>
-          <h4 className="text-sm font-medium mb-2">Type</h4>
-          <p>{title}</p>
-        </div>
-      )}
+    <div className="flex flex-col h-full gap-4">
+      <div className="shrink-0">
+        {title && (
+          <div>
+            <h4 className="text-sm font-medium mb-2">Type</h4>
+            <p>{title}</p>
+          </div>
+        )}
 
-      {message && (
-        <div>
-          <h4 className="text-sm font-medium mb-2">Message</h4>
-          <p>{message}</p>
-        </div>
-      )}
+        {message && (
+          <div className="mt-4">
+            <h4 className="text-sm font-medium mb-2">Message</h4>
+            <p>{message}</p>
+          </div>
+        )}
+      </div>
 
       {stackTrace && (
-        <div>
+        <div className="flex-1 min-h-0 overflow-auto">
           <h4 className="text-sm font-medium mb-2">Stack Trace</h4>
-          <div className="w-full max-h-[50vh] overflow-auto border border-border rounded-md">
+          <div className="w-full overflow-auto border border-border rounded-md">
             <SyntaxHighlighter
               language="csharp"
               style={createPrismTheme()}
@@ -59,14 +61,16 @@ export const ErrorDisplay: React.FC<ErrorDisplayProps> = ({ title, message, stac
         </div>
       )}
 
-      <Button onClick={copyToClipboard} className="mt-4 flex items-center gap-2" variant="outline">
-        {copied ? (
-          <Check className="h-4 w-4 text-primary animate-in fade-in duration-500" />
-        ) : (
-          <ClipboardCopy className="h-4 w-4" />
-        )}
-        Copy Details
-      </Button>
+      <div className="shrink-0 pt-4 border-t">
+        <Button onClick={copyToClipboard} className="flex items-center gap-2" variant="outline">
+          {copied ? (
+            <Check className="h-4 w-4 text-primary animate-in fade-in duration-500" />
+          ) : (
+            <ClipboardCopy className="h-4 w-4" />
+          )}
+          Copy Details
+        </Button>
+      </div>
     </div>
   );
 };

--- a/src/frontend/src/components/ErrorSheet.tsx
+++ b/src/frontend/src/components/ErrorSheet.tsx
@@ -36,7 +36,7 @@ export function ErrorSheet() {
                 An error occurred in the application. Details are shown below.
               </SheetDescription>
             </SheetHeader>
-            <div className="flex-1 min-h-0 overflow-y-auto">
+            <div className="flex-1 min-h-0 flex flex-col">
               <ErrorDisplay title={title} message={message} stackTrace={stackTrace} />
             </div>
           </SheetContent>


### PR DESCRIPTION
## Changes

Restructured the `ErrorDisplay` component to use a flex column layout so that the error title and message remain visible at the top of the sheet, the stack trace scrolls independently in the middle, and the Copy Details button is pinned at the bottom with a border separator. Updated `ErrorSheet` to pass flex layout through instead of wrapping everything in a single scrollable div.

## API Changes

None.

## Files Modified

- **src/frontend/src/components/ErrorDisplay.tsx** — Changed root layout from `space-y-4` to `flex flex-col h-full gap-4`, wrapped title/message in `shrink-0` div, made stack trace section `flex-1 min-h-0 overflow-auto`, pinned button with `shrink-0 pt-4 border-t`
- **src/frontend/src/components/ErrorSheet.tsx** — Changed inner wrapper from `overflow-y-auto` to `flex flex-col` so ErrorDisplay manages its own scrolling

## Commits

- `3a8629bd9` [01280] Fix error sheet scrolling for large content