### PR TITLE
[03097] Apply error-tuple pattern to FetchAssigneesFromGhCliAsync and FetchLabelsFromGhCliAsync

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/GithubServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/GithubServiceTests.cs
@@ -152,6 +152,32 @@ public class GithubServiceTests
         Assert.Empty(issues);
     }
 
+    [Fact]
+    public async Task GetAssigneesAsync_Returns_Error_When_Command_Fails()
+    {
+        var configService = new ConfigService(new TendrilSettings());
+        var githubService = new GithubService(configService);
+
+        var (assignees, error) = await githubService.GetAssigneesAsync(
+            "nonexistent-owner-xyz-000", "nonexistent-repo-xyz-000");
+
+        Assert.Empty(assignees);
+        Assert.NotNull(error);
+    }
+
+    [Fact]
+    public async Task GetLabelsAsync_Returns_Error_When_Command_Fails()
+    {
+        var configService = new ConfigService(new TendrilSettings());
+        var githubService = new GithubService(configService);
+
+        var (labels, error) = await githubService.GetLabelsAsync(
+            "nonexistent-owner-xyz-000", "nonexistent-repo-xyz-000");
+
+        Assert.Empty(labels);
+        Assert.NotNull(error);
+    }
+
     private static string CreateTempGitRepo(string remoteUrl)
     {
         var tempDir = Path.Combine(Path.GetTempPath(), $"ivy-github-test-{Guid.NewGuid()}");

--- a/src/tendril/Ivy.Tendril/AppShell/Dialogs/ImportIssuesDialog.cs
+++ b/src/tendril/Ivy.Tendril/AppShell/Dialogs/ImportIssuesDialog.cs
@@ -21,16 +21,29 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
         var errorMessage = UseState<string?>(null);
         var isFetching = UseState(false);
         var isImporting = UseState(false);
+        var assigneesError = UseState<string?>(null);
+        var labelsError = UseState<string?>(null);
 
         var assigneesQuery = UseQuery<string[], string>(
             selectedRepo.Value ?? "",
             async (repoName, _) =>
             {
-                if (string.IsNullOrEmpty(repoName)) return Array.Empty<string>();
+                if (string.IsNullOrEmpty(repoName))
+                {
+                    assigneesError.Set(null);
+                    return Array.Empty<string>();
+                }
                 var repos = githubService.GetRepos();
                 var repo = repos.FirstOrDefault(r => r.DisplayName == repoName);
-                if (repo is null) return Array.Empty<string>();
-                return (await githubService.GetAssigneesAsync(repo.Owner, repo.Name)).ToArray();
+                if (repo is null)
+                {
+                    assigneesError.Set(null);
+                    return Array.Empty<string>();
+                }
+
+                var (assignees, error) = await githubService.GetAssigneesAsync(repo.Owner, repo.Name);
+                assigneesError.Set(error);
+                return assignees.ToArray();
             },
             initialValue: Array.Empty<string>()
         );
@@ -39,11 +52,22 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
             selectedRepo.Value ?? "",
             async (repoName, _) =>
             {
-                if (string.IsNullOrEmpty(repoName)) return Array.Empty<string>();
+                if (string.IsNullOrEmpty(repoName))
+                {
+                    labelsError.Set(null);
+                    return Array.Empty<string>();
+                }
                 var repos = githubService.GetRepos();
                 var repo = repos.FirstOrDefault(r => r.DisplayName == repoName);
-                if (repo is null) return Array.Empty<string>();
-                return (await githubService.GetLabelsAsync(repo.Owner, repo.Name)).ToArray();
+                if (repo is null)
+                {
+                    labelsError.Set(null);
+                    return Array.Empty<string>();
+                }
+
+                var (labels, error) = await githubService.GetLabelsAsync(repo.Owner, repo.Name);
+                labelsError.Set(error);
+                return labels.ToArray();
             },
             initialValue: Array.Empty<string>()
         );
@@ -54,6 +78,8 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
             errorMessage.Set(null);
             selectedAssignee.Set(null);
             selectedLabels.Set(Array.Empty<string>());
+            assigneesError.Set(null);
+            labelsError.Set(null);
         }, selectedRepo);
 
         if (!_dialogOpen.Value) return null;
@@ -193,6 +219,12 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
                     .Nullable().WithField().Label("Assignee")
                 | selectedLabels.ToSelectInput(labelsQuery.Value.ToOptions())
                     .Placeholder("Select labels...").WithField().Label("Labels")
