### PR TITLE
[03087] Add automatic worktree cleanup to ExecutePlan completion

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/ExecutePlanWorktreeCleanupTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/ExecutePlanWorktreeCleanupTests.cs
@@ -1,0 +1,145 @@
+using System.Diagnostics;
+
+namespace Ivy.Tendril.Test;
+
+public class ExecutePlanWorktreeCleanupTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string _scriptPath;
+
+    public ExecutePlanWorktreeCleanupTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"tendril-ep-cleanup-test-{Guid.NewGuid()}");
+        Directory.CreateDirectory(_tempDir);
+
+        _scriptPath = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory, "..", "..", "..", "..",
+            "Ivy.Tendril", "Promptwares", "ExecutePlan", "Tools", "Cleanup-Worktrees.ps1"));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, true);
+    }
+
+    private string CreateFakePlan(string name)
+    {
+        var planDir = Path.Combine(_tempDir, name);
+        Directory.CreateDirectory(planDir);
+        File.WriteAllText(Path.Combine(planDir, "plan.yaml"),
+            "state: Completed\nproject: Test\ntitle: Test Plan\nupdated: 2020-01-01T00:00:00Z\n");
+        return planDir;
+    }
+
+    private string CreateWorktreeDir(string planDir, string repoName, bool withGitFile = false)
+    {
+        var wtDir = Path.Combine(planDir, "worktrees", repoName);
+        Directory.CreateDirectory(wtDir);
+        File.WriteAllText(Path.Combine(wtDir, "dummy.cs"), "// test");
+
+        if (withGitFile)
+            File.WriteAllText(Path.Combine(wtDir, ".git"),
+                "gitdir: /nonexistent/.git/worktrees/" + repoName);
+
+        return wtDir;
+    }
+
+    private (int exitCode, string output) RunCleanupScript(string planPath, Dictionary<string, string>? envVars = null)
+    {
+        var psi = new ProcessStartInfo("pwsh", $"-NoProfile -File \"{_scriptPath}\" -PlanPath \"{planPath}\"")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        if (envVars != null)
+        {
+            foreach (var kv in envVars)
+                psi.EnvironmentVariables[kv.Key] = kv.Value;
+        }
+
+        using var process = Process.Start(psi)!;
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit(30000);
+        return (process.ExitCode, stdout + stderr);
+    }
+
+    [Fact]
+    public void CleanupScript_Removes_Worktree_Directory()
+    {
+        var planDir = CreateFakePlan("01000-CleanupTest");
+        var wtDir = CreateWorktreeDir(planDir, "TestRepo");
+
+        Assert.True(Directory.Exists(wtDir));
+
+        var (exitCode, _) = RunCleanupScript(planDir);
+
+        Assert.Equal(0, exitCode);
+        Assert.False(Directory.Exists(wtDir), "Worktree directory should be removed");
+        Assert.False(Directory.Exists(Path.Combine(planDir, "worktrees")),
+            "Worktrees parent directory should be removed");
+    }
+
+    [Fact]
+    public void CleanupScript_Handles_Orphaned_Worktree_Without_GitFile()
+    {
+        var planDir = CreateFakePlan("02000-OrphanTest");
+        var wtDir = CreateWorktreeDir(planDir, "OrphanRepo");
+
+        var (exitCode, _) = RunCleanupScript(planDir);
+
+        Assert.Equal(0, exitCode);
+        Assert.False(Directory.Exists(wtDir), "Orphaned worktree without .git should still be cleaned");
+    }
+
+    [Fact]
+    public void CleanupScript_Handles_Stale_GitFile()
+    {
+        var planDir = CreateFakePlan("03000-StaleGitTest");
+        var wtDir = CreateWorktreeDir(planDir, "StaleRepo", withGitFile: true);
+
+        var (exitCode, _) = RunCleanupScript(planDir);
+
+        Assert.Equal(0, exitCode);
+        Assert.False(Directory.Exists(wtDir), "Worktree with stale .git should be cleaned");
+    }
+
+    [Fact]
+    public void CleanupScript_NoOp_When_No_Worktrees_Directory()
+    {
+        var planDir = CreateFakePlan("04000-NoWorktreeDir");
+
+        var (exitCode, _) = RunCleanupScript(planDir);
+
+        Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
+    public void CleanupScript_Removes_Multiple_Worktrees()
+    {
+        var planDir = CreateFakePlan("05000-MultiWorktree");
+        CreateWorktreeDir(planDir, "RepoA");
+        CreateWorktreeDir(planDir, "RepoB");
+        CreateWorktreeDir(planDir, "RepoC");
+
+        var (exitCode, _) = RunCleanupScript(planDir);
+
+        Assert.Equal(0, exitCode);
+        Assert.False(Directory.Exists(Path.Combine(planDir, "worktrees")),
+            "All worktrees and parent directory should be removed");
+    }
+
+    [Fact]
+    public void GracePeriod_Is_Ten_Minutes()
+    {
+        var field = typeof(Services.WorktreeCleanupService)
+            .GetField("GracePeriod", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        Assert.NotNull(field);
+        var value = (TimeSpan)field!.GetValue(null)!;
+        Assert.Equal(TimeSpan.FromMinutes(10), value);
+    }
+}

--- a/src/tendril/Ivy.Tendril.Test/ExecutePlanWorktreeCleanupTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/ExecutePlanWorktreeCleanupTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using Ivy.Tendril.Services;
 
 namespace Ivy.Tendril.Test;
 
@@ -13,7 +14,7 @@ public class ExecutePlanWorktreeCleanupTests : IDisposable
         Directory.CreateDirectory(_tempDir);
 
         _scriptPath = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "..",
+            System.AppContext.BaseDirectory, "..", "..", "..", "..",
             "Ivy.Tendril", "Promptwares", "ExecutePlan", "Tools", "Cleanup-Worktrees.ps1"));
     }
 
