### PR TITLE
[01516] Extend builder convention test pattern to density, padding, and gap

### DIFF
--- a/src/Ivy.Tests/Views/DetailsBuilderDensityTests.cs
+++ b/src/Ivy.Tests/Views/DetailsBuilderDensityTests.cs
@@ -1,0 +1,50 @@
+using Ivy.Views.Builders;
+
+namespace Ivy.Tests.Views;
+
+public class DetailsBuilderDensityTests
+{
+    private class TestModel
+    {
+        public string Name { get; set; } = string.Empty;
+        public int Age { get; set; }
+    }
+
+    private static Density GetDensity<T>(DetailsBuilder<T> builder)
+    {
+        var flags = System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance;
+        var field = builder.GetType().GetField("_density", flags)!;
+        return (Density)field.GetValue(builder)!;
+    }
+
+    [Fact]
+    public void Density_DefaultsToMedium()
+    {
+        var builder = new DetailsBuilder<TestModel>(new TestModel());
+        Assert.Equal(Density.Medium, GetDensity(builder));
+    }
+
+    [Fact]
+    public void Density_SetsValue()
+    {
+        var builder = new DetailsBuilder<TestModel>(new TestModel());
+        builder.Density(Density.Small);
+        Assert.Equal(Density.Small, GetDensity(builder));
+    }
+
+    [Fact]
+    public void Small_SetsDensityToSmall()
+    {
+        var builder = new DetailsBuilder<TestModel>(new TestModel());
+        builder.Small();
+        Assert.Equal(Density.Small, GetDensity(builder));
+    }
+
+    [Fact]
+    public void Large_SetsDensityToLarge()
+    {
+        var builder = new DetailsBuilder<TestModel>(new TestModel());
+        builder.Large();
+        Assert.Equal(Density.Large, GetDensity(builder));
+    }
+}

--- a/src/Ivy.Tests/Views/FormBuilderDensityTests.cs
+++ b/src/Ivy.Tests/Views/FormBuilderDensityTests.cs
@@ -1,0 +1,56 @@
+using Ivy.Core.Hooks;
+
+namespace Ivy.Tests.Views;
+
+public class FormBuilderDensityTests
+{
+    private class TestModel
+    {
+        public string Name { get; set; } = string.Empty;
+        public int Age { get; set; }
+    }
+
+    private static Density GetDensity<T>(FormBuilder<T> builder)
+    {
+        var flags = System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance;
+        var field = builder.GetType().GetField("_density", flags)!;
+        return (Density)field.GetValue(builder)!;
+    }
+
+    private static FormBuilder<TestModel> CreateBuilder()
+    {
+        var state = new State<TestModel>(new TestModel());
+        return new FormBuilder<TestModel>(state);
+    }
+
+    [Fact]
+    public void Density_DefaultsToMedium()
+    {
+        var builder = CreateBuilder();
+        Assert.Equal(Density.Medium, GetDensity(builder));
+    }
+
+    [Fact]
+    public void Density_SetsValue()
+    {
+        var builder = CreateBuilder();
+        builder.Density(Density.Small);
+        Assert.Equal(Density.Small, GetDensity(builder));
+    }
+
+    [Fact]
+    public void Small_SetsDensityToSmall()
+    {
+        var builder = CreateBuilder();
+        builder.Small();
+        Assert.Equal(Density.Small, GetDensity(builder));
+    }
+
+    [Fact]
+    public void Large_SetsDensityToLarge()
+    {
+        var builder = CreateBuilder();
+        builder.Large();
+        Assert.Equal(Density.Large, GetDensity(builder));
+    }
+}

--- a/src/Ivy.Tests/Views/GridViewConventionTests.cs
+++ b/src/Ivy.Tests/Views/GridViewConventionTests.cs
@@ -1,0 +1,60 @@
+namespace Ivy.Tests.Views;
+
+public class GridViewConventionTests
+{
+    private static object GetDefinition(GridView view)
+    {
+        var flags = System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance;
+        var field = view.GetType().GetField("_definition", flags)!;
+        return field.GetValue(view)!;
+    }
+
+    private static int GetRowGap(GridView view)
+    {
+        var def = GetDefinition(view);
+        return (int)def.GetType().GetProperty("RowGap")!.GetValue(def)!;
+    }
+
+    private static int GetColumnGap(GridView view)
+    {
+        var def = GetDefinition(view);
+        return (int)def.GetType().GetProperty("ColumnGap")!.GetValue(def)!;
+    }
+
+    private static Thickness GetPadding(GridView view)
+    {
+        var def = GetDefinition(view);
+        return (Thickness)def.GetType().GetProperty("Padding")!.GetValue(def)!;
+    }
+
+    [Fact]
+    public void Gap_SetsRowAndColumnGap()
+    {
+        var view = Layout.Grid("item1").Gap(8);
+        Assert.Equal(8, GetRowGap(view));
+        Assert.Equal(8, GetColumnGap(view));
+    }
+
+    [Fact]
+    public void RowGap_SetsOnlyRowGap()
+    {
+        var view = Layout.Grid("item1").RowGap(6);
+        Assert.Equal(6, GetRowGap(view));
+        Assert.Equal(4, GetColumnGap(view));
+    }
+
+    [Fact]
+    public void ColumnGap_SetsOnlyColumnGap()
+    {
+        var view = Layout.Grid("item1").ColumnGap(6);
+        Assert.Equal(4, GetRowGap(view));
+        Assert.Equal(6, GetColumnGap(view));
+    }
+
+    [Fact]
+    public void Padding_SetsDefinitionPadding()
+    {
+        var view = Layout.Grid("item1").Padding(4);
+        Assert.Equal(new Thickness(4), GetPadding(view));
+    }
+}

