### PR TITLE
[01381] Fix ThemeCustomizer initial color mismatch with client theme mode

### DIFF
--- a/src/Ivy.Samples.Shared/Apps/Demos/ThemeCustomizer.cs
+++ b/src/Ivy.Samples.Shared/Apps/Demos/ThemeCustomizer.cs
@@ -13,6 +13,7 @@ public class ThemeCustomizer : SampleBase
         var client = UseService<IClientProvider>();
         var selectedMode = UseState("light"); // "light" or "dark"
         var editingTheme = UseState(CloneTheme(Theme.Default));
+        var initialized = UseState(false);
         var themeQuery = UseQuery(
             key: editingTheme.Value,
             fetcher: async ct =>
@@ -24,6 +25,14 @@ public class ThemeCustomizer : SampleBase
                 await Task.CompletedTask;
                 return true;
             });
+
+        // Synchronize client theme mode on mount so color pickers match the rendered preview
+        if (!initialized.Value)
+        {
+            initialized.Set(true);
+            var mode = selectedMode.Value == "dark" ? ThemeMode.Dark : ThemeMode.Light;
+            client.SetThemeMode(mode);
+        }
 
         void LoadPreset(Theme preset)
         {


### PR DESCRIPTION
## Summary

Added initialization logic to ThemeCustomizer sample app to synchronize the client's theme mode on first render. Uses a `UseState(false)` boolean flag to gate a one-time `client.SetThemeMode()` call, ensuring the browser's theme class matches the sidebar's initial "light" state from the start.

## API Changes

None.

## Files Modified

- **src/Ivy.Samples.Shared/Apps/Demos/ThemeCustomizer.cs** — Added `initialized` state and conditional `SetThemeMode` call after UseQuery block

## Commits

- `fda35e169` — [01381] Fix ThemeCustomizer initial color mismatch with client theme mode