@@ -136,7 +137,7 @@ public class ExecutePlanWorktreeCleanupTests : IDisposable
     [Fact]
     public void GracePeriod_Is_Ten_Minutes()
     {
-        var field = typeof(Services.WorktreeCleanupService)
+        var field = typeof(WorktreeCleanupService)
             .GetField("GracePeriod", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
         Assert.NotNull(field);
         var value = (TimeSpan)field!.GetValue(null)!;

--- a/src/tendril/Ivy.Tendril.Test/WorktreeCleanupServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/WorktreeCleanupServiceTests.cs
@@ -91,8 +91,8 @@ public class WorktreeCleanupServiceTests : IDisposable
     [Fact]
     public void RunCleanup_Respects_Grace_Period()
     {
-        // Plan just failed 10 minutes ago — should NOT be cleaned
-        var dir = CreatePlan("03000-RecentFail", "Failed", DateTime.UtcNow.AddMinutes(-10));
+        // Plan just failed 5 minutes ago — should NOT be cleaned (grace period is 10 minutes)
+        var dir = CreatePlan("03000-RecentFail", "Failed", DateTime.UtcNow.AddMinutes(-5));
         CreateWorktreeDir(dir, "Repo");
 
         _service.RunCleanup();

--- a/src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/ExecutePlan.ps1
+++ b/src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/ExecutePlan.ps1
@@ -154,4 +154,16 @@ finally {
     Stop-Heartbeat $heartbeat
     Pop-Location
     Remove-Item $promptFile -ErrorAction SilentlyContinue
+
+    if (-not $env:KEEP_WORKTREES) {
+        Write-Host "Cleaning up worktrees..." -ForegroundColor Gray
+        try {
+            $cleanupScript = Join-Path $PSScriptRoot "Tools" "Cleanup-Worktrees.ps1"
+            & $cleanupScript -PlanPath $PlanPath
+        } catch {
+            Write-Warning "Worktree cleanup failed (non-fatal): $_"
+        }
+    } else {
+        Write-Host "KEEP_WORKTREES is set - skipping worktree cleanup" -ForegroundColor Gray
+    }
 }

--- a/src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
+++ b/src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
@@ -470,6 +470,19 @@ After all verifications pass:
 
 3. Run `git status` in every worktree. If there are any uncommitted files (from verification fixes, generated files, etc.), commit or discard them. The worktrees must be completely clean before finishing.
 
+### 8.5. Clean Up Worktrees
+
+After all verifications pass and the worktrees are clean, the launcher script automatically removes all worktree directories to free disk space.
+
+**Worktree cleanup includes:**
+1. Deregister each worktree from git via `git worktree remove --force`
+2. Force-delete the worktree directory (with Windows `rmdir /s /q` fallback for locked files)
+3. Remove the parent `worktrees/` directory
+
+**Git branches are preserved** — MakePr uses the `plan-<ID>-<repo>` branch to create pull requests. Only the worktree filesystem directories are removed.
+
+**Debugging tip:** To keep worktrees for manual inspection after failure, set the `KEEP_WORKTREES=1` environment variable before running ExecutePlan. The WorktreeCleanupService will still clean them up after the grace period (10 minutes + 30 minute cycle).
+
 ### 9. Plan State
 
 The launcher script handles state transitions (Completed/Failed) based on exit code.

--- a/src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/Tools/Cleanup-Worktrees.ps1
+++ b/src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/Tools/Cleanup-Worktrees.ps1
@@ -1,0 +1,44 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$PlanPath
+)
+
+$worktreesDir = Join-Path $PlanPath "worktrees"
+if (-not (Test-Path $worktreesDir)) {
+    return
+}
+
+Get-ChildItem $worktreesDir -Directory | ForEach-Object {
+    $wtDir = $_.FullName
+    $repoName = $_.Name
+
+    Write-Host "Removing worktree: $repoName"
+
+    $gitFile = Join-Path $wtDir ".git"
+    if (Test-Path $gitFile) {
+        $gitContent = Get-Content $gitFile -Raw
+        if ($gitContent -match 'gitdir:\s*(.+)') {
+            $gitDir = $Matches[1].Trim()
+            $repoGitDir = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($gitDir, "..", ".."))
+            $repoRoot = [System.IO.Path]::GetDirectoryName($repoGitDir)
+
+            if ($repoRoot -and (Test-Path $repoRoot)) {
+                Push-Location $repoRoot
+                git worktree remove $wtDir --force 2>$null
+                Pop-Location
+            }
+        }
+    }
+
+    if (Test-Path $wtDir) {
+        Remove-Item $wtDir -Recurse -Force -ErrorAction SilentlyContinue
+
+        if (Test-Path $wtDir) {
+            cmd /c "rmdir /s /q `"$wtDir`"" 2>$null
+        }
+    }
+}
+
+if (Test-Path $worktreesDir) {
+    Remove-Item $worktreesDir -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/src/tendril/Ivy.Tendril/Services/WorktreeCleanupService.cs
+++ b/src/tendril/Ivy.Tendril/Services/WorktreeCleanupService.cs
@@ -12,7 +12,7 @@ public class WorktreeCleanupService : IStartable, IDisposable
     private static readonly HashSet<string> TerminalStates = new(StringComparer.OrdinalIgnoreCase)
         { "Completed", "Failed", "Skipped", "Icebox" };
 
-    private static readonly TimeSpan GracePeriod = TimeSpan.FromHours(1);
+    private static readonly TimeSpan GracePeriod = TimeSpan.FromMinutes(10);
     private static readonly TimeSpan TimerInterval = TimeSpan.FromMinutes(30);
 
     private readonly string _plansDirectory;


### PR DESCRIPTION
# Summary

## Changes

Added automatic worktree cleanup to ExecutePlan's completion flow. When ExecutePlan finishes (success, failure, or exception), the `Cleanup-Worktrees.ps1` tool deregisters worktrees from git and force-deletes their directories. The `KEEP_WORKTREES=1` environment variable skips cleanup for debugging. The background `WorktreeCleanupService` grace period was reduced from 1 hour to 10 minutes since it now serves as a safety net rather than the primary cleanup mechanism.

## API Changes

None.

## Files Modified

- **New:** `src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/Tools/Cleanup-Worktrees.ps1` — PowerShell tool for worktree cleanup
- **New:** `src/tendril/Ivy.Tendril.Test/ExecutePlanWorktreeCleanupTests.cs` — 6 tests for the cleanup feature
- **Modified:** `src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/ExecutePlan.ps1` — Added cleanup call in `finally` block
- **Modified:** `src/tendril/Ivy.Tendril/Services/WorktreeCleanupService.cs` — Grace period 1h -> 10min
- **Modified:** `src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/Program.md` — Added Section 8.5 documentation
- **Modified:** `src/tendril/Ivy.Tendril.Test/WorktreeCleanupServiceTests.cs` — Updated grace period boundary test

---

## Commits

- a5fdbcd59 [03087] Fix test compilation: qualify System.AppContext, add using directive
- e39038944 [03087] Add automatic worktree cleanup on ExecutePlan completion