### PR TITLE
[03073] Include Arguments in InvokePromptwareAgent log line

### DIFF
--- a/src/tendril/Ivy.Tendril/Promptwares/.shared/Utils.ps1
+++ b/src/tendril/Ivy.Tendril/Promptwares/.shared/Utils.ps1
@@ -445,6 +445,7 @@ function InvokePromptwareAgent {
     $agentInfo = $codingAgent
     if ($agent.Model) { $agentInfo += ", model=$($agent.Model)" }
     if ($agent.Effort) { $agentInfo += ", effort=$($agent.Effort)" }
+    if ($agent.Arguments -and $agent.Arguments.Count -gt 0) { $agentInfo += ", args=$($agent.Arguments -join ' ')" }
     Write-Host "Starting Agent ($agentInfo)..."
     if ($Action) { SendStatusMessage "Running $Action" }
     Push-Location $WorkDir


### PR DESCRIPTION
# Summary

## Changes

Added the `Arguments` field to the `InvokePromptwareAgent` log line in `Utils.ps1`. When an agent has arguments configured, the log now displays them as `args=<space-joined arguments>` alongside the existing `model=` and `effort=` fields.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Promptwares/.shared/Utils.ps1` — Added arguments logging to the agent info string (1 line added)

## Commits

- cabe4ba48 [03073] Include Arguments in InvokePromptwareAgent log line