### PR TITLE
[01557] Reclassify simple Widgets as Primitives

### DIFF
--- a/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/BadgeApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/BadgeApp.cs
@@ -1,4 +1,4 @@
-namespace Ivy.Samples.Shared.Apps.Widgets;
+namespace Ivy.Samples.Shared.Apps.Widgets.Primitives;
 
 [App(icon: Icons.Pill, group: ["Widgets"], searchHints: ["tag", "label", "chip", "status", "indicator", "pill"])]
 public class BadgeApp : SampleBase

--- a/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/ButtonApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/ButtonApp.cs
@@ -1,5 +1,5 @@
 
-namespace Ivy.Samples.Shared.Apps.Widgets;
+namespace Ivy.Samples.Shared.Apps.Widgets.Primitives;
 
 [App(icon: Icons.SquareChevronRight, group: ["Widgets"], searchHints: ["click", "action", "submit", "cta", "interactive", "control"])]
 public class ButtonApp() : SampleBase

--- a/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/PaginationApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/PaginationApp.cs
@@ -1,5 +1,5 @@
 
-namespace Ivy.Samples.Shared.Apps.Widgets;
+namespace Ivy.Samples.Shared.Apps.Widgets.Primitives;
 
 [App(icon: Icons.SquareChevronRight, group: ["Widgets"], searchHints: ["paging", "navigation", "pages", "next", "previous", "numbers"])]
 public class PaginationApp() : SampleBase

--- a/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/ProgressApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/ProgressApp.cs
@@ -1,5 +1,5 @@
 
-namespace Ivy.Samples.Shared.Apps.Widgets;
+namespace Ivy.Samples.Shared.Apps.Widgets.Primitives;
 
 [App(icon: Icons.Gauge, group: ["Widgets"], searchHints: ["loading", "percentage", "bar", "indicator", "status", "completion"])]
 public class ProgressApp : SampleBase

--- a/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/StackedProgressApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/StackedProgressApp.cs
@@ -1,4 +1,4 @@
-namespace Ivy.Samples.Shared.Apps.Widgets;
+namespace Ivy.Samples.Shared.Apps.Widgets.Primitives;
 
 [App(icon: Icons.ChartBarStacked, group: ["Widgets"], searchHints: ["stacked", "segmented", "multi", "progress", "bar"])]
 public class StackedProgressApp : SampleBase

--- a/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/TooltipApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/TooltipApp.cs
@@ -1,5 +1,5 @@
 
-namespace Ivy.Samples.Shared.Apps.Widgets;
+namespace Ivy.Samples.Shared.Apps.Widgets.Primitives;
 
 [App(icon: Icons.MessageSquare, group: ["Widgets"], searchHints: ["hint", "hover", "popover", "help", "info", "overlay"])]
 public class TooltipApp : SampleBase


### PR DESCRIPTION
# Summary

## Changes

Moved 6 simple leaf widget sample apps (BadgeApp, ButtonApp, PaginationApp, ProgressApp, StackedProgressApp, TooltipApp) from `Widgets/` to `Widgets/Primitives/` and updated their namespaces from `Ivy.Samples.Shared.Apps.Widgets` to `Ivy.Samples.Shared.Apps.Widgets.Primitives`.

## API Changes

None. This is a file move and namespace change only. The framework discovers sample apps via reflection, so no registrations were affected.

## Files Modified

- **Moved to Primitives/:**
  - `src/Ivy.Samples.Shared/Apps/Widgets/Primitives/BadgeApp.cs`
  - `src/Ivy.Samples.Shared/Apps/Widgets/Primitives/ButtonApp.cs`
  - `src/Ivy.Samples.Shared/Apps/Widgets/Primitives/PaginationApp.cs`
  - `src/Ivy.Samples.Shared/Apps/Widgets/Primitives/ProgressApp.cs`
  - `src/Ivy.Samples.Shared/Apps/Widgets/Primitives/StackedProgressApp.cs`
  - `src/Ivy.Samples.Shared/Apps/Widgets/Primitives/TooltipApp.cs`

## Commits

- `bf12d5823` — Reclassify simple Widgets as Primitives