### PR TITLE
[03062] Remove unused _prStatusCache from GithubService

### DIFF
--- a/src/tendril/Ivy.Tendril/Services/GithubService.cs
+++ b/src/tendril/Ivy.Tendril/Services/GithubService.cs
@@ -12,7 +12,6 @@ public class GithubService(IConfigService config) : IGithubService
     private readonly ConcurrentDictionary<string, List<string>> _assigneeCache = new();
     private readonly IConfigService _config = config;
     private readonly ConcurrentDictionary<string, List<string>> _labelCache = new();
-    private readonly ConcurrentDictionary<string, Dictionary<string, string>> _prStatusCache = new();
     private List<RepoConfig>? _repoCache;
 
     public List<RepoConfig> GetRepos()
@@ -61,13 +60,7 @@ public class GithubService(IConfigService config) : IGithubService
 
     public async Task<Dictionary<string, string>> GetPrStatusesAsync(string owner, string repo)
     {
-        var key = $"{owner}/{repo}";
-        if (_prStatusCache.TryGetValue(key, out var cached))
-            return cached;
-
-        var statuses = await FetchPrStatusesFromGhCliAsync(owner, repo);
-        _prStatusCache[key] = statuses;
-        return statuses;
+        return await FetchPrStatusesFromGhCliAsync(owner, repo);
     }
 
     public async Task<List<GitHubIssue>> SearchIssuesAsync(string owner, string repo, string? query, string? assignee,


### PR DESCRIPTION
# Summary

## Changes

Removed the unused `_prStatusCache` (ConcurrentDictionary) field from `GithubService` and simplified `GetPrStatusesAsync()` to always fetch fresh data from the GitHub CLI. The in-memory cache was redundant since PR statuses are now persisted in SQLite by `PrStatusSyncService` and all consumers read from the database.

## API Changes

- `GithubService.GetPrStatusesAsync(string owner, string repo)` — no signature change, but now always fetches fresh data instead of returning cached results.

## Files Modified

- **src/tendril/Ivy.Tendril/Services/GithubService.cs** — Removed `_prStatusCache` field, simplified `GetPrStatusesAsync` to delegate directly to `FetchPrStatusesFromGhCliAsync`.

## Commits

- 1791a72a4 [03062] Remove unused _prStatusCache from GithubService