### PR TITLE
[01436] Extract useDialogBlurTracking hook from FileInputWidget

### DIFF
--- a/src/frontend/src/widgets/inputs/FileInputWidget.test.ts
+++ b/src/frontend/src/widgets/inputs/FileInputWidget.test.ts
@@ -45,6 +45,12 @@ describe("FileInputWidget", () => {
     it("should import useEventHandler", () => {
       expect(source).toContain('import { useEventHandler } from "@/components/event-handler"');
     });
+
+    it("should import useDialogBlurTracking from shared", () => {
+      expect(source).toContain(
+        'import { useDialogBlurTracking } from "./shared/useDialogBlurTracking"',
+      );
+    });
   });
 
   describe("handleUploadFile", () => {
@@ -214,19 +220,9 @@ describe("FileInputWidget", () => {
       expect(block).toContain("!disabled && inputRef.current");
     });
 
-    it("should set dialogWasOpenRef when hasBlurHandler is true", () => {
+    it("should call markDialogOpened when hasBlurHandler is true", () => {
       const block = extractBlock("openFileDialog");
-      expect(block).toContain("dialogWasOpenRef.current = true");
-    });
-
-    it("should reset filesSelectedInCurrentDialogRef when hasBlurHandler", () => {
-      const block = extractBlock("openFileDialog");
-      expect(block).toContain("filesSelectedInCurrentDialogRef.current = false");
-    });
-
-    it("should reset blurFiredRef when hasBlurHandler", () => {
-      const block = extractBlock("openFileDialog");
-      expect(block).toContain("blurFiredRef.current = false");
+      expect(block).toContain("markDialogOpened()");
     });
 
     it("should call inputRef.current.click()", () => {
@@ -234,77 +230,44 @@ describe("FileInputWidget", () => {
       expect(block).toContain("inputRef.current.click()");
     });
 
-    it("should include disabled and hasBlurHandler in dependency array", () => {
+    it("should include disabled, hasBlurHandler, and markDialogOpened in dependency array", () => {
       const block = extractBlock("openFileDialog");
-      expect(block).toContain("[disabled, hasBlurHandler]");
+      expect(block).toContain("[disabled, hasBlurHandler, markDialogOpened]");
     });
   });
 
-  describe("window focus blur-tracking useEffect", () => {
-    /**
-     * Helper: extract the useEffect block that contains handleWindowFocus.
-     */
-    function extractUseEffectBlock(): string {
-      const marker = "const handleWindowFocus = ()";
-      const start = source.lastIndexOf("useEffect(", source.indexOf(marker));
-      const depsEnd = "}, [hasBlurHandler, handleEvent, id]);";
-      const deps = source.indexOf(depsEnd, start);
-      return source.slice(start, deps + depsEnd.length);
-    }
-
-    it("should early return when no blur handler", () => {
-      const block = extractUseEffectBlock();
-      expect(block).toContain("if (!hasBlurHandler) return");
+  describe("blur-tracking via useDialogBlurTracking hook", () => {
+    it("should use useDialogBlurTracking hook instead of inline useEffect", () => {
+      expect(source).toContain("useDialogBlurTracking({");
+      // The inline useEffect with handleWindowFocus should no longer exist
+      expect(source).not.toContain("const handleWindowFocus = ()");
     });
 
-    it("should register window focus listener", () => {
-      const block = extractUseEffectBlock();
-      expect(block).toContain('window.addEventListener("focus", handleWindowFocus)');
+    it("should pass enabled: hasBlurHandler to the hook", () => {
+      expect(source).toContain("enabled: hasBlurHandler");
     });
 
-    it("should cleanup by removing listener", () => {
-      const block = extractUseEffectBlock();
-      expect(block).toContain('window.removeEventListener("focus", handleWindowFocus)');
+    it("should pass onBlur callback that fires OnBlur event", () => {
+      expect(source).toContain('onBlur: () => handleEvent("OnBlur", id, [])');
     });
 
-    it("should check dialogWasOpenRef", () => {
-      const block = extractUseEffectBlock();
-      expect(block).toContain("if (dialogWasOpenRef.current)");
+    it("should destructure markDialogOpened, markFilesSelected, markBlurFired from hook", () => {
+      expect(source).toContain("{ markDialogOpened, markFilesSelected, markBlurFired }");
     });
 
-    it("should reset dialogWasOpenRef", () => {
-      const block = extractUseEffectBlock();
-      expect(block).toContain("dialogWasOpenRef.current = false");
+    it("should call markFilesSelected in handleChange when files are selected", () => {
+      const block = extractBlock("handleChange");
+      expect(block).toContain("markFilesSelected()");
     });
 
-    it("should use queueMicrotask for timing", () => {
-      const block = extractUseEffectBlock();
-      expect(block).toContain("queueMicrotask(");
+    it("should call markBlurFired in handleChange after upload", () => {
+      const block = extractBlock("handleChange");
+      expect(block).toContain("markBlurFired()");
     });
 
-    it("should skip blur if files were selected", () => {
-      const block = extractUseEffectBlock();
-      expect(block).toContain("!filesSelectedInCurrentDialogRef.current");
-    });
-
-    it("should skip blur if already fired", () => {
-      const block = extractUseEffectBlock();
-      expect(block).toContain("!blurFiredRef.current");
-    });
-
-    it("should set blurFiredRef on fire", () => {
-      const block = extractUseEffectBlock();
-      expect(block).toContain("blurFiredRef.current = true");
-    });
-
-    it("should fire OnBlur event", () => {
-      const block = extractUseEffectBlock();
-      expect(block).toContain('handleEvent("OnBlur", id, [])');
-    });
-
-    it("should have correct dependency array", () => {
-      const block = extractUseEffectBlock();
-      expect(block).toContain("[hasBlurHandler, handleEvent, id]");
+    it("should include markBlurFired in handleChange dependency array", () => {
+      const block = extractBlock("handleChange");
+      expect(block).toContain("markBlurFired");
     });
   });
 });

--- a/src/frontend/src/widgets/inputs/FileInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/FileInputWidget.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useState, useRef, useEffect } from "react";
+import { useDialogBlurTracking } from "./shared/useDialogBlurTracking";
 import { Input } from "@/components/ui/input";
 import { Upload } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -65,13 +66,15 @@ export const FileInputWidget: React.FC<FileInputWidgetProps> = ({
     cancelUpload: cancelClientUpload,
   } = useUploadWithProgress();
   const inputRef = useRef<HTMLInputElement>(null);
-  const filesSelectedInCurrentDialogRef = useRef(false);
-  const dialogWasOpenRef = useRef(false);
-  const blurFiredRef = useRef(false);
 
   // Be defensive in case events is undefined at runtime
   const hasCancelHandler = Array.isArray(events) && events.includes("OnCancel");
   const hasBlurHandler = Array.isArray(events) && events.includes("OnBlur");
+
+  const { markDialogOpened, markFilesSelected, markBlurFired } = useDialogBlurTracking({
+    enabled: hasBlurHandler,
+    onBlur: () => handleEvent("OnBlur", id, []),
+  });
 
   const handleUploadFile = useCallback(
     async (file: File): Promise<void> => {
@@ -94,24 +97,17 @@ export const FileInputWidget: React.FC<FileInputWidgetProps> = ({
     [uploadUrl, accept, maxFileSize, minFileSize, uploadSingleFile],
   );
 
-  const handleBlur = useCallback(() => {
-    if (hasBlurHandler) {
-      handleEvent("OnBlur", id, []);
-    }
-  }, [hasBlurHandler, handleEvent, id]);
-
   const handleChange = useCallback(
     async (e: React.ChangeEvent<HTMLInputElement>) => {
       const files = e.target.files;
       if (!files || files.length === 0) {
         // No files selected - dialog was likely cancelled
         // Blur will be handled by the window focus event listener
-        filesSelectedInCurrentDialogRef.current = false;
         return;
       }
 
       // Mark that files were selected in this dialog session
-      filesSelectedInCurrentDialogRef.current = true;
+      markFilesSelected();
 
       // Check max files limit (including already uploaded files)
       const currentFileCount = Array.isArray(value) ? value.length : value ? 1 : 0;
@@ -139,41 +135,10 @@ export const FileInputWidget: React.FC<FileInputWidgetProps> = ({
       // Dialog closed after file selection - trigger blur after upload completes
       // This ensures the server state is updated before blur fires
       // Only fire blur if window focus handler hasn't already fired it
-      if (!blurFiredRef.current) {
-        blurFiredRef.current = true;
-        handleBlur();
-      }
+      markBlurFired();
     },
-    [multiple, handleUploadFile, maxFiles, value, handleBlur],
+    [multiple, handleUploadFile, maxFiles, value, markBlurFired],
   );
-
-  // Detect when file dialog closes without selection (cancel case only)
-  useEffect(() => {
-    if (!hasBlurHandler) return;
-
-    const handleWindowFocus = () => {
-      if (dialogWasOpenRef.current) {
-        dialogWasOpenRef.current = false;
-        // Use queueMicrotask to allow onChange to run first
-        // This prevents double blur when files are selected
-        queueMicrotask(() => {
-          // Check if files were actually selected by looking at the flag
-          // If files were selected, blur will be handled by handleChange after upload
-          // Only fire blur if no files were selected (cancel case) and we haven't already fired
-          if (!filesSelectedInCurrentDialogRef.current && !blurFiredRef.current) {
-            blurFiredRef.current = true;
-            handleEvent("OnBlur", id, []);
-          }
-        });
-      }
-    };
-
-    window.addEventListener("focus", handleWindowFocus);
-
-    return () => {
-      window.removeEventListener("focus", handleWindowFocus);
-    };
-  }, [hasBlurHandler, handleEvent, id]);
 
   const handleCancel = useCallback(
     (fileId: string) => {
@@ -255,13 +220,11 @@ export const FileInputWidget: React.FC<FileInputWidgetProps> = ({
   const openFileDialog = useCallback(() => {
     if (!disabled && inputRef.current) {
       if (hasBlurHandler) {
-        dialogWasOpenRef.current = true;
-        filesSelectedInCurrentDialogRef.current = false;
-        blurFiredRef.current = false;
+        markDialogOpened();
       }
       inputRef.current.click();
     }
-  }, [disabled, hasBlurHandler]);
+  }, [disabled, hasBlurHandler, markDialogOpened]);
 
   const hasAutoFocusedRef = useRef(false);
   useEffect(() => {

--- a/src/frontend/src/widgets/inputs/shared/useDialogBlurTracking.test.ts
+++ b/src/frontend/src/widgets/inputs/shared/useDialogBlurTracking.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * Source-analysis tests for the useDialogBlurTracking custom hook.
+ *
+ * Verifies the hook exports, ref management, event listener setup/cleanup,
+ * and microtask usage by inspecting the source code.
+ */
+describe("useDialogBlurTracking", () => {
+  const source = fs.readFileSync(path.resolve(__dirname, "./useDialogBlurTracking.ts"), "utf-8");
+
+  it("should export useDialogBlurTracking function", () => {
+    expect(source).toContain("export function useDialogBlurTracking");
+  });
+
+  it("should contain useRef calls for the three tracking refs", () => {
+    expect(source).toContain("const dialogWasOpenRef = useRef(false)");
+    expect(source).toContain("const filesSelectedInCurrentDialogRef = useRef(false)");
+    expect(source).toContain("const blurFiredRef = useRef(false)");
+  });
+
+  it("should register window.addEventListener('focus', ...) when enabled", () => {
+    expect(source).toContain('window.addEventListener("focus", handleWindowFocus)');
+  });
+
+  it("should remove event listener on cleanup (removeEventListener)", () => {
+    expect(source).toContain('window.removeEventListener("focus", handleWindowFocus)');
+  });
+
+  it("should use queueMicrotask for timing coordination", () => {
+    expect(source).toContain("queueMicrotask(");
+  });
+
+  it("should return markDialogOpened, markFilesSelected, markBlurFired", () => {
+    expect(source).toContain("return { markDialogOpened, markFilesSelected, markBlurFired }");
+  });
+
+  it("should early return when not enabled", () => {
+    expect(source).toContain("if (!enabled) return");
+  });
+
+  it("should check dialogWasOpenRef before handling focus", () => {
+    expect(source).toContain("if (dialogWasOpenRef.current)");
+  });
+
+  it("should reset dialogWasOpenRef on focus", () => {
+    expect(source).toContain("dialogWasOpenRef.current = false");
+  });
+
+  it("should check filesSelectedInCurrentDialogRef and blurFiredRef in microtask", () => {
+    expect(source).toContain("!filesSelectedInCurrentDialogRef.current && !blurFiredRef.current");
+  });
+
+  it("should set blurFiredRef when firing blur", () => {
+    expect(source).toContain("blurFiredRef.current = true");
+  });
+
+  it("should call onBlur callback", () => {
+    expect(source).toContain("onBlur()");
+  });
+
+  describe("markDialogOpened", () => {
+    it("should set dialogWasOpenRef to true", () => {
+      expect(source).toContain("dialogWasOpenRef.current = true");
+    });
+
+    it("should reset filesSelectedInCurrentDialogRef to false", () => {
+      const markDialogOpenedStart = source.indexOf("const markDialogOpened");
+      const markDialogOpenedEnd = source.indexOf("};", markDialogOpenedStart);
+      const block = source.slice(markDialogOpenedStart, markDialogOpenedEnd);
+      expect(block).toContain("filesSelectedInCurrentDialogRef.current = false");
+    });
+
+    it("should reset blurFiredRef to false", () => {
+      const markDialogOpenedStart = source.indexOf("const markDialogOpened");
+      const markDialogOpenedEnd = source.indexOf("};", markDialogOpenedStart);
+      const block = source.slice(markDialogOpenedStart, markDialogOpenedEnd);
+      expect(block).toContain("blurFiredRef.current = false");
+    });
+  });
+
+  describe("markFilesSelected", () => {
+    it("should set filesSelectedInCurrentDialogRef to true", () => {
+      const markFilesSelectedStart = source.indexOf("const markFilesSelected");
+      const markFilesSelectedEnd = source.indexOf("};", markFilesSelectedStart);
+      const block = source.slice(markFilesSelectedStart, markFilesSelectedEnd);
+      expect(block).toContain("filesSelectedInCurrentDialogRef.current = true");
+    });
+  });
+
+  describe("markBlurFired", () => {
+    it("should guard against double-firing with blurFiredRef check", () => {
+      const markBlurFiredStart = source.indexOf("const markBlurFired");
+      const markBlurFiredEnd = source.indexOf("};", markBlurFiredStart);
+      const block = source.slice(markBlurFiredStart, markBlurFiredEnd);
+      expect(block).toContain("if (!blurFiredRef.current)");
+    });
+
+    it("should set blurFiredRef and call onBlur", () => {
+      const markBlurFiredStart = source.indexOf("const markBlurFired");
+      const markBlurFiredEnd = source.indexOf("};", markBlurFiredStart);
+      const block = source.slice(markBlurFiredStart, markBlurFiredEnd);
+      expect(block).toContain("blurFiredRef.current = true");
+      expect(block).toContain("onBlur()");
+    });
+  });
+});

--- a/src/frontend/src/widgets/inputs/shared/useDialogBlurTracking.ts
+++ b/src/frontend/src/widgets/inputs/shared/useDialogBlurTracking.ts
@@ -1,0 +1,68 @@
+import { useRef, useEffect } from "react";
+
+interface UseDialogBlurTrackingOptions {
+  enabled: boolean;
+  onBlur: () => void;
+}
+
+interface UseDialogBlurTrackingResult {
+  markDialogOpened: () => void;
+  markFilesSelected: () => void;
+  markBlurFired: () => void;
+}
+
+export function useDialogBlurTracking({
+  enabled,
+  onBlur,
+}: UseDialogBlurTrackingOptions): UseDialogBlurTrackingResult {
+  const dialogWasOpenRef = useRef(false);
+  const filesSelectedInCurrentDialogRef = useRef(false);
+  const blurFiredRef = useRef(false);
+
+  // Detect when file dialog closes without selection (cancel case only)
+  useEffect(() => {
+    if (!enabled) return;
+
+    const handleWindowFocus = () => {
+      if (dialogWasOpenRef.current) {
+        dialogWasOpenRef.current = false;
+        // Use queueMicrotask to allow onChange to run first
+        // This prevents double blur when files are selected
+        queueMicrotask(() => {
+          // Check if files were actually selected by looking at the flag
+          // If files were selected, blur will be handled by handleChange after upload
+          // Only fire blur if no files were selected (cancel case) and we haven't already fired
+          if (!filesSelectedInCurrentDialogRef.current && !blurFiredRef.current) {
+            blurFiredRef.current = true;
+            onBlur();
+          }
+        });
+      }
+    };
+
+    window.addEventListener("focus", handleWindowFocus);
+
+    return () => {
+      window.removeEventListener("focus", handleWindowFocus);
+    };
+  }, [enabled, onBlur]);
+
+  const markDialogOpened = () => {
+    dialogWasOpenRef.current = true;
+    filesSelectedInCurrentDialogRef.current = false;
+    blurFiredRef.current = false;
+  };
+
+  const markFilesSelected = () => {
+    filesSelectedInCurrentDialogRef.current = true;
+  };
+
+  const markBlurFired = () => {
+    if (!blurFiredRef.current) {
+      blurFiredRef.current = true;
+      onBlur();
+    }
+  };
+
+  return { markDialogOpened, markFilesSelected, markBlurFired };
+}


### PR DESCRIPTION
# Summary

## Changes

Extracted the blur-tracking logic (3 refs + useEffect with window focus listener) from `FileInputWidget.tsx` into a reusable `useDialogBlurTracking` custom hook. The hook encapsulates `dialogWasOpenRef`, `filesSelectedInCurrentDialogRef`, `blurFiredRef`, and the window focus event listener with `queueMicrotask` timing. `FileInputWidget` now consumes the hook via `markDialogOpened()`, `markFilesSelected()`, and `markBlurFired()` functions.

## API Changes

- **New:** `useDialogBlurTracking({ enabled, onBlur })` hook exported from `src/frontend/src/widgets/inputs/shared/useDialogBlurTracking.ts`
  - Returns `{ markDialogOpened, markFilesSelected, markBlurFired }`
- **Removed:** `handleBlur` useCallback from `FileInputWidget` (now handled internally by the hook)
- **Changed:** `openFileDialog` dependency array now includes `markDialogOpened`
- **Changed:** `handleChange` dependency array now includes `markBlurFired` instead of `handleBlur`

## Files Modified

- **New:** `src/frontend/src/widgets/inputs/shared/useDialogBlurTracking.ts` — the extracted custom hook
- **New:** `src/frontend/src/widgets/inputs/shared/useDialogBlurTracking.test.ts` — source-analysis tests for the hook
- **Modified:** `src/frontend/src/widgets/inputs/FileInputWidget.tsx` — replaced inline refs/useEffect with hook consumption
- **Modified:** `src/frontend/src/widgets/inputs/FileInputWidget.test.ts` — updated tests to verify hook usage instead of inline refs

## Commits

- `33d58ebd6` [01436] Extract useDialogBlurTracking hook from FileInputWidget