### PR TITLE
[01525] Rework CameraInputApp to use Layout.Tabs pattern

### DIFF
--- a/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/CameraInputApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/CameraInputApp.cs
@@ -7,43 +7,14 @@ public class CameraInputApp() : SampleBase
 {
     protected override object? BuildSample()
     {
-        var dummyUpload = UseUpload(
-            (fileUpload, stream, cancellationToken) => System.Threading.Tasks.Task.CompletedTask,
-            defaultContentType: "image/png"
-        );
-
         return Layout.Vertical()
                | Text.H1("Camera Input")
-               | Text.P("Demonstrates the CameraInput widget for capturing photos from the user's webcam/camera.")
-               | Text.H2("Examples")
-               | (Layout.Horizontal()
-                    | new Card(new CameraInputBasic()).Title("Basic")
-                    | new Card(new CameraInputEvents()).Title("OnFocus / OnBlur")
-                    | new Card(new CameraInputDisabledState()).Title("Disabled State"))
-               | Text.H2("Validation")
-               | new CameraInput(dummyUpload.Value, "Take a photo")
-                   .Invalid("Camera input is invalid")
-               | Text.H2("Sizes")
-               | CreateSizesSection(dummyUpload.Value);
-    }
-
-    private object CreateSizesSection(UploadContext upload)
-    {
-        return Layout.Grid().Columns(4)
-               | Text.Monospaced("Description")
-               | Text.Monospaced("Small")
-               | Text.Monospaced("Medium")
-               | Text.Monospaced("Large")
-
-               | Text.Monospaced("Camera Input")
-               | new CameraInput(upload, "Take a photo").Small()
-               | new CameraInput(upload, "Take a photo")
-               | new CameraInput(upload, "Take a photo").Large()
-
-               | Text.Monospaced("Disabled State")
-               | new CameraInput(upload, "Take a photo", disabled: true).Small()
-               | new CameraInput(upload, "Take a photo", disabled: true)
-               | new CameraInput(upload, "Take a photo", disabled: true).Large();
+               | Layout.Tabs(
+                   new Tab("Examples", new CameraInputBasic()),
+                   new Tab("Validation", new CameraInputValidation()),
+                   new Tab("Sizes", new CameraInputSizes()),
+                   new Tab("Events", new CameraInputEvents())
+               ).Variant(TabsVariant.Content);
     }
 }
 
@@ -91,6 +62,49 @@ public class CameraInputDisabledState : ViewBase
     }
 }
 
+public class CameraInputValidation : ViewBase
+{
+    public override object? Build()
+    {
+        var dummyUpload = UseUpload(
+            (fileUpload, stream, cancellationToken) => System.Threading.Tasks.Task.CompletedTask,
+            defaultContentType: "image/png"
+        );
+
+        return Layout.Vertical().Gap(4)
+               | Text.P("Demonstrates CameraInput with validation error state.")
+               | new CameraInput(dummyUpload.Value, "Take a photo")
+                   .Invalid("Camera input is invalid");
+    }
+}
+
+public class CameraInputSizes : ViewBase
+{
+    public override object? Build()
+    {
+        var dummyUpload = UseUpload(
+            (fileUpload, stream, cancellationToken) => System.Threading.Tasks.Task.CompletedTask,
+            defaultContentType: "image/png"
+        );
+
+        return Layout.Grid().Columns(4)
+               | Text.Monospaced("Description")
+               | Text.Monospaced("Small")
+               | Text.Monospaced("Medium")
+               | Text.Monospaced("Large")
+
+               | Text.Monospaced("Camera Input")
+               | new CameraInput(dummyUpload.Value, "Take a photo").Small()
+               | new CameraInput(dummyUpload.Value, "Take a photo")
+               | new CameraInput(dummyUpload.Value, "Take a photo").Large()
+
+               | Text.Monospaced("Disabled State")
+               | new CameraInput(dummyUpload.Value, "Take a photo", disabled: true).Small()
+               | new CameraInput(dummyUpload.Value, "Take a photo", disabled: true)
+               | new CameraInput(dummyUpload.Value, "Take a photo", disabled: true).Large();
+    }
+}
+
 public class CameraInputEvents : ViewBase
 {
     public override object? Build()
@@ -124,4 +138,3 @@ public class CameraInputEvents : ViewBase
                | Text.P($"Last event: {lastEvent.Value ?? "—"}").Small();
     }
 }
-


### PR DESCRIPTION
## Changes

Refactored `CameraInputApp.cs` to replace the flat `Layout.Vertical()` with H2 headings with a `Layout.Tabs(...).Variant(TabsVariant.Content)` pattern, matching other input sample apps like BoolInputApp. Created new `CameraInputValidation` and `CameraInputSizes` ViewBase classes extracted from the inline sections, and reorganized existing `CameraInputBasic` and `CameraInputEvents` into dedicated tabs.

## API Changes

None.

## Files Modified

- `src/Ivy.Samples.Shared/Apps/Widgets/Inputs/CameraInputApp.cs` — Replaced `BuildSample()` flat layout with tabs; added `CameraInputValidation` and `CameraInputSizes` classes; removed `CreateSizesSection` private method.

## Commits

- `73d026beb` — [01525] Rework CameraInputApp to use Layout.Tabs pattern