### PR TITLE
[01540] Rework FieldApp and DictationApp to use Layout.Tabs pattern

### DIFF
--- a/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/DictationApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/DictationApp.cs
@@ -5,17 +5,34 @@ public class DictationApp : SampleBase
 {
     protected override object? BuildSample()
     {
+        return Layout.Tabs(
+            new Tab("Basic", new DictationBasicSample()),
+            new Tab("Multiline", new DictationMultilineSample())
+        ).Variant(TabsVariant.Content);
+    }
+}
+
+public class DictationBasicSample : ViewBase
+{
+    public override object? Build()
+    {
         var text = UseState("");
+
+        return Layout.Vertical()
+            | Text.P("TextInput with speech-to-text dictation. Click the microphone icon to start recording, click again to stop. The audio is sent to the server for transcription and the result is appended to the input.")
+            | text.ToTextInput().Placeholder("Click mic to dictate...").EnableDictation()
+            | Text.Muted($"Value: {text.Value}");
+    }
+}
+
+public class DictationMultilineSample : ViewBase
+{
+    public override object? Build()
+    {
         var multilineText = UseState("");
 
         return Layout.Vertical()
-               | Text.H1("Dictation")
-               | Text.P("TextInput with speech-to-text dictation. Click the microphone icon to start recording, click again to stop. The audio is sent to the server for transcription and the result is appended to the input.")
-               | Text.H2("Basic Dictation")
-               | text.ToTextInput().Placeholder("Click mic to dictate...").EnableDictation()
-               | Text.Muted($"Value: {text.Value}")
-               | Text.H2("Multiline Dictation")
-               | multilineText.ToTextareaInput().Placeholder("Dictate into a textarea...").EnableDictation()
-               | Text.Muted($"Value: {multilineText.Value}");
+            | multilineText.ToTextareaInput().Placeholder("Dictate into a textarea...").EnableDictation()
+            | Text.Muted($"Value: {multilineText.Value}");
     }
 }

