### PR TITLE
[01446] Add Density method to DetailsBuilder

### DIFF
--- a/src/Ivy/Views/Builders/DetailsBuilder.cs
+++ b/src/Ivy/Views/Builders/DetailsBuilder.cs
@@ -103,23 +103,17 @@ public class DetailsBuilder<TModel> : ViewBase, IStateless
         return this;
     }
 
-    public DetailsBuilder<TModel> Large()
+    public DetailsBuilder<TModel> Density(Density density)
     {
-        _density = Density.Large;
+        _density = density;
         return this;
     }
 
-    public DetailsBuilder<TModel> Small()
-    {
-        _density = Density.Small;
-        return this;
-    }
+    public DetailsBuilder<TModel> Large() => Density(Ivy.Density.Large);
 
-    public DetailsBuilder<TModel> Medium()
-    {
-        _density = Density.Medium;
-        return this;
-    }
+    public DetailsBuilder<TModel> Small() => Density(Ivy.Density.Small);
+
+    public DetailsBuilder<TModel> Medium() => Density(Ivy.Density.Medium);
 
     public DetailsBuilder<TModel> Remove(params Expression<Func<TModel, object>>[] fields)
     {

--- a/src/Ivy/Views/Builders/DetailsBuilder.cs
+++ b/src/Ivy/Views/Builders/DetailsBuilder.cs
@@ -47,7 +47,7 @@ public class DetailsBuilder<TModel> : ViewBase, IStateless
     private bool _removeEmpty;
     private readonly Dictionary<string, Item> _items;
     private readonly TModel _model;
-    private Density _density = Density.Medium;
+    private Density _density = Ivy.Density.Medium;
 
     public DetailsBuilder(TModel model)
     {


### PR DESCRIPTION
## Summary

- Added a `Density(Density)` method to `DetailsBuilder<T>` for consistency with all other builder classes that store a `_density` field
- Refactored existing `Small()`, `Medium()`, and `Large()` convenience methods to delegate to the new `Density()` method
- Fully qualified `Density` field initializer to `Ivy.Density.Medium` to resolve CS0119 name conflict

## API Changes

- **Added:** `DetailsBuilder<TModel>.Density(Density density)` — sets the density directly, returns the builder for chaining

## Files Modified

- `src/Ivy/Views/Builders/DetailsBuilder.cs`

## Commits

- `d09673ad1` [01446] Add Density(Density) method to DetailsBuilder<T>
- `170dadfaa` [01446] Fully qualify Density field initializer to fix CS0119