### PR TITLE
[03076] Fix DataTable Column Order in PullRequestApp

### DIFF
--- a/src/Ivy.Tests/Views/DataTables/DataTableScaffoldTests.cs
+++ b/src/Ivy.Tests/Views/DataTables/DataTableScaffoldTests.cs
@@ -1,3 +1,6 @@
+using Apache.Arrow.Ipc;
+using Ivy.Protos.DataTable;
+
 namespace Ivy.Tests.Views.DataTables;
 
 public class DataTableScaffoldTests
@@ -120,5 +123,37 @@ public class DataTableScaffoldTests
     {
         var builder = new[] { new EntityWithPrimitives() }.AsQueryable().ToDataTable().Large();
         Assert.Equal(Density.Large, GetDensity(builder));
+    }
+
+    private class ColumnOrderEntity
+    {
+        public string Id { get; set; } = "";
+        public string Name { get; set; } = "";
+        public int Age { get; set; }
+        public string City { get; set; } = "";
+    }
+
+    [Fact]
+    public void ConvertToArrowTable_ShouldRespectSelectColumnsOrder()
+    {
+        var data = new[]
+        {
+            new ColumnOrderEntity { Id = "1", Name = "Alice", Age = 30, City = "NYC" }
+        }.AsQueryable();
+
+        var query = new DataTableQuery { Offset = 0, Limit = 100 };
+        query.SelectColumns.AddRange(["City", "Name", "Age"]);
+
+        var processor = new QueryProcessor();
+        var result = processor.ProcessQuery(data, query);
+
+        using var stream = new MemoryStream(result.ArrowData);
+        using var reader = new ArrowStreamReader(stream);
+        var batch = reader.ReadNextRecordBatch();
+
+        Assert.NotNull(batch);
+        Assert.Equal("City", batch.Schema.FieldsList[0].Name);
+        Assert.Equal("Name", batch.Schema.FieldsList[1].Name);
+        Assert.Equal("Age", batch.Schema.FieldsList[2].Name);
     }
 }

--- a/src/Ivy/Views/DataTables/QueryProcessor.cs
+++ b/src/Ivy/Views/DataTables/QueryProcessor.cs
@@ -934,10 +934,14 @@ public class QueryProcessor(ILogger<QueryProcessor>? logger = null, IDistributed
 
         var properties = elementType.GetProperties(BindingFlags.Public | BindingFlags.Instance);
 
-        // Filter properties if selectColumns is specified
+        // Filter and order properties according to selectColumns
         if (selectColumns.Any())
         {
-            properties = properties.Where(p => selectColumns.Contains(p.Name)).ToArray();
+            var selectColumnsList = selectColumns.ToList();
+            properties = selectColumnsList
+                .Select(columnName => properties.FirstOrDefault(p => p.Name == columnName))
+                .Where(p => p != null)
+                .ToArray()!;
         }
 
         var fields = new List<ArrowField>();


### PR DESCRIPTION
# Summary

## Changes

Fixed `ConvertToArrowTable` in `QueryProcessor.cs` to respect the `selectColumns` ordering instead of using reflection property declaration order. This ensures DataTable columns display in the order specified by `.Order()`, fixing the column misalignment bug in PullRequestApp and all other DataTable usages.

## API Changes

None.

## Files Modified

- **src/Ivy/Views/DataTables/QueryProcessor.cs** — Changed `selectColumns` filtering logic to preserve column order using `Select`+`FirstOrDefault` instead of `Where`
- **src/Ivy.Tests/Views/DataTables/DataTableScaffoldTests.cs** — Added test verifying Arrow table column order matches `selectColumns` order

## Commits

- b7e14a71e [03076] Fix DataTable column order to respect selectColumns ordering