### PR TITLE
[03103] Guard against worktrees in worktrees and prevent worktrees from being pushed

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -425,3 +425,9 @@ Ivy.Samples/.claude/settings.local.json
 # Claude Code worktrees
 .worktrees/
 
+# Tendril plan worktrees (without leading dot)
+worktrees/
+
+# Nested Plans artifacts (belt-and-suspenders)
+**/worktrees/**/Plans/
+

--- a/src/tendril/Ivy.Tendril.Test/WorktreeValidationTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/WorktreeValidationTests.cs
@@ -1,0 +1,131 @@
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Test;
+
+public class WorktreeValidationTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public WorktreeValidationTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"wt-validation-test-{Guid.NewGuid()}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, true);
+    }
+
+    [Fact]
+    public void IsWorktree_Returns_True_For_Worktree_Directory()
+    {
+        File.WriteAllText(
+            Path.Combine(_tempDir, ".git"),
+            "gitdir: /path/to/repo/.git/worktrees/name");
+
+        Assert.True(WorktreeValidationHelper.IsWorktree(_tempDir));
+    }
+
+    [Fact]
+    public void IsWorktree_Returns_False_For_Main_Repository()
+    {
+        Directory.CreateDirectory(Path.Combine(_tempDir, ".git"));
+
+        Assert.False(WorktreeValidationHelper.IsWorktree(_tempDir));
+    }
+
+    [Fact]
+    public void IsWorktree_Returns_False_For_Non_Git_Directory()
+    {
+        Assert.False(WorktreeValidationHelper.IsWorktree(_tempDir));
+    }
+
+    [Fact]
+    public void IsWorktree_Returns_False_For_Nonexistent_Directory()
+    {
+        var nonExistent = Path.Combine(_tempDir, "does-not-exist");
+
+        Assert.False(WorktreeValidationHelper.IsWorktree(nonExistent));
+    }
+
+    [Fact]
+    public void ConfigService_ValidateRepoPathsAreNotWorktrees_Logs_Error_For_Worktree_Repo()
+    {
+        var fakeRepoDir = Path.Combine(_tempDir, "fake-repo");
+        Directory.CreateDirectory(fakeRepoDir);
+        File.WriteAllText(
+            Path.Combine(fakeRepoDir, ".git"),
+            "gitdir: /somewhere/.git/worktrees/fake-repo");
+
+        var yaml = $@"
+projects:
+  - name: TestProject
+    repos:
+      - path: {fakeRepoDir.Replace("\\", "\\\\")}
+";
+
+        var configDir = Path.Combine(_tempDir, "config");
+        Directory.CreateDirectory(configDir);
+        File.WriteAllText(Path.Combine(configDir, "config.yaml"), yaml);
+
+        var writer = new StringWriter();
+        var originalErr = Console.Error;
+        Console.SetError(writer);
+
+        try
+        {
+            var service = new ConfigService(new TendrilSettings());
+            service.SetTendrilHome(configDir);
+
+            service.ValidateRepoPathsAreNotWorktrees();
+
+            var output = writer.ToString();
+            Assert.Contains("CRITICAL", output);
+            Assert.Contains("worktree", output, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            Console.SetError(originalErr);
+        }
+    }
+
+    [Fact]
+    public void ConfigService_ValidateRepoPathsAreNotWorktrees_NoError_For_Normal_Repo()
+    {
+        var fakeRepoDir = Path.Combine(_tempDir, "normal-repo");
+        Directory.CreateDirectory(fakeRepoDir);
+        Directory.CreateDirectory(Path.Combine(fakeRepoDir, ".git"));
+
+        var yaml = $@"
+projects:
+  - name: TestProject
+    repos:
+      - path: {fakeRepoDir.Replace("\\", "\\\\")}
+";
+
+        var configDir = Path.Combine(_tempDir, "config");
+        Directory.CreateDirectory(configDir);
+        File.WriteAllText(Path.Combine(configDir, "config.yaml"), yaml);
+
+        var writer = new StringWriter();
+        var originalErr = Console.Error;
+        Console.SetError(writer);
+
+        try
+        {
+            var service = new ConfigService(new TendrilSettings());
+            service.SetTendrilHome(configDir);
+
+            service.ValidateRepoPathsAreNotWorktrees();
+
+            var output = writer.ToString();
+            Assert.DoesNotContain("CRITICAL", output);
+        }
+        finally
+        {
+            Console.SetError(originalErr);
+        }
+    }
+}

--- a/src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
+++ b/src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
@@ -58,6 +58,43 @@ If `plan.yaml` has a `dependsOn` list, for each entry:
 
 **Note:** The JobService also performs this check before launching ExecutePlan, but this step acts as a safety net in case the dependency state changed between job launch and execution.
 
