### PR TITLE
[03102] Abbreviate Backspace in shortcut display for compact UIs

### DIFF
--- a/src/frontend/src/lib/shortcut.ts
+++ b/src/frontend/src/lib/shortcut.ts
@@ -76,6 +76,12 @@ export const keyToCode = (key: string): string => {
   return specialKeys[k] ?? key;
 };
 
+const keyDisplayNames: Record<string, string> = {
+  backspace: "⌫",
+  delete: "Del",
+  escape: "Esc",
+};
+
 /**
  * Formats a shortcut string for display as React nodes.
  * Converts modifier keys to platform-appropriate symbols (e.g., ⌘ on Mac).
@@ -110,7 +116,13 @@ export const formatShortcutForDisplay = (shortcutStr?: string): React.ReactNode[
     } else if (!isMac && part.toLowerCase() === "ctrl") {
       result.push("Ctrl");
     } else {
-      result.push(part.charAt(0).toUpperCase() + part.slice(1));
+      const normalized = part.toLowerCase();
+      const displayName = keyDisplayNames[normalized];
+      if (displayName) {
+        result.push(displayName);
+      } else {
+        result.push(part.charAt(0).toUpperCase() + part.slice(1));
+      }
     }
   });
 


### PR DESCRIPTION
# Summary

## Changes

Added a `keyDisplayNames` mapping to `formatShortcutForDisplay` in `shortcut.ts` that abbreviates long key names for compact UI display: Backspace→⌫, Delete→Del, Escape→Esc. The mapping is checked before the default capitalization fallback, matching the existing pattern used for the Mac Command key (⌘).

## API Changes

None. The `formatShortcutForDisplay` function signature is unchanged — only its output for Backspace/Delete/Escape keys is affected.

## Files Modified

- **src/frontend/src/lib/shortcut.ts** — Added `keyDisplayNames` mapping and lookup in `formatShortcutForDisplay`

---

**Commits:**
- 82ad5d8fa [03102] Abbreviate Backspace, Delete, Escape in shortcut display