### PR TITLE
[03100] Verify PlansApp Multi-Project Badge Rendering

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Plans/SidebarView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Plans/SidebarView.cs
@@ -1,3 +1,4 @@
+using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Services;
 
 namespace Ivy.Tendril.Apps.Plans;
@@ -67,8 +68,12 @@ public class SidebarView(
             var badges = Layout.Horizontal().Gap(1);
             if (plan.Status != PlanStatus.Draft)
                 badges |= new Badge(plan.Status.ToString()).Variant(stateBadgeVariant).Small();
-            badges |= new Badge(plan.Project).Variant(BadgeVariant.Outline).Small()
-                .WithProjectColor(_config, plan.Project);
+            var projects = ProjectHelper.ParseProjects(plan.Project);
+            foreach (var proj in projects)
+            {
+                badges |= new Badge(proj).Variant(BadgeVariant.Outline).Small()
+                    .WithProjectColor(_config, proj);
+            }
             badges |= new Badge(plan.Level).Variant(_config.GetBadgeVariant(plan.Level)).Small();
 
             return new ListItem($"#{plan.Id} {plan.Title}")


### PR DESCRIPTION
# Summary

## Changes

Updated PlansApp SidebarView to parse multi-project plan values using `ProjectHelper.ParseProjects()` and render separate badges for each project, matching the existing fix in JobsApp from plan [03060].

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Apps/Plans/SidebarView.cs` — Added `using Ivy.Tendril.Helpers;`, replaced single badge creation with a loop over parsed projects

## Commits

- ffb32b4c9 [03100] Render separate project badges for multi-project plans in PlansApp sidebar