### PR TITLE
[03089] Fix NullReferenceException Flash In ReviewApp

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -77,7 +77,8 @@ public class ContentView(
             async (filePath, ct) =>
             {
                 if (string.IsNullOrEmpty(filePath)) return "";
-                var artifactsDir = Path.GetFullPath(Path.Combine(_selectedPlan!.FolderPath, "artifacts"));
+                if (_selectedPlan is null) return "";
+                var artifactsDir = Path.GetFullPath(Path.Combine(_selectedPlan.FolderPath, "artifacts"));
                 var resolvedPath = Path.GetFullPath(filePath);
                 if (!resolvedPath.StartsWith(artifactsDir, StringComparison.OrdinalIgnoreCase))
                     return "Access denied: file is outside the artifacts folder.";
@@ -92,7 +93,8 @@ public class ContentView(
             async (hash, ct) =>
             {
                 if (string.IsNullOrEmpty(hash)) return null;
-                var repoPaths2 = _selectedPlan!.GetEffectiveRepoPaths(_config);
+                if (_selectedPlan is null) return null;
+                var repoPaths2 = _selectedPlan.GetEffectiveRepoPaths(_config);
                 return await Task.Run(() =>
                 {
                     foreach (var repo in repoPaths2)


### PR DESCRIPTION
# Summary

## Changes

Added null guards for `_selectedPlan` in two `UseQuery` callbacks in `ContentView.cs` to prevent a `NullReferenceException` from flashing when opening or navigating between plans in the Review app. Removed the null-forgiving operator (`!`) in favor of proper null checks with early returns.

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs** — Added `if (_selectedPlan is null) return ...;` guards in `artifactContentQuery` and `commitQuery` callbacks.

## Commits

- 8963b12d3