### PR TITLE
[03067] Fix OnboardingTest ExampleConfig Verification Check

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/OnboardingSetupServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/OnboardingSetupServiceTests.cs
@@ -223,10 +223,10 @@ public class OnboardingSetupServiceTests : IAsyncLifetime
         var examplePath = Path.Combine(baseDir, "example.config.yaml");
         var exampleContent = File.Exists(examplePath) ? await File.ReadAllTextAsync(examplePath) : "";
 
-        if (!exampleContent.Contains("DotnetBuild"))
+        if (!exampleContent.Contains("Build"))
         {
             exampleContent =
-                "codingAgent: claude\nprojects: []\nverifications:\n- name: DotnetBuild\n  prompt: Build\n";
+                "codingAgent: claude\nprojects: []\nverifications:\n- name: Build\n  prompt: Build\n";
             await File.WriteAllTextAsync(examplePath, exampleContent);
         }
 
@@ -236,7 +236,7 @@ public class OnboardingSetupServiceTests : IAsyncLifetime
 
             var configPath = Path.Combine(_tempDir, "config.yaml");
             var content = await File.ReadAllTextAsync(configPath);
-            Assert.Contains("DotnetBuild", content);
+            Assert.Contains("Build", content);
         }
         finally
         {


### PR DESCRIPTION
# Summary

## Changes

Updated `OnboardingSetupServiceTests.CompleteSetupAsync_ExampleConfigContainsVerifications` to check for the generic "Build" verification name instead of the stack-specific "DotnetBuild". This aligns the test with the current stack-agnostic `example.config.yaml` that was updated in commit [02364].

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril.Test/OnboardingSetupServiceTests.cs** — Changed 3 occurrences of "DotnetBuild" to "Build" in the ExampleConfig verification test (lines 226, 229, 239)

---

**Commits:**
- a98612e6f [03067] Fix OnboardingTest to check for generic Build verification