--- a/src/Ivy.Tests/Views/LayoutViewGapTests.cs
+++ b/src/Ivy.Tests/Views/LayoutViewGapTests.cs
@@ -1,0 +1,50 @@
+namespace Ivy.Tests.Views;
+
+public class LayoutViewGapTests
+{
+    private static int GetRowGap(LayoutView view)
+    {
+        var flags = System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance;
+        var field = view.GetType().GetField("_rowGap", flags)!;
+        return (int)field.GetValue(view)!;
+    }
+
+    private static int GetColumnGap(LayoutView view)
+    {
+        var flags = System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance;
+        var field = view.GetType().GetField("_columnGap", flags)!;
+        return (int)field.GetValue(view)!;
+    }
+
+    [Fact]
+    public void Gap_DefaultsTo4()
+    {
+        var view = Layout.Horizontal();
+        Assert.Equal(4, GetRowGap(view));
+        Assert.Equal(4, GetColumnGap(view));
+    }
+
+    [Fact]
+    public void Gap_Int_SetsBoth()
+    {
+        var view = Layout.Horizontal().Gap(8);
+        Assert.Equal(8, GetRowGap(view));
+        Assert.Equal(8, GetColumnGap(view));
+    }
+
+    [Fact]
+    public void Gap_TwoInts_SetsSeparately()
+    {
+        var view = Layout.Horizontal().Gap(2, 6);
+        Assert.Equal(2, GetRowGap(view));
+        Assert.Equal(6, GetColumnGap(view));
+    }
+
+    [Fact]
+    public void Gap_BoolFalse_SetsToZero()
+    {
+        var view = Layout.Horizontal().Gap(false);
+        Assert.Equal(0, GetRowGap(view));
+        Assert.Equal(0, GetColumnGap(view));
+    }
+}

--- a/src/Ivy.Tests/Views/LayoutViewPaddingTests.cs
+++ b/src/Ivy.Tests/Views/LayoutViewPaddingTests.cs
@@ -1,0 +1,39 @@
+namespace Ivy.Tests.Views;
+
+public class LayoutViewPaddingTests
+{
+    private static Thickness? GetPadding(LayoutView view)
+    {
+        var flags = System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance;
+        var field = view.GetType().GetField("_padding", flags)!;
+        return (Thickness?)field.GetValue(view);
+    }
+
+    [Fact]
+    public void Padding_DefaultsToNull()
+    {
+        var view = Layout.Horizontal();
+        Assert.Null(GetPadding(view));
+    }
+
+    [Fact]
+    public void Padding_Int_SetsUniform()
+    {
+        var view = Layout.Horizontal().Padding(8);
+        Assert.Equal(new Thickness(8), GetPadding(view));
+    }
+
+    [Fact]
+    public void Padding_HorizontalVertical_SetsCorrectly()
+    {
+        var view = Layout.Horizontal().Padding(4, 8);
+        Assert.Equal(new Thickness(4, 8), GetPadding(view));
+    }
+
+    [Fact]
+    public void Padding_FourSided_SetsCorrectly()
+    {
+        var view = Layout.Horizontal().Padding(1, 2, 3, 4);
+        Assert.Equal(new Thickness(1, 2, 3, 4), GetPadding(view));
+    }
+}

--- a/src/Ivy.Tests/Views/RichTextBuilderDensityTests.cs
+++ b/src/Ivy.Tests/Views/RichTextBuilderDensityTests.cs
@@ -1,0 +1,42 @@
+namespace Ivy.Tests.Views;
+
+public class RichTextBuilderDensityTests
+{
+    private static Density? GetDensity(RichTextBuilder builder)
+    {
+        var flags = System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance;
+        var field = builder.GetType().GetField("_density", flags)!;
+        return (Density?)field.GetValue(builder);
+    }
+
+    [Fact]
+    public void Density_DefaultsToNull()
+    {
+        var builder = Text.Rich();
+        Assert.Null(GetDensity(builder));
+    }
+
+    [Fact]
+    public void Density_SetsValue()
+    {
+        var builder = Text.Rich();
+        builder.Density(Density.Small);
+        Assert.Equal(Density.Small, GetDensity(builder));
+    }
+
+    [Fact]
+    public void Small_SetsDensityToSmall()
+    {
+        var builder = Text.Rich();
+        builder.Small();
+        Assert.Equal(Density.Small, GetDensity(builder));
+    }
+
+    [Fact]
+    public void Large_SetsDensityToLarge()
+    {
+        var builder = Text.Rich();
+        builder.Large();
+        Assert.Equal(Density.Large, GetDensity(builder));
+    }
+}

