### PR TITLE
fix(frontend): resolve failing unit test in FileInputWidget

### DIFF
--- a/src/frontend/src/widgets/inputs/FileInputWidget.test.ts
+++ b/src/frontend/src/widgets/inputs/FileInputWidget.test.ts
@@ -50,7 +50,9 @@ describe("FileInputWidget", () => {
   describe("handleUploadFile", () => {
     it("should contain !uploadUrl guard for early return", () => {
       const block = extractBlock("handleUploadFile");
-      expect(block).toContain("if (!uploadUrl) return");
+      expect(block).toContain("if (!uploadUrl)");
+      expect(block).toContain("toast({");
+      expect(block).toContain("return;");
     });
 
     it("should call validateFileWithToast with file, accept, maxFileSize, minFileSize", () => {


### PR DESCRIPTION
This PR updates the unit tests for FileInputWidget to match the implementation. The test was previously failing because it expected a silent return for the uploadUrl guard, whereas the code now correctly uses a toast notification for better UX.