### PR TITLE
[03068] Fix ConfigService Constructor Testability

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/ConfigServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/ConfigServiceTests.cs
@@ -659,6 +659,21 @@ promptwares:
     }
 
     [Fact]
+    public void Constructor_WithEmptyString_SetsNoHome()
+    {
+        var service = new ConfigService(new TendrilSettings(), "");
+        Assert.Equal("", service.TendrilHome);
+    }
+
+    [Fact]
+    public void Constructor_WithNull_FallsBackToEnvVar()
+    {
+        var service = new ConfigService(new TendrilSettings(), null);
+        var expected = Environment.GetEnvironmentVariable("TENDRIL_HOME") ?? "";
+        Assert.Equal(expected, service.TendrilHome);
+    }
+
+    [Fact]
     public void SaveSettings_PersistsAdvancedSettings()
     {
         var yaml = @"

--- a/src/tendril/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/tendril/Ivy.Tendril/Services/ConfigService.cs
@@ -143,12 +143,10 @@ public class ConfigService : IConfigService
     private string? _pendingTendrilHome;
     private List<VerificationConfig>? _pendingVerificationDefinitions;
 
-    internal ConfigService(TendrilSettings settings, string tendrilHome = "")
+    internal ConfigService(TendrilSettings settings, string? tendrilHome = null)
     {
         Settings = settings;
-        TendrilHome = !string.IsNullOrEmpty(tendrilHome)
-            ? tendrilHome
-            : Environment.GetEnvironmentVariable("TENDRIL_HOME") ?? "";
+        TendrilHome = tendrilHome ?? Environment.GetEnvironmentVariable("TENDRIL_HOME") ?? "";
         ConfigPath = !string.IsNullOrEmpty(TendrilHome)
             ? Path.Combine(TendrilHome, "config.yaml")
             : Path.Combine(System.AppContext.BaseDirectory, "config.yaml");


### PR DESCRIPTION
# Summary

## Changes

Changed the `ConfigService` internal constructor's `tendrilHome` parameter from `string tendrilHome = ""` to `string? tendrilHome = null`. This makes `null` trigger the env-var fallback while `""` explicitly means "no home configured", fixing testability for the onboarding setup scenario. Added two unit tests verifying both behaviors.

## API Changes

- `ConfigService(TendrilSettings, string)` internal constructor: parameter type changed from `string` (default `""`) to `string?` (default `null`). Binary-compatible for all existing call sites.

## Files Modified

- `src/tendril/Ivy.Tendril/Services/ConfigService.cs` — Constructor signature and body
- `src/tendril/Ivy.Tendril.Test/ConfigServiceTests.cs` — Two new test methods

## Commits

- 39036f264 [03068] Fix ConfigService constructor testability