### PR TITLE
[01563] Improve CameraInputEvents to use real upload handler

### DIFF
--- a/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/CameraInputApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/CameraInputApp.cs
@@ -119,11 +119,20 @@ public class CameraInputEvents : ViewBase
     {
         var focused = UseState(false);
         var lastEvent = UseState<string?>(() => null);
+        var photo = UseState<FileUpload<byte[]>?>();
 
-        var dummyUpload = UseUpload(
-            (fileUpload, stream, cancellationToken) => System.Threading.Tasks.Task.CompletedTask,
+        var upload = UseUpload(
+            MemoryStreamUploadHandler.Create(photo),
             defaultContentType: "image/png"
         );
+
+        UseEffect(() =>
+        {
+            if (photo.Value?.Status == FileUploadStatus.Finished)
+            {
+                lastEvent.Set("Captured");
+            }
+        }, photo);
 
         void onFocus()
         {
@@ -138,11 +147,12 @@ public class CameraInputEvents : ViewBase
         }
 
         return Layout.Vertical()
-               | Text.P("Focus the camera input (Tab / click), then blur it to trigger events.")
-               | new CameraInput(dummyUpload.Value, "Take a photo")
+               | Text.P("Focus, blur, and capture the camera input to trigger events.")
+               | new CameraInput(upload.Value, "Take a photo")
                    .OnFocus(onFocus)
                    .OnBlur(onBlur)
                | Text.P($"Focused: {focused.Value}").Small()
-               | Text.P($"Last event: {lastEvent.Value ?? "—"}").Small();
+               | Text.P($"Last event: {lastEvent.Value ?? "—"}").Small()
+               | Text.P($"Captured: {(photo.Value != null ? photo.Value.FileName : "—")}").Small();
     }
 }


### PR DESCRIPTION
## Changes

Replaced the dummy upload handler in `CameraInputEvents` with a real `MemoryStreamUploadHandler` that captures photos into memory, matching the pattern already used by `CameraInputBasic`. Added a `UseEffect` hook to track capture events and a new status line showing the captured photo filename.

## Files Modified

- **src/Ivy.Samples.Shared/Apps/Widgets/Inputs/CameraInputApp.cs** — Rewrote `CameraInputEvents.Build()` to use `MemoryStreamUploadHandler.Create(photo)` instead of a no-op lambda, added `UseEffect` for capture tracking, added captured filename display line.

## Commits

- b4964e354