### PR TITLE
[03105] Add Logging to PlanReaderService Exception Catch Block

### DIFF
--- a/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
@@ -1116,9 +1116,12 @@ public class PlanReaderService(
                         item.DeclineReason
                     ));
             }
-            catch
+            catch (Exception ex)
             {
-                // Skip malformed YAML files
+                _logger.LogWarning(
+                    "Failed to load recommendations from {RecommendationsPath}: {Message}",
+                    recommendationsPath,
+                    ex.Message);
             }
         }
 


### PR DESCRIPTION
# Summary

## Changes

Replaced the silent empty \`catch\` block in \`PlanReaderService.ComputeRecommendations()\` with a \`catch (Exception ex)\` that logs a warning via \`_logger.LogWarning()\`, including the recommendations file path and exception message. This preserves the existing behavior of skipping malformed files while making failures visible in logs.

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/Services/PlanReaderService.cs** — Updated catch block at lines 1119-1125 to log warnings on recommendation loading failures

## Commits

- e2f0b04a1