### PR TITLE
[01549] Make PaginationLink, PaginationPrevious, PaginationNext, and PaginationEllipsis density-aware

### DIFF
--- a/src/frontend/src/components/ui/pagination.tsx
+++ b/src/frontend/src/components/ui/pagination.tsx
@@ -4,6 +4,7 @@ import { ChevronLeft, ChevronRight, MoreHorizontal } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { ButtonProps } from "@/components/ui/button/button";
 import { buttonVariant } from "@/components/ui/button";
+import { Densities } from "@/types/density";
 
 const Pagination = ({ className, ...props }: React.ComponentProps<"nav">) => (
   <nav aria-label="pagination" className={cn("flex w-fit justify-center", className)} {...props} />
@@ -24,16 +25,38 @@ PaginationItem.displayName = "PaginationItem";
 
 type PaginationLinkProps = {
   isActive?: boolean;
+  density?: Densities;
 } & Pick<ButtonProps, "size"> &
   React.ComponentProps<"a">;
 
-const PaginationLink = ({ className, isActive, size = "icon", ...props }: PaginationLinkProps) => (
+function getLinkSize(
+  density: Densities | undefined,
+  isIconOnly: boolean,
+): ButtonProps["size"] {
+  if (density === Densities.Small) return isIconOnly ? "icon-sm" : "sm";
+  if (density === Densities.Large) return "lg";
+  return isIconOnly ? "icon" : "default";
+}
+
+function getIconClass(density: Densities | undefined): string {
+  if (density === Densities.Small) return "h-3 w-3";
+  if (density === Densities.Large) return "h-5 w-5";
+  return "h-4 w-4";
+}
+
+const PaginationLink = ({
+  className,
+  isActive,
+  density,
+  size,
+  ...props
+}: PaginationLinkProps) => (
   <a
     aria-current={isActive ? "page" : undefined}
     className={cn(
       buttonVariant({
         variant: isActive ? "outline" : "ghost",
-        size,
+        size: size ?? getLinkSize(density, true),
       }),
       className,
     )}
@@ -42,45 +65,63 @@ const PaginationLink = ({ className, isActive, size = "icon", ...props }: Pagina
 );
 PaginationLink.displayName = "PaginationLink";
 
-const PaginationPrevious = ({
-  className,
-  ...props
-}: React.ComponentProps<typeof PaginationLink>) => (
-  <PaginationLink
-    aria-label="Go to previous page"
-    size="default"
-    className={cn("gap-1 pl-2.5", className)}
-    {...props}
-  >
-    <ChevronLeft className="h-4 w-4" />
-    <span>Previous</span>
-  </PaginationLink>
-);
+type PaginationNavProps = {
+  density?: Densities;
+} & React.ComponentProps<typeof PaginationLink>;
+
+const PaginationPrevious = ({ className, density, ...props }: PaginationNavProps) => {
+  const gapClass = density === Densities.Small ? "gap-0.5" : density === Densities.Large ? "gap-1.5" : "gap-1";
+  const paddingClass = density === Densities.Small ? "pl-1.5" : density === Densities.Large ? "pl-3" : "pl-2.5";
+  return (
+    <PaginationLink
+      aria-label="Go to previous page"
+      size={getLinkSize(density, false)}
+      density={density}
+      className={cn(gapClass, paddingClass, className)}
+      {...props}
+    >
+      <ChevronLeft className={getIconClass(density)} />
+      <span>Previous</span>
+    </PaginationLink>
+  );
+};
 PaginationPrevious.displayName = "PaginationPrevious";
 
-const PaginationNext = ({ className, ...props }: React.ComponentProps<typeof PaginationLink>) => (
-  <PaginationLink
-    aria-label="Go to next page"
-    size="default"
-    className={cn("gap-1 pr-2.5", className)}
-    {...props}
-  >
-    <span>Next</span>
-    <ChevronRight className="h-4 w-4" />
-  </PaginationLink>
-);
+const PaginationNext = ({ className, density, ...props }: PaginationNavProps) => {
+  const gapClass = density === Densities.Small ? "gap-0.5" : density === Densities.Large ? "gap-1.5" : "gap-1";
+  const paddingClass = density === Densities.Small ? "pr-1.5" : density === Densities.Large ? "pr-3" : "pr-2.5";
+  return (
+    <PaginationLink
+      aria-label="Go to next page"
+      size={getLinkSize(density, false)}
+      density={density}
+      className={cn(gapClass, paddingClass, className)}
+      {...props}
+    >
+      <span>Next</span>
+      <ChevronRight className={getIconClass(density)} />
+    </PaginationLink>
+  );
+};
 PaginationNext.displayName = "PaginationNext";
 
-const PaginationEllipsis = ({ className, ...props }: React.ComponentProps<"span">) => (
-  <span
-    aria-hidden
-    className={cn("flex h-9 w-9 items-center justify-center", className)}
-    {...props}
-  >
-    <MoreHorizontal className="h-4 w-4" />
-    <span className="sr-only">More pages</span>
-  </span>
-);
+type PaginationEllipsisProps = {
+  density?: Densities;
+} & React.ComponentProps<"span">;
+
+const PaginationEllipsis = ({ className, density, ...props }: PaginationEllipsisProps) => {
+  const containerClass = density === Densities.Small ? "h-6 w-6" : density === Densities.Large ? "h-11 w-11" : "h-9 w-9";
+  return (
+    <span
+      aria-hidden
+      className={cn("flex items-center justify-center", containerClass, className)}
+      {...props}
+    >
+      <MoreHorizontal className={getIconClass(density)} />
+      <span className="sr-only">More pages</span>
+    </span>
+  );
+};
 PaginationEllipsis.displayName = "PaginationEllipsis";
 
 export {

--- a/src/frontend/src/components/ui/pagination.tsx
+++ b/src/frontend/src/components/ui/pagination.tsx
@@ -29,10 +29,7 @@ type PaginationLinkProps = {
 } & Pick<ButtonProps, "size"> &
   React.ComponentProps<"a">;
 
-function getLinkSize(
-  density: Densities | undefined,
-  isIconOnly: boolean,
-): ButtonProps["size"] {
+function getLinkSize(density: Densities | undefined, isIconOnly: boolean): ButtonProps["size"] {
   if (density === Densities.Small) return isIconOnly ? "icon-sm" : "sm";
   if (density === Densities.Large) return "lg";
   return isIconOnly ? "icon" : "default";
@@ -44,13 +41,7 @@ function getIconClass(density: Densities | undefined): string {
   return "h-4 w-4";
 }
 
-const PaginationLink = ({
-  className,
-  isActive,
-  density,
-  size,
-  ...props
-}: PaginationLinkProps) => (
+const PaginationLink = ({ className, isActive, density, size, ...props }: PaginationLinkProps) => (
   <a
     aria-current={isActive ? "page" : undefined}
     className={cn(
@@ -70,8 +61,10 @@ type PaginationNavProps = {
 } & React.ComponentProps<typeof PaginationLink>;
 
 const PaginationPrevious = ({ className, density, ...props }: PaginationNavProps) => {
-  const gapClass = density === Densities.Small ? "gap-0.5" : density === Densities.Large ? "gap-1.5" : "gap-1";
-  const paddingClass = density === Densities.Small ? "pl-1.5" : density === Densities.Large ? "pl-3" : "pl-2.5";
+  const gapClass =
+    density === Densities.Small ? "gap-0.5" : density === Densities.Large ? "gap-1.5" : "gap-1";
+  const paddingClass =
+    density === Densities.Small ? "pl-1.5" : density === Densities.Large ? "pl-3" : "pl-2.5";
   return (
     <PaginationLink
       aria-label="Go to previous page"
@@ -88,8 +81,10 @@ const PaginationPrevious = ({ className, density, ...props }: PaginationNavProps
 PaginationPrevious.displayName = "PaginationPrevious";
 
 const PaginationNext = ({ className, density, ...props }: PaginationNavProps) => {
-  const gapClass = density === Densities.Small ? "gap-0.5" : density === Densities.Large ? "gap-1.5" : "gap-1";
-  const paddingClass = density === Densities.Small ? "pr-1.5" : density === Densities.Large ? "pr-3" : "pr-2.5";
+  const gapClass =
+    density === Densities.Small ? "gap-0.5" : density === Densities.Large ? "gap-1.5" : "gap-1";
+  const paddingClass =
+    density === Densities.Small ? "pr-1.5" : density === Densities.Large ? "pr-3" : "pr-2.5";
   return (
     <PaginationLink
       aria-label="Go to next page"
@@ -110,7 +105,8 @@ type PaginationEllipsisProps = {
 } & React.ComponentProps<"span">;
 
 const PaginationEllipsis = ({ className, density, ...props }: PaginationEllipsisProps) => {
-  const containerClass = density === Densities.Small ? "h-6 w-6" : density === Densities.Large ? "h-11 w-11" : "h-9 w-9";
+  const containerClass =
+    density === Densities.Small ? "h-6 w-6" : density === Densities.Large ? "h-11 w-11" : "h-9 w-9";
   return (
     <span
       aria-hidden

--- a/src/frontend/src/widgets/pagination/PaginationWidget.tsx
+++ b/src/frontend/src/widgets/pagination/PaginationWidget.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/pagination";
 import { useEventHandler } from "@/components/event-handler";
 import { cn } from "@/lib/utils";
+import { Densities } from "@/types/density";
 
 interface PaginationWidgetProps {
   id: string;
@@ -18,6 +19,7 @@ interface PaginationWidgetProps {
   siblings?: number;
   boundaries?: number;
   disabled?: boolean;
+  density?: Densities;
 }
 
 export const PaginationWidget: React.FC<PaginationWidgetProps> = ({
@@ -27,6 +29,7 @@ export const PaginationWidget: React.FC<PaginationWidgetProps> = ({
   siblings = 1,
   boundaries = 1,
   disabled = false,
+  density,
 }) => {
   const eventHandler = useEventHandler();
 
@@ -57,6 +60,7 @@ export const PaginationWidget: React.FC<PaginationWidgetProps> = ({
       <PaginationContent>
         <PaginationItem>
           <PaginationPrevious
+            density={density}
             aria-disabled={disabled || !page || page === 1}
             className={cn(
               "select-none",
@@ -76,6 +80,7 @@ export const PaginationWidget: React.FC<PaginationWidgetProps> = ({
                 (isOneGap ? (
                   <PaginationItem>
                     <PaginationLink
+                      density={density}
                       aria-disabled={disabled}
                       className={disabled ? "pointer-events-none opacity-50" : undefined}
                       onClick={
@@ -88,11 +93,12 @@ export const PaginationWidget: React.FC<PaginationWidgetProps> = ({
                   </PaginationItem>
                 ) : (
                   <PaginationItem>
-                    <PaginationEllipsis />
+                    <PaginationEllipsis density={density} />
                   </PaginationItem>
                 ))}
               <PaginationItem>
                 <PaginationLink
+                  density={density}
                   aria-disabled={disabled}
                   className={disabled ? "pointer-events-none opacity-50" : undefined}
                   onClick={p === page ? undefined : () => eventHandler("OnChange", id, [p])}
@@ -106,6 +112,7 @@ export const PaginationWidget: React.FC<PaginationWidgetProps> = ({
         })}
         <PaginationItem>
           <PaginationNext
+            density={density}
             aria-disabled={disabled || !page || page === numPages}
             className={cn(
               "select-none",


### PR DESCRIPTION
## Summary

Added density-awareness to four pagination sub-components (`PaginationLink`, `PaginationPrevious`, `PaginationNext`, `PaginationEllipsis`) in `pagination.tsx`. Each component now accepts an optional `density` prop that scales button sizes, icon sizes, gaps, and padding according to Small/Medium/Large density values. The `PaginationWidget` was updated to thread the `density` prop from the backend through to all sub-components.

## API Changes

- `PaginationLinkProps` — added optional `density?: Densities` prop
- `PaginationNavProps` — new type for `PaginationPrevious` and `PaginationNext` with `density?: Densities`
- `PaginationEllipsisProps` — new type with `density?: Densities`
- `PaginationWidgetProps` — added optional `density?: Densities` prop
- `getLinkSize(density, isIconOnly)` — new helper function mapping density to buttonVariant size
- `getIconClass(density)` — new helper function mapping density to icon size classes

## Files Modified

- **UI component:** `src/frontend/src/components/ui/pagination.tsx` — density-aware sizing for all four sub-components
- **Widget:** `src/frontend/src/widgets/pagination/PaginationWidget.tsx` — threads density to all sub-components

## Commits

- `c2ba7d747` — Make PaginationLink, PaginationPrevious, PaginationNext, and PaginationEllipsis density-aware
- `f622ce325` — Fix formatting in pagination.tsx