### PR TITLE
[03084] Import issues from Github isn't doing anything

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/GithubServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/GithubServiceTests.cs
@@ -141,7 +141,7 @@ public class GithubServiceTests
     [Fact]
     public void ParseIssuesFromJson_Throws_JsonException_For_Invalid_Json()
     {
-        Assert.Throws<System.Text.Json.JsonException>(() =>
+        Assert.ThrowsAny<System.Text.Json.JsonException>(() =>
             GithubService.ParseIssuesFromJson("not valid json"));
     }
 

--- a/src/tendril/Ivy.Tendril.Test/GithubServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/GithubServiceTests.cs
@@ -100,6 +100,58 @@ public class GithubServiceTests
         }
     }
 
+    [Fact]
+    public async Task SearchIssuesAsync_Returns_Error_When_Command_Fails()
+    {
+        var configService = new ConfigService(new TendrilSettings());
+        var githubService = new GithubService(configService);
+
+        var (issues, error) = await githubService.SearchIssuesAsync(
+            "nonexistent-owner-xyz-000", "nonexistent-repo-xyz-000", null, null, null);
+
+        Assert.Empty(issues);
+        Assert.NotNull(error);
+    }
+
+    [Fact]
+    public void ParseIssuesFromJson_Returns_Issues_For_Valid_Json()
+    {
+        var json = """
+                   [
+                     {
+                       "number": 42,
+                       "title": "Test issue",
+                       "body": "Issue body text",
+                       "labels": [{"name": "bug"}],
+                       "assignees": [{"login": "testuser"}]
+                     }
+                   ]
+                   """;
+
+        var issues = GithubService.ParseIssuesFromJson(json);
+
+        Assert.Single(issues);
+        Assert.Equal(42, issues[0].Number);
+        Assert.Equal("Test issue", issues[0].Title);
+        Assert.Equal("Issue body text", issues[0].Body);
+        Assert.Equal(["bug"], issues[0].Labels);
+        Assert.Equal(["testuser"], issues[0].Assignees);
+    }
+
+    [Fact]
+    public void ParseIssuesFromJson_Throws_JsonException_For_Invalid_Json()
+    {
+        Assert.Throws<System.Text.Json.JsonException>(() =>
+            GithubService.ParseIssuesFromJson("not valid json"));
+    }
+
+    [Fact]
+    public void ParseIssuesFromJson_Returns_Empty_List_For_Empty_Array()
+    {
+        var issues = GithubService.ParseIssuesFromJson("[]");
+        Assert.Empty(issues);
+    }
+
     private static string CreateTempGitRepo(string remoteUrl)
     {
         var tempDir = Path.Combine(Path.GetTempPath(), $"ivy-github-test-{Guid.NewGuid()}");

--- a/src/tendril/Ivy.Tendril/AppShell/Dialogs/ImportIssuesDialog.cs
+++ b/src/tendril/Ivy.Tendril/AppShell/Dialogs/ImportIssuesDialog.cs
@@ -18,6 +18,7 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
         var selectedAssignee = UseState<string?>(null);
         var selectedLabels = UseState(Array.Empty<string>());
         var fetchedIssues = UseState<List<GitHubIssue>?>(null);
+        var errorMessage = UseState<string?>(null);
         var isFetching = UseState(false);
         var isImporting = UseState(false);
 
@@ -50,6 +51,7 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
         UseEffect(() =>
         {
             fetchedIssues.Set(null);
+            errorMessage.Set(null);
             selectedAssignee.Set(null);
             selectedLabels.Set(Array.Empty<string>());
         }, selectedRepo);
@@ -66,20 +68,30 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
             if (repo is null) return;
 
             isFetching.Set(true);
+            errorMessage.Set(null);
             try
             {
                 var labels = selectedLabels.Value.Length > 0 ? selectedLabels.Value : null;
-                var issues = await githubService.SearchIssuesAsync(
+                var (issues, error) = await githubService.SearchIssuesAsync(
                     repo.Owner, repo.Name,
                     string.IsNullOrWhiteSpace(searchQuery.Value) ? null : searchQuery.Value,
                     selectedAssignee.Value,
                     labels);
-                fetchedIssues.Set(issues);
+
+                if (error is not null)
+                {
+                    errorMessage.Set(error);
+                    fetchedIssues.Set(null);
+                }
+                else
+                {
+                    fetchedIssues.Set(issues);
+                }
             }
             catch (Exception ex)
             {
-                Console.Error.WriteLine($"[ImportIssuesDialog] Fetch failed: {ex.Message}");
-                fetchedIssues.Set([]);
+                errorMessage.Set($"Failed to fetch issues: {ex.Message}");
+                fetchedIssues.Set(null);
             }
             finally
             {
@@ -164,6 +176,7 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
             _ =>
             {
                 fetchedIssues.Set(null);
+                errorMessage.Set(null);
                 searchQuery.Set("");
                 selectedAssignee.Set(null);
                 selectedLabels.Set(Array.Empty<string>());
@@ -182,12 +195,16 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
                     .Placeholder("Select labels...").WithField().Label("Labels")
                 | new Button("Fetch Issues").Outline().Loading(isFetching.Value)
                     .OnClick(async () => await FetchIssues())
+                | (errorMessage.Value is { } error
+                    ? Text.Danger(error).Small()
+                    : null)
                 | issuesList
             ),
             new DialogFooter(
                 new Button("Cancel").Outline().OnClick(() =>
                 {
                     fetchedIssues.Set(null);
+                    errorMessage.Set(null);
                     searchQuery.Set("");
                     selectedAssignee.Set(null);
                     selectedLabels.Set(Array.Empty<string>());

--- a/src/tendril/Ivy.Tendril/Services/GithubService.cs
+++ b/src/tendril/Ivy.Tendril/Services/GithubService.cs
@@ -63,12 +63,13 @@ public class GithubService(IConfigService config) : IGithubService
         return await FetchPrStatusesFromGhCliAsync(owner, repo);
     }
 
-    public async Task<List<GitHubIssue>> SearchIssuesAsync(string owner, string repo, string? query, string? assignee,
-        string[]? labels)
+    public async Task<(List<GitHubIssue> issues, string? error)> SearchIssuesAsync(string owner, string repo,
+        string? query, string? assignee, string[]? labels)
     {
         try
         {
-            var args = $"issue list --repo {owner}/{repo} --state open --limit 100 --json number,title,body,labels,assignees";
+            var args =
+                $"issue list --repo {owner}/{repo} --state open --limit 100 --json number,title,body,labels,assignees";
             if (!string.IsNullOrWhiteSpace(query))
                 args += $" --search \"{query}\"";
             if (!string.IsNullOrWhiteSpace(assignee))
@@ -87,7 +88,8 @@ public class GithubService(IConfigService config) : IGithubService
             };
 
             using var process = Process.Start(psi);
-            if (process is null) return [];
+            if (process is null)
+                return ([], "GitHub CLI (gh) is not available. Please install it from https://cli.github.com/");
 
             var output = await process.StandardOutput.ReadToEndAsync();
             var stderr = await process.StandardError.ReadToEndAsync();
@@ -96,32 +98,46 @@ public class GithubService(IConfigService config) : IGithubService
             if (process.ExitCode != 0)
             {
                 Console.Error.WriteLine($"[GithubService] gh issue list failed for {owner}/{repo}: {stderr}");
-                return [];
+                var errorMsg = !string.IsNullOrWhiteSpace(stderr)
+                    ? stderr.Trim()
+                    : $"GitHub CLI exited with code {process.ExitCode}";
+                return ([], errorMsg);
             }
 
-            var issues = new List<GitHubIssue>();
-            using var doc = JsonDocument.Parse(output);
-            foreach (var element in doc.RootElement.EnumerateArray())
-            {
-                var number = element.GetProperty("number").GetInt32();
-                var title = element.GetProperty("title").GetString() ?? "";
-                var body = element.TryGetProperty("body", out var bodyProp) ? bodyProp.GetString() : null;
-                var issueLabels = element.GetProperty("labels").EnumerateArray()
-                    .Select(l => l.GetProperty("name").GetString() ?? "")
-                    .ToArray();
-                var issueAssignees = element.GetProperty("assignees").EnumerateArray()
-                    .Select(a => a.GetProperty("login").GetString() ?? "")
-                    .ToArray();
-                issues.Add(new GitHubIssue(number, title, body, issueLabels, issueAssignees));
-            }
-
-            return issues;
+            var issues = ParseIssuesFromJson(output);
+            return (issues, null);
+        }
+        catch (JsonException ex)
+        {
+            Console.Error.WriteLine($"[GithubService] Failed to parse issues for {owner}/{repo}: {ex.Message}");
+            return ([], "Invalid response from GitHub CLI. The output could not be parsed.");
         }
         catch (Exception ex)
         {
             Console.Error.WriteLine($"[GithubService] Failed to search issues for {owner}/{repo}: {ex.Message}");
-            return [];
+            return ([], $"Failed to fetch issues: {ex.Message}");
         }
+    }
+
+    internal static List<GitHubIssue> ParseIssuesFromJson(string json)
+    {
+        var issues = new List<GitHubIssue>();
+        using var doc = JsonDocument.Parse(json);
+        foreach (var element in doc.RootElement.EnumerateArray())
+        {
+            var number = element.GetProperty("number").GetInt32();
+            var title = element.GetProperty("title").GetString() ?? "";
+            var body = element.TryGetProperty("body", out var bodyProp) ? bodyProp.GetString() : null;
+            var issueLabels = element.GetProperty("labels").EnumerateArray()
+                .Select(l => l.GetProperty("name").GetString() ?? "")
+                .ToArray();
+            var issueAssignees = element.GetProperty("assignees").EnumerateArray()
+                .Select(a => a.GetProperty("login").GetString() ?? "")
+                .ToArray();
+            issues.Add(new GitHubIssue(number, title, body, issueLabels, issueAssignees));
+        }
+
+        return issues;
     }
 
     internal static RepoConfig? GetRepoConfigFromPath(string repoPath)

--- a/src/tendril/Ivy.Tendril/Services/IGithubService.cs
+++ b/src/tendril/Ivy.Tendril/Services/IGithubService.cs
@@ -14,5 +14,5 @@ public interface IGithubService
     Task<List<string>> GetAssigneesAsync(string owner, string repo);
     Task<List<string>> GetLabelsAsync(string owner, string repo);
     Task<Dictionary<string, string>> GetPrStatusesAsync(string owner, string repo);
-    Task<List<GitHubIssue>> SearchIssuesAsync(string owner, string repo, string? query, string? assignee, string[]? labels);
+    Task<(List<GitHubIssue> issues, string? error)> SearchIssuesAsync(string owner, string repo, string? query, string? assignee, string[]? labels);
 }


### PR DESCRIPTION
# Summary

## Changes

Changed `SearchIssuesAsync` to return a `(List<GitHubIssue> issues, string? error)` tuple instead of silently returning empty lists on failure. The `ImportIssuesDialog` now displays error messages (via `Text.Danger`) when the GitHub CLI fails, distinguishing between "no issues found" and "an error occurred." Extracted `ParseIssuesFromJson` as an internal static method for testability, and added unit tests covering JSON parsing success, failure, and CLI error propagation.

## API Changes

- `IGithubService.SearchIssuesAsync` return type changed from `Task<List<GitHubIssue>>` to `Task<(List<GitHubIssue> issues, string? error)>`
- `GithubService.SearchIssuesAsync` — same signature change, now returns descriptive error strings instead of empty lists
- `GithubService.ParseIssuesFromJson(string json)` — new `internal static` method extracted from `SearchIssuesAsync`

## Files Modified

- **Services/IGithubService.cs** — Updated `SearchIssuesAsync` return type to tuple
- **Services/GithubService.cs** — Updated implementation to return error tuples, extracted `ParseIssuesFromJson`, added `JsonException` catch
- **AppShell/Dialogs/ImportIssuesDialog.cs** — Added `errorMessage` state, updated `FetchIssues` to handle error tuple, display errors in UI, clear errors on repo change/dialog close
- **Ivy.Tendril.Test/GithubServiceTests.cs** — Added 4 tests: CLI error returns error tuple, JSON parsing valid/invalid/empty

## Commits

- 51e3dbddc [03084] Fix test to use ThrowsAny for JsonException subclass
- 9f11b4da6 [03084] Surface GitHub CLI errors in ImportIssuesDialog