### PR TITLE
[01584] Extract shared dummy upload helper in CameraInputApp

### DIFF
--- a/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/CameraInputApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/CameraInputApp.cs
@@ -1,6 +1,14 @@
 
 namespace Ivy.Samples.Shared.Apps.Widgets.Inputs;
 
+file static class CameraInputHelpers
+{
+    internal static readonly UploadDelegate NoOpUploadHandler =
+        (fileUpload, stream, cancellationToken) => Task.CompletedTask;
+
+    internal const string DefaultImageContentType = "image/png";
+}
+
 [App(icon: Icons.Camera, group: ["Widgets", "Inputs"], searchHints: ["camera", "webcam", "photo", "capture", "snapshot", "picture"])]
 
 public class CameraInputApp() : SampleBase
@@ -53,8 +61,8 @@ public class CameraInputStates : ViewBase
     public override object? Build()
     {
         var dummyUpload = UseUpload(
-            (fileUpload, stream, cancellationToken) => System.Threading.Tasks.Task.CompletedTask,
-            defaultContentType: "image/png"
+            CameraInputHelpers.NoOpUploadHandler,
+            defaultContentType: CameraInputHelpers.DefaultImageContentType
         );
 
         return Layout.Grid().Columns(4)
@@ -75,8 +83,8 @@ public class CameraInputValidation : ViewBase
     public override object? Build()
     {
         var dummyUpload = UseUpload(
-            (fileUpload, stream, cancellationToken) => System.Threading.Tasks.Task.CompletedTask,
-            defaultContentType: "image/png"
+            CameraInputHelpers.NoOpUploadHandler,
+            defaultContentType: CameraInputHelpers.DefaultImageContentType
         );
 
         return Layout.Vertical().Gap(4)
@@ -91,8 +99,8 @@ public class CameraInputSizes : ViewBase
     public override object? Build()
     {
         var dummyUpload = UseUpload(
-            (fileUpload, stream, cancellationToken) => System.Threading.Tasks.Task.CompletedTask,
-            defaultContentType: "image/png"
+            CameraInputHelpers.NoOpUploadHandler,
+            defaultContentType: CameraInputHelpers.DefaultImageContentType
         );
 
         return Layout.Grid().Columns(4)

--- a/src/frontend/src/widgets/calendar/CalendarWidget.tsx
+++ b/src/frontend/src/widgets/calendar/CalendarWidget.tsx
@@ -28,7 +28,6 @@ import type { CalendarWidgetProps, CalendarView, CalendarEvent } from "./types";
 import { Densities } from "@/types/density";
 import { CALENDAR_DENSITY_CONFIG } from "./constants";
 import { cn } from "@/lib/utils";
-import { Densities } from "@/types/density";
 
 const HOURS = Array.from({ length: 24 }, (_, i) => i);
 


### PR DESCRIPTION
## Changes

Extracted the duplicated dummy upload handler pattern from `CameraInputStates`, `CameraInputValidation`, and `CameraInputSizes` into a shared `file static class CameraInputHelpers` with a `NoOpUploadHandler` delegate and `DefaultImageContentType` constant. All three call sites now reference the shared helper instead of inlining identical lambdas.

## Files Modified

- **src/Ivy.Samples.Shared/Apps/Widgets/Inputs/CameraInputApp.cs** — Added `CameraInputHelpers` file-scoped static class; replaced 3 inline `UseUpload` lambdas with references to shared fields
- **src/frontend/src/widgets/calendar/CalendarWidget.tsx** — Removed pre-existing duplicate `Densities` import (lint fix)

## Commits

- `49b9f1c6e` [01584] Extract shared dummy upload helper in CameraInputApp
- `1e03f8968` [01584] Fix pre-existing duplicate import in CalendarWidget.tsx