--- a/src/Ivy.Tests/Views/TabViewPaddingTests.cs
+++ b/src/Ivy.Tests/Views/TabViewPaddingTests.cs
@@ -1,0 +1,39 @@
+namespace Ivy.Tests.Views;
+
+public class TabViewPaddingTests
+{
+    private static Thickness? GetPadding(TabView view)
+    {
+        var flags = System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance;
+        var field = view.GetType().GetField("_padding", flags)!;
+        return (Thickness?)field.GetValue(view);
+    }
+
+    [Fact]
+    public void Padding_DefaultsToThickness4()
+    {
+        var view = Layout.Tabs(new Tab("t1", "content"));
+        Assert.Equal(new Thickness(4), GetPadding(view));
+    }
+
+    [Fact]
+    public void Padding_Int_SetsUniform()
+    {
+        var view = Layout.Tabs(new Tab("t1", "content")).Padding(8);
+        Assert.Equal(new Thickness(8), GetPadding(view));
+    }
+
+    [Fact]
+    public void Padding_HorizontalVertical_SetsCorrectly()
+    {
+        var view = Layout.Tabs(new Tab("t1", "content")).Padding(4, 8);
+        Assert.Equal(new Thickness(4, 8), GetPadding(view));
+    }
+
+    [Fact]
+    public void Padding_FourSided_SetsCorrectly()
+    {
+        var view = Layout.Tabs(new Tab("t1", "content")).Padding(1, 2, 3, 4);
+        Assert.Equal(new Thickness(1, 2, 3, 4), GetPadding(view));
+    }
+}

--- a/src/Ivy.Tests/Views/TextBuilderDensityTests.cs
+++ b/src/Ivy.Tests/Views/TextBuilderDensityTests.cs
@@ -1,0 +1,42 @@
+namespace Ivy.Tests.Views;
+
+public class TextBuilderDensityTests
+{
+    private static Density? GetDensity(TextBuilder builder)
+    {
+        var flags = System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance;
+        var field = builder.GetType().GetField("_density", flags)!;
+        return (Density?)field.GetValue(builder);
+    }
+
+    [Fact]
+    public void Density_DefaultsToNull()
+    {
+        var builder = Text.P("test");
+        Assert.Null(GetDensity(builder));
+    }
+
+    [Fact]
+    public void Density_SetsValue()
+    {
+        var builder = Text.P("test");
+        builder.Density(Density.Small);
+        Assert.Equal(Density.Small, GetDensity(builder));
+    }
+
+    [Fact]
+    public void Small_SetsDensityToSmall()
+    {
+        var builder = Text.P("test");
+        builder.Small();
+        Assert.Equal(Density.Small, GetDensity(builder));
+    }
+
+    [Fact]
+    public void Large_SetsDensityToLarge()
+    {
+        var builder = Text.P("test");
+        builder.Large();
+        Assert.Equal(Density.Large, GetDensity(builder));
+    }
+}


### PR DESCRIPTION
## Summary

Added 8 new test files with 32 test methods covering builder convention patterns for density, padding, and gap across FormBuilder, DetailsBuilder, TextBuilder, RichTextBuilder, LayoutView, TabView, and GridView. All tests use the existing reflection-based pattern from TableBuilderTests.

## API Changes

None.

## Files Modified

- **Density convention tests:**
  - `src/Ivy.Tests/Views/FormBuilderDensityTests.cs` (new) — 4 tests
  - `src/Ivy.Tests/Views/DetailsBuilderDensityTests.cs` (new) — 4 tests
  - `src/Ivy.Tests/Views/TextBuilderDensityTests.cs` (new) — 4 tests (nullable density)
  - `src/Ivy.Tests/Views/RichTextBuilderDensityTests.cs` (new) — 4 tests (nullable density)

- **Padding convention tests:**
  - `src/Ivy.Tests/Views/LayoutViewPaddingTests.cs` (new) — 4 tests
  - `src/Ivy.Tests/Views/TabViewPaddingTests.cs` (new) — 4 tests
  - `src/Ivy.Tests/Views/GridViewConventionTests.cs` (new) — 4 tests (gap + padding)

- **Gap convention tests:**
  - `src/Ivy.Tests/Views/LayoutViewGapTests.cs` (new) — 4 tests

## Commits

- `6373a6ce2` [01516] Add convention tests for density, padding, and gap builders