### PR TITLE
[03085] Add New Plan Button to Empty State in PlansApp

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Plans/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Plans/ContentView.cs
@@ -2,6 +2,7 @@ using System.Text.RegularExpressions;
 using Ivy.Core;
 using Ivy.Tendril.Apps.Plans.Dialogs;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Views;
 
 namespace Ivy.Tendril.Apps.Plans;
 
@@ -168,7 +169,8 @@ public class ContentView(
             if (_allPlans.Count == 0)
                 return Layout.Vertical().AlignContent(Align.Center).Height(Size.Full()).Gap(2)
                        | new Icon(Icons.Inbox).Large().Color(Colors.Gray)
-                       | Text.Muted("No draft plans yet");
+                       | Text.Muted("No draft plans yet")
+                       | new NewPlanButton();
 
             return Layout.Vertical().AlignContent(Align.Center).Height(Size.Full())
                    | Text.Muted("Select a plan from the sidebar");


### PR DESCRIPTION
# Summary

## Changes

Added the existing `NewPlanButton` component to the empty state view in PlansApp's `ContentView.cs`. When no draft plans exist, users now see a "New Plan" button below the "No draft plans yet" message, providing a clear call-to-action.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Apps/Plans/ContentView.cs` — Added `using Ivy.Tendril.Views;` import and appended `new NewPlanButton()` to the empty state layout

## Commits

- d3eea63e5 [03085] Add NewPlanButton to empty state in PlansApp