### PR TITLE
[01406] Add unit tests for window focus blur-tracking useEffect in FileInputWidget

### DIFF
--- a/src/frontend/src/widgets/inputs/FileInputWidget.test.ts
+++ b/src/frontend/src/widgets/inputs/FileInputWidget.test.ts
@@ -173,4 +173,72 @@ describe("FileInputWidget", () => {
       expect(block).toContain("setIsDragging(false)");
     });
   });
+
+  describe("window focus blur-tracking useEffect", () => {
+    /**
+     * Helper: extract the useEffect block that contains handleWindowFocus.
+     */
+    function extractUseEffectBlock(): string {
+      const marker = "const handleWindowFocus = ()";
+      const start = source.lastIndexOf("useEffect(", source.indexOf(marker));
+      const depsEnd = "}, [hasBlurHandler, handleEvent, id]);";
+      const deps = source.indexOf(depsEnd, start);
+      return source.slice(start, deps + depsEnd.length);
+    }
+
+    it("should early return when no blur handler", () => {
+      const block = extractUseEffectBlock();
+      expect(block).toContain("if (!hasBlurHandler) return");
+    });
+
+    it("should register window focus listener", () => {
+      const block = extractUseEffectBlock();
+      expect(block).toContain('window.addEventListener("focus", handleWindowFocus)');
+    });
+
+    it("should cleanup by removing listener", () => {
+      const block = extractUseEffectBlock();
+      expect(block).toContain('window.removeEventListener("focus", handleWindowFocus)');
+    });
+
+    it("should check dialogWasOpenRef", () => {
+      const block = extractUseEffectBlock();
+      expect(block).toContain("if (dialogWasOpenRef.current)");
+    });
+
+    it("should reset dialogWasOpenRef", () => {
+      const block = extractUseEffectBlock();
+      expect(block).toContain("dialogWasOpenRef.current = false");
+    });
+
+    it("should use queueMicrotask for timing", () => {
+      const block = extractUseEffectBlock();
+      expect(block).toContain("queueMicrotask(");
+    });
+
+    it("should skip blur if files were selected", () => {
+      const block = extractUseEffectBlock();
+      expect(block).toContain("!filesSelectedInCurrentDialogRef.current");
+    });
+
+    it("should skip blur if already fired", () => {
+      const block = extractUseEffectBlock();
+      expect(block).toContain("!blurFiredRef.current");
+    });
+
+    it("should set blurFiredRef on fire", () => {
+      const block = extractUseEffectBlock();
+      expect(block).toContain("blurFiredRef.current = true");
+    });
+
+    it("should fire OnBlur event", () => {
+      const block = extractUseEffectBlock();
+      expect(block).toContain('handleEvent("OnBlur", id, [])');
+    });
+
+    it("should have correct dependency array", () => {
+      const block = extractUseEffectBlock();
+      expect(block).toContain("[hasBlurHandler, handleEvent, id]");
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Added 11 source-pattern analysis unit tests covering the window focus blur-tracking `useEffect` in `FileInputWidget.tsx`. The tests verify the effect's early return guard, event listener registration/cleanup, ref-based state management (`dialogWasOpenRef`, `filesSelectedInCurrentDialogRef`, `blurFiredRef`), `queueMicrotask` timing coordination, `OnBlur` event dispatch, and the dependency array.

## API Changes

None.

## Files Modified

- **Frontend tests:**
  - `src/frontend/src/widgets/inputs/FileInputWidget.test.ts` — Added new `describe("window focus blur-tracking useEffect")` block with `extractUseEffectBlock` helper and 11 test cases

## Commits

- af29f3ed5 [01406] Add unit tests for window focus blur-tracking useEffect in FileInputWidget