### PR TITLE
[03054] Investigate and Fix Root Cause of Missing .git Files in Worktree Directories

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/WorktreeCleanupServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/WorktreeCleanupServiceTests.cs
@@ -386,6 +386,41 @@ public class WorktreeCleanupServiceTests : IDisposable
             Directory.Delete(testDir, true);
     }
 
+    [Fact]
+    public void CleanupPlanWorktrees_LogsMissingGitFileAge()
+    {
+        var dir = CreatePlan("12000-MissingGitAge", "Completed", DateTime.UtcNow.AddHours(-2));
+        var worktreeDir = Path.Combine(dir, "worktrees", "TestRepo");
+        Directory.CreateDirectory(worktreeDir);
+        File.WriteAllText(Path.Combine(worktreeDir, "file.txt"), "content");
+
+        var logEntries = new List<string>();
+        var logger = new CapturingLogger(logEntries);
+
+        WorktreeCleanupService.CleanupPlanWorktrees(dir, logger);
+
+        Assert.Contains(logEntries, e => e.Contains("no .git file") && e.Contains("ago"));
+        Assert.False(Directory.Exists(worktreeDir), "Orphan directory should still be cleaned up");
+    }
+
+    [Fact]
+    public void CleanupPlanWorktrees_HandlesVeryRecentOrphanedDirectory()
+    {
+        var dir = CreatePlan("12001-RecentOrphan", "Completed", DateTime.UtcNow.AddHours(-2));
+        var worktreeDir = Path.Combine(dir, "worktrees", "TestRepo");
+        Directory.CreateDirectory(worktreeDir);
+        File.WriteAllText(Path.Combine(worktreeDir, "file.txt"), "content");
+
+        var logEntries = new List<string>();
+        var logger = new CapturingLogger(logEntries);
+
+        WorktreeCleanupService.CleanupPlanWorktrees(dir, logger);
+
+        var ageLog = logEntries.FirstOrDefault(e => e.Contains("no .git file") && e.Contains("ago"));
+        Assert.NotNull(ageLog);
+        Assert.False(Directory.Exists(worktreeDir), "Very recent orphan should still be cleaned up");
+    }
+
     private class CapturingLogger(List<string> entries) : ILogger
     {
         public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;

--- a/src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
+++ b/src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
@@ -210,6 +210,19 @@ git worktree add "<PlanFolder>/worktrees/<RepoName>" -b "plan-<PlanId>-<RepoName
 
 **Important:** Always branch from `origin/<default-branch>`, not local HEAD. This ensures the PR only contains the plan's commits, not any unpushed local work.
 
+4. After creating the worktree, **verify the `.git` file exists** and fail fast if it's missing:
+
+```bash
+if [ ! -f "<PlanFolder>/worktrees/<repo-folder-name>/.git" ]; then
+    echo "ERROR: Worktree creation failed - .git file missing at <PlanFolder>/worktrees/<repo-folder-name>/.git"
+    echo "This indicates git worktree add did not fully initialize the worktree."
+    exit 1
+fi
+cat "<PlanFolder>/worktrees/<repo-folder-name>/.git"
+```
+
+This ensures ExecutePlan fails immediately if worktree creation is incomplete, rather than leaving orphaned directories that trigger warnings during cleanup.
+
 ### 2.5. Setup Frontend Dependencies (JavaScript/TypeScript Projects Only)
 
 **Note:** This section applies only to projects using npm/pnpm. Skip if not applicable.

--- a/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
@@ -892,7 +892,10 @@ public class PlanReaderService(
             var gitFile = Path.Combine(wtDir, ".git");
             if (!File.Exists(gitFile))
             {
-                logger?.LogWarning("Worktree directory has no .git file, skipping git removal: {Path}", wtDir);
+                var dirAge = DateTime.UtcNow - new DirectoryInfo(wtDir).CreationTimeUtc;
+                logger?.LogWarning(
+                    "Worktree directory has no .git file (created {Age} ago), skipping git removal: {Path}",
+                    dirAge, wtDir);
                 continue;
             }
 

--- a/src/tendril/Ivy.Tendril/Services/WorktreeCleanupService.cs
+++ b/src/tendril/Ivy.Tendril/Services/WorktreeCleanupService.cs
@@ -93,10 +93,17 @@ public class WorktreeCleanupService : IStartable, IDisposable
 
         PlanReaderService.RemoveWorktrees(planFolderPath, logger);
 
-        // Force-delete any remaining worktree directories that git couldn't remove
-        // (orphaned .git files, missing entries, Windows file locks, etc.)
         foreach (var wtDir in Directory.GetDirectories(worktreesDir))
         {
+            var gitFile = Path.Combine(wtDir, ".git");
+            if (!File.Exists(gitFile))
+            {
+                var dirAge = DateTime.UtcNow - new DirectoryInfo(wtDir).CreationTimeUtc;
+                logger?.LogWarning(
+                    "Force-deleting orphaned worktree directory (no .git file, created {Age} ago): {Path}",
+                    dirAge, Path.GetFileName(wtDir));
+            }
+
             try
             {
                 ForceDeleteDirectory(wtDir, logger);


### PR DESCRIPTION
# Summary

## Changes

Added diagnostic logging and fail-fast detection for missing `.git` files in worktree directories. ExecutePlan's Program.md now includes a verification step that fails immediately if a worktree's `.git` file is missing after creation. Both `PlanReaderService.RemoveWorktrees` and `WorktreeCleanupService.CleanupPlanWorktrees` now log the directory age when encountering orphaned worktree directories, enabling diagnosis of whether the issue is creation failure vs. post-creation deletion.

## API Changes

None.

## Files Modified

- **Promptwares/ExecutePlan/Program.md** — Added Step 4 to worktree creation: `.git` file existence check with fail-fast
- **Services/PlanReaderService.cs** — Enhanced missing `.git` warning to include directory creation age
- **Services/WorktreeCleanupService.cs** — Added age-based diagnostic logging before force-deleting orphaned worktree dirs
- **WorktreeCleanupServiceTests.cs** — Added `CleanupPlanWorktrees_LogsMissingGitFileAge` and `CleanupPlanWorktrees_HandlesVeryRecentOrphanedDirectory` tests

## Commits

- 3e9a20d4e [03054] Add diagnostic logging and fail-fast for missing .git files in worktrees