### PR TITLE
[01532] Rework SignatureInputApp to use Layout.Tabs pattern

### DIFF
--- a/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/SignatureInputApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/SignatureInputApp.cs
@@ -8,15 +8,12 @@ public class SignatureInputApp : SampleBase
     {
         return Layout.Vertical()
                | Text.H1("Signature Input")
-               | Text.H2("Basic Signature")
-               | new SignatureInputBasic()
-               | Text.H2("Custom Styling")
-               | new SignatureInputStyling()
-               | Text.H2("States")
-               | new SignatureInputStates()
-               | Text.H2("Events")
-               | new SignatureInputEvents()
-            ;
+               | Layout.Tabs(
+                   new Tab("Basic", new SignatureInputBasic()),
+                   new Tab("Custom Styling", new SignatureInputStyling()),
+                   new Tab("States", new SignatureInputStates()),
+                   new Tab("Events", new SignatureInputEvents())
+               ).Variant(TabsVariant.Content);
     }
 }
 


### PR DESCRIPTION
## Changes

Replaced the flat `Layout.Vertical()` with H2 section headings in `SignatureInputApp.BuildSample()` with a `Layout.Tabs(...).Variant(TabsVariant.Content)` pattern. Each existing ViewBase helper class (SignatureInputBasic, SignatureInputStyling, SignatureInputStates, SignatureInputEvents) is now wrapped in a `Tab` instance. All helper classes remain unchanged.

## API Changes

None.

## Files Modified

- **src/Ivy.Samples.Shared/Apps/Widgets/Inputs/SignatureInputApp.cs** — Replaced `BuildSample()` body to use `Layout.Tabs` with four tabs instead of H2-separated sections.

## Commits

- a23108c45 [01532] Rework SignatureInputApp to use Layout.Tabs pattern