### PR TITLE
fix: resolve frontend build and lint errors

### DIFF
--- a/src/frontend/src/widgets/calendar/CalendarWidget.tsx
+++ b/src/frontend/src/widgets/calendar/CalendarWidget.tsx
@@ -28,7 +28,6 @@ import type { CalendarWidgetProps, CalendarView, CalendarEvent } from "./types";
 import { Densities } from "@/types/density";
 import { CALENDAR_DENSITY_CONFIG } from "./constants";
 import { cn } from "@/lib/utils";
-import { Densities } from "@/types/density";
 
 const HOURS = Array.from({ length: 24 }, (_, i) => i);
 

--- a/src/frontend/src/widgets/calendar/types.ts
+++ b/src/frontend/src/widgets/calendar/types.ts
@@ -45,8 +45,8 @@ export interface CalendarWidgetProps {
   events?: string[];
   width?: string;
   height?: string;
-  density?: Densities;
   children?: React.ReactNode;
+
   slots?: {
     default?: React.ReactNode[];
   };

--- a/src/frontend/src/widgets/pagination/PaginationWidget.tsx
+++ b/src/frontend/src/widgets/pagination/PaginationWidget.tsx
@@ -57,7 +57,7 @@ export const PaginationWidget: React.FC<PaginationWidgetProps> = ({
 
   return (
     <Pagination>
-      <PaginationContent density={density}>
+      <PaginationContent density={_density}>
         <PaginationItem>
           <PaginationPrevious
             aria-disabled={disabled || !page || page === 1}


### PR DESCRIPTION
This PR fixes duplicate identifier errors in calendar types and variable naming errors in the pagination widget.
- Removed redundant import in CalendarWidget.tsx
- Removed duplicate density property in calendar types.ts
- Fixed variable name reference in PaginationWidget.tsx