### PR TITLE
[01475] Rework AvatarApp with Layout.Tabs

### DIFF
--- a/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/AvatarApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/AvatarApp.cs
@@ -6,6 +6,60 @@ public class AvatarApp : SampleBase
 {
     protected override object? BuildSample()
     {
+        return Layout.Tabs(
+            new Tab("Basic", new AvatarBasicExample()),
+            new Tab("Sizes", new AvatarSizesExample()),
+            new Tab("Colors", new AvatarColorsExample()),
+            new Tab("Team", new AvatarTeamExample()),
+            new Tab("Cards", new AvatarCardsExample())
+        ).Variant(TabsVariant.Content);
+    }
+}
+
+public class AvatarBasicExample : ViewBase
+{
+    public override object? Build()
+    {
+        return Layout.Horizontal()
+            | new Avatar("Niels Bosma", "https://api.images.cat/150/150?1")
+            | new Avatar("Niels Bosma");
+    }
+}
+
+public class AvatarSizesExample : ViewBase
+{
+    public override object? Build()
+    {
+        return Layout.Horizontal()
+            | new Avatar("Small", "https://api.images.cat/150/150?1").Small()
+            | new Avatar("Medium", "https://api.images.cat/150/150?2").Medium()
+            | new Avatar("Large", "https://api.images.cat/150/150?3").Large();
+    }
+}
+
+public class AvatarColorsExample : ViewBase
+{
+    public override object? Build()
+    {
+        return Layout.Vertical()
+            | Text.Muted("When the image fails to load (or is not provided), the fallback uses the specified color.")
+            | Layout.Horizontal()
+                | new Avatar("Primary").Color(Colors.Primary)
+                | new Avatar("Secondary").Color(Colors.Secondary)
+                | new Avatar("Destructive").Color(Colors.Destructive)
+                | new Avatar("Success").Color(Colors.Success)
+                | new Avatar("Warning").Color(Colors.Warning)
+                | new Avatar("Info").Color(Colors.Info)
+                | new Avatar("Blue").Color(Colors.Blue)
+                | new Avatar("Green").Color(Colors.Green)
+                | new Avatar("Pink").Color(Colors.Pink);
+    }
+}
+
+public class AvatarTeamExample : ViewBase
+{
+    public override object? Build()
+    {
         var team = new Dictionary<string, string>
         {
             { "Niels Bosma",    "https://api.images.cat/150/150?1" },
@@ -24,51 +78,26 @@ public class AvatarApp : SampleBase
                       .Title(name);
         }
 
-        return Layout.Vertical()
+        return teamGrid;
+    }
+}
 
-               | Text.H1("Avatar")
-
-               | Text.H2("Basic")
-               | Layout.Horizontal()
-                   | new Avatar("Niels Bosma", "https://api.images.cat/150/150?1")
-                   | new Avatar("Niels Bosma")
-
-               | Text.H2("Sizes")
-               | Layout.Horizontal()
-                   | new Avatar("Small", "https://api.images.cat/150/150?1").Small()
-                   | new Avatar("Medium", "https://api.images.cat/150/150?2").Medium()
-                   | new Avatar("Large", "https://api.images.cat/150/150?3").Large()
-
-               | Text.H2("Colors")
-               | Text.Muted("When the image fails to load (or is not provided), the fallback uses the specified color.")
-               | Layout.Horizontal()
-                   | new Avatar("Primary").Color(Colors.Primary)
-                   | new Avatar("Secondary").Color(Colors.Secondary)
-                   | new Avatar("Destructive").Color(Colors.Destructive)
-                   | new Avatar("Success").Color(Colors.Success)
-                   | new Avatar("Warning").Color(Colors.Warning)
-                   | new Avatar("Info").Color(Colors.Info)
-                   | new Avatar("Blue").Color(Colors.Blue)
-                   | new Avatar("Green").Color(Colors.Green)
-                   | new Avatar("Pink").Color(Colors.Pink)
-
-               | Text.H2("Team")
-               | teamGrid
-
-               | Text.H2("Integration with Cards")
-               | Layout.Horizontal()
-                   | new Card(
-                         new Avatar("Köttbullar", "https://api.images.cat/150/150?7"),
-                         new Button("Add to order"))
-                       .Title("Köttbullar")
-                       .Description("The quintessential Swedish food.")
-                       .Width(Size.Units(100))
-                   | new Card(
-                         new Avatar("Pytt i Panna", "https://api.images.cat/150/150?8"),
-                         new Button("Add to order"))
-                       .Title("Pytt i Panna")
-                       .Description("Hearty hash of potatoes, onions, and meat.")
-                       .Width(Size.Units(100))
-               ;
+public class AvatarCardsExample : ViewBase
+{
+    public override object? Build()
+    {
+        return Layout.Horizontal()
+            | new Card(
+                  new Avatar("Köttbullar", "https://api.images.cat/150/150?7"),
+                  new Button("Add to order"))
+                .Title("Köttbullar")
+                .Description("The quintessential Swedish food.")
+                .Width(Size.Units(100))
+            | new Card(
+                  new Avatar("Pytt i Panna", "https://api.images.cat/150/150?8"),
+                  new Button("Add to order"))
+                .Title("Pytt i Panna")
+                .Description("Hearty hash of potatoes, onions, and meat.")
+                .Width(Size.Units(100));
     }
 }


### PR DESCRIPTION
## Summary

Reworked `AvatarApp` to use the `Layout.Tabs` pattern with `TabsVariant.Content`, replacing the old `Layout.Vertical()` with `Text.H1`/`Text.H2` headings. Extracted each demo section into a separate `ViewBase` subclass (`AvatarBasicExample`, `AvatarSizesExample`, `AvatarColorsExample`, `AvatarTeamExample`, `AvatarCardsExample`), matching the pattern already used by `CalloutApp`, `CodeBlockApp`, `MarkdownApp`, and `TextApp`.

## Files Modified

- `src/Ivy.Samples.Shared/Apps/Widgets/Primitives/AvatarApp.cs` — Replaced monolithic `BuildSample()` with `Layout.Tabs` and five `ViewBase` example classes

## Commits

- e1867e023