--- a/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/FieldApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/FieldApp.cs
@@ -5,6 +5,18 @@ public class FieldApp : SampleBase
 {
     protected override object? BuildSample()
     {
+        return Layout.Tabs(
+            new Tab("Field", new FieldBasicSample()),
+            new Tab("Horizontal Labels", new FieldHorizontalLabelsSample()),
+            new Tab("Events", new FieldEventsSample())
+        ).Variant(TabsVariant.Content);
+    }
+}
+
+public class FieldBasicSample : ViewBase
+{
+    public override object? Build()
+    {
         var nameState = UseState<string>();
         var emailState = UseState<string>();
         var passwordState = UseState<string>();
@@ -12,105 +24,112 @@ public class FieldApp : SampleBase
         var addressState = UseState<string>();
         var disabledState = UseState("Disabled value");
         var invalidState = UseState("abc");
+        var options = new List<string>() { "I read the terms and conditions and I agree" };
+
+        return Layout.Vertical().Gap(6).Padding(2)
+            // Explicit Field
+            | new Field(
+                nameState.ToTextInput()
+                    .Placeholder("Enter your name")
+            )
+            .Label("Name")
+            .Description("Your full name")
+            .Required()
+
+            // Using .WithField() shortcut with help text
+            | emailState.ToTextInput()
+                .Placeholder("Enter your email")
+                .WithField()
+                .Label("Email")
+                .Description("Required for contact")
+                .Help("We will never share your email with third parties")
+                .Required()
+
+            // Password field, disabled if name is empty, with help text
+            | passwordState.ToPasswordInput()
+                .Placeholder("Enter password")
+                .Disabled(string.IsNullOrWhiteSpace(nameState.Value))
+                .WithField()
+                .Label("Password")
+                .Description("At least 8 characters")
+                .Help("Use a mix of letters, numbers, and symbols for better security")
+
+            // Checkbox wrapped with .WithField()
+            | acceptedTerms.ToSelectInput(options.ToOptions())
+                            .Variant(SelectInputVariant.List)
+                .WithField()
+                .Label("Accept Terms & Conditions")
+                .Description("You must accept to continue")
+                .Required()
+
+            // TextArea input using .WithField()
+            | addressState.ToTextareaInput()
+                .Placeholder("Street, City, ZIP")
+                .WithField()
+                .Label("Address")
+                .Description("Your mailing address")
+
+            // Disabled TextInput
+            | disabledState.ToTextInput()
+                .Disabled()
+                .WithField()
+                .Label("Disabled Field")
+                .Description("This field is disabled")
+
+            // Invalid example
+            | invalidState.ToTextInput()
+                .Invalid("Must be numeric")
+                .WithField()
+                .Label("Invalid Example");
+    }
+}
+
+public class FieldHorizontalLabelsSample : ViewBase
+{
+    public override object? Build()
+    {
+        var emailState = UseState<string>();
+        var passwordState = UseState<string>();
+
+        return Layout.Vertical().Gap(6).Padding(2)
+            // Horizontal label using .LabelPosition
+            | emailState.ToTextInput()
+                .Variant(TextInputVariant.Email)
+                .WithField()
+                .Label("Work Email")
+                .LabelPosition(LabelPosition.Left)
+                .Description("We'll send updates here")
+                .Required()
+
+            // Horizontal password field
+            | passwordState.ToPasswordInput()
+                .WithField()
+                .Label("App Password")
+                .LabelPosition(LabelPosition.Left);
+    }
+}
+
+public class FieldEventsSample : ViewBase
+{
+    public override object? Build()
+    {
         var eventsState = UseState<string>();
         var eventsOnBlurLabel = UseState("");
         var eventsOnFocusLabel = UseState("");
-        var options = new List<string>() { "I read the terms and conditions and I agree" };
 
-        return Layout.Vertical().Center()
-            | Text.H1("Field")
-            | (new Card(
-                Layout.Vertical().Gap(6).Padding(2)
-                | Text.H2("Field")
-
-                // Explicit Field
-                | new Field(
-                    nameState.ToTextInput()
-                        .Placeholder("Enter your name")
-                )
-                .Label("Name")
-                .Description("Your full name")
-                .Required()
-
-                // Using .WithField() shortcut with help text
-                | emailState.ToTextInput()
-                    .Placeholder("Enter your email")
-                    .WithField()
-                    .Label("Email")
-                    .Description("Required for contact")
-                    .Help("We will never share your email with third parties")
-                    .Required()
-
-                // Password field, disabled if name is empty, with help text
-                | passwordState.ToPasswordInput()
-                    .Placeholder("Enter password")
-                    .Disabled(string.IsNullOrWhiteSpace(nameState.Value))
-                    .WithField()
-                    .Label("Password")
-                    .Description("At least 8 characters")
-                    .Help("Use a mix of letters, numbers, and symbols for better security")
-
-                // Checkbox wrapped with .WithField()
-                | acceptedTerms.ToSelectInput(options.ToOptions())
-                                .Variant(SelectInputVariant.List)
-                    .WithField()
-                    .Label("Accept Terms & Conditions")
-                    .Description("You must accept to continue")
-                    .Required()
-
-                // TextArea input using .WithField()
-                | addressState.ToTextareaInput()
-                    .Placeholder("Street, City, ZIP")
-                    .WithField()
-                    .Label("Address")
-                    .Description("Your mailing address")
-
-                // Disabled TextInput
-                | disabledState.ToTextInput()
-                    .Disabled()
-                    .WithField()
-                    .Label("Disabled Field")
-                    .Description("This field is disabled")
-
-                // Invalid example
-                | invalidState.ToTextInput()
-                    .Invalid("Must be numeric")
-                    .WithField()
-                    .Label("Invalid Example")
-
-                | new Spacer().Height(Size.Units(6))
-                | Text.H3("Horizontal Labels")
-
-                // Horizontal label using .LabelPosition
-                | emailState.ToTextInput()
-                    .Variant(TextInputVariant.Email)
-                    .WithField()
-                    .Label("Work Email")
-                    .LabelPosition(LabelPosition.Left)
-                    .Description("We'll send updates here")
-                    .Required()
-
-                // Horizontal password field
-                | passwordState.ToPasswordInput()
-                    .WithField()
-                    .Label("App Password")
-                    .LabelPosition(LabelPosition.Left)
-                    | Text.H3("OnFocus/OnBlur")
-                    | eventsState.ToTextInput()
-                        .Placeholder("Click in, then click away")
-                        .OnFocus(_ => eventsOnFocusLabel.Set("Focus Event Triggered"))
-                        .OnBlur(_ => eventsOnBlurLabel.Set("Blur Event Triggered"))
-                        .WithField()
-                        .Label("Focusable field")
-                        .Description("Use mouse click or tab to trigger events")
-                    | (eventsOnFocusLabel.Value != ""
-                        ? Callout.Success(eventsOnFocusLabel.Value)
-                        : Callout.Info("Focus the field to see OnFocus"))
-                    | (eventsOnBlurLabel.Value != ""
-                        ? Callout.Success(eventsOnBlurLabel.Value)
-                        : Callout.Info("Blur the field to see OnBlur"))
-            )
-            .Width(Size.Units(120).Max(500))
-        );
+        return Layout.Vertical().Gap(6).Padding(2)
+            | eventsState.ToTextInput()
+                .Placeholder("Click in, then click away")
+                .OnFocus(_ => eventsOnFocusLabel.Set("Focus Event Triggered"))
+                .OnBlur(_ => eventsOnBlurLabel.Set("Blur Event Triggered"))
+                .WithField()
+                .Label("Focusable field")
+                .Description("Use mouse click or tab to trigger events")
+            | (eventsOnFocusLabel.Value != ""
+                ? Callout.Success(eventsOnFocusLabel.Value)
+                : Callout.Info("Focus the field to see OnFocus"))
+            | (eventsOnBlurLabel.Value != ""
+                ? Callout.Success(eventsOnBlurLabel.Value)
+                : Callout.Info("Blur the field to see OnBlur"));
     }
 }


### PR DESCRIPTION
## Summary

Refactored `FieldApp.cs` and `DictationApp.cs` to use the `Layout.Tabs` pattern with `TabsVariant.Content`, replacing the flat `Layout.Vertical()` with `Text.H2()` section headings. Each logical section was extracted into its own `ViewBase` subclass.

## Files Modified

- **src/Ivy.Samples.Shared/Apps/Widgets/Inputs/FieldApp.cs** — Replaced monolithic `BuildSample()` with `Layout.Tabs` containing three tabs (Field, Horizontal Labels, Events). Extracted `FieldBasicSample`, `FieldHorizontalLabelsSample`, and `FieldEventsSample` subclasses.
- **src/Ivy.Samples.Shared/Apps/Widgets/Inputs/DictationApp.cs** — Replaced monolithic `BuildSample()` with `Layout.Tabs` containing two tabs (Basic, Multiline). Extracted `DictationBasicSample` and `DictationMultilineSample` subclasses.

## Commits

- `06905fbc4` [01540] Rework FieldApp and DictationApp to use Layout.Tabs pattern