### PR TITLE
[03075] Remove legacy .promptwares directories and verify references

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/WorktreeCleanupServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/WorktreeCleanupServiceTests.cs
@@ -421,7 +421,80 @@ public class WorktreeCleanupServiceTests : IDisposable
         Assert.False(Directory.Exists(worktreeDir), "Very recent orphan should still be cleaned up");
     }
 
+    [Fact]
+    public void CleanupLegacyPromptwaresDirs_Removes_DotPromptwaresInWorktrees()
+    {
+        var dir = CreatePlan("13000-LegacyCleanup", "Executing");
+        var promptwaresDir = Path.Combine(dir, "worktrees", "TestRepo", ".promptwares");
+        Directory.CreateDirectory(promptwaresDir);
+
+        _service.CleanupLegacyPromptwaresDirs();
+
+        Assert.False(Directory.Exists(promptwaresDir), ".promptwares directory should be removed");
+    }
+
+    [Fact]
+    public void CleanupLegacyPromptwaresDirs_Handles_Nested_DotPromptwaresDirs()
+    {
+        var dir = CreatePlan("13001-NestedLegacy", "Executing");
+        var nestedDir = Path.Combine(dir, "worktrees", "Repo", "src", "tendril", ".promptwares");
+        Directory.CreateDirectory(nestedDir);
+        File.WriteAllText(Path.Combine(nestedDir, "leftover.md"), "old content");
+
+        _service.CleanupLegacyPromptwaresDirs();
+
+        Assert.False(Directory.Exists(nestedDir), "Nested .promptwares directory should be removed");
+    }
+
+    [Fact]
+    public void CleanupLegacyPromptwaresDirs_Skips_Plans_With_No_Worktrees()
+    {
+        CreatePlan("13002-NoWorktrees", "Executing");
+
+        var ex = Record.Exception(() => _service.CleanupLegacyPromptwaresDirs());
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void CleanupLegacyPromptwaresDirs_Logs_On_Delete_Failure()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        var dir = CreatePlan("13003-LockedLegacy", "Executing");
+        var promptwaresDir = Path.Combine(dir, "worktrees", "TestRepo", ".promptwares");
+        Directory.CreateDirectory(promptwaresDir);
+        var lockedFile = Path.Combine(promptwaresDir, "locked.txt");
+        File.WriteAllText(lockedFile, "content");
+
+        var logEntries = new List<string>();
+        var logger = new CapturingLogger(logEntries);
+        var service = new WorktreeCleanupService(_plansDir, new CapturingLogger<WorktreeCleanupService>(logEntries));
+
+        using (var stream = new FileStream(lockedFile, FileMode.Open, FileAccess.Read, FileShare.None))
+        {
+            service.CleanupLegacyPromptwaresDirs();
+        }
+
+        Assert.Contains(logEntries, e => e.Contains("Failed to delete legacy .promptwares"));
+
+        // Cleanup
+        if (Directory.Exists(promptwaresDir))
+            Directory.Delete(promptwaresDir, true);
+    }
+
     private class CapturingLogger(List<string> entries) : ILogger
+    {
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            entries.Add(formatter(state, exception));
+        }
+    }
+
+    private class CapturingLogger<T>(List<string> entries) : ILogger<T>
     {
         public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
         public bool IsEnabled(LogLevel logLevel) => true;

--- a/src/tendril/Ivy.Tendril/Services/PromptwareDeployer.cs
+++ b/src/tendril/Ivy.Tendril/Services/PromptwareDeployer.cs
@@ -4,6 +4,10 @@ namespace Ivy.Tendril.Services;
 
 internal static class PromptwareDeployer
 {
+    /// <summary>
+    ///     Embedded promptwares zip resource. Uses lowercase "promptwares" for historical reasons;
+    ///     the directory structure was migrated from .promptwares/ to Promptwares/ in plan 02306.
+    /// </summary>
     private const string ResourceName = "Ivy.Tendril.promptwares.zip";
 
     /// <summary>

--- a/src/tendril/Ivy.Tendril/Services/WorktreeCleanupService.cs
+++ b/src/tendril/Ivy.Tendril/Services/WorktreeCleanupService.cs
@@ -41,6 +41,8 @@ public class WorktreeCleanupService : IStartable, IDisposable
         {
             if (!Directory.Exists(_plansDirectory)) return;
 
+            CleanupLegacyPromptwaresDirs();
+
             foreach (var dir in Directory.GetDirectories(_plansDirectory))
             {
                 try
@@ -207,6 +209,54 @@ public class WorktreeCleanupService : IStartable, IDisposable
         catch
         {
             // handle.exe not installed or failed — silently skip
+        }
+    }
+
+    internal void CleanupLegacyPromptwaresDirs()
+    {
+        try
+        {
+            if (!Directory.Exists(_plansDirectory)) return;
+
+            foreach (var planDir in Directory.GetDirectories(_plansDirectory))
+            {
+                try
+                {
+                    var worktreesDir = Path.Combine(planDir, "worktrees");
+                    if (!Directory.Exists(worktreesDir)) continue;
+
+                    var legacyDirs = Directory.GetDirectories(worktreesDir, ".promptwares", SearchOption.AllDirectories);
+
+                    foreach (var legacyDir in legacyDirs)
+                    {
+                        try
+                        {
+                            _logger.LogInformation(
+                                "Removing legacy .promptwares directory at {Path} (parent: {Parent})",
+                                legacyDir.Replace(_plansDirectory + Path.DirectorySeparatorChar, ""),
+                                Path.GetFileName(planDir));
+
+                            ForceDeleteDirectory(legacyDir, _logger);
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogWarning(ex,
+                                "Failed to delete legacy .promptwares directory {Path}",
+                                legacyDir.Replace(_plansDirectory + Path.DirectorySeparatorChar, ""));
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex,
+                        "Failed to scan for legacy .promptwares in {PlanFolder}",
+                        Path.GetFileName(planDir));
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Legacy .promptwares cleanup scan failed");
         }
     }
 


### PR DESCRIPTION
# Summary

## Changes

Added `CleanupLegacyPromptwaresDirs()` method to `WorktreeCleanupService` that scans all plan worktrees for leftover `.promptwares` directories from the pre-migration era and removes them. The method is called from `RunCleanup()` before regular worktree cleanup. Added a documentation comment to `PromptwareDeployer.cs` explaining why the embedded resource uses the lowercase `promptwares` name. Added 4 unit tests covering the new cleanup method.

## API Changes

- `WorktreeCleanupService.CleanupLegacyPromptwaresDirs()` — new `internal` method that removes legacy `.promptwares` directories within plan worktrees

## Files Modified

- **WorktreeCleanupService.cs** — Added `CleanupLegacyPromptwaresDirs()` method and call from `RunCleanup()`
- **PromptwareDeployer.cs** — Added XML doc comment on `ResourceName` constant documenting the historical naming
- **WorktreeCleanupServiceTests.cs** — Added 4 tests and a `CapturingLogger<T>` helper for typed logger injection

---

## Commits

- ea6bc5582 [03075] Add legacy .promptwares cleanup to WorktreeCleanupService