### PR TITLE
[03088] Normalize Path Separators In Project Validation

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/ConfigServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/ConfigServiceTests.cs
@@ -351,71 +351,39 @@ projects:
     }
 
     [Fact]
-    public void LoadSettings_NormalizesRepoPathSeparators()
-    {
-        var yaml = @"
-projects:
-  - name: TestProject
-    repos:
-      - path: D:/Repos/Mixed\Path
-";
-
-        var tempDir = CreateTempConfigFile(yaml);
-        var service = new ConfigService(new TendrilSettings());
-
-        try
-        {
-            service.SetTendrilHome(tempDir);
-
-            var repo = service.Settings.Projects[0].Repos[0];
-            if (Path.DirectorySeparatorChar == '\\')
-                Assert.Equal(@"D:\Repos\Mixed\Path", repo.Path);
-            else
-                Assert.Equal("D:/Repos/Mixed/Path", repo.Path);
-        }
-        finally
-        {
-            Directory.Delete(tempDir, true);
-        }
-    }
-
-    [Fact]
-    public void LoadSettings_NormalizesForwardSlashPaths()
-    {
-        var yaml = @"
-projects:
-  - name: TestProject
-    repos:
-      - path: D:/Repos/ForwardSlash
-";
-
-        var tempDir = CreateTempConfigFile(yaml);
-        var service = new ConfigService(new TendrilSettings());
-
-        try
-        {
-            service.SetTendrilHome(tempDir);
-
-            var repo = service.Settings.Projects[0].Repos[0];
-            if (Path.DirectorySeparatorChar == '\\')
-                Assert.Equal(@"D:\Repos\ForwardSlash", repo.Path);
-            else
-                Assert.Equal("D:/Repos/ForwardSlash", repo.Path);
-        }
-        finally
-        {
-            Directory.Delete(tempDir, true);
-        }
-    }
-
-    [Fact]
-    public void VariableExpansion_NormalizesPathSeparators()
+    public void ExpandVariables_NormalizesMixedPathSeparators()
     {
         var result = VariableExpansion.ExpandVariables(@"D:/Repos/Mixed\Path", "");
         if (Path.DirectorySeparatorChar == '\\')
             Assert.Equal(@"D:\Repos\Mixed\Path", result);
         else
             Assert.Equal("D:/Repos/Mixed/Path", result);
+    }
+
+    [Fact]
+    public void ExpandVariables_NormalizesForwardSlashesOnWindows()
+    {
+        var result = VariableExpansion.ExpandVariables("D:/Repos/ForwardSlash", "");
+        if (Path.DirectorySeparatorChar == '\\')
+            Assert.Equal(@"D:\Repos\ForwardSlash", result);
+        else
+            Assert.Equal("D:/Repos/ForwardSlash", result);
+    }
+
+    [Fact]
+    public void ExpandVariables_ExpandsEnvironmentVariables()
+    {
+        var tempValue = $"test-{Guid.NewGuid()}";
+        Environment.SetEnvironmentVariable("IVY_TEST_VAR", tempValue);
+        try
+        {
+            var result = VariableExpansion.ExpandVariables("%IVY_TEST_VAR%", "");
+            Assert.Equal(tempValue, result);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("IVY_TEST_VAR", null);
+        }
     }
 
     [Fact]

--- a/src/tendril/Ivy.Tendril.Test/ConfigServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/ConfigServiceTests.cs
@@ -351,6 +351,74 @@ projects:
     }
 
     [Fact]
