### PR TITLE
[01411] Add Density method to TableBuilder

### DIFF
--- a/src/Ivy.Test/TableBuilderTests.cs
+++ b/src/Ivy.Test/TableBuilderTests.cs
@@ -24,6 +24,48 @@ public class TableBuilderTests
         public string Region { get; set; } = string.Empty;
     }
 
+    private static Density GetDensity<T>(TableBuilder<T> builder)
+    {
+        var flags = System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance;
+        var field = builder.GetType().GetField("_density", flags)!;
+        return (Density)field.GetValue(builder)!;
+    }
+
+    [Fact]
+    public void Density_DefaultsToMedium()
+    {
+        var data = new[] { new TestModel { Name = "Alice", Age = 30, IsActive = true } };
+        var builder = new TableBuilder<TestModel>(data);
+        Assert.Equal(Density.Medium, GetDensity(builder));
+    }
+
+    [Fact]
+    public void Density_SetsValue()
+    {
+        var data = new[] { new TestModel { Name = "Alice", Age = 30, IsActive = true } };
+        var builder = new TableBuilder<TestModel>(data);
+        builder.Density(Density.Small);
+        Assert.Equal(Density.Small, GetDensity(builder));
+    }
+
+    [Fact]
+    public void Small_SetsDensityToSmall()
+    {
+        var data = new[] { new TestModel { Name = "Alice", Age = 30, IsActive = true } };
+        var builder = new TableBuilder<TestModel>(data);
+        builder.Small();
+        Assert.Equal(Density.Small, GetDensity(builder));
+    }
+
+    [Fact]
+    public void Large_SetsDensityToLarge()
+    {
+        var data = new[] { new TestModel { Name = "Alice", Age = 30, IsActive = true } };
+        var builder = new TableBuilder<TestModel>(data);
+        builder.Large();
+        Assert.Equal(Density.Large, GetDensity(builder));
+    }
+
     [Fact]
     public void SubProperty_MultipleHeaderCalls_CreatesSeparateColumns()
     {

--- a/src/Ivy/Views/Tables/TableBuilder.cs
+++ b/src/Ivy/Views/Tables/TableBuilder.cs
@@ -223,6 +223,12 @@ public class TableBuilder<TModel> : ViewBase, IStateless
         return this;
     }
 
+    public TableBuilder<TModel> Density(Density density)
+    {
+        _density = density;
+        return this;
+    }
+
     public TableBuilder<TModel> Large()
     {
         _density = Density.Large;

--- a/src/Ivy/Views/Tables/TableBuilder.cs
+++ b/src/Ivy/Views/Tables/TableBuilder.cs
@@ -90,7 +90,7 @@ public class TableBuilder<TModel> : ViewBase, IStateless
     }
 
     private Size? _width;
-    private Density _density = Density.Medium;
+    private Density _density = Ivy.Density.Medium;
     private readonly IEnumerable<TModel> _records;
     private readonly Dictionary<string, TableBuilderColumn> _columns;
     private readonly BuilderFactory<TModel> _builderFactory;
@@ -223,7 +223,7 @@ public class TableBuilder<TModel> : ViewBase, IStateless
         return this;
     }
 
-    public TableBuilder<TModel> Density(Density density)
+    public TableBuilder<TModel> Density(Ivy.Density density)
     {
         _density = density;
         return this;
@@ -231,19 +231,19 @@ public class TableBuilder<TModel> : ViewBase, IStateless
 
     public TableBuilder<TModel> Large()
     {
-        _density = Density.Large;
+        _density = Ivy.Density.Large;
         return this;
     }
 
     public TableBuilder<TModel> Small()
     {
-        _density = Density.Small;
+        _density = Ivy.Density.Small;
         return this;
     }
 
     public TableBuilder<TModel> Medium()
     {
-        _density = Density.Medium;
+        _density = Ivy.Density.Medium;
         return this;
     }
 


### PR DESCRIPTION
## Changes

Added a `.Density(Density density)` method to `TableBuilder<TModel>`, making the API consistent with `DataTableBuilder<TModel>` which already has this method. Also fully qualified existing `Density` enum references as `Ivy.Density` to avoid method/type name conflict (matching the DataTableBuilder pattern). Added four unit tests verifying the density behavior.

## API Changes

- `TableBuilder<TModel>.Density(Density density)` — new method that sets the table density directly from a `Density` enum value

## Files Modified

- **src/Ivy/Views/Tables/TableBuilder.cs** — Added `Density(Density)` method
- **src/Ivy.Test/TableBuilderTests.cs** — Added 4 density tests and `GetDensity` helper

## Commits

- `30b601704` — Add Density method to TableBuilder
- `0e65528fe` — Add unit tests for TableBuilder density