### PR TITLE
[01542] Add States tab to CameraInputApp

### DIFF
--- a/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/CameraInputApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/CameraInputApp.cs
@@ -11,6 +11,7 @@ public class CameraInputApp() : SampleBase
                | Text.H1("Camera Input")
                | Layout.Tabs(
                    new Tab("Examples", new CameraInputBasic()),
+                   new Tab("States", new CameraInputStates()),
                    new Tab("Validation", new CameraInputValidation()),
                    new Tab("Sizes", new CameraInputSizes()),
                    new Tab("Events", new CameraInputEvents())
@@ -47,7 +48,7 @@ public class CameraInputBasic : ViewBase
     }
 }
 
-public class CameraInputDisabledState : ViewBase
+public class CameraInputStates : ViewBase
 {
     public override object? Build()
     {
@@ -56,9 +57,16 @@ public class CameraInputDisabledState : ViewBase
             defaultContentType: "image/png"
         );
 
-        return Layout.Vertical()
-               | Text.P("Demonstrates the CameraInput widget in a disabled state. The camera cannot be activated.")
-               | new CameraInput(dummyUpload.Value, "Take a photo", disabled: true);
+        return Layout.Grid().Columns(4)
+               | Text.Monospaced("Description")
+               | Text.Monospaced("Default")
+               | Text.Monospaced("Disabled")
+               | Text.Monospaced("Invalid")
+
+               | Text.Monospaced("Camera Input")
+               | new CameraInput(dummyUpload.Value, "Take a photo")
+               | new CameraInput(dummyUpload.Value, "Take a photo", disabled: true)
+               | new CameraInput(dummyUpload.Value, "Take a photo").Invalid("Camera input is required");
     }
 }
 


### PR DESCRIPTION
## Summary

Replaced the orphaned `CameraInputDisabledState` ViewBase class with a new `CameraInputStates` class that demonstrates all CameraInput widget states (default, disabled, invalid) in a 4-column grid layout. Added a "States" tab to the `Layout.Tabs` call in `CameraInputApp.BuildSample()`.

## Files Modified

- **src/Ivy.Samples.Shared/Apps/Widgets/Inputs/CameraInputApp.cs** — Replaced `CameraInputDisabledState` with `CameraInputStates` grid; added "States" tab to tabs layout.

## Commits

- `3202609a3` — [01542] Add States tab to CameraInputApp with default/disabled/invalid grid