### PR TITLE
[03080] Tendril config.yaml Parse Error Handling and Autohealing

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/BackgroundServiceActivatorTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/BackgroundServiceActivatorTests.cs
@@ -173,12 +173,16 @@ public class BackgroundServiceActivatorTests : IAsyncLifetime
         public string[] LevelNames => Array.Empty<string>();
         public EditorConfig Editor => Settings.Editor ?? new EditorConfig();
         public bool NeedsOnboarding => true;
+        public ConfigParseError? ParseError => null;
 
         public ProjectConfig? GetProject(string name) => null;
         public BadgeVariant GetBadgeVariant(string level) => BadgeVariant.Outline;
         public Colors? GetProjectColor(string projectName) => null;
         public void SaveSettings() { }
         public void ReloadSettings() { }
+        public bool TryAutoHeal() => false;
+        public void ResetToDefaults() { }
+        public void RetryLoadConfig() { }
 #pragma warning disable CS0067
         public event EventHandler? SettingsReloaded;
 #pragma warning restore CS0067

--- a/src/tendril/Ivy.Tendril.Test/ConfigServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/ConfigServiceTests.cs
@@ -796,4 +796,201 @@ editor:
             Directory.Delete(tempDir, true);
         }
     }
+
+    [Fact]
+    public void Should_Capture_Parse_Error_When_Config_Malformed()
+    {
+        var tempDir = CreateTempConfigFile("invalid: yaml: [unclosed");
+        var service = new ConfigService(new TendrilSettings());
+
+        try
+        {
+            service.SetTendrilHome(tempDir);
+
+            // SetTendrilHome silently catches errors, so test via constructor-like reload
+            // Write malformed config and retry
+            File.WriteAllText(Path.Combine(tempDir, "config.yaml"), "invalid: yaml: [unclosed");
+            service.RetryLoadConfig();
+
+            Assert.NotNull(service.ParseError);
+            Assert.Contains(tempDir, service.ParseError.FilePath);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void Should_Backup_Broken_Config_On_Parse_Error()
+    {
+        var malformedYaml = "projects:\n  - name: [invalid\n    bad: {unclosed";
+        var tempDir = CreateTempConfigFile(malformedYaml);
+        var service = new ConfigService(new TendrilSettings());
+
+        try
+        {
+            service.SetTendrilHome(tempDir);
+            service.RetryLoadConfig();
+
+            var backupFiles = Directory.GetFiles(tempDir, "config.yaml.broken.*.bak");
+            Assert.NotEmpty(backupFiles);
+
+            var backupContent = File.ReadAllText(backupFiles[0]);
+            Assert.Contains("[invalid", backupContent);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void Should_Auto_Heal_With_Minimal_Config()
+    {
+        var malformedYaml = "projects:\n  - name: [invalid";
+        var tempDir = CreateTempConfigFile(malformedYaml);
+        var service = new ConfigService(new TendrilSettings());
+
+        try
+        {
+            service.SetTendrilHome(tempDir);
+
+            // Force a parse error
+            File.WriteAllText(Path.Combine(tempDir, "config.yaml"), malformedYaml);
+            service.RetryLoadConfig();
+            Assert.NotNull(service.ParseError);
+
+            var healed = service.TryAutoHeal();
+            Assert.True(healed);
+
+            // Verify the healed config can be parsed
+            var yaml = File.ReadAllText(Path.Combine(tempDir, "config.yaml"));
+            var settings = YamlHelper.Deserializer.Deserialize<TendrilSettings>(yaml);
+            Assert.NotNull(settings);
+            Assert.Equal("claude", settings.CodingAgent);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void Should_Restore_From_Backup_When_Available()
+    {
+        var validYaml = @"
+codingAgent: test-agent
+jobTimeout: 42
+projects: []
+";
+        var tempDir = CreateTempConfigFile(validYaml);
+        var service = new ConfigService(new TendrilSettings());
+
+        try
+        {
+            service.SetTendrilHome(tempDir);
+
+            // SaveSettings creates a .backup
+            service.SaveSettings();
+            Assert.True(File.Exists(Path.Combine(tempDir, "config.yaml.backup")));
+
+            // Break the main config
+            File.WriteAllText(Path.Combine(tempDir, "config.yaml"), "broken: [yaml");
+            service.RetryLoadConfig();
+            Assert.NotNull(service.ParseError);
+
+            // TryAutoHeal should restore from backup
+            var healed = service.TryAutoHeal();
+            Assert.True(healed);
+
+            // Verify it restored from the backup
+            Assert.Equal(42, service.Settings.JobTimeout);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void Should_Create_Backup_On_Successful_Save()
+    {
+        var yaml = @"
+codingAgent: claude
+jobTimeout: 30
+";
+        var tempDir = CreateTempConfigFile(yaml);
+        var service = new ConfigService(new TendrilSettings());
+
+        try
+        {
+            service.SetTendrilHome(tempDir);
+            service.SaveSettings();
+
+            var backupPath = Path.Combine(tempDir, "config.yaml.backup");
+            Assert.True(File.Exists(backupPath));
+
+            var backupSettings =
+                YamlHelper.Deserializer.Deserialize<TendrilSettings>(File.ReadAllText(backupPath));
+            Assert.NotNull(backupSettings);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void RetryLoadConfig_Clears_ParseError_On_Success()
+    {
+        var tempDir = CreateTempConfigFile("broken: [yaml");
+        var service = new ConfigService(new TendrilSettings());
+
+        try
+        {
+            service.SetTendrilHome(tempDir);
+            service.RetryLoadConfig();
+            Assert.NotNull(service.ParseError);
+
+            // Fix the config
+            File.WriteAllText(Path.Combine(tempDir, "config.yaml"), "codingAgent: claude\n");
+            service.RetryLoadConfig();
+
+            Assert.Null(service.ParseError);
+            Assert.False(service.NeedsOnboarding);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void ResetToDefaults_Clears_Error_And_Sets_Onboarding()
+    {
+        var tempDir = CreateTempConfigFile("broken: [yaml");
+        var service = new ConfigService(new TendrilSettings());
+
+        try
+        {
+            service.SetTendrilHome(tempDir);
+            service.RetryLoadConfig();
+            Assert.NotNull(service.ParseError);
+
+            service.ResetToDefaults();
+
+            Assert.Null(service.ParseError);
+            Assert.True(service.NeedsOnboarding);
+
+            // Verify the new config is valid
+            var yaml = File.ReadAllText(Path.Combine(tempDir, "config.yaml"));
+            var settings = YamlHelper.Deserializer.Deserialize<TendrilSettings>(yaml);
+            Assert.NotNull(settings);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
 }

--- a/src/tendril/Ivy.Tendril.Test/PlanContentHelpersTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/PlanContentHelpersTests.cs
@@ -180,11 +180,15 @@ public class PlanContentHelpersTests
         public string[] LevelNames => [];
         public EditorConfig Editor => new() { Command = "code", Label = "VS Code" };
         public bool NeedsOnboarding => false;
+        public ConfigParseError? ParseError => null;
         public ProjectConfig? GetProject(string name) => null;
         public BadgeVariant GetBadgeVariant(string level) => BadgeVariant.Outline;
         public Colors? GetProjectColor(string projectName) => null;
         public void SaveSettings() { }
         public void ReloadSettings() { }
+        public bool TryAutoHeal() => false;
+        public void ResetToDefaults() { }
+        public void RetryLoadConfig() { }
 #pragma warning disable CS0067
         public event EventHandler? SettingsReloaded;
 #pragma warning restore CS0067

--- a/src/tendril/Ivy.Tendril.Test/Services/FileLinkHelperTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/Services/FileLinkHelperTests.cs
@@ -109,12 +109,16 @@ public class FileLinkHelperTests
         public string[] LevelNames => [];
         public EditorConfig Editor => new() { Command = "code", Label = "VS Code" };
         public bool NeedsOnboarding => false;
+        public ConfigParseError? ParseError => null;
 
         public ProjectConfig? GetProject(string name) => null;
         public BadgeVariant GetBadgeVariant(string level) => BadgeVariant.Outline;
         public Colors? GetProjectColor(string projectName) => null;
         public void SaveSettings() { }
         public void ReloadSettings() { }
+        public bool TryAutoHeal() => false;
+        public void ResetToDefaults() { }
+        public void RetryLoadConfig() { }
 #pragma warning disable CS0067
         public event EventHandler? SettingsReloaded;
 #pragma warning restore CS0067

--- a/src/tendril/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/tendril/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -461,6 +461,9 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
                 );
         }
 
+        if (config.ParseError != null)
+            return new ConfigErrorApp(config);
+
         if (config.NeedsOnboarding) return new OnboardingApp();
 
         return new Fragment(

--- a/src/tendril/Ivy.Tendril/Apps/ConfigErrorApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/ConfigErrorApp.cs
@@ -1,0 +1,73 @@
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Apps;
+
+public class ConfigErrorApp(IConfigService config) : ViewBase
+{
+    public override object Build()
+    {
+        var showDetails = UseState(false);
+        var client = UseService<IClientProvider>();
+        var parseError = config.ParseError;
+
+        if (parseError == null)
+        {
+            client.Redirect("/", true);
+            return Text.P("Redirecting...");
+        }
+
+        var errorSummary = parseError.Message.Length > 200
+            ? parseError.Message[..200] + "..."
+            : parseError.Message;
+
+        var content = Layout.Vertical().Gap(4);
+
+        content |= new Image("/tendril/assets/Tendril.svg").Width(Size.Units(20)).Height(Size.Auto());
+
+        content |= Callout.Error(
+            $"The configuration file could not be parsed:\n\n`{errorSummary}`\n\nA backup of the broken file has been saved.",
+            "Configuration Error"
+        );
+
+        content |= Layout.Horizontal().Gap(2)
+                   | new Button("Edit Config")
+                       .Icon(Icons.FileText)
+                       .OnClick(() => config.OpenInEditor(config.ConfigPath))
+                   | new Button("Reload Config")
+                       .Icon(Icons.RefreshCw)
+                       .Variant(ButtonVariant.Outline)
+                       .OnClick(() =>
+                       {
+                           config.RetryLoadConfig();
+                           if (config.ParseError == null)
+                               client.Redirect("/", true);
+                       })
+                   | new Button("Reset to Defaults")
+                       .Icon(Icons.RotateCcw)
+                       .Variant(ButtonVariant.Destructive)
+                       .OnClick(() =>
+                       {
+                           config.ResetToDefaults();
+                           client.Redirect("/", true);
+                       })
+                   | new Button(showDetails.Value ? "Hide Details" : "View Details")
+                       .Icon(Icons.Info)
+                       .Variant(ButtonVariant.Ghost)
+                       .OnClick(() => showDetails.Set(!showDetails.Value));
+
+        if (showDetails.Value)
+        {
+            var details = $"**File:** `{parseError.FilePath}`\n\n" +
+                          $"**Error:**\n```\n{parseError.Message}\n```";
+            if (parseError.InnerException != null)
+                details += $"\n\n**Stack Trace:**\n```\n{parseError.InnerException.StackTrace}\n```";
+
+            content |= new Callout(details, "Error Details");
+        }
+
+        content |= Text.Muted("Broken config files are backed up with a `.broken.{timestamp}.bak` extension.").Small();
+
+        return Layout.TopCenter()
+               | (content.Margin(0, 20).Width(150));
+    }
+}

--- a/src/tendril/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/tendril/Ivy.Tendril/Services/ConfigService.cs
@@ -135,6 +135,8 @@ public class TendrilSettings
     };
 }
 
+public record ConfigParseError(string Message, string FilePath, Exception? InnerException);
+
 public class ConfigService : IConfigService
 {
     private string[]? _levelNamesCache;
@@ -182,13 +184,22 @@ public class ConfigService : IConfigService
                 yaml = Regex.Replace(yaml, @"(?m)^(\s*-\s+)(%\w+%.*)$", "$1'$2'");
                 Settings = YamlHelper.Deserializer.Deserialize<TendrilSettings>(yaml) ?? new TendrilSettings();
                 MigrateProjectColors();
+                CreateConfigBackup();
                 NeedsOnboarding = false;
             }
             catch (Exception ex)
             {
                 Console.Error.WriteLine($"Failed to load Tendril config '{ConfigPath}': {ex}");
-                NeedsOnboarding = true;
+                ParseError = new ConfigParseError(ex.Message, ConfigPath, ex);
+                BackupBrokenConfig();
                 Settings = new TendrilSettings();
+                NeedsOnboarding = true;
+
+                if (TryAutoHeal())
+                {
+                    ParseError = null;
+                    NeedsOnboarding = false;
+                }
             }
         }
         else
@@ -200,18 +211,10 @@ public class ConfigService : IConfigService
 
         if (Settings != null && !NeedsOnboarding)
         {
-            // Initialize basic stuff
             VariableExpansion.InitializeUserSecrets(TendrilHome);
             ExpandSettingsVariables();
+            ExpandRepoPaths();
 
-            // Expand repo paths
-            if (Settings.Projects != null)
-                foreach (var proj in Settings.Projects)
-                    if (proj.Repos != null)
-                        foreach (var repo in proj.Repos)
-                            repo.Path = VariableExpansion.ExpandVariables(repo.Path, TendrilHome);
-
-            // Ensure directories exist
             Directory.CreateDirectory(TendrilHome);
             Directory.CreateDirectory(Path.Combine(TendrilHome, "Inbox"));
             Directory.CreateDirectory(Path.Combine(TendrilHome, "Plans"));
@@ -271,7 +274,20 @@ public class ConfigService : IConfigService
     {
         _levelNamesCache = null;
         var yaml = YamlHelper.SerializerCompact.Serialize(Settings);
+
+        // Validate the YAML can be deserialized back before writing
+        try
+        {
+            YamlHelper.Deserializer.Deserialize<TendrilSettings>(yaml);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException(
+                $"Generated YAML failed validation and was not saved: {ex.Message}", ex);
+        }
+
         FileHelper.WriteAllText(ConfigPath, yaml);
+        CreateConfigBackup();
         ReloadSettings();
     }
 
@@ -302,6 +318,8 @@ public class ConfigService : IConfigService
 
     // Onboarding support
     public bool NeedsOnboarding { get; private set; }
+
+    public ConfigParseError? ParseError { get; private set; }
 
     public void SetPendingTendrilHome(string path)
     {
@@ -380,6 +398,134 @@ public class ConfigService : IConfigService
         {
             return false;
         }
+    }
+
+    public bool TryAutoHeal()
+    {
+        // Strategy 1: Restore from last known good backup
+        var backupPath = ConfigPath + ".backup";
+        if (File.Exists(backupPath))
+        {
+            try
+            {
+                var backupYaml = FileHelper.ReadAllText(backupPath);
+                var restored = YamlHelper.Deserializer.Deserialize<TendrilSettings>(backupYaml);
+                if (restored != null)
+                {
+                    FileHelper.WriteAllText(ConfigPath, backupYaml);
+                    Settings = restored;
+                    MigrateProjectColors();
+                    VariableExpansion.InitializeUserSecrets(TendrilHome);
+                    ExpandSettingsVariables();
+                    ExpandRepoPaths();
+                    return true;
+                }
+            }
+            catch
+            {
+                // Backup is also corrupt, fall through
+            }
+        }
+
+        // Strategy 2: Create minimal valid config
+        Settings = CreateMinimalSettings();
+        var minimalYaml = YamlHelper.SerializerCompact.Serialize(Settings);
+        FileHelper.WriteAllText(ConfigPath, minimalYaml);
+        return true;
+    }
+
+    public void ResetToDefaults()
+    {
+        BackupBrokenConfig();
+        Settings = CreateMinimalSettings();
+        var yaml = YamlHelper.SerializerCompact.Serialize(Settings);
+        FileHelper.WriteAllText(ConfigPath, yaml);
+        ParseError = null;
+        NeedsOnboarding = true;
+    }
+
+    public void RetryLoadConfig()
+    {
+        if (!File.Exists(ConfigPath)) return;
+
+        try
+        {
+            var yaml = FileHelper.ReadAllText(ConfigPath);
+            yaml = Regex.Replace(yaml, @"(?m)(?<=:\s+)(%\w+%.*)$", "'$1'");
+            yaml = Regex.Replace(yaml, @"(?m)^(\s*-\s+)(%\w+%.*)$", "$1'$2'");
+            Settings = YamlHelper.Deserializer.Deserialize<TendrilSettings>(yaml) ?? new TendrilSettings();
+            MigrateProjectColors();
+            CreateConfigBackup();
+            ParseError = null;
+            NeedsOnboarding = false;
+            _levelNamesCache = null;
+            VariableExpansion.InitializeUserSecrets(TendrilHome);
+            ExpandSettingsVariables();
+            ExpandRepoPaths();
+            SettingsReloaded?.Invoke(this, EventArgs.Empty);
+        }
+        catch (Exception ex)
+        {
+            BackupBrokenConfig();
+            ParseError = new ConfigParseError(ex.Message, ConfigPath, ex);
+        }
+    }
+
+    private void BackupBrokenConfig()
+    {
+        try
+        {
+            if (!File.Exists(ConfigPath)) return;
+            var timestamp = DateTime.UtcNow.ToString("yyyyMMddTHHmmss");
+            var brokenPath = Path.Combine(
+                Path.GetDirectoryName(ConfigPath)!,
+                $"config.yaml.broken.{timestamp}.bak");
+            File.Copy(ConfigPath, brokenPath, true);
+        }
+        catch
+        {
+            // Best-effort backup
+        }
+    }
+
+    private void CreateConfigBackup()
+    {
+        try
+        {
+            if (!File.Exists(ConfigPath)) return;
+            var backupPath = ConfigPath + ".backup";
+            File.Copy(ConfigPath, backupPath, true);
+        }
+        catch
+        {
+            // Best-effort backup
+        }
+    }
+
+    private static TendrilSettings CreateMinimalSettings()
+    {
+        return new TendrilSettings
+        {
+            CodingAgent = "claude",
+            Projects = new List<ProjectConfig>(),
+            Verifications = new List<VerificationConfig>(),
+            Levels = new List<LevelConfig>
+            {
+                new() { Name = "Bug", Badge = "Destructive" },
+                new() { Name = "Critical", Badge = "Warning" },
+                new() { Name = "NiceToHave", Badge = "Outline" },
+                new() { Name = "Epic", Badge = "Info" }
+            }
+        };
+    }
+
+    private void ExpandRepoPaths()
+    {
+        if (Settings.Projects != null)
+            foreach (var proj in Settings.Projects)
+                if (proj.Repos != null)
+                    foreach (var repo in proj.Repos)
+                        repo.Path = VariableExpansion.ExpandVariables(repo.Path, TendrilHome);
     }
 
     internal static string? MigrateProjectColor(string? colorValue)

--- a/src/tendril/Ivy.Tendril/Services/IConfigService.cs
+++ b/src/tendril/Ivy.Tendril/Services/IConfigService.cs
@@ -11,8 +11,12 @@ public interface IConfigService
     string[] LevelNames { get; }
     EditorConfig Editor { get; }
     bool NeedsOnboarding { get; }
+    ConfigParseError? ParseError { get; }
 
     ProjectConfig? GetProject(string name);
+    bool TryAutoHeal();
+    void ResetToDefaults();
+    void RetryLoadConfig();
     BadgeVariant GetBadgeVariant(string level);
     Colors? GetProjectColor(string projectName);
     void SaveSettings();


### PR DESCRIPTION
# Summary

## Changes

Added comprehensive config.yaml parse error handling and autohealing to Tendril. When config.yaml is malformed, ConfigService now captures the error details, attempts cascading recovery (restore from backup, then create minimal config), and exposes the error to the UI. A dedicated ConfigErrorApp shows an error callout with Edit/Reload/Reset/Details actions when autohealing fails. SaveSettings now validates YAML round-trips correctly and creates backups on every successful load and save.

## API Changes

- `ConfigParseError` — new public record in `Ivy.Tendril.Services` with `Message`, `FilePath`, `InnerException`
- `IConfigService.ParseError` — new property exposing parse error state
- `IConfigService.TryAutoHeal()` — new method for cascading recovery (restore from backup or create minimal config)
- `IConfigService.RetryLoadConfig()` — new method to re-parse config after user edits
- `IConfigService.ResetToDefaults()` — new method to reset config with backup
- `SaveSettings()` — now validates YAML round-trip before writing and creates `config.yaml.backup`
- `ConfigErrorApp` — new app shown when config parse error is detected

## Files Modified

- **Core:**
  - `src/tendril/Ivy.Tendril/Services/IConfigService.cs` — added `ParseError`, `TryAutoHeal()`, `RetryLoadConfig()`, `ResetToDefaults()`
  - `src/tendril/Ivy.Tendril/Services/ConfigService.cs` — added `ConfigParseError` record, autohealing, backup methods, enhanced constructor and `SaveSettings()`
- **UI:**
  - `src/tendril/Ivy.Tendril/Apps/ConfigErrorApp.cs` — new dedicated error recovery app
  - `src/tendril/Ivy.Tendril/AppShell/TendrilAppShell.cs` — intercept parse error before onboarding redirect
- **Tests:**
  - `src/tendril/Ivy.Tendril.Test/ConfigServiceTests.cs` — added 7 new tests
  - `src/tendril/Ivy.Tendril.Test/BackgroundServiceActivatorTests.cs` — updated stub
  - `src/tendril/Ivy.Tendril.Test/PlanContentHelpersTests.cs` — updated stub
  - `src/tendril/Ivy.Tendril.Test/Services/FileLinkHelperTests.cs` — updated stub

## Commits

- 4fc5451f2 [03080] Add config.yaml parse error handling and autohealing