+### 1.6. Validate Worktree Isolation
+
+Before creating worktrees, verify the execution environment is safe:
+
+1. **Check each repo is not itself a worktree** — If `<repo-path>/.git` is a file containing `gitdir:`, the repo is a worktree. Fail with error:
+   > ERROR: Repository at <repo-path> is itself a worktree. ExecutePlan cannot create worktrees inside worktrees. Update config.yaml to use the main repo path.
+
+2. **Check Plans directory is not inside a worktree** — If `$TENDRIL_HOME` or its parent contains a worktree `.git` file, fail with error:
+   > ERROR: TENDRIL_HOME is inside a git worktree. Move your Tendril installation or change the Plans directory.
+
+```bash
+# For each repo in plan.yaml repos (or project repos if empty):
+cd <repo-path>
+
+# Check if current directory is a worktree
+if [ -f .git ] && grep -q "gitdir:" .git; then
+    echo "ERROR: Repository at <repo-path> is itself a worktree."
+    echo "ExecutePlan cannot create worktrees inside worktrees."
+    echo "Check that config.yaml repo paths point to main repositories, not worktrees."
+    exit 1
+fi
+
+# Check if Plans directory would be created inside a worktree
+PLANS_DIR_PARENT=$(dirname "$TENDRIL_HOME")
+cd "$PLANS_DIR_PARENT"
+if git rev-parse --is-inside-work-tree 2>/dev/null && [ -f "$PLANS_DIR_PARENT/.git" ]; then
+    if grep -q "gitdir:" "$PLANS_DIR_PARENT/.git"; then
+        echo "ERROR: TENDRIL_HOME ($TENDRIL_HOME) is inside a git worktree."
+        echo "Plans and their worktrees cannot be created inside worktrees."
+        echo "Move your Tendril installation outside the worktree or use a different Plans directory."
+        exit 1
+    fi
+fi
+```
+
+This prevents recursive worktree scenarios that would corrupt git state and cause massive repo bloat.
+
 ### 1.7. Validate Code State
 
 After reading the plan revision, scan it for code validation markers to detect stale plans (where the described code has already been changed by another plan).

--- a/src/tendril/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/tendril/Ivy.Tendril/Services/ConfigService.cs
@@ -211,6 +211,9 @@ public class ConfigService : IConfigService
                         foreach (var repo in proj.Repos)
                             repo.Path = VariableExpansion.ExpandVariables(repo.Path, TendrilHome);
 
+            // Validate repo paths are not worktrees
+            ValidateRepoPathsAreNotWorktrees();
+
             // Ensure directories exist
             Directory.CreateDirectory(TendrilHome);
             Directory.CreateDirectory(Path.Combine(TendrilHome, "Inbox"));
@@ -357,6 +360,30 @@ public class ConfigService : IConfigService
 
         SaveSettings();
         NeedsOnboarding = false;
+    }
+
+    internal void ValidateRepoPathsAreNotWorktrees()
+    {
+        if (Settings?.Projects == null) return;
+
+        foreach (var project in Settings.Projects)
+        {
+            if (project.Repos == null) continue;
+
+            foreach (var repo in project.Repos)
+            {
+                if (string.IsNullOrEmpty(repo.Path) || !Directory.Exists(repo.Path))
+                    continue;
+
+                if (WorktreeValidationHelper.IsWorktree(repo.Path))
+                {
+                    Console.Error.WriteLine(
+                        $"CRITICAL: Project '{project.Name}' repo path is a worktree, not a main repository: {repo.Path}. " +
+                        "This will cause nested worktrees during plan execution. " +
+                        "Update config.yaml to point to the main repo, not a worktree.");
+                }
+            }
+        }
     }
 
     internal static bool IsCommandAvailable(string command)

--- a/src/tendril/Ivy.Tendril/Services/WorktreeValidationHelper.cs
+++ b/src/tendril/Ivy.Tendril/Services/WorktreeValidationHelper.cs
@@ -1,0 +1,21 @@
+namespace Ivy.Tendril.Services;
+
+public static class WorktreeValidationHelper
+{
+    public static bool IsWorktree(string path)
+    {
+        var gitPath = Path.Combine(path, ".git");
+        if (!File.Exists(gitPath) || Directory.Exists(gitPath))
+            return false;
+
+        try
+        {
+            var content = File.ReadAllText(gitPath);
+            return content.Contains("gitdir:");
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
# Summary

## Changes

Added multi-layered defense against nested worktrees and accidental worktree commits. A new `WorktreeValidationHelper.IsWorktree()` utility detects git worktrees by checking if `.git` is a file containing `gitdir:`. The `ConfigService` now validates repo paths at startup, logging a critical error if any configured repo path is itself a worktree. The `.gitignore` was updated to cover `worktrees/` (Tendril plan worktrees) and nested Plans artifacts. ExecutePlan's `Program.md` now documents Step 1.6 for validating worktree isolation before execution.

## API Changes

- `WorktreeValidationHelper.IsWorktree(string path)` — new static method returning `bool`
- `ConfigService.ValidateRepoPathsAreNotWorktrees()` — new internal method called during startup

## Files Modified

- **New:** `src/tendril/Ivy.Tendril/Services/WorktreeValidationHelper.cs` — worktree detection utility
- **New:** `src/tendril/Ivy.Tendril.Test/WorktreeValidationTests.cs` — 6 unit tests
- **Modified:** `src/tendril/Ivy.Tendril/Services/ConfigService.cs` — startup repo path validation
- **Modified:** `src/.gitignore` — added `worktrees/` and nested Plans patterns
- **Modified:** `src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/Program.md` — Step 1.6 documentation

---

## Commits
- 67eb27b31 [03103] Guard against worktrees in worktrees and prevent worktrees from being pushed