### PR TITLE
[03081] Increase max concurrent jobs limit from 50 to 100 in settings UI

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Setup/AdvancedSetupView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Setup/AdvancedSetupView.cs
@@ -27,7 +27,7 @@ public class AdvancedSetupView : ViewBase
                        .WithField().Label("Job Timeout")
                    | staleOutputTimeout.ToNumberInput().Min(1).Max(60).Suffix("min")
                        .WithField().Label("Stale Output Timeout")
-                   | maxConcurrentJobs.ToNumberInput().Min(1).Max(50)
+                   | maxConcurrentJobs.ToNumberInput().Min(1).Max(100)
                        .WithField().Label("Max Concurrent Jobs")
                    | Text.Block("Editor").Bold()
                    | editorCommand.ToTextInput("e.g. code, vim")


### PR DESCRIPTION
# Summary

## Changes

Increased the maximum allowed value for the "Max Concurrent Jobs" number input from 50 to 100 in the Advanced Settings UI. This is a single-line change to the UI validation constraint; the underlying `JobService` already supports arbitrary concurrency values.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Apps/Setup/AdvancedSetupView.cs` — Changed `.Max(50)` to `.Max(100)` on the `maxConcurrentJobs` number input

## Commits

- b48ad1bce [03081] Increase max concurrent jobs limit from 50 to 100 in settings UI