+                | (assigneesError.Value is { } assigneeErr
+                    ? Text.Danger(assigneeErr).Small()
+                    : null)
+                | (labelsError.Value is { } labelErr
+                    ? Text.Danger(labelErr).Small()
+                    : null)
                 | new Button("Fetch Issues").Outline().Loading(isFetching.Value)
                     .OnClick(async () => await FetchIssues())
                 | (errorMessage.Value is { } error

--- a/src/tendril/Ivy.Tendril/Apps/Plans/Dialogs/CreateIssueDialog.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Plans/Dialogs/CreateIssueDialog.cs
@@ -30,8 +30,8 @@ public class CreateIssueDialog(
                 var repos = githubService.GetRepos();
                 var selectedRepo = repos.FirstOrDefault(r => r.DisplayName == repoName);
                 if (selectedRepo is null) return Array.Empty<string>();
-                var result = await githubService.GetAssigneesAsync(selectedRepo.Owner, selectedRepo.Name);
-                return result.ToArray();
+                var (assignees, _) = await githubService.GetAssigneesAsync(selectedRepo.Owner, selectedRepo.Name);
+                return assignees.ToArray();
             },
             initialValue: Array.Empty<string>()
         );
@@ -44,8 +44,8 @@ public class CreateIssueDialog(
                 var repos = githubService.GetRepos();
                 var selectedRepo = repos.FirstOrDefault(r => r.DisplayName == repoName);
                 if (selectedRepo is null) return Array.Empty<string>();
-                var result = await githubService.GetLabelsAsync(selectedRepo.Owner, selectedRepo.Name);
-                return result.ToArray();
+                var (labels, _) = await githubService.GetLabelsAsync(selectedRepo.Owner, selectedRepo.Name);
+                return labels.ToArray();
             },
             initialValue: Array.Empty<string>()
         );

--- a/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -50,8 +50,8 @@ public class ContentView(
                 if (repoPath is null) return Array.Empty<string>();
                 var repoConfig = GithubService.GetRepoConfigFromPath(repoPath);
                 if (repoConfig is null) return Array.Empty<string>();
-                var result = await githubService.GetAssigneesAsync(repoConfig.Owner, repoConfig.Name);
-                return result.ToArray();
+                var (assignees, _) = await githubService.GetAssigneesAsync(repoConfig.Owner, repoConfig.Name);
+                return assignees.ToArray();
             },
             initialValue: Array.Empty<string>()
         );

--- a/src/tendril/Ivy.Tendril/Services/GithubService.cs
+++ b/src/tendril/Ivy.Tendril/Services/GithubService.cs
@@ -36,26 +36,32 @@ public class GithubService(IConfigService config) : IGithubService
         return repos;
     }
 
-    public async Task<List<string>> GetAssigneesAsync(string owner, string repo)
+    public async Task<(List<string> assignees, string? error)> GetAssigneesAsync(string owner, string repo)
     {
         var key = $"{owner}/{repo}";
         if (_assigneeCache.TryGetValue(key, out var cached))
-            return cached;
+            return (cached, null);
 
-        var assignees = await FetchAssigneesFromGhCliAsync(owner, repo);
-        _assigneeCache[key] = assignees;
-        return assignees;
+        var (assignees, error) = await FetchAssigneesFromGhCliAsync(owner, repo);
+
+        if (error is null)
+            _assigneeCache[key] = assignees;
+
+        return (assignees, error);
     }
 
-    public async Task<List<string>> GetLabelsAsync(string owner, string repo)
+    public async Task<(List<string> labels, string? error)> GetLabelsAsync(string owner, string repo)
     {
         var key = $"{owner}/{repo}";
         if (_labelCache.TryGetValue(key, out var cached))
-            return cached;
+            return (cached, null);
 
-        var labels = await FetchLabelsFromGhCliAsync(owner, repo);
-        _labelCache[key] = labels;
-        return labels;
+        var (labels, error) = await FetchLabelsFromGhCliAsync(owner, repo);
+
+        if (error is null)
+            _labelCache[key] = labels;
+
+        return (labels, error);
     }
 
     public async Task<Dictionary<string, string>> GetPrStatusesAsync(string owner, string repo)
@@ -182,7 +188,7 @@ public class GithubService(IConfigService config) : IGithubService
         };
     }
 
-    private static async Task<List<string>> FetchLabelsFromGhCliAsync(string owner, string repo)
+    private static async Task<(List<string> labels, string? error)> FetchLabelsFromGhCliAsync(string owner, string repo)
     {
         try
         {
@@ -197,7 +203,8 @@ public class GithubService(IConfigService config) : IGithubService
             };
 
             using var process = Process.Start(psi);
-            if (process is null) return new List<string>();
+            if (process is null)
+                return ([], "GitHub CLI (gh) is not available. Please install it from https://cli.github.com/");
 
             var output = await process.StandardOutput.ReadToEndAsync();
             var stderr = await process.StandardError.ReadToEndAsync();
@@ -206,17 +213,21 @@ public class GithubService(IConfigService config) : IGithubService
             if (process.ExitCode != 0)
             {
                 Console.Error.WriteLine($"[GithubService] gh api labels failed for {owner}/{repo}: {stderr}");
-                return new List<string>();
+                var errorMsg = !string.IsNullOrWhiteSpace(stderr)
+                    ? stderr.Trim()
+                    : $"GitHub CLI exited with code {process.ExitCode}";
+                return ([], errorMsg);
             }
 
-            return output.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            var labels = output.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
                 .OrderBy(x => x)
                 .ToList();
+            return (labels, null);
         }
         catch (Exception ex)
         {
             Console.Error.WriteLine($"[GithubService] Failed to fetch labels for {owner}/{repo}: {ex.Message}");
-            return new List<string>();
+            return ([], $"Failed to fetch labels: {ex.Message}");
         }
     }
 
