### PR TITLE
[01352] Implement Density API in DataTable

### DIFF
--- a/src/Ivy.Tests/Views/DataTables/DataTableScaffoldTests.cs
+++ b/src/Ivy.Tests/Views/DataTables/DataTableScaffoldTests.cs
@@ -93,4 +93,32 @@ public class DataTableScaffoldTests
         Assert.False(IsColumnRemoved(builder, "CreatedAt"));
         Assert.False(IsColumnRemoved(builder, "Amount"));
     }
+
+    private static Density GetDensity<T>(DataTableBuilder<T> builder)
+    {
+        var flags = System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance;
+        var field = builder.GetType().GetField("_density", flags)!;
+        return (Density)field.GetValue(builder)!;
+    }
+
+    [Fact]
+    public void Density_DefaultsToMedium()
+    {
+        var builder = new[] { new EntityWithPrimitives() }.AsQueryable().ToDataTable();
+        Assert.Equal(Density.Medium, GetDensity(builder));
+    }
+
+    [Fact]
+    public void Small_SetsDensityToSmall()
+    {
+        var builder = new[] { new EntityWithPrimitives() }.AsQueryable().ToDataTable().Small();
+        Assert.Equal(Density.Small, GetDensity(builder));
+    }
+
+    [Fact]
+    public void Large_SetsDensityToLarge()
+    {
+        var builder = new[] { new EntityWithPrimitives() }.AsQueryable().ToDataTable().Large();
+        Assert.Equal(Density.Large, GetDensity(builder));
+    }
 }

