### PR TITLE
[03059] Detect and remove recursive worktree artifacts in Plans directory

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/WorktreeCleanupServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/WorktreeCleanupServiceTests.cs
@@ -421,6 +421,97 @@ public class WorktreeCleanupServiceTests : IDisposable
         Assert.False(Directory.Exists(worktreeDir), "Very recent orphan should still be cleaned up");
     }
 
+    [Fact]
+    public void CleanupRecursiveArtifacts_Removes_Nested_Plans_In_Worktrees()
+    {
+        var dir = CreatePlan("13000-RecursiveTest", "Executing");
+        var worktreeDir = Path.Combine(dir, "worktrees", "TestRepo");
+        var nestedPlans = Path.Combine(worktreeDir, "src", "tendril", "Plans", "01234-OldPlan");
+        Directory.CreateDirectory(nestedPlans);
+        File.WriteAllText(Path.Combine(nestedPlans, "plan.yaml"), "state: Completed");
+
+        _service.RunCleanup();
+
+        Assert.False(Directory.Exists(Path.Combine(worktreeDir, "src", "tendril", "Plans")),
+            "Nested Plans directory should be deleted");
+        Assert.True(Directory.Exists(worktreeDir),
+            "Worktree repo directory should remain");
+    }
+
+    [Fact]
+    public void CleanupRecursiveArtifacts_Handles_Multiple_Nesting_Levels()
+    {
+        var dir = CreatePlan("13001-MultiLevel", "Executing");
+        var worktreeDir = Path.Combine(dir, "worktrees", "Repo");
+
+        // Level 1: Plans/B inside worktree
+        var level1 = Path.Combine(worktreeDir, "Plans", "B-Plan", "worktrees", "Repo");
+        Directory.CreateDirectory(level1);
+
+        // Level 2: Plans/C nested inside level 1
+        var level2 = Path.Combine(level1, "Plans", "C-Plan");
+        Directory.CreateDirectory(level2);
+        File.WriteAllText(Path.Combine(level2, "plan.yaml"), "state: Failed");
+
+        _service.RunCleanup();
+
+        Assert.False(Directory.Exists(Path.Combine(worktreeDir, "Plans")),
+            "All nested Plans directories should be removed");
+        Assert.True(Directory.Exists(worktreeDir),
+            "Top-level worktree directory should remain");
+    }
+
+    [Fact]
+    public void CleanupRecursiveArtifacts_Skips_Plans_With_No_Worktrees()
+    {
+        CreatePlan("13002-NoWorktrees", "Executing");
+
+        var ex = Record.Exception(() => _service.RunCleanup());
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void CleanupRecursiveArtifacts_Logs_On_Delete_Failure()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        var logEntries = new List<string>();
+        var logger = new CapturingLogger(logEntries);
+        var service = new WorktreeCleanupService(_plansDir, new LoggerAdapter(logger));
+
+        var dir = CreatePlan("13003-LockedNested", "Executing");
+        var worktreeDir = Path.Combine(dir, "worktrees", "Repo");
+        var nestedPlans = Path.Combine(worktreeDir, "src", "Plans", "OldPlan");
+        Directory.CreateDirectory(nestedPlans);
+        var lockedFile = Path.Combine(nestedPlans, "locked.txt");
+        File.WriteAllText(lockedFile, "content");
+
+        using (var stream = new FileStream(lockedFile, FileMode.Open, FileAccess.Read, FileShare.None))
+        {
+            service.RunCleanup();
+        }
+
+        Assert.Contains(logEntries, e => e.Contains("Removing recursive Plans artifact") || e.Contains("Failed to delete nested Plans"));
+
+        // Cleanup
+        if (Directory.Exists(nestedPlans))
+            Directory.Delete(nestedPlans, true);
+
+        service.Dispose();
+    }
+
+    private class LoggerAdapter(ILogger inner) : ILogger<WorktreeCleanupService>
+    {
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => inner.BeginScope(state);
+        public bool IsEnabled(LogLevel logLevel) => inner.IsEnabled(logLevel);
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            inner.Log(logLevel, eventId, state, exception, formatter);
+        }
+    }
+
     private class CapturingLogger(List<string> entries) : ILogger
     {
         public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;

--- a/src/tendril/Ivy.Tendril/Services/WorktreeCleanupService.cs
+++ b/src/tendril/Ivy.Tendril/Services/WorktreeCleanupService.cs
@@ -41,6 +41,10 @@ public class WorktreeCleanupService : IStartable, IDisposable
         {
             if (!Directory.Exists(_plansDirectory)) return;
 
+            // First pass: remove recursive Plans artifacts within worktrees
+            CleanupRecursiveArtifacts();
+
+            // Second pass: regular plan-level worktree cleanup
             foreach (var dir in Directory.GetDirectories(_plansDirectory))
             {
                 try
@@ -56,6 +60,54 @@ public class WorktreeCleanupService : IStartable, IDisposable
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Worktree cleanup scan failed");
+        }
+    }
+
+    internal void CleanupRecursiveArtifacts()
+    {
+        try
+        {
+            if (!Directory.Exists(_plansDirectory)) return;
+
+            foreach (var planDir in Directory.GetDirectories(_plansDirectory))
+            {
+                try
+                {
+                    var worktreesDir = Path.Combine(planDir, "worktrees");
+                    if (!Directory.Exists(worktreesDir)) continue;
+
+                    var nestedPlans = Directory.GetDirectories(worktreesDir, "Plans", SearchOption.AllDirectories);
+
+                    foreach (var nestedPlanDir in nestedPlans)
+                    {
+                        try
+                        {
+                            _logger.LogInformation(
+                                "Removing recursive Plans artifact at {Path} (parent: {Parent})",
+                                nestedPlanDir.Replace(_plansDirectory + Path.DirectorySeparatorChar, ""),
+                                Path.GetFileName(planDir));
+
+                            ForceDeleteDirectory(nestedPlanDir, _logger);
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogWarning(ex,
+                                "Failed to delete nested Plans directory {Path}",
+                                nestedPlanDir.Replace(_plansDirectory + Path.DirectorySeparatorChar, ""));
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex,
+                        "Failed to scan for recursive artifacts in {PlanFolder}",
+                        Path.GetFileName(planDir));
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Recursive artifact cleanup scan failed");
         }
     }
 


### PR DESCRIPTION
# Summary

## Changes

Added `CleanupRecursiveArtifacts()` method to `WorktreeCleanupService` that scans for and removes nested Plans directories within worktrees. Updated `RunCleanup()` to call this new method before the regular plan-level worktree cleanup, preventing exponential path traversal from recursive worktree-within-worktree artifacts.

## API Changes

- `WorktreeCleanupService.CleanupRecursiveArtifacts()` — new internal instance method that removes nested Plans directories found inside `{planDir}/worktrees/**/Plans/`

## Files Modified

- `src/tendril/Ivy.Tendril/Services/WorktreeCleanupService.cs` — Added `CleanupRecursiveArtifacts()` method, updated `RunCleanup()` to call it first
- `src/tendril/Ivy.Tendril.Test/WorktreeCleanupServiceTests.cs` — Added 4 new tests and `LoggerAdapter` helper class

## Commits

- 2cce4b342 [03059] Detect and remove recursive worktree artifacts in Plans directory