### PR TITLE
[01309] Add toast feedback to handleFileInputChange when uploadUrl is missing

### DIFF
--- a/src/frontend/src/widgets/inputs/ContentInputWidget/useFileAttachments.test.ts
+++ b/src/frontend/src/widgets/inputs/ContentInputWidget/useFileAttachments.test.ts
@@ -168,6 +168,63 @@ describe("useFileAttachments", () => {
     });
   });
 
+  describe("handleFileInputChange guards", () => {
+    it("should show toast when uploadUrl is missing for file input", () => {
+      const handleFileInputChangeIndex = source.indexOf("const handleFileInputChange");
+      expect(handleFileInputChangeIndex).toBeGreaterThan(-1);
+
+      const handleFileInputChangeBlock = source.slice(
+        handleFileInputChangeIndex,
+        source.indexOf("\n  const", handleFileInputChangeIndex + 1),
+      );
+      expect(handleFileInputChangeBlock).toContain("!uploadUrl");
+      expect(handleFileInputChangeBlock).toContain("toast(");
+      expect(handleFileInputChangeBlock).toContain('"Upload not available"');
+    });
+
+    it("should not call uploadFiles when uploadUrl is missing", () => {
+      const handleFileInputChangeIndex = source.indexOf("const handleFileInputChange");
+      expect(handleFileInputChangeIndex).toBeGreaterThan(-1);
+
+      const handleFileInputChangeBlock = source.slice(
+        handleFileInputChangeIndex,
+        source.indexOf("\n  const", handleFileInputChangeIndex + 1),
+      );
+      // The !uploadUrl check should appear before uploadFiles call, with a return
+      const uploadUrlCheckIndex = handleFileInputChangeBlock.indexOf("!uploadUrl");
+      const returnIndex = handleFileInputChangeBlock.indexOf("return;", uploadUrlCheckIndex);
+      const uploadFilesIndex = handleFileInputChangeBlock.indexOf("await uploadFiles");
+      expect(uploadUrlCheckIndex).toBeGreaterThan(-1);
+      expect(returnIndex).toBeGreaterThan(-1);
+      expect(returnIndex).toBeLessThan(uploadFilesIndex);
+    });
+
+    it("should reset e.target.value even when uploadUrl is missing", () => {
+      const handleFileInputChangeIndex = source.indexOf("const handleFileInputChange");
+      expect(handleFileInputChangeIndex).toBeGreaterThan(-1);
+
+      const handleFileInputChangeBlock = source.slice(
+        handleFileInputChangeIndex,
+        source.indexOf("\n  const", handleFileInputChangeIndex + 1),
+      );
+      // There should be two e.target.value = "" assignments (one in guard, one after upload)
+      const matches = handleFileInputChangeBlock.match(/e\.target\.value\s*=\s*""/g);
+      expect(matches).not.toBeNull();
+      expect(matches!.length).toBe(2);
+    });
+
+    it("should include uploadUrl in handleFileInputChange dependency array", () => {
+      const handleFileInputChangeIndex = source.indexOf("const handleFileInputChange");
+      expect(handleFileInputChangeIndex).toBeGreaterThan(-1);
+
+      const handleFileInputChangeBlock = source.slice(
+        handleFileInputChangeIndex,
+        source.indexOf("\n  const", handleFileInputChangeIndex + 1),
+      );
+      expect(handleFileInputChangeBlock).toContain("[uploadUrl, uploadFiles],");
+    });
+  });
+
   describe("openFilePicker guard", () => {
     it("should contain !disabled && fileInputRef.current guard", () => {
       expect(source).toContain("!disabled && fileInputRef.current");

--- a/src/frontend/src/widgets/inputs/ContentInputWidget/useFileAttachments.ts
+++ b/src/frontend/src/widgets/inputs/ContentInputWidget/useFileAttachments.ts
@@ -136,10 +136,19 @@ export function useFileAttachments(options: UseFileAttachmentsOptions) {
     async (e: React.ChangeEvent<HTMLInputElement>) => {
       const fileList = e.target.files;
       if (!fileList || fileList.length === 0) return;
+      if (!uploadUrl) {
+        toast({
+          title: "Upload not available",
+          description: "File uploads are not configured for this input.",
+          variant: "destructive",
+        });
+        e.target.value = "";
+        return;
+      }
       await uploadFiles(Array.from(fileList));
       e.target.value = "";
     },
-    [uploadFiles],
+    [uploadUrl, uploadFiles],
   );
 
   const dragHandlers = {


### PR DESCRIPTION
## Changes

Added an `!uploadUrl` guard with destructive toast notification to `handleFileInputChange` in `useFileAttachments.ts`. This completes the toast feedback pattern across all file upload entry points (paste, drop, and file picker), matching the pattern established by plan 01286. Added 4 new test cases to verify the guard behavior.

## API Changes

None.

## Files Modified

- **Hook implementation:** `src/frontend/src/widgets/inputs/ContentInputWidget/useFileAttachments.ts` — added uploadUrl check with toast before calling `uploadFiles`, updated dependency array
- **Tests:** `src/frontend/src/widgets/inputs/ContentInputWidget/useFileAttachments.test.ts` — added `handleFileInputChange guards` test suite (4 tests)

## Commits

- b10be01a8