### PR TITLE
[01354] Add Density tab to DataTable sample app

### DIFF
--- a/src/Ivy.Samples.Shared/Apps/Widgets/DataTableApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/DataTableApp.cs
@@ -10,6 +10,7 @@ public class DataTableApp : SampleBase
             new Tab("Header Slots", new DataTableHeaderSlotsSample()),
             new Tab("Footer", new DataTableFooterSample()),
             new Tab("Multi Agg", new DataTableMultiAggSample()),
+            new Tab("Density", new DataTableDensitySample()),
             new Tab("Million Rows", new DataTablesMillionRowsSample())
         ).Variant(TabsVariant.Content);
     }
@@ -290,6 +291,46 @@ public class DataTableMultiAggSample : ViewBase
             .AlignContent(x => x.Sales, Align.Right)
             .AlignContent(x => x.Target, Align.Right)
             .Height(Size.Units(60));
+    }
+}
+
+public class DataTableDensitySample : ViewBase
+{
+    public override object? Build()
+    {
+        var density = UseState(() => Density.Medium);
+
+        var data = new[]
+        {
+            new { Id = 1, Name = "Alpha", Category = "A", Price = 10.00m },
+            new { Id = 2, Name = "Beta", Category = "B", Price = 25.50m },
+            new { Id = 3, Name = "Gamma", Category = "A", Price = 17.99m },
+            new { Id = 4, Name = "Delta", Category = "C", Price = 42.00m },
+            new { Id = 5, Name = "Epsilon", Category = "B", Price = 8.75m },
+        }.AsQueryable();
+
+        var table = data.ToDataTable()
+            .Header(x => x.Id, "ID")
+            .Header(x => x.Name, "Name")
+            .Header(x => x.Category, "Category")
+            .Header(x => x.Price, "Price")
+            .Width(x => x.Id, Size.Px(60))
+            .Width(x => x.Name, Size.Px(120))
+            .Width(x => x.Category, Size.Px(100))
+            .Width(x => x.Price, Size.Px(100))
+            .AlignContent(x => x.Price, Align.Right)
+            .Density(density.Value)
+            .Height(Size.Units(60));
+
+        return Layout.Vertical().Gap(4)
+            | Layout.Horizontal().Gap(2)
+                | new Button("Small").OnClick(_ => density.Set(Density.Small))
+                    .Variant(density.Value == Density.Small ? ButtonVariant.Primary : ButtonVariant.Outline).Small()
+                | new Button("Medium").OnClick(_ => density.Set(Density.Medium))
+                    .Variant(density.Value == Density.Medium ? ButtonVariant.Primary : ButtonVariant.Outline).Small()
+                | new Button("Large").OnClick(_ => density.Set(Density.Large))
+                    .Variant(density.Value == Density.Large ? ButtonVariant.Primary : ButtonVariant.Outline).Small()
+            | table;
     }
 }
 


### PR DESCRIPTION
## Summary

Added a new "Density" tab to the DataTable sample app (`DataTableApp.cs`). The tab contains a `DataTableDensitySample` class that renders a small data table with three toggle buttons (Small, Medium, Large) allowing developers to interactively switch between density levels using the `DataTableBuilder.Density()` API.

## API Changes

None. This change only adds a sample demonstrating the existing `Density` API from plan 01352.

## Files Modified

- **src/Ivy.Samples.Shared/Apps/Widgets/DataTableApp.cs** — Added `Tab("Density", new DataTableDensitySample())` to the tabs list; added `DataTableDensitySample` class with inline dataset and density toggle buttons.

## Commits

- d8dd82133