### PR TITLE
[03104] Fix ModelPricingService dictionary iteration order for deterministic pricing

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/ModelPricingServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/ModelPricingServiceTests.cs
@@ -416,10 +416,13 @@ public class ModelPricingServiceTests
     }
 
     [Fact]
-    public void GetPricing_OrderMatters_MiniBeforeBase()
+    public void GetPricing_LongestMatchFirst_SelectsMostSpecificKey()
     {
         var mini = _service.GetPricing("gpt-5.4-mini");
         Assert.Equal(1.10, mini.Input);
+
+        var baseModel = _service.GetPricing("gpt-5.4");
+        Assert.Equal(10.00, baseModel.Input);
     }
 
     [Fact]

--- a/src/tendril/Ivy.Tendril/Assets/models.yaml
+++ b/src/tendril/Ivy.Tendril/Assets/models.yaml
@@ -1,7 +1,7 @@
 # Source: https://www.anthropic.com/pricing, https://openai.com/api/pricing/, https://ai.google.dev/pricing
 # Last verified: 2026-04-09
-# IMPORTANT: Entries are ordered most-specific first because GetPricing() uses
-# Contains-based matching and returns the first hit.
+# IMPORTANT: GetPricing() uses longest-match-first ordering to ensure
+# deterministic matching when model names contain multiple keys as substrings.
 # NOTE: Some entries below (gpt-5.4*, gpt-5.3-codex, gemini-3-flash-preview,
 # gemini-2.5-flash-lite) are fictional placeholder models used in example.config.yaml.
 # Replace with actual model names and pricing when configuring real agents.

--- a/src/tendril/Ivy.Tendril/Services/ModelPricingService.cs
+++ b/src/tendril/Ivy.Tendril/Services/ModelPricingService.cs
@@ -34,7 +34,7 @@ public class ModelPricingService : IModelPricingService
 
     public ModelPricing GetPricing(string modelName)
     {
-        foreach (var key in Pricing.Keys)
+        foreach (var key in Pricing.Keys.OrderByDescending(k => k.Length))
             if (modelName.Contains(key, StringComparison.OrdinalIgnoreCase))
                 return Pricing[key];
 


### PR DESCRIPTION
# Summary

## Changes

Changed `ModelPricingService.GetPricing()` to sort dictionary keys by length descending before iteration, ensuring longest (most-specific) keys match first. This makes substring-based model pricing lookup deterministic regardless of dictionary iteration order. Updated the YAML comment and renamed the existing fragile test to reflect the new behavior, adding an additional assertion for the base model.

## API Changes

None. The `GetPricing(string modelName)` method signature is unchanged; only internal iteration order changed.

## Files Modified

- **Services/ModelPricingService.cs** — Added `.OrderByDescending(k => k.Length)` to key iteration
- **Assets/models.yaml** — Updated comment to reflect longest-match-first ordering
- **ModelPricingServiceTests.cs** — Renamed `GetPricing_OrderMatters_MiniBeforeBase` to `GetPricing_LongestMatchFirst_SelectsMostSpecificKey` and added base model assertion

---

**Commits:**
- 243fc2320 [03104] Fix ModelPricingService dictionary iteration order for deterministic pricing