### PR TITLE
[03069] Add Log Warning When GetPricing Falls Back To Default Pricing

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/BackgroundServiceActivatorTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/BackgroundServiceActivatorTests.cs
@@ -116,7 +116,7 @@ public class BackgroundServiceActivatorTests : IAsyncLifetime
 
         var services = new ServiceCollection();
         services.AddSingleton<IConfigService>(config);
-        services.AddSingleton(new ModelPricingService());
+        services.AddSingleton(new ModelPricingService(NullLogger<ModelPricingService>.Instance));
         services.AddSingleton<IPlanReaderService>(sp =>
             new PlanReaderService(sp.GetRequiredService<IConfigService>(), NullLogger<PlanReaderService>.Instance));
         services.AddSingleton<ITelemetryService>(sp => new TelemetryService(false));

--- a/src/tendril/Ivy.Tendril.Test/ModelPricingServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/ModelPricingServiceTests.cs
@@ -1,10 +1,12 @@
 using Ivy.Tendril.Services;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Ivy.Tendril.Test;
 
 public class ModelPricingServiceTests
 {
-    private readonly ModelPricingService _service = new();
+    private readonly ModelPricingService _service = new(NullLogger<ModelPricingService>.Instance);
 
     [Fact]
     public void LoadsEmbeddedModelsYaml()
@@ -418,5 +420,45 @@ public class ModelPricingServiceTests
     {
         var mini = _service.GetPricing("gpt-5.4-mini");
         Assert.Equal(1.10, mini.Input);
+    }
+
+    [Fact]
+    public void GetPricing_LogsWarning_WhenModelNotFound()
+    {
+        var logger = new CapturingLogger<ModelPricingService>();
+        var service = new ModelPricingService(logger);
+
+        service.GetPricing("totally-unknown-model");
+
+        Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Warning, logger.Entries[0].Level);
+        Assert.Contains("totally-unknown-model", logger.Entries[0].Message);
+        Assert.Contains("not found in pricing database", logger.Entries[0].Message);
+    }
+
+    [Fact]
+    public void GetPricing_DoesNotLogWarning_WhenModelFound()
+    {
+        var logger = new CapturingLogger<ModelPricingService>();
+        var service = new ModelPricingService(logger);
+
+        service.GetPricing("claude-opus-4");
+
+        Assert.Empty(logger.Entries);
+    }
+
+    private class CapturingLogger<T> : ILogger<T>
+    {
+        public List<(LogLevel Level, string Message)> Entries { get; } = new();
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            Entries.Add((logLevel, formatter(state, exception)));
+        }
     }
 }

--- a/src/tendril/Ivy.Tendril/Services/ModelPricingService.cs
+++ b/src/tendril/Ivy.Tendril/Services/ModelPricingService.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using System.Text.Json;
+using Microsoft.Extensions.Logging;
 using YamlDotNet.Serialization;
 
 namespace Ivy.Tendril.Services;
@@ -21,9 +22,11 @@ public record CostCalculation
 public class ModelPricingService : IModelPricingService
 {
     private static readonly IDeserializer DefaultDeserializer = new DeserializerBuilder().Build();
+    private readonly ILogger<ModelPricingService> _logger;
 
-    public ModelPricingService()
+    public ModelPricingService(ILogger<ModelPricingService> logger)
     {
+        _logger = logger;
         Pricing = LoadEmbeddedPricing();
     }
 
@@ -36,6 +39,11 @@ public class ModelPricingService : IModelPricingService
                 return Pricing[key];
 
         // Fallback to Opus 4.6 (current default model)
+        _logger.LogWarning(
+            "Model '{ModelName}' not found in pricing database. Falling back to Claude Opus 4.6 pricing ($5.00/$25.00). " +
+            "Check config.yaml for typos or add the model to Assets/models.yaml.",
+            modelName);
+
         return Pricing.TryGetValue("claude-opus-4-6", out var fallback)
             ? fallback
             : new ModelPricing { Input = 5.0, Output = 25.0, CacheWrite = 6.25, CacheRead = 0.50 };

--- a/src/tendril/Ivy.Tendril/TendrilServer.cs
+++ b/src/tendril/Ivy.Tendril/TendrilServer.cs
@@ -24,9 +24,9 @@ public static class TendrilServer
         server.Services.AddSingleton<IConfigService>(configService);
         server.Services.AddSingleton<ConfigService>(configService);
 
-        var modelPricingService = new ModelPricingService();
-        server.Services.AddSingleton<IModelPricingService>(modelPricingService);
-        server.Services.AddSingleton(modelPricingService);
+        server.Services.AddSingleton<ModelPricingService>(sp =>
+            new ModelPricingService(sp.GetRequiredService<ILogger<ModelPricingService>>()));
+        server.Services.AddSingleton<IModelPricingService>(sp => sp.GetRequiredService<ModelPricingService>());
 
         // Register IChatClient if LLM is configured
         if (configService.Settings.Llm is { } llmConfig && !string.IsNullOrEmpty(llmConfig.ApiKey))


### PR DESCRIPTION
# Summary

## Changes

Added `ILogger<ModelPricingService>` dependency injection to `ModelPricingService` and a `LogWarning` call when `GetPricing()` cannot find a matching model in the pricing dictionary. Updated all instantiation sites (TendrilServer DI, BackgroundServiceActivatorTests, ModelPricingServiceTests) to pass the logger. Added two new tests verifying the warning behavior.

## API Changes

- `ModelPricingService` constructor now requires `ILogger<ModelPricingService>` parameter (breaking change for direct instantiation; DI consumers unaffected)
- `TendrilServer.cs` DI registration changed from eager `new ModelPricingService()` to factory-based `sp => new ModelPricingService(sp.GetRequiredService<ILogger<ModelPricingService>>())`

## Files Modified

- **Service:** `src/tendril/Ivy.Tendril/Services/ModelPricingService.cs` — added logger field, constructor param, and `LogWarning` in fallback path
- **DI registration:** `src/tendril/Ivy.Tendril/TendrilServer.cs` — factory-based singleton with logger injection
- **Tests:** `src/tendril/Ivy.Tendril.Test/ModelPricingServiceTests.cs` — updated fixture, added `GetPricing_LogsWarning_WhenModelNotFound` and `GetPricing_DoesNotLogWarning_WhenModelFound` tests
- **Tests:** `src/tendril/Ivy.Tendril.Test/BackgroundServiceActivatorTests.cs` — pass `NullLogger` instance

---

## Commits

- 5fdd0fbd5 [03069] Add log warning when GetPricing falls back to default pricing