### PR TITLE
[03061] Fix anyAgentHealthy check for Gemini in SoftwareCheckStepView

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Onboarding/SoftwareCheckStepView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Onboarding/SoftwareCheckStepView.cs
@@ -25,10 +25,10 @@ public class SoftwareCheckStepView(
                                     checkResults.Value["gemini"]);
 
         var ghHealthy = healthResults.Value?.GetValueOrDefault("gh") == HealthCheckStatus.Authenticated;
-        var anyAgentHealthy = healthResults.Value != null
-                              && (healthResults.Value.GetValueOrDefault("claude") == HealthCheckStatus.Authenticated
-                                  || healthResults.Value.GetValueOrDefault("codex") == HealthCheckStatus.Authenticated
-                                  || healthResults.Value.GetValueOrDefault("gemini") == HealthCheckStatus.Authenticated);
+        var anyAgentHealthy = (healthResults.Value != null
+                               && (healthResults.Value.GetValueOrDefault("claude") == HealthCheckStatus.Authenticated
+                                   || healthResults.Value.GetValueOrDefault("codex") == HealthCheckStatus.Authenticated))
+                              || (checkResults.Value != null && checkResults.Value.GetValueOrDefault("gemini"));
 
         var allRequiredPassed = checkResults.Value != null
                                 && checkResults.Value["gh"] && ghHealthy


### PR DESCRIPTION
# Summary

## Changes

Fixed the `anyAgentHealthy` boolean in `SoftwareCheckStepView` to treat Gemini's installation status (from `checkResults`) as sufficient, since Gemini CLI has no non-interactive health check. Previously, Gemini-only users were blocked at onboarding because `healthResults` never contained a "gemini" entry.

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/Apps/Onboarding/SoftwareCheckStepView.cs** — Changed `anyAgentHealthy` logic to check `checkResults.Value.GetValueOrDefault("gemini")` instead of `healthResults.Value.GetValueOrDefault("gemini") == HealthCheckStatus.Authenticated`

## Commits

- a47e8a478 [03061] Fix anyAgentHealthy check to use installation status for Gemini