### PR TITLE
[03060] Refactor JobItem.Project for Multi-Select Support

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/ProjectHelperTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/ProjectHelperTests.cs
@@ -1,0 +1,45 @@
+using Ivy.Tendril.Helpers;
+
+namespace Ivy.Tendril.Test;
+
+public class ProjectHelperTests
+{
+    [Theory]
+    [InlineData("Framework", new[] { "Framework" })]
+    [InlineData("Framework, Tendril", new[] { "Framework", "Tendril" })]
+    [InlineData("Framework,Tendril,Agent", new[] { "Framework", "Tendril", "Agent" })]
+    [InlineData("  Framework  ,  Tendril  ", new[] { "Framework", "Tendril" })]
+    [InlineData("", new string[0])]
+    [InlineData(null, new string[0])]
+    public void ParseProjects_HandlesVariousFormats(string? input, string[] expected)
+    {
+        var result = ProjectHelper.ParseProjects(input);
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("Framework", "Framework", true)]
+    [InlineData("Framework, Tendril", "Framework", true)]
+    [InlineData("Framework, Tendril", "Tendril", true)]
+    [InlineData("Framework, Tendril", "Agent", false)]
+    [InlineData("Framework", "framework", true)]
+    [InlineData("", "Framework", false)]
+    [InlineData(null, "Framework", false)]
+    public void ContainsProject_ChecksMembership(string? projectValue, string projectToFind, bool expected)
+    {
+        var result = ProjectHelper.ContainsProject(projectValue, projectToFind);
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("Framework", "Framework")]
+    [InlineData("Framework, Tendril", "Framework, Tendril")]
+    [InlineData("  Framework  ,  Tendril  ", "Framework, Tendril")]
+    [InlineData("", "[Auto]")]
+    [InlineData(null, "[Auto]")]
+    public void FormatProjectsForDisplay_FormatsCorrectly(string? input, string expected)
+    {
+        var result = ProjectHelper.FormatProjectsForDisplay(input);
+        Assert.Equal(expected, result);
+    }
+}

--- a/src/tendril/Ivy.Tendril/Apps/JobsApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/JobsApp.cs
@@ -2,6 +2,7 @@ using System.Reactive.Disposables;
 using System.Text.RegularExpressions;
 using Ivy.Tendril.Apps.Jobs;
 using Ivy.Tendril.Apps.Plans;
+using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Services;
 
 namespace Ivy.Tendril.Apps;
@@ -68,7 +69,7 @@ public class JobsApp : ViewBase
                 PlanId = displayPlanId,
                 Plan = GetPromptDisplay(j, planService),
                 Type = j.Type,
-                Project = j.Project,
+                Project = string.Join(", ", ProjectHelper.ParseProjects(j.Project)),
                 Timer = FormatTimer(j),
                 Cost = j.Cost.HasValue ? $"${j.Cost.Value:F2}" : "",
                 Tokens = j.Tokens.HasValue ? FormatHelper.FormatTokens(j.Tokens.Value) : "",

--- a/src/tendril/Ivy.Tendril/Apps/Plans/Models.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Plans/Models.cs
@@ -1,3 +1,5 @@
+using Ivy.Tendril.Helpers;
+
 namespace Ivy.Tendril.Apps.Plans;
 
 public enum PlanStatus
@@ -79,7 +81,7 @@ public static class PlanFilters
             filtered = filtered.Where(p => p.Level == level);
 
         if (projectFilter is { } project)
