### PR TITLE
[03055] Audit FileHelper.ReadAllText Call Sites For Defensive Checks

### DIFF
--- a/src/tendril/Ivy.Tendril/Services/FileHelper.cs
+++ b/src/tendril/Ivy.Tendril/Services/FileHelper.cs
@@ -42,6 +42,12 @@ internal static class FileHelper
         return null;
     }
 
+    /// <summary>
+    ///     Reads all text from a file with retry logic for transient IO errors.
+    ///     Callers should check <see cref="File.Exists(string)"/> before calling unless
+    ///     the path comes from <c>Directory.GetFiles</c>/<c>EnumerateFiles</c> or an
+    ///     explicit try-catch handles <see cref="FileNotFoundException"/>.
+    /// </summary>
     public static string ReadAllText(string path)
     {
         for (var attempt = 0; ; attempt++)
@@ -91,6 +97,7 @@ internal static class FileHelper
             }
     }
 
+    /// <inheritdoc cref="ReadAllText"/>
     public static async Task<string> ReadAllTextAsync(string path)
     {
         for (var attempt = 0; ; attempt++)


### PR DESCRIPTION
# Summary

## Changes

Added XML documentation to `FileHelper.ReadAllText` and `ReadAllTextAsync` methods documenting that callers should check `File.Exists()` before calling, unless the path originates from `Directory.GetFiles`/`EnumerateFiles` or an explicit try-catch handles `FileNotFoundException`. This was the optional documentation improvement identified by the audit of all 34 call sites.

## API Changes

- `FileHelper.ReadAllText(string path)` — added `<summary>` XML doc with usage guidance
- `FileHelper.ReadAllTextAsync(string path)` — added `<inheritdoc cref="ReadAllText"/>` to share the same documentation

## Files Modified

- `src/tendril/Ivy.Tendril/Services/FileHelper.cs` — XML documentation added to two methods

## Commits

- e4aeab911 [03055] Add XML documentation to FileHelper.ReadAllText methods