### PR TITLE
[03058] Centralize Worktree Lifecycle Logging

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/WorktreeLifecycleLoggerTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/WorktreeLifecycleLoggerTests.cs
@@ -1,0 +1,131 @@
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Test;
+
+public class WorktreeLifecycleLoggerTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly WorktreeLifecycleLogger _logger;
+
+    public WorktreeLifecycleLoggerTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"wt-lifecycle-test-{Guid.NewGuid()}");
+        Directory.CreateDirectory(_tempDir);
+        _logger = new WorktreeLifecycleLogger(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, true);
+    }
+
+    [Fact]
+    public void LogCreation_WritesFormattedEntry()
+    {
+        _logger.LogCreation("03058", @"D:\Repos\MyRepo", @"D:\Plans\03058\worktrees\MyRepo", "plan-03058-MyRepo");
+
+        var logFile = Path.Combine(_tempDir, "Logs", "worktrees.log");
+        Assert.True(File.Exists(logFile));
+
+        var content = File.ReadAllText(logFile);
+        Assert.Contains("[03058]", content);
+        Assert.Contains("[Creation]", content);
+        Assert.Contains("repo=\"D:\\Repos\\MyRepo\"", content);
+        Assert.Contains("branch=\"plan-03058-MyRepo\"", content);
+    }
+
+    [Fact]
+    public void LogCreationFailed_WritesErrorEntry()
+    {
+        _logger.LogCreationFailed("03058", @"D:\Repos\MyRepo", @"D:\Plans\worktrees\MyRepo", "branch already exists");
+
+        var content = ReadLogContent();
+        Assert.Contains("[CreationFailed]", content);
+        Assert.Contains("error=\"branch already exists\"", content);
+    }
+
+    [Fact]
+    public void LogCleanupAttempt_WritesGitFileExistsFlag()
+    {
+        _logger.LogCleanupAttempt("03058", @"D:\Plans\worktrees\MyRepo", "TerminalState(Completed)", true);
+
+        var content = ReadLogContent();
+        Assert.Contains("[CleanupAttempt]", content);
+        Assert.Contains("trigger=\"TerminalState(Completed)\"", content);
+        Assert.Contains("gitFileExists=\"True\"", content);
+    }
+
+    [Fact]
+    public void LogCleanupSuccess_WritesSuccessEntry()
+    {
+        _logger.LogCleanupSuccess("03058", @"D:\Plans\worktrees\MyRepo");
+
+        var content = ReadLogContent();
+        Assert.Contains("[CleanupSuccess]", content);
+        Assert.Contains("worktree=\"D:\\Plans\\worktrees\\MyRepo\"", content);
+    }
+
+    [Fact]
+    public void LogCleanupFailed_WritesErrorEntry()
+    {
+        _logger.LogCleanupFailed("03058", @"D:\Plans\worktrees\MyRepo", "Access denied");
+
+        var content = ReadLogContent();
+        Assert.Contains("[CleanupFailed]", content);
+        Assert.Contains("error=\"Access denied\"", content);
+    }
+
+    [Fact]
+    public async Task ConcurrentWrites_AllEntriesWritten()
+    {
+        const int threadCount = 10;
+        var tasks = new Task[threadCount];
+        for (int i = 0; i < threadCount; i++)
+        {
+            var planId = $"{i:D5}";
+            tasks[i] = Task.Run(() =>
+                _logger.LogCreation(planId, @"D:\Repos\MyRepo", @"D:\Plans\worktrees\MyRepo", "branch"));
+        }
+
+        await Task.WhenAll(tasks);
+
+        var lines = File.ReadAllLines(Path.Combine(_tempDir, "Logs", "worktrees.log"));
+        Assert.Equal(threadCount, lines.Length);
+    }
+
+    [Fact]
+    public void LogCreatesDirectoryIfNotExists()
+    {
+        var nestedDir = Path.Combine(_tempDir, "nested", "deep");
+        var logger = new WorktreeLifecycleLogger(nestedDir);
+
+        logger.LogCreation("03058", "repo", "wt", "branch");
+
+        Assert.True(File.Exists(Path.Combine(nestedDir, "Logs", "worktrees.log")));
+    }
+
+    [Theory]
+    [InlineData(@"D:\Tendril\Plans\03058-CentralizeWorktreeLifecycleLogging", "03058")]
+    [InlineData(@"D:\Plans\00015-LogWarning", "00015")]
+    [InlineData(@"D:\Plans\unknown-folder", "unknown")]
+    [InlineData(@"D:\Plans\03058-Test\", "03058")]
+    public void ExtractPlanId_ParsesCorrectly(string path, string expected)
+    {
+        Assert.Equal(expected, WorktreeLifecycleLogger.ExtractPlanId(path));
+    }
+
+    [Fact]
+    public void LogCreationFailed_EscapesQuotesInError()
+    {
+        _logger.LogCreationFailed("03058", "repo", "wt", "error with \"quotes\" inside");
+
+        var content = ReadLogContent();
+        Assert.Contains("error=\"error with \\\"quotes\\\" inside\"", content);
+    }
+
+    private string ReadLogContent()
+    {
+        return File.ReadAllText(Path.Combine(_tempDir, "Logs", "worktrees.log"));
+    }
+}

--- a/src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/Tools/Log-WorktreeEvent.ps1
+++ b/src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/Tools/Log-WorktreeEvent.ps1
@@ -1,0 +1,25 @@
+param(
+    [Parameter(Mandatory)]
+    [ValidateSet("Creation", "CreationFailed", "CleanupAttempt", "CleanupSuccess", "CleanupFailed")]
+    [string]$Event,
+
+    [Parameter(Mandatory)]
+    [string]$PlanId,
+
+    [Parameter(Mandatory)]
+    [string]$WorktreePath,
+
+    [hashtable]$Metadata = @{}
+)
+
+$logDir = Join-Path $env:TENDRIL_HOME "Logs"
+if (-not (Test-Path $logDir)) {
+    New-Item -ItemType Directory -Path $logDir -Force | Out-Null
+}
+
+$logPath = Join-Path $logDir "worktrees.log"
+$timestamp = (Get-Date).ToUniversalTime().ToString("o")
+$metaStr = ($Metadata.GetEnumerator() | ForEach-Object { "$($_.Key)=`"$($_.Value)`"" }) -join " "
+$entry = "[$timestamp] [$PlanId] [$Event] worktree=`"$WorktreePath`" $metaStr".TrimEnd()
+
+Add-Content -Path $logPath -Value $entry -Encoding UTF8

--- a/src/tendril/Ivy.Tendril/Services/IWorktreeLifecycleLogger.cs
+++ b/src/tendril/Ivy.Tendril/Services/IWorktreeLifecycleLogger.cs
@@ -1,0 +1,10 @@
+namespace Ivy.Tendril.Services;
+
+public interface IWorktreeLifecycleLogger
+{
+    void LogCreation(string planId, string repoPath, string worktreePath, string branch);
+    void LogCreationFailed(string planId, string repoPath, string worktreePath, string error);
+    void LogCleanupAttempt(string planId, string worktreePath, string trigger, bool gitFileExists);
+    void LogCleanupSuccess(string planId, string worktreePath);
+    void LogCleanupFailed(string planId, string worktreePath, string error);
+}

--- a/src/tendril/Ivy.Tendril/Services/JobService.cs
+++ b/src/tendril/Ivy.Tendril/Services/JobService.cs
@@ -68,6 +68,7 @@ public class JobService : IJobService
     private readonly TimeSpan _staleOutputTimeout;
     private readonly SynchronizationContext? _syncContext;
     private readonly ITelemetryService? _telemetryService;
+    private readonly IWorktreeLifecycleLogger? _worktreeLifecycleLogger;
     private int _counter;
 
     public JobService(
@@ -76,7 +77,8 @@ public class JobService : IJobService
         IPlanReaderService? planReaderService = null,
         ITelemetryService? telemetryService = null,
         IPlanWatcherService? planWatcherService = null,
-        IPlanDatabaseService? database = null)
+        IPlanDatabaseService? database = null,
+        IWorktreeLifecycleLogger? worktreeLifecycleLogger = null)
     {
         _syncContext = SynchronizationContext.Current;
         _configService = configService;
@@ -85,6 +87,7 @@ public class JobService : IJobService
         _telemetryService = telemetryService;
         _planWatcherService = planWatcherService;
         _database = database;
+        _worktreeLifecycleLogger = worktreeLifecycleLogger;
         _jobTimeout = TimeSpan.FromMinutes(configService.Settings.JobTimeout);
         _staleOutputTimeout = TimeSpan.FromMinutes(configService.Settings.StaleOutputTimeout);
         _maxConcurrentJobs = configService.Settings.MaxConcurrentJobs;
@@ -1122,7 +1125,7 @@ public class JobService : IJobService
         }
     }
 
-    private static void ScheduleWorktreeCleanup(JobItem job)
+    private void ScheduleWorktreeCleanup(JobItem job)
     {
         if (job.Type != "ExecutePlan") return;
 
@@ -1132,13 +1135,14 @@ public class JobService : IJobService
         var worktreesDir = Path.Combine(planFolder, "worktrees");
         if (!Directory.Exists(worktreesDir)) return;
 
-        // Clean up immediately after failure — no grace period needed since the plan just failed
+        var lifecycleLogger = _worktreeLifecycleLogger;
+
         Task.Run(async () =>
         {
             await Task.Delay(TimeSpan.FromSeconds(30));
             try
             {
-                PlanReaderService.RemoveWorktrees(planFolder);
+                PlanReaderService.RemoveWorktrees(planFolder, lifecycleLogger: lifecycleLogger);
 
                 if (Directory.Exists(worktreesDir) && Directory.GetDirectories(worktreesDir).Length == 0)
                     Directory.Delete(worktreesDir, false);

--- a/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
@@ -10,12 +10,14 @@ namespace Ivy.Tendril.Services;
 public class PlanReaderService(
     IConfigService config,
     ILogger<PlanReaderService> logger,
-    ITelemetryService? telemetryService = null) : IPlanReaderService
+    ITelemetryService? telemetryService = null,
+    IWorktreeLifecycleLogger? worktreeLifecycleLogger = null) : IPlanReaderService
 {
     private static readonly Regex FolderNameRegex = new(@"^(\d{5})-(.+)$", RegexOptions.Compiled);
     private readonly IConfigService _config = config;
 
     private readonly ILogger<PlanReaderService> _logger = logger;
+    private readonly IWorktreeLifecycleLogger? _worktreeLifecycleLogger = worktreeLifecycleLogger;
 
     private readonly TimeCache<Dictionary<string, DashboardStats>> _dashboardCache =
         new(TimeSpan.FromSeconds(10));
@@ -327,7 +329,7 @@ public class PlanReaderService(
         WriteFileInBackground(() =>
         {
             if (!Directory.Exists(folderPath)) return;
-            RemoveWorktrees(folderPath, _logger);
+            RemoveWorktrees(folderPath, _logger, _worktreeLifecycleLogger);
             WorktreeCleanupService.ForceDeleteDirectory(folderPath, _logger);
         });
     }
@@ -882,10 +884,12 @@ public class PlanReaderService(
         return latestFile != null ? FileHelper.ReadAllText(latestFile) : string.Empty;
     }
 
-    internal static void RemoveWorktrees(string planFolderPath, ILogger? logger = null)
+    internal static void RemoveWorktrees(string planFolderPath, ILogger? logger = null, IWorktreeLifecycleLogger? lifecycleLogger = null)
     {
         var worktreesDir = Path.Combine(planFolderPath, "worktrees");
         if (!Directory.Exists(worktreesDir)) return;
+
+        var planId = WorktreeLifecycleLogger.ExtractPlanId(planFolderPath);
 
         foreach (var wtDir in Directory.GetDirectories(worktreesDir))
         {
@@ -896,6 +900,7 @@ public class PlanReaderService(
                 logger?.LogWarning(
                     "Worktree directory has no .git file (created {Age} ago), skipping git removal: {Path}",
                     dirAge, wtDir);
+                lifecycleLogger?.LogCleanupAttempt(planId, wtDir, "RemoveWorktrees", gitFileExists: false);
                 continue;
             }
 
@@ -911,6 +916,8 @@ public class PlanReaderService(
             var repoRoot = Path.GetDirectoryName(repoGitDir);
             if (repoRoot == null || !Directory.Exists(repoRoot)) continue;
 
+            lifecycleLogger?.LogCleanupAttempt(planId, wtDir, "RemoveWorktrees", gitFileExists: true);
+
             try
             {
                 var psi = new ProcessStartInfo("git", $"worktree remove --force \"{wtDir}\"")
@@ -923,11 +930,11 @@ public class PlanReaderService(
                 };
                 using var process = Process.Start(psi);
                 process.WaitForExitOrKill(10000);
+                lifecycleLogger?.LogCleanupSuccess(planId, wtDir);
             }
-            catch
+            catch (Exception ex)
             {
-                // Best-effort: if git worktree remove fails, the fallback
-                // ClearReadOnlyAttributes + Directory.Delete may still work.
+                lifecycleLogger?.LogCleanupFailed(planId, wtDir, ex.Message);
             }
         }
     }

--- a/src/tendril/Ivy.Tendril/Services/WorktreeCleanupService.cs
+++ b/src/tendril/Ivy.Tendril/Services/WorktreeCleanupService.cs
@@ -17,12 +17,14 @@ public class WorktreeCleanupService : IStartable, IDisposable
 
     private readonly string _plansDirectory;
     private readonly ILogger<WorktreeCleanupService> _logger;
+    private readonly IWorktreeLifecycleLogger? _lifecycleLogger;
     private Timer? _timer;
 
-    public WorktreeCleanupService(string plansDirectory, ILogger<WorktreeCleanupService> logger)
+    public WorktreeCleanupService(string plansDirectory, ILogger<WorktreeCleanupService> logger, IWorktreeLifecycleLogger? lifecycleLogger = null)
     {
         _plansDirectory = plansDirectory;
         _logger = logger;
+        _lifecycleLogger = lifecycleLogger;
     }
 
     public void Start()
@@ -45,7 +47,7 @@ public class WorktreeCleanupService : IStartable, IDisposable
             {
                 try
                 {
-                    CleanupPlanWorktrees(dir);
+                    CleanupPlanWorktrees(dir, _logger, _lifecycleLogger);
                 }
                 catch (Exception ex)
                 {
@@ -59,7 +61,7 @@ public class WorktreeCleanupService : IStartable, IDisposable
         }
     }
 
-    internal static void CleanupPlanWorktrees(string planFolderPath, ILogger? logger = null)
+    internal static void CleanupPlanWorktrees(string planFolderPath, ILogger? logger = null, IWorktreeLifecycleLogger? lifecycleLogger = null)
     {
         var worktreesDir = Path.Combine(planFolderPath, "worktrees");
         if (!Directory.Exists(worktreesDir)) return;
@@ -88,15 +90,19 @@ public class WorktreeCleanupService : IStartable, IDisposable
 
         if (DateTime.UtcNow - planYaml.Updated < GracePeriod) return;
 
+        var planId = WorktreeLifecycleLogger.ExtractPlanId(planFolderPath);
+
         logger?.LogInformation("Cleaning up worktrees for plan {PlanFolder} (state: {State}, updated: {Updated})",
             Path.GetFileName(planFolderPath), planYaml.State, planYaml.Updated.ToString("o", CultureInfo.InvariantCulture));
 
-        PlanReaderService.RemoveWorktrees(planFolderPath, logger);
+        PlanReaderService.RemoveWorktrees(planFolderPath, logger, lifecycleLogger);
 
         foreach (var wtDir in Directory.GetDirectories(worktreesDir))
         {
             var gitFile = Path.Combine(wtDir, ".git");
-            if (!File.Exists(gitFile))
+            var gitFileExists = File.Exists(gitFile);
+
+            if (!gitFileExists)
             {
                 var dirAge = DateTime.UtcNow - new DirectoryInfo(wtDir).CreationTimeUtc;
                 logger?.LogWarning(
@@ -104,12 +110,16 @@ public class WorktreeCleanupService : IStartable, IDisposable
                     dirAge, Path.GetFileName(wtDir));
             }
 
+            lifecycleLogger?.LogCleanupAttempt(planId, wtDir, $"TerminalState({planYaml.State})", gitFileExists);
+
             try
             {
                 ForceDeleteDirectory(wtDir, logger);
+                lifecycleLogger?.LogCleanupSuccess(planId, wtDir);
             }
             catch (Exception ex)
             {
+                lifecycleLogger?.LogCleanupFailed(planId, wtDir, ex.Message);
                 logger?.LogWarning(ex, "Failed to force-delete worktree directory {Dir}", Path.GetFileName(wtDir));
             }
         }
@@ -212,6 +222,6 @@ public class WorktreeCleanupService : IStartable, IDisposable
 
     private void CleanupPlanWorktrees(string planFolderPath)
     {
-        CleanupPlanWorktrees(planFolderPath, _logger);
+        CleanupPlanWorktrees(planFolderPath, _logger, _lifecycleLogger);
     }
 }

--- a/src/tendril/Ivy.Tendril/Services/WorktreeLifecycleLogger.cs
+++ b/src/tendril/Ivy.Tendril/Services/WorktreeLifecycleLogger.cs
@@ -1,0 +1,67 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace Ivy.Tendril.Services;
+
+public class WorktreeLifecycleLogger : IWorktreeLifecycleLogger
+{
+    private static readonly Regex PlanIdRegex = new(@"(\d{5})-", RegexOptions.Compiled);
+    private readonly string _logFilePath;
+    private readonly object _lock = new();
+
+    public WorktreeLifecycleLogger(string tendrilHome)
+    {
+        var logDir = Path.Combine(tendrilHome, "Logs");
+        Directory.CreateDirectory(logDir);
+        _logFilePath = Path.Combine(logDir, "worktrees.log");
+    }
+
+    public void LogCreation(string planId, string repoPath, string worktreePath, string branch)
+    {
+        WriteEntry(planId, "Creation",
+            $"repo=\"{repoPath}\" worktree=\"{worktreePath}\" branch=\"{branch}\"");
+    }
+
+    public void LogCreationFailed(string planId, string repoPath, string worktreePath, string error)
+    {
+        WriteEntry(planId, "CreationFailed",
+            $"repo=\"{repoPath}\" worktree=\"{worktreePath}\" error=\"{Escape(error)}\"");
+    }
+
+    public void LogCleanupAttempt(string planId, string worktreePath, string trigger, bool gitFileExists)
+    {
+        WriteEntry(planId, "CleanupAttempt",
+            $"worktree=\"{worktreePath}\" trigger=\"{trigger}\" gitFileExists=\"{gitFileExists}\"");
+    }
+
+    public void LogCleanupSuccess(string planId, string worktreePath)
+    {
+        WriteEntry(planId, "CleanupSuccess", $"worktree=\"{worktreePath}\"");
+    }
+
+    public void LogCleanupFailed(string planId, string worktreePath, string error)
+    {
+        WriteEntry(planId, "CleanupFailed",
+            $"worktree=\"{worktreePath}\" error=\"{Escape(error)}\"");
+    }
+
+    public static string ExtractPlanId(string planFolderPath)
+    {
+        var folderName = Path.GetFileName(planFolderPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+        var match = PlanIdRegex.Match(folderName);
+        return match.Success ? match.Groups[1].Value : "unknown";
+    }
+
+    private void WriteEntry(string planId, string eventType, string metadata)
+    {
+        var timestamp = DateTime.UtcNow.ToString("o", CultureInfo.InvariantCulture);
+        var entry = $"[{timestamp}] [{planId}] [{eventType}] {metadata}";
+
+        lock (_lock)
+        {
+            File.AppendAllText(_logFilePath, entry + Environment.NewLine);
+        }
+    }
+
+    private static string Escape(string value) => value.Replace("\"", "\\\"").Replace("\n", " ").Replace("\r", "");
+}

--- a/src/tendril/Ivy.Tendril/TendrilServer.cs
+++ b/src/tendril/Ivy.Tendril/TendrilServer.cs
@@ -47,12 +47,19 @@ public static class TendrilServer
         server.Services.AddSingleton<IGithubService>(sp => sp.GetRequiredService<GithubService>());
         server.Services.AddSingleton<GitService>();
         server.Services.AddSingleton<IGitService>(sp => sp.GetRequiredService<GitService>());
+        server.Services.AddSingleton<IWorktreeLifecycleLogger>(sp =>
+        {
+            var config = sp.GetRequiredService<IConfigService>();
+            return new WorktreeLifecycleLogger(
+                string.IsNullOrEmpty(config.TendrilHome) ? "." : config.TendrilHome);
+        });
         server.Services.AddSingleton<PlanReaderService>(sp =>
         {
             var planService = new PlanReaderService(
                 sp.GetRequiredService<IConfigService>(),
                 sp.GetRequiredService<ILogger<PlanReaderService>>(),
-                sp.GetRequiredService<ITelemetryService>());
+                sp.GetRequiredService<ITelemetryService>(),
+                sp.GetRequiredService<IWorktreeLifecycleLogger>());
             planService.RepairPlans();
             planService.RecoverStuckPlans();
             return planService;
@@ -95,7 +102,8 @@ public static class TendrilServer
                 sp.GetRequiredService<IPlanReaderService>(),
                 sp.GetRequiredService<ITelemetryService>(),
                 sp.GetRequiredService<IPlanWatcherService>(),
-                string.IsNullOrEmpty(cfg.TendrilHome) ? null : sp.GetRequiredService<IPlanDatabaseService>());
+                string.IsNullOrEmpty(cfg.TendrilHome) ? null : sp.GetRequiredService<IPlanDatabaseService>(),
+                sp.GetRequiredService<IWorktreeLifecycleLogger>());
         });
         server.Services.AddSingleton<IJobService>(sp => sp.GetRequiredService<JobService>());
         server.Services.AddSingleton<PlanWatcherService>(sp =>
@@ -123,7 +131,8 @@ public static class TendrilServer
         {
             var config = sp.GetRequiredService<IConfigService>();
             var logger = sp.GetRequiredService<ILogger<WorktreeCleanupService>>();
-            return new WorktreeCleanupService(config.PlanFolder, logger);
+            var lifecycleLogger = sp.GetRequiredService<IWorktreeLifecycleLogger>();
+            return new WorktreeCleanupService(config.PlanFolder, logger, lifecycleLogger);
         });
         server.Services.AddSingleton<IStartable>(sp => sp.GetRequiredService<WorktreeCleanupService>());
         server.Services.AddSingleton<PrStatusSyncService>(sp =>


### PR DESCRIPTION
# Summary

## Changes

Added a centralized `WorktreeLifecycleLogger` service that writes structured log entries to `{TendrilHome}/Logs/worktrees.log` for all worktree creation and cleanup operations. Integrated the logger into `PlanReaderService.RemoveWorktrees`, `WorktreeCleanupService.CleanupPlanWorktrees`, and `JobService.ScheduleWorktreeCleanup`. Also created a `Log-WorktreeEvent.ps1` PowerShell tool for use by ExecutePlan during worktree creation from bash.

## API Changes

- **New interface:** `IWorktreeLifecycleLogger` with methods `LogCreation`, `LogCreationFailed`, `LogCleanupAttempt`, `LogCleanupSuccess`, `LogCleanupFailed`
- **New class:** `WorktreeLifecycleLogger` implementing the interface, with static `ExtractPlanId(string)` helper
- **Modified:** `PlanReaderService.RemoveWorktrees` — added optional `IWorktreeLifecycleLogger? lifecycleLogger` parameter
- **Modified:** `WorktreeCleanupService.CleanupPlanWorktrees` — added optional `IWorktreeLifecycleLogger? lifecycleLogger` parameter
- **Modified:** `WorktreeCleanupService` constructor — added optional `IWorktreeLifecycleLogger? lifecycleLogger` parameter
- **Modified:** `PlanReaderService` constructor — added optional `IWorktreeLifecycleLogger? worktreeLifecycleLogger` parameter
- **Modified:** `JobService` constructor — added optional `IWorktreeLifecycleLogger? worktreeLifecycleLogger` parameter
- **Modified:** `JobService.ScheduleWorktreeCleanup` — changed from `static` to instance method to access lifecycle logger

## Files Modified

- **New:** `Services/IWorktreeLifecycleLogger.cs` — interface definition
- **New:** `Services/WorktreeLifecycleLogger.cs` — implementation with structured log file writing
- **Modified:** `Services/PlanReaderService.cs` — lifecycle logging in `RemoveWorktrees`
- **Modified:** `Services/WorktreeCleanupService.cs` — lifecycle logging in cleanup flow
- **Modified:** `Services/JobService.cs` — lifecycle logging in failure cleanup
- **Modified:** `TendrilServer.cs` — DI registration
- **New:** `Promptwares/ExecutePlan/Tools/Log-WorktreeEvent.ps1` — PowerShell tool for bash-based logging
- **New:** `Ivy.Tendril.Test/WorktreeLifecycleLoggerTests.cs` — 12 unit tests

## Commits

- 6753eccf9 [03058] Add Log-WorktreeEvent.ps1 tool for ExecutePlan worktree logging
- f7ef76a31 [03058] Add unit tests for WorktreeLifecycleLogger
- 089e6ed48 [03058] Integrate WorktreeLifecycleLogger into PlanReaderService, WorktreeCleanupService, and JobService
- 8d68a7742 [03058] Add WorktreeLifecycleLogger service for centralized worktree audit trail