+    public void LoadSettings_NormalizesRepoPathSeparators()
+    {
+        var yaml = @"
+projects:
+  - name: TestProject
+    repos:
+      - path: D:/Repos/Mixed\Path
+";
+
+        var tempDir = CreateTempConfigFile(yaml);
+        var service = new ConfigService(new TendrilSettings());
+
+        try
+        {
+            service.SetTendrilHome(tempDir);
+
+            var repo = service.Settings.Projects[0].Repos[0];
+            if (Path.DirectorySeparatorChar == '\\')
+                Assert.Equal(@"D:\Repos\Mixed\Path", repo.Path);
+            else
+                Assert.Equal("D:/Repos/Mixed/Path", repo.Path);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void LoadSettings_NormalizesForwardSlashPaths()
+    {
+        var yaml = @"
+projects:
+  - name: TestProject
+    repos:
+      - path: D:/Repos/ForwardSlash
+";
+
+        var tempDir = CreateTempConfigFile(yaml);
+        var service = new ConfigService(new TendrilSettings());
+
+        try
+        {
+            service.SetTendrilHome(tempDir);
+
+            var repo = service.Settings.Projects[0].Repos[0];
+            if (Path.DirectorySeparatorChar == '\\')
+                Assert.Equal(@"D:\Repos\ForwardSlash", repo.Path);
+            else
+                Assert.Equal("D:/Repos/ForwardSlash", repo.Path);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void VariableExpansion_NormalizesPathSeparators()
+    {
+        var result = VariableExpansion.ExpandVariables(@"D:/Repos/Mixed\Path", "");
+        if (Path.DirectorySeparatorChar == '\\')
+            Assert.Equal(@"D:\Repos\Mixed\Path", result);
+        else
+            Assert.Equal("D:/Repos/Mixed/Path", result);
+    }
+
+    [Fact]
     public void GetRepoRef_ReturnsMatchingRepo()
     {
         var project = new ProjectConfig

--- a/src/tendril/Ivy.Tendril/Apps/Onboarding/ProjectSetupStepView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Onboarding/ProjectSetupStepView.cs
@@ -99,12 +99,12 @@ public class ProjectSetupStepView(IState<int> stepperIndex) : ViewBase
 
                           var invalidRepo = filledRepos.FirstOrDefault(p =>
                           {
-                              var expanded = Environment.ExpandEnvironmentVariables(p);
+                              var expanded = VariableExpansion.ExpandVariables(p, "");
                               return !Directory.Exists(expanded) || !Path.Exists(Path.Combine(expanded, ".git"));
                           });
                           if (invalidRepo != null)
                           {
-                              var expanded = Environment.ExpandEnvironmentVariables(invalidRepo);
+                              var expanded = VariableExpansion.ExpandVariables(invalidRepo, "");
                               error.Set(!Directory.Exists(expanded)
                                   ? $"Directory does not exist: {expanded}"
                                   : $"Directory is not a git repository: {expanded}");

--- a/src/tendril/Ivy.Tendril/Apps/Onboarding/TendrilHomeStepView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Onboarding/TendrilHomeStepView.cs
@@ -35,7 +35,7 @@ public class TendrilHomeStepView(IState<int> stepperIndex) : ViewBase
                        try
                        {
                            var tendrilHome = folderPath.Value;
-                           tendrilHome = Environment.ExpandEnvironmentVariables(tendrilHome);
+                           tendrilHome = VariableExpansion.ExpandVariables(tendrilHome, "");
 
                            if (tendrilHome.StartsWith("~"))
                            {

--- a/src/tendril/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs
@@ -72,7 +72,7 @@ public class EditProjectDialog(
         {
             var ri = i;
             var repo = currentRepos[ri];
-            var expandedPath = Environment.ExpandEnvironmentVariables(repo.Path);
+            var expandedPath = VariableExpansion.ExpandVariables(repo.Path, _config.TendrilHome);
             var pathExists = Directory.Exists(expandedPath);
             var isGitRepo = pathExists && Path.Exists(Path.Combine(expandedPath, ".git"));
             var isEditing = editingRepoIndex.Value == ri;
@@ -99,7 +99,7 @@ public class EditProjectDialog(
                                        return;
                                    }
 
-                                   var expandedNewPath = Environment.ExpandEnvironmentVariables(newPath);
+                                   var expandedNewPath = VariableExpansion.ExpandVariables(newPath, _config.TendrilHome);
                                    if (!Directory.Exists(expandedNewPath))
                                    {
                                        editingRepoError.Set($"Directory does not exist: {expandedNewPath}");
@@ -167,7 +167,7 @@ public class EditProjectDialog(
                        {
                            if (!string.IsNullOrWhiteSpace(newRepoPath.Value))
                            {
-                               var expandedNewPath = Environment.ExpandEnvironmentVariables(newRepoPath.Value);
+                               var expandedNewPath = VariableExpansion.ExpandVariables(newRepoPath.Value, _config.TendrilHome);
 
                                if (!Directory.Exists(expandedNewPath))
                                {


### PR DESCRIPTION
# Summary

## Changes

Replaced `Environment.ExpandEnvironmentVariables()` with `VariableExpansion.ExpandVariables()` in all path validation code across EditProjectDialog, ProjectSetupStepView, and TendrilHomeStepView. This ensures UI path validation applies the same path separator normalization as config loading, fixing false "Directory does not exist" errors when paths contain mixed or non-standard separators.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs` — 3 call sites replaced
- `src/tendril/Ivy.Tendril/Apps/Onboarding/ProjectSetupStepView.cs` — 2 call sites replaced
- `src/tendril/Ivy.Tendril/Apps/Onboarding/TendrilHomeStepView.cs` — 1 call site replaced
- `src/tendril/Ivy.Tendril.Test/ConfigServiceTests.cs` — 3 new tests for VariableExpansion path normalization

## Commits

- 9f3951206 [03088] Fix tests to validate VariableExpansion directly
- 1b7fc6bca [03088] Normalize path separators in project validation