### PR TITLE
[01308] Add uploadUrl guard toast to FileInputWidget

### DIFF
--- a/src/frontend/src/widgets/inputs/FileInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/FileInputWidget.tsx
@@ -75,7 +75,14 @@ export const FileInputWidget: React.FC<FileInputWidgetProps> = ({
 
   const handleUploadFile = useCallback(
     async (file: File): Promise<void> => {
-      if (!uploadUrl) return;
+      if (!uploadUrl) {
+        toast({
+          title: "Upload not available",
+          description: "File uploads are not configured for this input.",
+          variant: "destructive",
+        });
+        return;
+      }
 
       // Validate file before upload - show toast on error
       if (!validateFileWithToast({ file, accept, maxFileSize, minFileSize })) {


### PR DESCRIPTION
## Summary

Replaced the silent `return` guard in `FileInputWidget.tsx`'s `handleUploadFile` callback with a destructive toast notification when `uploadUrl` is missing. This provides user feedback when file uploads are not configured, matching the pattern established by plan 01286 in `useFileAttachments.ts`.

## API Changes

None.

## Files Modified

- **src/frontend/src/widgets/inputs/FileInputWidget.tsx** — Added toast notification to the `handleUploadFile` guard when `uploadUrl` is not set

## Commits

- `82a89233f` [01308] Add toast feedback when uploadUrl is missing in FileInputWidget