### PR TITLE
[01518] Extract shared CreateInputVariants helper to eliminate guard clause duplication in DataBinding classes

### DIFF
--- a/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/BoolInputApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/BoolInputApp.cs
@@ -333,31 +333,13 @@ public class BoolInputDataBinding : ViewBase
         }
     }
 
-    private static object CreateBoolInputVariants(object state)
-    {
-        if (state is not IAnyState anyState)
-            return Text.Block("Not an IAnyState");
-
-        var stateType = anyState.GetStateType();
-        var isNullable = stateType.IsNullableType();
-
-        if (isNullable)
-        {
-            // For nullable states, only show checkbox variant
-            return anyState.ToBoolInput();
-        }
-
-        // For non-nullable states, show all three variants
-        return Layout.Vertical()
-               | anyState.ToBoolInput()
-               | anyState
-                   .ToBoolInput()
-                   .Variant(BoolInputVariant.Switch)
-               | anyState
-                   .ToBoolInput()
-                   .Variant(BoolInputVariant.Toggle)
-                   .Icon(Icons.Star);
-    }
+    private static object CreateBoolInputVariants(object state) =>
+        InputDataBindingHelper.CreateInputVariants(state,
+            anyState => Layout.Vertical()
+                | anyState.ToBoolInput()
+                | anyState.ToBoolInput().Variant(BoolInputVariant.Switch)
+                | anyState.ToBoolInput().Variant(BoolInputVariant.Toggle).Icon(Icons.Star),
+            anyState => anyState.ToBoolInput());
 }
 
 public class BoolInputSizes : ViewBase

--- a/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/CodeInputApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/CodeInputApp.cs
@@ -327,26 +327,13 @@ public class CodeInputDataBindings : ViewBase
         return Layout.Grid().Columns(6) | gridItems.ToArray();
     }
 
-    private static object CreateCodeInputVariants(object state)
-    {
-        if (state is not IAnyState anyState)
-            return Text.Block("Not an IAnyState");
-
-        var stateType = anyState.GetStateType();
-        var isNullable = stateType.IsNullableType();
-
-        if (isNullable)
-        {
-            // For nullable states, show with placeholder
-            return anyState.ToCodeInput().Placeholder("Enter code here...");
-        }
-
-        // For non-nullable states, show all variants
-        return Layout.Vertical()
-               | anyState.ToCodeInput()
-               | anyState.ToCodeInput().Language(Languages.Csharp)
-               | anyState.ToCodeInput().Language(Languages.Csharp).ShowCopyButton();
-    }
+    private static object CreateCodeInputVariants(object state) =>
+        InputDataBindingHelper.CreateInputVariants(state,
+            anyState => Layout.Vertical()
+                | anyState.ToCodeInput()
+                | anyState.ToCodeInput().Language(Languages.Csharp)
+                | anyState.ToCodeInput().Language(Languages.Csharp).ShowCopyButton(),
+            anyState => anyState.ToCodeInput().Placeholder("Enter code here..."));
 
     private object FormatStateValue(string typeName, object? value, bool isNullable)
     {

--- a/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/ColorInputApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/ColorInputApp.cs
@@ -293,26 +293,13 @@ public class ColorInputDataBindings : ViewBase
         return Layout.Grid().Columns(6) | gridItems.ToArray();
     }
 
-    private static object CreateColorInputVariants(object state)
-    {
-        if (state is not IAnyState anyState)
-            return Text.Block("Not an IAnyState");
-
-        var stateType = anyState.GetStateType();
-        var isNullable = stateType.IsNullableType();
-
-        if (isNullable)
-        {
-            // For nullable states, show basic variant
-            return anyState.ToColorInput();
-        }
-
-        // For non-nullable states, show all variants
-        return Layout.Vertical()
-               | anyState.ToColorInput()
-               | anyState.ToColorInput().Placeholder("Select color")
-               | anyState.ToColorInput().Disabled();
-    }
+    private static object CreateColorInputVariants(object state) =>
+        InputDataBindingHelper.CreateInputVariants(state,
+            anyState => Layout.Vertical()
+                | anyState.ToColorInput()
+                | anyState.ToColorInput().Placeholder("Select color")
+                | anyState.ToColorInput().Disabled(),
+            anyState => anyState.ToColorInput());
 
     private static object FormatStateValue(string typeName, object? value, bool isNullable)
     {

--- a/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/InputDataBindingHelper.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/InputDataBindingHelper.cs
@@ -1,0 +1,19 @@
+
+namespace Ivy.Samples.Shared.Apps.Widgets.Inputs;
+
+internal static class InputDataBindingHelper
+{
+    public static object CreateInputVariants(
+        object state,
+        Func<IAnyState, object> nonNullableFactory,
+        Func<IAnyState, object> nullableFactory)
+    {
+        if (state is not IAnyState anyState)
+            return Text.Block("Not an IAnyState");
+
+        var stateType = anyState.GetStateType();
+        var isNullable = stateType.IsNullableType();
+
+        return isNullable ? nullableFactory(anyState) : nonNullableFactory(anyState);
+    }
+}

--- a/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/NumberInputApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/NumberInputApp.cs
@@ -505,17 +505,12 @@ public class NumberInputApp : SampleBase
         }
     }
 
-    private static object CreateNumberInputVariants(object state)
-    {
-        if (state is not IAnyState anyState)
-            return Text.Block("Not an IAnyState");
-
-        var stateType = anyState.GetStateType();
-        var isNullable = stateType.IsNullableType();
-
-        // For both nullable and non-nullable states, show both number input and slider variants
-        return Layout.Vertical()
-               | anyState.ToNumberInput()
-               | anyState.ToSliderInput();
-    }
+    private static object CreateNumberInputVariants(object state) =>
+        InputDataBindingHelper.CreateInputVariants(state,
+            anyState => Layout.Vertical()
+                | anyState.ToNumberInput()
+                | anyState.ToSliderInput(),
+            anyState => Layout.Vertical()
+                | anyState.ToNumberInput()
+                | anyState.ToSliderInput());
 }


### PR DESCRIPTION
## Summary

Created a shared `InputDataBindingHelper.CreateInputVariants` static method that encapsulates the common guard clause pattern (`IAnyState` check, state type extraction, nullable branching) used across multiple `Create*Variants` methods. Replaced four method bodies in BoolInputApp, CodeInputApp, ColorInputApp, and NumberInputApp to delegate to the helper with widget-specific factory lambdas.

## API Changes

- **New:** `InputDataBindingHelper.CreateInputVariants(object state, Func<IAnyState, object> nonNullableFactory, Func<IAnyState, object> nullableFactory)` — internal static helper for sample apps

## Files Modified

- **New:** `src/Ivy.Samples.Shared/Apps/Widgets/Inputs/InputDataBindingHelper.cs` — shared helper class
- **Modified:** `src/Ivy.Samples.Shared/Apps/Widgets/Inputs/BoolInputApp.cs` — replaced `CreateBoolInputVariants` body
- **Modified:** `src/Ivy.Samples.Shared/Apps/Widgets/Inputs/CodeInputApp.cs` — replaced `CreateCodeInputVariants` body
- **Modified:** `src/Ivy.Samples.Shared/Apps/Widgets/Inputs/ColorInputApp.cs` — replaced `CreateColorInputVariants` body
- **Modified:** `src/Ivy.Samples.Shared/Apps/Widgets/Inputs/NumberInputApp.cs` — replaced `CreateNumberInputVariants` body

## Commits

- `ac76c9b6c` — [01518] Extract shared CreateInputVariants helper to eliminate guard clause duplication