@@ -278,7 +289,7 @@ public class GithubService(IConfigService config) : IGithubService
         }
     }
 
-    private static async Task<List<string>> FetchAssigneesFromGhCliAsync(string owner, string repo)
+    private static async Task<(List<string> assignees, string? error)> FetchAssigneesFromGhCliAsync(string owner, string repo)
     {
         try
         {
@@ -293,7 +304,8 @@ public class GithubService(IConfigService config) : IGithubService
             };
 
             using var process = Process.Start(psi);
-            if (process is null) return new List<string>();
+            if (process is null)
+                return ([], "GitHub CLI (gh) is not available. Please install it from https://cli.github.com/");
 
             var output = await process.StandardOutput.ReadToEndAsync();
             var stderr = await process.StandardError.ReadToEndAsync();
@@ -302,17 +314,21 @@ public class GithubService(IConfigService config) : IGithubService
             if (process.ExitCode != 0)
             {
                 Console.Error.WriteLine($"[GithubService] gh api assignees failed for {owner}/{repo}: {stderr}");
-                return new List<string>();
+                var errorMsg = !string.IsNullOrWhiteSpace(stderr)
+                    ? stderr.Trim()
+                    : $"GitHub CLI exited with code {process.ExitCode}";
+                return ([], errorMsg);
             }
 
-            return output.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            var assignees = output.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
                 .OrderBy(x => x)
                 .ToList();
+            return (assignees, null);
         }
         catch (Exception ex)
         {
             Console.Error.WriteLine($"[GithubService] Failed to fetch assignees for {owner}/{repo}: {ex.Message}");
-            return new List<string>();
+            return ([], $"Failed to fetch assignees: {ex.Message}");
         }
     }
 }

--- a/src/tendril/Ivy.Tendril/Services/IGithubService.cs
+++ b/src/tendril/Ivy.Tendril/Services/IGithubService.cs
@@ -11,8 +11,8 @@ public record GitHubIssue(
 public interface IGithubService
 {
     List<RepoConfig> GetRepos();
-    Task<List<string>> GetAssigneesAsync(string owner, string repo);
-    Task<List<string>> GetLabelsAsync(string owner, string repo);
+    Task<(List<string> assignees, string? error)> GetAssigneesAsync(string owner, string repo);
+    Task<(List<string> labels, string? error)> GetLabelsAsync(string owner, string repo);
     Task<Dictionary<string, string>> GetPrStatusesAsync(string owner, string repo);
     Task<(List<GitHubIssue> issues, string? error)> SearchIssuesAsync(string owner, string repo, string? query, string? assignee, string[]? labels);
 }


### PR DESCRIPTION
# Summary

## Changes

Applied the error-tuple pattern (established in plan 03084 for `SearchIssuesAsync`) to `FetchAssigneesFromGhCliAsync` and `FetchLabelsFromGhCliAsync`. Both methods and their public wrappers now return `(List<string>, string? error)` tuples instead of silently returning empty lists on failure. The `ImportIssuesDialog` displays error messages when assignee/label fetches fail, and all other callers (`CreateIssueDialog`, `ContentView`) were updated to destructure the tuple.

## API Changes

- `IGithubService.GetAssigneesAsync` — return type changed from `Task<List<string>>` to `Task<(List<string> assignees, string? error)>`
- `IGithubService.GetLabelsAsync` — return type changed from `Task<List<string>>` to `Task<(List<string> labels, string? error)>`
- `GithubService.GetAssigneesAsync` — only caches successful results (error is null)
- `GithubService.GetLabelsAsync` — only caches successful results (error is null)

## Files Modified

- **Interface & Service:**
  - `src/tendril/Ivy.Tendril/Services/IGithubService.cs` — updated method signatures
  - `src/tendril/Ivy.Tendril/Services/GithubService.cs` — updated private Fetch methods and public Get methods

- **UI Callers:**
  - `src/tendril/Ivy.Tendril/AppShell/Dialogs/ImportIssuesDialog.cs` — added error state, error display
  - `src/tendril/Ivy.Tendril/Apps/Plans/Dialogs/CreateIssueDialog.cs` — destructure tuple
  - `src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs` — destructure tuple

- **Tests:**
  - `src/tendril/Ivy.Tendril.Test/GithubServiceTests.cs` — added `GetAssigneesAsync_Returns_Error_When_Command_Fails` and `GetLabelsAsync_Returns_Error_When_Command_Fails`

## Commits

- 18789ca80