--- a/src/Ivy/Views/DataTables/DataTableBuilder.cs
+++ b/src/Ivy/Views/DataTables/DataTableBuilder.cs
@@ -27,7 +27,7 @@ public class DataTableBuilder<TModel>(
     private FuncViewBuilder? _headerLeftFactory;
     private FuncViewBuilder? _headerRightFactory;
     private Dictionary<string, object>? _footerValuesByColumn;
-    private Density _density = Density.Medium;
+    private Density _density = Ivy.Density.Medium;
 
     private readonly string? _idColumnName =
         idSelector != null ? TypeHelper.GetNameFromMemberExpression(idSelector.Body) : null;
@@ -477,7 +477,7 @@ public class DataTableBuilder<TModel>(
         return this;
     }
 
-    public DataTableBuilder<TModel> Density(Density density)
+    public DataTableBuilder<TModel> Density(Ivy.Density density)
     {
         _density = density;
         return this;

--- a/src/Ivy/Views/DataTables/DataTableBuilder.cs
+++ b/src/Ivy/Views/DataTables/DataTableBuilder.cs
@@ -27,6 +27,7 @@ public class DataTableBuilder<TModel>(
     private FuncViewBuilder? _headerLeftFactory;
     private FuncViewBuilder? _headerRightFactory;
     private Dictionary<string, object>? _footerValuesByColumn;
+    private Density _density = Density.Medium;
 
     private readonly string? _idColumnName =
         idSelector != null ? TypeHelper.GetNameFromMemberExpression(idSelector.Body) : null;
@@ -476,6 +477,30 @@ public class DataTableBuilder<TModel>(
         return this;
     }
 
+    public DataTableBuilder<TModel> Density(Density density)
+    {
+        _density = density;
+        return this;
+    }
+
+    public DataTableBuilder<TModel> Small()
+    {
+        _density = Ivy.Density.Small;
+        return this;
+    }
+
+    public DataTableBuilder<TModel> Medium()
+    {
+        _density = Ivy.Density.Medium;
+        return this;
+    }
+
+    public DataTableBuilder<TModel> Large()
+    {
+        _density = Ivy.Density.Large;
+        return this;
+    }
+
     public override object? Build()
     {
         Context.TryUseService<IChatClient>(out var chatClient);
@@ -540,6 +565,7 @@ public class DataTableBuilder<TModel>(
             _height,
             columns,
             configuration,
+            density: _density,
             onCellClick: onCellClick,
             onCellActivated: _onCellActivated,
             rowActions: _menuItemRowActions,

--- a/src/Ivy/Views/DataTables/DataTableView.cs
+++ b/src/Ivy/Views/DataTables/DataTableView.cs
@@ -9,6 +9,7 @@ public class DataTableView(
     Size? height,
     DataTableColumn[] columns,
     DataTableConfig config,
+    Density density = Density.Medium,
     Func<Event<DataTable, CellClickEventArgs>, ValueTask>? onCellClick = null,
     Func<Event<DataTable, CellClickEventArgs>, ValueTask>? onCellActivated = null,
     MenuItem[]? rowActions = null,
@@ -29,6 +30,7 @@ public class DataTableView(
 
         var table = new DataTable(connection, width, height, columns, config)
         {
+            Density = density,
             OnCellClick = onCellClick.ToEventHandler(),
             OnCellActivated = onCellActivated.ToEventHandler(),
             RowActions = rowActions,

--- a/src/frontend/src/widgets/dataTables/DataTableWidget.tsx
+++ b/src/frontend/src/widgets/dataTables/DataTableWidget.tsx
@@ -11,6 +11,7 @@ import { DataTableOption } from "./DataTableOption";
 import { DataTableFilterOption } from "./options/DataTableFilterOption";
 import { Filter as FilterIcon } from "lucide-react";
 import { tableStyles } from "./styles/style";
+import { Densities } from "@/types/density";
 import { TableProps } from "./types/types";
 import { getWidth, getHeight } from "@/lib/styles";
 import { applyConfigDefaults, applyColumnsDefaults } from "./DataTableDefaults";
@@ -37,6 +38,7 @@ const TableLayout: React.FC<TableLayoutProps> = ({ children, emptyView }) => {
 };
 
 interface DataTableWidgetProps extends TableProps {
+  density?: Densities;
   slots?: {
     EmptyView?: React.ReactNode[];
     HeaderLeft?: React.ReactNode[];
@@ -52,6 +54,7 @@ export const DataTable: React.FC<DataTableWidgetProps> = ({
   editable = false,
   width = "Full",
   height = "Full",
+  density,
   rowActions,
   slots,
   "data-testid": dataTestId,
@@ -99,6 +102,7 @@ export const DataTable: React.FC<DataTableWidgetProps> = ({
         connection={connection}
         config={finalConfig}
         editable={editable}
+        density={density}
       >
         <TableLayout emptyView={slots?.EmptyView}>
           <DataTableHeader>

--- a/src/frontend/src/widgets/dataTables/dataTableContext/tableProvider.tsx
+++ b/src/frontend/src/widgets/dataTables/dataTableContext/tableProvider.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useRef, useState } from "react";
 import * as arrow from "apache-arrow";
 import { Filter } from "@/services/grpcTableService";
+import { Densities } from "@/types/density";
 import { TableContext } from "./tableContext";
 import { TableProviderProps, TableContextType } from "./types";
 import { useDataLoading, useColumnManagement, useSorting, useRowData } from "./hooks";
@@ -11,6 +12,7 @@ export const TableProvider: React.FC<TableProviderProps> = ({
   connection,
   config,
   editable = false,
+  density = Densities.Medium,
 }) => {
   const [visibleRows, setVisibleRows] = useState(0);
   const [error, setError] = useState<string | null>(null);
@@ -73,6 +75,7 @@ export const TableProvider: React.FC<TableProviderProps> = ({
       activeFilter,
       activeSort,
       columnOrder,
+      density,
       getRowData,
       arrowTableRef,
       loadMoreData,
@@ -96,6 +99,7 @@ export const TableProvider: React.FC<TableProviderProps> = ({
     activeFilter,
     activeSort,
     columnOrder,
+    density,
     getRowData,
     arrowTableRef,
     loadMoreData,

--- a/src/frontend/src/widgets/dataTables/dataTableContext/types.ts
+++ b/src/frontend/src/widgets/dataTables/dataTableContext/types.ts
@@ -2,6 +2,7 @@ import React from "react";
 import * as arrow from "apache-arrow";
 import { Filter, SortOrder } from "@/services/grpcTableService";
 import { GridColumn } from "@glideapps/glide-data-grid";
+import { Densities } from "@/types/density";
 import { DataColumn, DataRow, DataTableConfig, DataTableConnection } from "../types/types";
 
 export interface TableContextType {
@@ -18,6 +19,7 @@ export interface TableContextType {
   activeFilter: Filter | null;
   activeSort: SortOrder[] | null;
   columnOrder: number[];
+  density: Densities;
   // Arrow table accessor - data is accessed directly from Arrow table via gRPC
   getRowData: (rowIndex: number) => DataRow | null;
   arrowTableRef: React.RefObject<arrow.Table | null>;
@@ -37,4 +39,5 @@ export interface TableProviderProps {
   connection: DataTableConnection;
   config: DataTableConfig;
   editable?: boolean;
+  density?: Densities;
 }

--- a/src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx
+++ b/src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx
@@ -25,7 +25,7 @@ import { useFooterColumnLayout } from "../hooks/useFooterColumnLayout";
 import { GridContainer } from "../components/GridContainer";
 import { AggregateFooter } from "../DataTableFooter";
 import { MenuItem } from "@/types/widgets";
-import { ROW_HEIGHT, GROUP_HEADER_HEIGHT } from "./constants";
+import { DENSITY_CONFIG } from "./constants";
 import { useCellContent, useGridColumns, useHeaderMenu } from "./hooks";
 import { getOrderedVisibleDataColumns } from "../utils/columnHelpers";
 
@@ -53,6 +53,7 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
     editable,
     config,
     columnOrder,
+    density,
     getRowData,
     arrowTableRef,
     loadMoreData,
@@ -60,6 +61,8 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
     handleSort,
     handleColumnReorder,
   } = useTable();
+
+  const densityConfig = DENSITY_CONFIG[density];
 
   const {
     allowColumnReordering,
@@ -150,6 +153,7 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
     enableRowHover: enableRowHover ?? false,
     visibleRows,
     hoverRow,
+    density,
   });
 
   const { onSearchResultsChanged, onSearchClose, highlightRegions } = useSearchNavigation(
@@ -166,7 +170,7 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
     visibleRows,
     hasMore,
     showGroups: showGroups ?? false,
-    rowHeight: ROW_HEIGHT,
+    rowHeight: densityConfig.rowHeight,
   });
 
   // Data loading
@@ -176,7 +180,7 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
     isLoading,
     hasMore,
     loadMoreData,
-    rowHeight: ROW_HEIGHT,
+    rowHeight: densityConfig.rowHeight,
   });
 
   // Generate header icons map for all column icons
@@ -287,8 +291,8 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
         onVisibleRegionChanged={handleVisibleRegionChanged}
         onHeaderClicked={allowSorting ? handleHeaderMenuClick : undefined}
         theme={tableTheme}
-        rowHeight={ROW_HEIGHT}
-        headerHeight={ROW_HEIGHT}
+        rowHeight={densityConfig.rowHeight}
+        headerHeight={densityConfig.rowHeight}
         freezeColumns={freezeColumns ?? 0}
         getCellsForSelection={(allowCopySelection ?? true) ? true : undefined}
         rowSelect={selectionProps.rowSelect}
@@ -302,7 +306,7 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
         }
         rowMarkers={showIndexColumn ? "number" : "none"}
         onColumnMoved={allowColumnReordering ? handleColumnReorder : undefined}
-        groupHeaderHeight={showGroups ? GROUP_HEADER_HEIGHT : undefined}
+        groupHeaderHeight={showGroups ? densityConfig.groupHeaderHeight : undefined}
         onCellClicked={handleCellClicked}
         onCellActivated={handleCellActivated}
         onGroupHeaderClicked={shouldUseColumnGroups ? onGroupHeaderClicked : undefined}

--- a/src/frontend/src/widgets/dataTables/dataTableEditor/constants.ts
+++ b/src/frontend/src/widgets/dataTables/dataTableEditor/constants.ts
@@ -1,5 +1,32 @@
-/**
- * Constants for DataTableEditor
- */
-export const ROW_HEIGHT = 38;
-export const GROUP_HEADER_HEIGHT = 36;
+import { Densities } from "@/types/density";
+
+export const DENSITY_CONFIG = {
+  [Densities.Small]: {
+    rowHeight: 30,
+    groupHeaderHeight: 28,
+    cellHorizontalPadding: 6,
+    cellVerticalPadding: 4,
+    headerIconSize: 16,
+    fontSize: "12px",
+  },
+  [Densities.Medium]: {
+    rowHeight: 38,
+    groupHeaderHeight: 36,
+    cellHorizontalPadding: 8,
+    cellVerticalPadding: 8,
+    headerIconSize: 20,
+    fontSize: "13px",
+  },
+  [Densities.Large]: {
+    rowHeight: 48,
+    groupHeaderHeight: 44,
+    cellHorizontalPadding: 12,
+    cellVerticalPadding: 12,
+    headerIconSize: 22,
+    fontSize: "14px",
+  },
+} as const;
+
+// Keep backward-compat exports for any external consumers
+export const ROW_HEIGHT = DENSITY_CONFIG[Densities.Medium].rowHeight;
+export const GROUP_HEADER_HEIGHT = DENSITY_CONFIG[Densities.Medium].groupHeaderHeight;

--- a/src/frontend/src/widgets/dataTables/hooks/useTableTheme.ts
+++ b/src/frontend/src/widgets/dataTables/hooks/useTableTheme.ts
@@ -2,12 +2,15 @@ import { useCallback } from "react";
 import { Theme } from "@glideapps/glide-data-grid";
 import { useThemeWithMonitoring } from "@/components/theme-provider";
 import { ThemeColors } from "@/lib/theme";
+import { Densities } from "@/types/density";
+import { DENSITY_CONFIG } from "../dataTableEditor/constants";
 
 interface UseTableThemeProps {
   showVerticalBorders: boolean | undefined;
   enableRowHover: boolean | undefined;
   visibleRows: number;
   hoverRow: number | undefined;
+  density?: Densities;
 }
 
 /**
@@ -18,7 +21,9 @@ export const useTableTheme = ({
   enableRowHover,
   visibleRows,
   hoverRow,
+  density = Densities.Medium,
 }: UseTableThemeProps) => {
+  const densityConfig = DENSITY_CONFIG[density];
   const {
     customTheme: tableTheme,
     colors: themeColors,
@@ -53,9 +58,9 @@ export const useTableTheme = ({
           ? colors.border || (isDark ? "#404045" : "#d1d5db")
           : "transparent",
       bgSearchResult: isDark ? "#3f3520" : "#fff9e3",
-      cellHorizontalPadding: 8,
-      cellVerticalPadding: 8,
-      headerIconSize: 20,
+      cellHorizontalPadding: densityConfig.cellHorizontalPadding,
+      cellVerticalPadding: densityConfig.cellVerticalPadding,
+      headerIconSize: densityConfig.headerIconSize,
       // Add proper text colors for group headers and icons
       textGroupHeader: colors.mutedForeground || (isDark ? "#a1a1aa" : "#6b7280"),
       // Icon foreground color


### PR DESCRIPTION
## Summary

Implemented end-to-end density support (Small/Medium/Large) in the DataTable widget, wiring it from the C# `DataTableBuilder` fluent API through `DataTableView` to the React frontend. Density controls row height, header height, cell padding, header icon size, and group header height. The current hardcoded values (38px rows, 8px padding) are preserved as the Medium default.

## API Changes

- **`DataTableBuilder<TModel>.Density(Density density)`** — new fluent method to set density
- **`DataTableBuilder<TModel>.Small()`** — shorthand for `Density(Density.Small)`
- **`DataTableBuilder<TModel>.Medium()`** — shorthand for `Density(Density.Medium)`
- **`DataTableBuilder<TModel>.Large()`** — shorthand for `Density(Density.Large)`
- **`DataTableView` constructor** — new `Density density = Density.Medium` parameter
- **Frontend `DENSITY_CONFIG`** — new exported constant mapping `Densities` to sizing values
- **Frontend `TableContextType.density`** — new context field for density
- **Frontend `TableProviderProps.density`** — new optional prop

## Files Modified

- **Backend:**
  - `src/Ivy/Views/DataTables/DataTableBuilder.cs` — density field + 4 fluent methods + forwarding to DataTableView
  - `src/Ivy/Views/DataTables/DataTableView.cs` — density parameter + widget property assignment

- **Frontend:**
  - `src/frontend/src/widgets/dataTables/dataTableEditor/constants.ts` — DENSITY_CONFIG map replacing single constants
  - `src/frontend/src/widgets/dataTables/DataTableWidget.tsx` — accepts and passes density prop
  - `src/frontend/src/widgets/dataTables/dataTableContext/types.ts` — density in context type and provider props
  - `src/frontend/src/widgets/dataTables/dataTableContext/tableProvider.tsx` — density in context value
  - `src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx` — dynamic row/header heights from density config
  - `src/frontend/src/widgets/dataTables/hooks/useTableTheme.ts` — dynamic padding/icon sizes from density config

- **Tests:**
  - `src/Ivy.Tests/Views/DataTables/DataTableScaffoldTests.cs` — 3 new density tests

## Commits

- `fc2d280a8`
- `4ca417e46`