-            filtered = filtered.Where(p => p.Project == project);
+            filtered = filtered.Where(p => ProjectHelper.ContainsProject(p.Project, project));
 
         if (!string.IsNullOrWhiteSpace(textFilter))
         {

--- a/src/tendril/Ivy.Tendril/Helpers/ProjectHelper.cs
+++ b/src/tendril/Ivy.Tendril/Helpers/ProjectHelper.cs
@@ -1,0 +1,31 @@
+namespace Ivy.Tendril.Helpers;
+
+public static class ProjectHelper
+{
+    public static string[] ParseProjects(string? projectValue)
+    {
+        if (string.IsNullOrWhiteSpace(projectValue))
+            return Array.Empty<string>();
+
+        return projectValue
+            .Split(',')
+            .Select(p => p.Trim())
+            .Where(p => !string.IsNullOrEmpty(p))
+            .ToArray();
+    }
+
+    public static bool ContainsProject(string? projectValue, string projectToFind)
+    {
+        if (string.IsNullOrWhiteSpace(projectValue) || string.IsNullOrWhiteSpace(projectToFind))
+            return false;
+
+        var projects = ParseProjects(projectValue);
+        return projects.Contains(projectToFind, StringComparer.OrdinalIgnoreCase);
+    }
+
+    public static string FormatProjectsForDisplay(string? projectValue)
+    {
+        var projects = ParseProjects(projectValue);
+        return projects.Length > 0 ? string.Join(", ", projects) : "[Auto]";
+    }
+}

--- a/src/tendril/Ivy.Tendril/Services/PlanDatabaseService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanDatabaseService.cs
@@ -238,9 +238,9 @@ public class PlanDatabaseService : IPlanDatabaseService
         try
         {
             var cutoff = DateTime.UtcNow.Date.AddDays(-6).ToString("yyyy-MM-dd");
-            var pf = projectFilter != null ? " AND Project = @project" : "";
-            var pfAlias = projectFilter != null ? " AND p.Project = @project" : "";
-            var pfAlias2 = projectFilter != null ? " AND p2.Project = @project2" : "";
+            var pf = projectFilter != null ? " AND (Project = @project OR Project LIKE @projectPattern)" : "";
+            var pfAlias = projectFilter != null ? " AND (p.Project = @project OR p.Project LIKE @projectPattern)" : "";
+            var pfAlias2 = projectFilter != null ? " AND (p2.Project = @project2 OR p2.Project LIKE @projectPattern2)" : "";
 
             // Query 1: Status counts + avg cost
             int totalCount, draftCount, inProgressCount, reviewCount, completedCount, failedCount;
@@ -265,7 +265,9 @@ public class PlanDatabaseService : IPlanDatabaseService
                 if (projectFilter != null)
                 {
                     cmd.Parameters.AddWithValue("@project", projectFilter);
+                    cmd.Parameters.AddWithValue("@projectPattern", $"%{projectFilter}%");
                     cmd.Parameters.AddWithValue("@project2", projectFilter);
+                    cmd.Parameters.AddWithValue("@projectPattern2", $"%{projectFilter}%");
                 }
 
                 using var r = cmd.ExecuteReader();
@@ -338,7 +340,11 @@ public class PlanDatabaseService : IPlanDatabaseService
                     """;
 
                 cmd.Parameters.AddWithValue("@cutoff", cutoff);
-                if (projectFilter != null) cmd.Parameters.AddWithValue("@project", projectFilter);
+                if (projectFilter != null)
+                {
+                    cmd.Parameters.AddWithValue("@project", projectFilter);
+                    cmd.Parameters.AddWithValue("@projectPattern", $"%{projectFilter}%");
+                }
                 for (var i = 0; i < days.Count; i++)
                     cmd.Parameters.AddWithValue($"@day{i}", days[i]);
 
@@ -433,7 +439,7 @@ public class PlanDatabaseService : IPlanDatabaseService
             var cutoff = DateTime.UtcNow.AddDays(-days);
 
             using var cmd = _connection.CreateCommand();
-            var projectClause = projectFilter != null ? " AND p.Project = @project" : "";
+            var projectClause = projectFilter != null ? " AND (p.Project = @project OR p.Project LIKE @projectPattern)" : "";
             cmd.CommandText = $"""
                                SELECT
                                    strftime('%Y-%m-%d %H:00:00', COALESCE(c.LogTimestamp, p.Updated)) as Hour,
@@ -448,7 +454,10 @@ public class PlanDatabaseService : IPlanDatabaseService
                                """;
             cmd.Parameters.AddWithValue("@cutoff", cutoff.ToString("O", CultureInfo.InvariantCulture));
             if (projectFilter != null)
+            {
                 cmd.Parameters.AddWithValue("@project", projectFilter);
+                cmd.Parameters.AddWithValue("@projectPattern", $"%{projectFilter}%");
+            }
 
             var result = new List<HourlyTokenBurn>();
             using var reader = cmd.ExecuteReader();


### PR DESCRIPTION
# Summary

## Changes

Added a `ProjectHelper` static utility class to parse, check membership in, and format comma-separated project strings. Updated `JobsApp`, `PlanDatabaseService`, and `PlanFilters` to use these helpers so that plans and jobs with multiple projects (e.g., "Framework, Tendril") are correctly displayed, filtered, and queried.

## API Changes

- **New class:** `Ivy.Tendril.Helpers.ProjectHelper`
  - `string[] ParseProjects(string? projectValue)` — splits comma-separated project string
  - `bool ContainsProject(string? projectValue, string projectToFind)` — case-insensitive membership check
  - `string FormatProjectsForDisplay(string? projectValue)` — normalizes for display

## Files Modified

- **New:** `src/tendril/Ivy.Tendril/Helpers/ProjectHelper.cs` — utility class
- **New:** `src/tendril/Ivy.Tendril.Test/ProjectHelperTests.cs` — 18 unit tests
- **Modified:** `src/tendril/Ivy.Tendril/Apps/JobsApp.cs` — normalize Project display via ParseProjects
- **Modified:** `src/tendril/Ivy.Tendril/Apps/Plans/Models.cs` — use ContainsProject in PlanFilters
- **Modified:** `src/tendril/Ivy.Tendril/Services/PlanDatabaseService.cs` — SQL LIKE patterns for multi-project filtering

## Commits

- 95c55baa0 [03060] Add ProjectHelper for multi-select project support