### PR TITLE
[03082] Make Settings Effective Without Restart

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/BackgroundServiceActivatorTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/BackgroundServiceActivatorTests.cs
@@ -178,6 +178,10 @@ public class BackgroundServiceActivatorTests : IAsyncLifetime
         public BadgeVariant GetBadgeVariant(string level) => BadgeVariant.Outline;
         public Colors? GetProjectColor(string projectName) => null;
         public void SaveSettings() { }
+        public void ReloadSettings() { }
+#pragma warning disable CS0067
+        public event EventHandler? SettingsReloaded;
+#pragma warning restore CS0067
         public void SetPendingCodingAgent(string name) { }
         public string? GetPendingCodingAgent() => null;
         public void SetPendingTendrilHome(string path) { }

--- a/src/tendril/Ivy.Tendril.Test/ConfigServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/ConfigServiceTests.cs
@@ -659,6 +659,89 @@ promptwares:
     }
 
     [Fact]
+    public void ReloadSettings_FiresEvent()
+    {
+        var yaml = @"
+jobTimeout: 30
+maxConcurrentJobs: 5
+";
+        var tempDir = CreateTempConfigFile(yaml);
+        var service = new ConfigService(new TendrilSettings());
+
+        try
+        {
+            service.SetTendrilHome(tempDir);
+            var eventFired = false;
+            service.SettingsReloaded += (s, e) => eventFired = true;
+
+            service.ReloadSettings();
+
+            Assert.True(eventFired);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void SaveSettings_FiresReloadEvent()
+    {
+        var yaml = @"
+jobTimeout: 30
+maxConcurrentJobs: 5
+";
+        var tempDir = CreateTempConfigFile(yaml);
+        var service = new ConfigService(new TendrilSettings());
+
+        try
+        {
+            service.SetTendrilHome(tempDir);
+            var eventFired = false;
+            service.SettingsReloaded += (s, e) => eventFired = true;
+
+            service.Settings.JobTimeout = 45;
+            service.SaveSettings();
+
+            Assert.True(eventFired);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void ReloadSettings_UpdatesSettingsFromDisk()
+    {
+        var yaml = @"
+jobTimeout: 30
+maxConcurrentJobs: 5
+";
+        var tempDir = CreateTempConfigFile(yaml);
+        var service = new ConfigService(new TendrilSettings());
+
+        try
+        {
+            service.SetTendrilHome(tempDir);
+            Assert.Equal(30, service.Settings.JobTimeout);
+
+            File.WriteAllText(Path.Combine(tempDir, "config.yaml"), @"
+jobTimeout: 60
+maxConcurrentJobs: 10
+");
+            service.ReloadSettings();
+
+            Assert.Equal(60, service.Settings.JobTimeout);
+            Assert.Equal(10, service.Settings.MaxConcurrentJobs);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
     public void Constructor_WithEmptyString_SetsNoHome()
     {
         var service = new ConfigService(new TendrilSettings(), "");

--- a/src/tendril/Ivy.Tendril.Test/PlanContentHelpersTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/PlanContentHelpersTests.cs
@@ -184,6 +184,10 @@ public class PlanContentHelpersTests
         public BadgeVariant GetBadgeVariant(string level) => BadgeVariant.Outline;
         public Colors? GetProjectColor(string projectName) => null;
         public void SaveSettings() { }
+        public void ReloadSettings() { }
+#pragma warning disable CS0067
+        public event EventHandler? SettingsReloaded;
+#pragma warning restore CS0067
         public void SetPendingCodingAgent(string name) { }
         public string? GetPendingCodingAgent() => null;
         public void SetPendingTendrilHome(string path) { }

--- a/src/tendril/Ivy.Tendril.Test/PlanCountsServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/PlanCountsServiceTests.cs
@@ -236,6 +236,8 @@ public class PlanCountsServiceTests : IDisposable
         public event Action? JobsChanged;
         public event Action<JobNotification>? NotificationReady;
 #pragma warning restore CS0067
+
+        public void Dispose() { }
     }
 
     private class FakePlanWatcherService : IPlanWatcherService

--- a/src/tendril/Ivy.Tendril.Test/Services/FileLinkHelperTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/Services/FileLinkHelperTests.cs
@@ -114,6 +114,10 @@ public class FileLinkHelperTests
         public BadgeVariant GetBadgeVariant(string level) => BadgeVariant.Outline;
         public Colors? GetProjectColor(string projectName) => null;
         public void SaveSettings() { }
+        public void ReloadSettings() { }
+#pragma warning disable CS0067
+        public event EventHandler? SettingsReloaded;
+#pragma warning restore CS0067
         public void SetPendingCodingAgent(string name) { }
         public string? GetPendingCodingAgent() => null;
         public void SetPendingTendrilHome(string path) { }

--- a/src/tendril/Ivy.Tendril.Test/Services/JobServiceSettingsTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/Services/JobServiceSettingsTests.cs
@@ -1,0 +1,114 @@
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Test.Services;
+
+public class JobServiceSettingsTests
+{
+    private static string CreateTempConfigFile(string yamlContent)
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"ivy-jobservice-test-{Guid.NewGuid()}");
+        Directory.CreateDirectory(tempDir);
+        Directory.CreateDirectory(Path.Combine(tempDir, "Inbox"));
+        Directory.CreateDirectory(Path.Combine(tempDir, "Plans"));
+        File.WriteAllText(Path.Combine(tempDir, "config.yaml"), yamlContent);
+        return tempDir;
+    }
+
+    [Fact]
+    public void JobService_UpdatesTimeoutsOnConfigReload()
+    {
+        var yaml = @"
+jobTimeout: 30
+staleOutputTimeout: 10
+maxConcurrentJobs: 5
+";
+        var tempDir = CreateTempConfigFile(yaml);
+        var config = new ConfigService(new TendrilSettings());
+        config.SetTendrilHome(tempDir);
+
+        try
+        {
+            var jobService = new JobService(config);
+
+            File.WriteAllText(Path.Combine(tempDir, "config.yaml"), @"
+jobTimeout: 60
+staleOutputTimeout: 20
+maxConcurrentJobs: 8
+");
+            config.ReloadSettings();
+
+            Assert.Equal(60, config.Settings.JobTimeout);
+            Assert.Equal(20, config.Settings.StaleOutputTimeout);
+            Assert.Equal(8, config.Settings.MaxConcurrentJobs);
+
+            jobService.Dispose();
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void JobService_UnsubscribesOnDispose()
+    {
+        var yaml = @"
+jobTimeout: 30
+staleOutputTimeout: 10
+maxConcurrentJobs: 5
+";
+        var tempDir = CreateTempConfigFile(yaml);
+        var config = new ConfigService(new TendrilSettings());
+        config.SetTendrilHome(tempDir);
+
+        try
+        {
+            var jobService = new JobService(config);
+            jobService.Dispose();
+
+            File.WriteAllText(Path.Combine(tempDir, "config.yaml"), @"
+jobTimeout: 99
+staleOutputTimeout: 99
+maxConcurrentJobs: 99
+");
+            config.ReloadSettings();
+
+            Assert.Equal(99, config.Settings.JobTimeout);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void SaveSettings_TriggersJobServiceReload()
+    {
+        var yaml = @"
+jobTimeout: 30
+staleOutputTimeout: 10
+maxConcurrentJobs: 5
+";
+        var tempDir = CreateTempConfigFile(yaml);
+        var config = new ConfigService(new TendrilSettings());
+        config.SetTendrilHome(tempDir);
+
+        try
+        {
+            var jobService = new JobService(config);
+
+            config.Settings.JobTimeout = 45;
+            config.Settings.StaleOutputTimeout = 15;
+            config.SaveSettings();
+
+            Assert.Equal(45, config.Settings.JobTimeout);
+            Assert.Equal(15, config.Settings.StaleOutputTimeout);
+
+            jobService.Dispose();
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+}

--- a/src/tendril/Ivy.Tendril/Apps/Setup/AdvancedSetupView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Setup/AdvancedSetupView.cs
@@ -44,7 +44,7 @@ public class AdvancedSetupView : ViewBase
                            config.Settings.Editor.Command = editorCommand.Value;
                            config.Settings.Editor.Label = editorLabel.Value;
                            config.SaveSettings();
-                           client.Toast("Settings saved successfully", "Saved");
+                           client.Toast("Settings saved and applied", "Saved");
                        });
 
         return form;

--- a/src/tendril/Ivy.Tendril/Apps/Setup/GeneralSetupView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Setup/GeneralSetupView.cs
@@ -36,7 +36,7 @@ public class GeneralSetupView : ViewBase
                            config.Settings.CodingAgent = codingAgent.Value;
                            config.Settings.PlanTemplate = planTemplate.Value;
                            config.SaveSettings();
-                           client.Toast("Settings saved successfully", "Saved");
+                           client.Toast("Settings saved and applied", "Saved");
                        });
 
         return form;

--- a/src/tendril/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/tendril/Ivy.Tendril/Services/ConfigService.cs
@@ -265,11 +265,39 @@ public class ConfigService : IConfigService
         return !string.IsNullOrEmpty(colorStr) && Enum.TryParse<Colors>(colorStr, out var c) ? c : null;
     }
 
+    public event EventHandler? SettingsReloaded;
+
     public void SaveSettings()
     {
         _levelNamesCache = null;
         var yaml = YamlHelper.SerializerCompact.Serialize(Settings);
         FileHelper.WriteAllText(ConfigPath, yaml);
+        ReloadSettings();
+    }
+
+    public void ReloadSettings()
+    {
+        if (!File.Exists(ConfigPath))
+            return;
+
+        try
+        {
+            var yaml = FileHelper.ReadAllText(ConfigPath);
+            yaml = Regex.Replace(yaml, @"(?m)(?<=:\s+)(%\w+%.*)$", "'$1'");
+            yaml = Regex.Replace(yaml, @"(?m)^(\s*-\s+)(%\w+%.*)$", "$1'$2'");
+            Settings = YamlHelper.Deserializer.Deserialize<TendrilSettings>(yaml) ?? new TendrilSettings();
+
+            MigrateProjectColors();
+            _levelNamesCache = null;
+            VariableExpansion.InitializeUserSecrets(TendrilHome);
+            ExpandSettingsVariables();
+
+            SettingsReloaded?.Invoke(this, EventArgs.Empty);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Failed to reload settings: {ex}");
+        }
     }
 
     // Onboarding support

--- a/src/tendril/Ivy.Tendril/Services/IConfigService.cs
+++ b/src/tendril/Ivy.Tendril/Services/IConfigService.cs
@@ -16,6 +16,8 @@ public interface IConfigService
     BadgeVariant GetBadgeVariant(string level);
     Colors? GetProjectColor(string projectName);
     void SaveSettings();
+    void ReloadSettings();
+    event EventHandler? SettingsReloaded;
     void SetPendingTendrilHome(string path);
     string? GetPendingTendrilHome();
     void SetPendingProject(ProjectConfig project);

--- a/src/tendril/Ivy.Tendril/Services/IJobService.cs
+++ b/src/tendril/Ivy.Tendril/Services/IJobService.cs
@@ -2,7 +2,7 @@ using Ivy.Tendril.Apps.Jobs;
 
 namespace Ivy.Tendril.Services;
 
-public interface IJobService
+public interface IJobService : IDisposable
 {
     event Action? JobsChanged;
     event Action<JobNotification>? NotificationReady;

--- a/src/tendril/Ivy.Tendril/Services/JobService.cs
+++ b/src/tendril/Ivy.Tendril/Services/JobService.cs
@@ -59,13 +59,13 @@ public class JobService : IJobService
     private readonly PriorityQueue<string, int> _jobQueue = new();
     private readonly object _queueLock = new();
     private readonly SemaphoreSlim _jobSlotSemaphore;
-    private readonly TimeSpan _jobTimeout;
+    private TimeSpan _jobTimeout;
     private readonly ConcurrentDictionary<string, JobItem> _jobs = new();
-    private readonly int _maxConcurrentJobs;
+    private int _maxConcurrentJobs;
     private readonly ModelPricingService? _modelPricingService;
     private readonly IPlanReaderService? _planReaderService;
     private readonly IPlanWatcherService? _planWatcherService;
-    private readonly TimeSpan _staleOutputTimeout;
+    private TimeSpan _staleOutputTimeout;
     private readonly SynchronizationContext? _syncContext;
     private readonly ITelemetryService? _telemetryService;
     private readonly IWorktreeLifecycleLogger? _worktreeLifecycleLogger;
@@ -95,6 +95,7 @@ public class JobService : IJobService
             ? new SemaphoreSlim(_maxConcurrentJobs, _maxConcurrentJobs)
             : new SemaphoreSlim(0, 1);
         _inboxPath = Path.Combine(configService.TendrilHome, "Inbox");
+        configService.SettingsReloaded += OnSettingsReloaded;
         LoadHistoricalJobs();
     }
 
@@ -610,6 +611,21 @@ public class JobService : IJobService
     ///     Removes a job from the dictionary. Used by tests to simulate concurrent removal.
     /// </summary>
     internal bool RemoveJob(string id) => _jobs.TryRemove(id, out _);
+
+    public void Dispose()
+    {
+        if (_configService != null)
+            _configService.SettingsReloaded -= OnSettingsReloaded;
+        _jobSlotSemaphore.Dispose();
+    }
+
+    private void OnSettingsReloaded(object? sender, EventArgs e)
+    {
+        if (_configService == null) return;
+        _jobTimeout = TimeSpan.FromMinutes(_configService.Settings.JobTimeout);
+        _staleOutputTimeout = TimeSpan.FromMinutes(_configService.Settings.StaleOutputTimeout);
+        _maxConcurrentJobs = _configService.Settings.MaxConcurrentJobs;
+    }
 
     private void LaunchJob(JobItem job)
     {


### PR DESCRIPTION
# Summary

## Changes

Added settings hot-reload mechanism to Tendril. ConfigService now exposes a `ReloadSettings()` method and `SettingsReloaded` event. `SaveSettings()` automatically triggers reload, which re-parses config.yaml and notifies all subscribers. JobService subscribes to update its cached timeout and concurrency values without requiring a restart. Setup views now show "saved and applied" toast to indicate immediate effect.

## API Changes

- `IConfigService.ReloadSettings()` — new method to reload settings from disk
- `IConfigService.SettingsReloaded` — new `EventHandler` event fired after reload
- `IJobService` now extends `IDisposable` for proper cleanup
- `JobService.Dispose()` — new method that unsubscribes from settings events and disposes semaphore
- `JobService.OnSettingsReloaded()` — private handler that refreshes `_jobTimeout`, `_staleOutputTimeout`, `_maxConcurrentJobs`

## Files Modified

**Core services:**
- `src/tendril/Ivy.Tendril/Services/IConfigService.cs` — added `ReloadSettings()` and `SettingsReloaded`
- `src/tendril/Ivy.Tendril/Services/ConfigService.cs` — implemented `ReloadSettings()`, updated `SaveSettings()` to auto-reload
- `src/tendril/Ivy.Tendril/Services/IJobService.cs` — extended with `IDisposable`
- `src/tendril/Ivy.Tendril/Services/JobService.cs` — subscribes to settings changes, implements `Dispose()`

**UI:**
- `src/tendril/Ivy.Tendril/Apps/Setup/GeneralSetupView.cs` — updated toast message
- `src/tendril/Ivy.Tendril/Apps/Setup/AdvancedSetupView.cs` — updated toast message

**Tests:**
- `src/tendril/Ivy.Tendril.Test/ConfigServiceTests.cs` — 3 new reload tests
- `src/tendril/Ivy.Tendril.Test/Services/JobServiceSettingsTests.cs` — new file with 3 settings reload tests
- 4 test stubs updated to implement new interface members

## Commits

- 6b7fb4794 [03082] Add settings hot-reload with change notifications