### PR TITLE
[03057] Split Multi-Project Parameter and Aggregate Repos in MakePlan

### DIFF
--- a/src/tendril/Ivy.Tendril/Promptwares/MakePlan/MakePlan.ps1
+++ b/src/tendril/Ivy.Tendril/Promptwares/MakePlan/MakePlan.ps1
@@ -31,6 +31,31 @@ $firmwareValues = @{
 if ($SourcePath) { $firmwareValues["SourcePath"] = $SourcePath }
 if ($Priority -ne 0) { $firmwareValues["Priority"] = $Priority }
 
+# Parse multi-project selection and aggregate repos for overlap detection
+$repos = @()
+if ($Project -ne "[Auto]") {
+    $projectNames = $Project -split ',' | ForEach-Object { $_.Trim() }
+
+    if (Test-Path $script:ConfigPath) {
+        try {
+            $config = Get-Content $script:ConfigPath -Raw | ConvertFrom-Yaml
+
+            foreach ($projName in $projectNames) {
+                $projectEntry = $config.projects | Where-Object { $_.name -eq $projName } | Select-Object -First 1
+                if ($projectEntry -and $projectEntry.repos) {
+                    $projectRepos = ExtractRepoPathsFromYaml $projectEntry.repos
+                    $repos += $projectRepos
+                }
+            }
+
+            $repos = $repos | Select-Object -Unique
+        }
+        catch {
+            Write-Warning "Failed to parse config.yaml for multi-project repos: $_"
+        }
+    }
+}
+
 # Pre-compute duplicate detection and active plans (skip duplicates if FORCE flag)
 if ($Description -notmatch '\[FORCE\]') {
     $keywords = ($Description -replace '\[.*?\]', '' -split '\s+') | Where-Object { $_.Length -ge 3 }
@@ -44,7 +69,7 @@ if ($Description -notmatch '\[FORCE\]') {
 }
 
 $activePlans = & "$programFolder/Tools/Find-ActivePlans.ps1" `
-    -PlansDirectory $script:PlansDir -Repos @()
+    -PlansDirectory $script:PlansDir -Repos $repos
 if ($activePlans) {
     $firmwareValues["ActivePlans"] = $activePlans
 }


### PR DESCRIPTION
# Summary

## Changes

Added multi-project repo aggregation to MakePlan.ps1. When the `-Project` parameter contains comma-separated project names (e.g., "Framework,Agent"), the script now splits them, looks up each project's repos from config.yaml using `ExtractRepoPathsFromYaml`, deduplicates the results, and passes the aggregated repos to `Find-ActivePlans.ps1` for proper overlap detection. Previously, an empty array `@()` was always passed, preventing concurrent plan detection for multi-project plans.

## API Changes

None. The `-Project` parameter already accepted comma-separated values; the change is internal behavior only.

## Files Modified

- **src/tendril/Ivy.Tendril/Promptwares/MakePlan/MakePlan.ps1** — Added repo aggregation block (lines 34-57) and updated Find-ActivePlans.ps1 call to use `$repos` instead of `@()`

## Commits

- 63125dd9c [03057] Split multi-project parameter and aggregate repos in MakePlan