### PR TITLE
[01521] Make PaginationContent gap density-aware

### DIFF
--- a/src/frontend/src/components/ui/pagination-variant.ts
+++ b/src/frontend/src/components/ui/pagination-variant.ts
@@ -1,0 +1,14 @@
+import { cva } from "class-variance-authority";
+
+export const paginationContentVariant = cva("flex flex-row items-center", {
+  variants: {
+    density: {
+      Small: "gap-0.5",
+      Medium: "gap-1",
+      Large: "gap-1.5",
+    },
+  },
+  defaultVariants: {
+    density: "Medium",
+  },
+});

--- a/src/frontend/src/components/ui/pagination.tsx
+++ b/src/frontend/src/components/ui/pagination.tsx
@@ -1,20 +1,23 @@
 import * as React from "react";
 import { ChevronLeft, ChevronRight, MoreHorizontal } from "lucide-react";
 
+import { type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 import { ButtonProps } from "@/components/ui/button/button";
 import { buttonVariant } from "@/components/ui/button";
+import { paginationContentVariant } from "@/components/ui/pagination-variant";
 
 const Pagination = ({ className, ...props }: React.ComponentProps<"nav">) => (
   <nav aria-label="pagination" className={cn("flex w-fit justify-center", className)} {...props} />
 );
 Pagination.displayName = "Pagination";
 
-const PaginationContent = React.forwardRef<HTMLUListElement, React.ComponentProps<"ul">>(
-  ({ className, ...props }, ref) => (
-    <ul ref={ref} className={cn("flex flex-row items-center gap-1", className)} {...props} />
-  ),
-);
+const PaginationContent = React.forwardRef<
+  HTMLUListElement,
+  React.ComponentProps<"ul"> & VariantProps<typeof paginationContentVariant>
+>(({ className, density, ...props }, ref) => (
+  <ul ref={ref} className={cn(paginationContentVariant({ density }), className)} {...props} />
+));
 PaginationContent.displayName = "PaginationContent";
 
 const PaginationItem = React.forwardRef<HTMLLIElement, React.ComponentProps<"li">>(

--- a/src/frontend/src/widgets/pagination/PaginationWidget.tsx
+++ b/src/frontend/src/widgets/pagination/PaginationWidget.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/pagination";
 import { useEventHandler } from "@/components/event-handler";
 import { cn } from "@/lib/utils";
+import { Densities } from "@/types/density";
 
 interface PaginationWidgetProps {
   id: string;
@@ -18,6 +19,7 @@ interface PaginationWidgetProps {
   siblings?: number;
   boundaries?: number;
   disabled?: boolean;
+  density?: Densities;
 }
 
 export const PaginationWidget: React.FC<PaginationWidgetProps> = ({
@@ -27,6 +29,7 @@ export const PaginationWidget: React.FC<PaginationWidgetProps> = ({
   siblings = 1,
   boundaries = 1,
   disabled = false,
+  density = Densities.Medium,
 }) => {
   const eventHandler = useEventHandler();
 
@@ -54,7 +57,7 @@ export const PaginationWidget: React.FC<PaginationWidgetProps> = ({
 
   return (
     <Pagination>
-      <PaginationContent>
+      <PaginationContent density={density}>
         <PaginationItem>
           <PaginationPrevious
             aria-disabled={disabled || !page || page === 1}


### PR DESCRIPTION
## Summary

Added density-aware gap styling to the `PaginationContent` component using the CVA variant pattern. The gap between pagination items now scales with density: `gap-0.5` for Small, `gap-1` for Medium, and `gap-1.5` for Large. The `PaginationWidget` forwards the `density` prop to the UI component.

## API Changes

- New file `pagination-variant.ts` exporting `paginationContentVariant` CVA variant
- `PaginationContent` component now accepts an optional `density` prop (via `VariantProps`)
- `PaginationWidget` component now accepts an optional `density?: Densities` prop (defaults to `Densities.Medium`)

## Files Modified

- **New:** `src/frontend/src/components/ui/pagination-variant.ts` — CVA variant definition for pagination content gap
- **Modified:** `src/frontend/src/components/ui/pagination.tsx` — Added density prop to `PaginationContent`
- **Modified:** `src/frontend/src/widgets/pagination/PaginationWidget.tsx` — Added density prop forwarding

## Commits

- `8552d6e26` [01521] Make PaginationContent gap density-aware