### PR TITLE
[03056] Remove redundant Watch Remove from Tendril csproj

### DIFF
--- a/src/tendril/Ivy.Tendril/Ivy.Tendril.csproj
+++ b/src/tendril/Ivy.Tendril/Ivy.Tendril.csproj
@@ -66,9 +66,6 @@
   <ItemGroup>
     <Folder Include="Apps" />
   </ItemGroup>
-  <ItemGroup>
-    <Watch Remove="Promptwares\**" />
-  </ItemGroup>
 
   <ItemGroup>
     <None Update="example.config.yaml">


### PR DESCRIPTION
# Summary

## Changes

Removed the redundant `<Watch Remove="Promptwares\**" />` ItemGroup (formerly lines 69-71) from `Ivy.Tendril.csproj`. The `DefaultItemExcludes` property at line 12 already prevents Promptwares files from entering any item group, making the Watch Remove directive unnecessary.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Ivy.Tendril.csproj` — removed 3 lines (the Watch Remove ItemGroup)

## Commits

- efddcf56d [03056] Remove redundant Watch Remove from Ivy.Tendril.csproj