### PR TITLE
[01552] Add multi-arg Padding overloads to GridView

### DIFF
--- a/src/Ivy.Tests/Views/GridViewConventionTests.cs
+++ b/src/Ivy.Tests/Views/GridViewConventionTests.cs
@@ -57,4 +57,18 @@ public class GridViewConventionTests
         var view = Layout.Grid("item1").Padding(4);
         Assert.Equal(new Thickness(4), GetPadding(view));
     }
+
+    [Fact]
+    public void Padding_HorizontalVertical_SetsCorrectly()
+    {
+        var view = Layout.Grid("item1").Padding(4, 8);
+        Assert.Equal(new Thickness(4, 8), GetPadding(view));
+    }
+
+    [Fact]
+    public void Padding_FourSided_SetsCorrectly()
+    {
+        var view = Layout.Grid("item1").Padding(1, 2, 3, 4);
+        Assert.Equal(new Thickness(1, 2, 3, 4), GetPadding(view));
+    }
 }

--- a/src/Ivy/Views/GridView.cs
+++ b/src/Ivy/Views/GridView.cs
@@ -57,6 +57,18 @@ public class GridView : ViewBase, IStateless
         return this;
     }
 
+    public GridView Padding(int horizontal, int vertical)
+    {
+        _definition.Padding = new(horizontal, vertical);
+        return this;
+    }
+
+    public GridView Padding(int left, int top, int right, int bottom)
+    {
+        _definition.Padding = new(left, top, right, bottom);
+        return this;
+    }
+
     public GridView AlignContent(Align align)
     {
         _definition.AlignContent = align;


### PR DESCRIPTION
## Summary

Added `Padding(int horizontal, int vertical)` and `Padding(int left, int top, int right, int bottom)` overloads to `GridView`, bringing it in line with `LayoutView` and `TabsView`. Added corresponding convention tests.

## API Changes

- `GridView.Padding(int horizontal, int vertical)` — new overload setting horizontal/vertical padding
- `GridView.Padding(int left, int top, int right, int bottom)` — new overload setting four-sided padding

## Files Modified

- `src/Ivy/Views/GridView.cs` — added two new `Padding` overloads
- `src/Ivy.Tests/Views/GridViewConventionTests.cs` — added `Padding_HorizontalVertical_SetsCorrectly` and `Padding_FourSided_SetsCorrectly` tests

## Commits

- cc658ca52