### PR TITLE
[03071] Use TryGetValue for defensive dictionary access in SoftwareCheckStepView

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Onboarding/SoftwareCheckStepView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Onboarding/SoftwareCheckStepView.cs
@@ -158,7 +158,7 @@ public class SoftwareCheckStepView(
         string installUrl,
         bool isRequired)
     {
-        var installed = results[key];
+        var installed = results.GetValueOrDefault(key);
         var healthStatus = health?.GetValueOrDefault(key);
 
         string statusText;


### PR DESCRIPTION
# Summary

## Changes

Changed `MakeSoftwareRow` in `SoftwareCheckStepView.cs` to use `results.GetValueOrDefault(key)` instead of `results[key]` for defensive dictionary access. This prevents `KeyNotFoundException` if a key is ever missing, consistent with the existing `health?.GetValueOrDefault(key)` pattern on the adjacent line.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Apps/Onboarding/SoftwareCheckStepView.cs` — changed direct dictionary indexer to `GetValueOrDefault`

## Commits

- 6c000151e