### PR TITLE
[03099] Refine project filtering to prevent substring matches

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/PlanDatabaseServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/PlanDatabaseServiceTests.cs
@@ -1042,6 +1042,37 @@ public class PlanDatabaseServiceTests : IDisposable
     }
 
     [Fact]
+    public void GetDashboardData_ProjectFilter_DoesNotMatchSubstrings()
+    {
+        _db.UpsertPlan(CreateTestPlan(3000, "Plan A", project: "Framework", status: PlanStatus.Completed));
+        _db.UpsertPlan(CreateTestPlan(3001, "Plan B", project: "FrameworkExtended", status: PlanStatus.Draft));
+        _db.UpsertPlan(CreateTestPlan(3002, "Plan C", project: "MyFramework", status: PlanStatus.Draft));
+
+        var stats = _db.GetDashboardData("Framework");
+
+        Assert.Equal(1, stats.TotalCount);
+        Assert.Equal(1, stats.CompletedCount);
+        Assert.Equal(0, stats.DraftCount);
+    }
+
+    [Fact]
+    public void GetHourlyTokenBurn_ProjectFilter_DoesNotMatchSubstrings()
+    {
+        _db.UpsertPlan(CreateTestPlan(3100, "Plan A", project: "Console"));
+        _db.UpsertPlan(CreateTestPlan(3101, "Plan B", project: "ConsoleApp"));
+
+        var now = DateTime.UtcNow;
+        _db.UpsertCosts(3100, [new("ExecutePlan", 50000, 1.50m, now)]);
+        _db.UpsertCosts(3101, [new("ExecutePlan", 30000, 0.90m, now)]);
+
+        var burn = _db.GetHourlyTokenBurn(projectFilter: "Console");
+
+        Assert.NotEmpty(burn);
+        Assert.All(burn, b => Assert.Equal("Console", b.Project));
+        Assert.Equal(50000, burn.Sum(b => b.Tokens));
+    }
+
+    [Fact]
     public void SearchPlans_FindsBySourceUrl()
     {
         var metadata = new PlanMetadata(

--- a/src/tendril/Ivy.Tendril/Services/PlanDatabaseService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanDatabaseService.cs
@@ -238,9 +238,9 @@ public class PlanDatabaseService : IPlanDatabaseService
         try
         {
             var cutoff = DateTime.UtcNow.Date.AddDays(-6).ToString("yyyy-MM-dd");
-            var pf = projectFilter != null ? " AND (Project = @project OR Project LIKE @projectPattern)" : "";
-            var pfAlias = projectFilter != null ? " AND (p.Project = @project OR p.Project LIKE @projectPattern)" : "";
-            var pfAlias2 = projectFilter != null ? " AND (p2.Project = @project2 OR p2.Project LIKE @projectPattern2)" : "";
+            var pf = projectFilter != null ? " AND Project = @project" : "";
+            var pfAlias = projectFilter != null ? " AND p.Project = @project" : "";
+            var pfAlias2 = projectFilter != null ? " AND p2.Project = @project2" : "";
 
             // Query 1: Status counts + avg cost
             int totalCount, draftCount, inProgressCount, reviewCount, completedCount, failedCount;
@@ -265,9 +265,7 @@ public class PlanDatabaseService : IPlanDatabaseService
                 if (projectFilter != null)
                 {
                     cmd.Parameters.AddWithValue("@project", projectFilter);
-                    cmd.Parameters.AddWithValue("@projectPattern", $"%{projectFilter}%");
                     cmd.Parameters.AddWithValue("@project2", projectFilter);
-                    cmd.Parameters.AddWithValue("@projectPattern2", $"%{projectFilter}%");
                 }
 
                 using var r = cmd.ExecuteReader();
@@ -343,7 +341,6 @@ public class PlanDatabaseService : IPlanDatabaseService
                 if (projectFilter != null)
                 {
                     cmd.Parameters.AddWithValue("@project", projectFilter);
-                    cmd.Parameters.AddWithValue("@projectPattern", $"%{projectFilter}%");
                 }
                 for (var i = 0; i < days.Count; i++)
                     cmd.Parameters.AddWithValue($"@day{i}", days[i]);
@@ -439,7 +436,7 @@ public class PlanDatabaseService : IPlanDatabaseService
             var cutoff = DateTime.UtcNow.AddDays(-days);
 
             using var cmd = _connection.CreateCommand();
-            var projectClause = projectFilter != null ? " AND (p.Project = @project OR p.Project LIKE @projectPattern)" : "";
+            var projectClause = projectFilter != null ? " AND p.Project = @project" : "";
             cmd.CommandText = $"""
                                SELECT
                                    strftime('%Y-%m-%d %H:00:00', COALESCE(c.LogTimestamp, p.Updated)) as Hour,
@@ -456,7 +453,6 @@ public class PlanDatabaseService : IPlanDatabaseService
             if (projectFilter != null)
             {
                 cmd.Parameters.AddWithValue("@project", projectFilter);
-                cmd.Parameters.AddWithValue("@projectPattern", $"%{projectFilter}%");
             }
 
             var result = new List<HourlyTokenBurn>();


### PR DESCRIPTION
# Summary

## Changes

Replaced `LIKE '%projectFilter%'` substring matching with exact `= @project` matching in `PlanDatabaseService` for both `GetDashboardData()` and `GetHourlyTokenBurn()`. This prevents incorrect project filtering when project names contain other project names as substrings. Added two tests verifying that filtering by "Framework" does not match "FrameworkExtended"/"MyFramework", and filtering by "Console" does not match "ConsoleApp".

## API Changes

None. The public method signatures are unchanged; only the SQL query behavior is tightened from substring to exact match.

## Files Modified

- `src/tendril/Ivy.Tendril/Services/PlanDatabaseService.cs` — Removed LIKE clauses and @projectPattern parameters from GetDashboardData and GetHourlyTokenBurn
- `src/tendril/Ivy.Tendril.Test/PlanDatabaseServiceTests.cs` — Added GetDashboardData_ProjectFilter_DoesNotMatchSubstrings and GetHourlyTokenBurn_ProjectFilter_DoesNotMatchSubstrings tests

## Commits

- 834aa3e1a [03099] Replace LIKE substring matching with exact match for project filtering