### PR TITLE
[01382] Rename remaining Scale API references to Density

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/05_Other/Hallucinations.md
+++ b/src/Ivy.Docs.Shared/Docs/05_Other/Hallucinations.md
@@ -1910,7 +1910,7 @@ Text.P(frequencyText).Small().Muted()
 Text.Block(frequencyText).Small().Muted()
 ```
 
-`Small()` is an instance modifier on `TextBuilder` (returns `Scale(Ivy.Scale.Small)`), not a static factory. The static factories are `Text.P()`, `Text.H1()`, `Text.H2()`, `Text.H3()`, `Text.H4()`, `Text.Block()`, `Text.Label()`, etc. Chain `.Small()` after creating the text.
+`Small()` is an instance modifier on `TextBuilder` (returns `Density(Ivy.Density.Small)`), not a static factory. The static factories are `Text.P()`, `Text.H1()`, `Text.H2()`, `Text.H3()`, `Text.H4()`, `Text.Block()`, `Text.Label()`, etc. Chain `.Small()` after creating the text.
 
 **Found In:**
 ce144de9-0688-490a-bef6-b2766e323154

--- a/src/Ivy.Samples.Shared/Apps/Widgets/ExpandableApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/ExpandableApp.cs
@@ -120,7 +120,7 @@ public class ExpandableApp : SampleBase
             | mediumIconExpandable
             | largeIconExpandable
             | Text.H2("Density Variations")
-            | Text.Block("Use the Scale helpers (Small / Medium / Large) to match the density of the surrounding layout.")
+            | Text.Block("Use the Density helpers (Small / Medium / Large) to match the density of the surrounding layout.")
             | smallDensityExpandable
             | mediumDensityExpandable
             | largeDensityExpandable

--- a/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/ContentInputApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/ContentInputApp.cs
@@ -13,7 +13,7 @@ public class ContentInputApp : SampleBase
                | Layout.Tabs(
                    new Tab("Basic", new ContentInputBasicExample()),
                    new Tab("With Files", new ContentInputWithFilesExample()),
-                   new Tab("Scale", new ContentInputScaleExample()),
+                   new Tab("Density", new ContentInputDensityExample()),
                    new Tab("Invalid", new ContentInputInvalidExample()),
                    new Tab("Configured", new ContentInputConfiguredExample()),
                    new Tab("Submit", new ContentInputSubmitExample())
@@ -70,7 +70,7 @@ public class ContentInputWithFilesExample : ViewBase
     }
 }
 
-public class ContentInputScaleExample : ViewBase
+public class ContentInputDensityExample : ViewBase
 {
     public override object? Build()
     {

--- a/src/frontend/src/components/ui/detail.tsx
+++ b/src/frontend/src/components/ui/detail.tsx
@@ -9,7 +9,7 @@ import {
   detailsSizeVariant,
 } from "./detail/detail-variant";
 import { DetailProvider } from "./detail/DetailContext";
-import { useDetailScale } from "./detail/useDetailScale";
+import { useDetailDensity } from "./detail/useDetailDensity";
 import { Densities } from "@/types/density";
 
 export interface DetailsProps
@@ -19,7 +19,7 @@ export interface DetailsProps
 
 const Details = React.forwardRef<HTMLDivElement, DetailsProps>(
   ({ className, density: propDensity, children, ...props }, ref) => {
-    const contextDensity = useDetailScale();
+    const contextDensity = useDetailDensity();
     const density = propDensity ?? contextDensity ?? Densities.Medium;
 
     return (
@@ -41,7 +41,7 @@ export interface DetailItemProps extends Omit<React.HTMLAttributes<HTMLDivElemen
 
 const DetailItem = React.forwardRef<HTMLDivElement, DetailItemProps>(
   ({ className, label, multiline, density: propDensity, children, ...props }, ref) => {
-    const contextDensity = useDetailScale();
+    const contextDensity = useDetailDensity();
     const density = propDensity ?? contextDensity;
 
     return (

--- a/src/frontend/src/components/ui/detail/useDetailDensity.ts
+++ b/src/frontend/src/components/ui/detail/useDetailDensity.ts
@@ -1,7 +1,7 @@
 import { useContext } from "react";
 import { DetailContext } from "./DetailContext";
 
-export const useDetailScale = () => {
+export const useDetailDensity = () => {
   const context = useContext(DetailContext);
   return context.density;
 };


### PR DESCRIPTION
# Summary

## Changes

Renamed all remaining "Scale" references (in the density/spacing context) to "Density" across sample apps, frontend hooks, and documentation. This completes the Scale→Density rename started in plan 01352.

## API Changes

- `ContentInputScaleExample` class → `ContentInputDensityExample`
- `useDetailScale` hook → `useDetailDensity` (file renamed: `useDetailScale.ts` → `useDetailDensity.ts`)
- Tab label `"Scale"` → `"Density"` in ContentInputApp

## Files Modified

- **Sample Apps:**
  - `src/Ivy.Samples.Shared/Apps/Widgets/Inputs/ContentInputApp.cs` — renamed class and tab label
  - `src/Ivy.Samples.Shared/Apps/Widgets/ExpandableApp.cs` — updated description text
- **Frontend:**
  - `src/frontend/src/components/ui/detail/useDetailScale.ts` → `useDetailDensity.ts` — renamed file and export
  - `src/frontend/src/components/ui/detail.tsx` — updated import and all usages
- **Documentation:**
  - `src/Ivy.Docs.Shared/Docs/05_Other/Hallucinations.md` — updated API reference text

## Commits

- `cdc78c2c6`