### PR TITLE
[01548] Fix DateRangeInputApp H1 typo

### DIFF
--- a/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/DateRangeInputApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/DateRangeInputApp.cs
@@ -97,7 +97,7 @@ public class DateRangeInputApp : SampleBase
                 .TestId("daterange-input-min-max-example");
 
         return Layout.Vertical()
-            | Text.H1("DateRang Input")
+            | Text.H1("DateRange Input")
             | Text.H2("Size Examples")
             | sizeExamplesGrid
             | Text.H2("Variants")


### PR DESCRIPTION
# Summary

## Changes

Fixed a typo in the DateRangeInputApp sample app where the H1 heading read "DateRang Input" instead of "DateRange Input" (missing 'e' in Range).

## API Changes

None.

## Files Modified

- `src/Ivy.Samples.Shared/Apps/Widgets/Inputs/DateRangeInputApp.cs` — Fixed H1 text string typo on line 100

## Commits

- c0aa8ace4 — [01548] Fix DateRangeInputApp H1 typo: 'DateRang' -> 'DateRange'