### PR TITLE
[01410] Add Layout.Tabs and density demo to PaginationApp

### DIFF
--- a/src/Ivy.Samples.Shared/Apps/Widgets/PaginationApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/PaginationApp.cs
@@ -6,6 +6,17 @@ public class PaginationApp() : SampleBase
 {
     protected override object? BuildSample()
     {
+        return Layout.Tabs(
+            new Tab("Overview", new PaginationOverviewSample()),
+            new Tab("Density", new PaginationDensitySample())
+        ).Variant(TabsVariant.Content);
+    }
+}
+
+public class PaginationOverviewSample : ViewBase
+{
+    public override object? Build()
+    {
         var page = UseState(10);
 
         var eventHandler = (Event<Pagination, int> e) =>
@@ -14,7 +25,6 @@ public class PaginationApp() : SampleBase
         };
 
         return Layout.Vertical()
-               | Text.H1("Pagination")
                | Text.H2("Siblings")
                | new Pagination(page.Value, 20, eventHandler).Siblings(0)
                | new Pagination(page.Value, 20, eventHandler).Siblings(1)
@@ -26,5 +36,31 @@ public class PaginationApp() : SampleBase
                | new Pagination(page.Value, 20, eventHandler).Boundaries(1)
                | new Pagination(page.Value, 20, eventHandler).Boundaries(2)
                | new Pagination(page.Value, 20, eventHandler).Boundaries(3);
+    }
+}
+
+public class PaginationDensitySample : ViewBase
+{
+    public override object? Build()
+    {
+        var page = UseState(5);
+        var density = UseState(() => Density.Medium);
+
+        var onChange = (Event<Pagination, int> e) =>
+        {
+            page.Set(e.Value);
+        };
+
+        return Layout.Vertical().Gap(4)
+               | Layout.Horizontal().Gap(2)
+                   | new Button("Small").OnClick(_ => density.Set(Density.Small))
+                       .Variant(density.Value == Density.Small ? ButtonVariant.Primary : ButtonVariant.Outline).Small()
+                   | new Button("Medium").OnClick(_ => density.Set(Density.Medium))
+                       .Variant(density.Value == Density.Medium ? ButtonVariant.Primary : ButtonVariant.Outline).Small()
+                   | new Button("Large").OnClick(_ => density.Set(Density.Large))
+                       .Variant(density.Value == Density.Large ? ButtonVariant.Primary : ButtonVariant.Outline).Small()
+               | new Pagination(page.Value, 20, onChange).Siblings(1).Density(density.Value)
+               | new Pagination(page.Value, 20, onChange).Siblings(2).Density(density.Value)
+               | new Pagination(page.Value, 20, onChange).Siblings(3).Density(density.Value);
     }
 }


### PR DESCRIPTION
## Summary

Refactored `PaginationApp` to use a tabbed layout with `Layout.Tabs`. Extracted the existing siblings and boundaries demo into a new `PaginationOverviewSample` class, and added a new `PaginationDensitySample` class that demonstrates the Density API with Small/Medium/Large toggle buttons applied to multiple Pagination widgets.

## Files Modified

- **Sample apps:**
  - `src/Ivy.Samples.Shared/Apps/Widgets/PaginationApp.cs` — Replaced flat layout with `Layout.Tabs`, added `PaginationOverviewSample` and `PaginationDensitySample` classes

## Commits

- 7d26f8b36 [01410] Add Layout.Tabs and density demo to PaginationApp