### PR TITLE
[03078] Replace Delete shortcut key with Backspace

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Plans/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Plans/ContentView.cs
@@ -369,7 +369,7 @@ public class ContentView(
                             _jobService.StartJob("ExpandPlan", planPath);
                             _refreshPlans();
                         })
-                        | new Button("Delete").Icon(Icons.Trash).Outline().ShortcutKey("Delete")
+                        | new Button("Delete").Icon(Icons.Trash).Outline().ShortcutKey("Backspace")
                             .OnClick(() => deleteDialogOpen.Set(true))
                         | new Button("Previous").Icon(Icons.ChevronLeft).Outline().OnClick(() => GoToPrevious())
                             .ShortcutKey("p")

--- a/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -474,7 +474,7 @@ public class ContentView(
                         {
                             suggestChangesOpen.Set(true);
                         }).ShortcutKey("d")
-                        | new Button("Discard").Icon(Icons.Trash).Outline().ShortcutKey("Delete").OnClick(() =>
+                        | new Button("Discard").Icon(Icons.Trash).Outline().ShortcutKey("Backspace").OnClick(() =>
                         {
                             discardDialogOpen.Set(true);
                         })


### PR DESCRIPTION
# Summary

## Changes

Replaced `.ShortcutKey("Delete")` with `.ShortcutKey("Backspace")` on the Delete plan button and the Discard button in two Tendril views. This ensures the keyboard shortcut works on keyboards without a physical forward-delete key (most laptops, especially Mac).

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Apps/Plans/ContentView.cs` — Delete plan button shortcut key
- `src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs` — Discard button shortcut key

## Commits

- 0c217c2f2 [03078] Replace Delete shortcut key with Backspace