### PR TITLE
[03108] Improve handling of worktree directories without .git files

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/WorktreeCleanupServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/WorktreeCleanupServiceTests.cs
@@ -149,20 +149,16 @@ public class WorktreeCleanupServiceTests : IDisposable
     }
 
     [Fact]
-    public void RemoveWorktrees_Remains_Functional_After_Extraction()
+    public void RemoveWorktrees_ForceDeletes_Directory_Without_GitFile()
     {
-        // Verify RemoveWorktrees is accessible as internal static
         var dir = CreatePlan("08000-ExtractTest", "Failed", DateTime.UtcNow.AddHours(-2));
         var worktreeDir = Path.Combine(dir, "worktrees", "TestRepo");
         Directory.CreateDirectory(worktreeDir);
-        // No .git file — RemoveWorktrees should skip this entry gracefully
         File.WriteAllText(Path.Combine(worktreeDir, "file.txt"), "test");
 
         PlanReaderService.RemoveWorktrees(dir);
 
-        // The directory still exists because there's no .git file for git worktree remove,
-        // but the method should not throw
-        Assert.True(Directory.Exists(worktreeDir));
+        Assert.False(Directory.Exists(worktreeDir), "Directory without .git file should be force-deleted");
     }
 
     [Fact]
@@ -276,7 +272,7 @@ public class WorktreeCleanupServiceTests : IDisposable
     }
 
     [Fact]
-    public void RemoveWorktrees_Logs_Warning_When_GitFile_Missing()
+    public void RemoveWorktrees_Logs_Info_And_ForceDeletes_When_GitFile_Missing()
     {
         var dir = CreatePlan("10000-LogWarningTest", "Failed", DateTime.UtcNow.AddHours(-2));
         var worktreeDir = Path.Combine(dir, "worktrees", "TestRepo");
@@ -288,9 +284,9 @@ public class WorktreeCleanupServiceTests : IDisposable
 
         PlanReaderService.RemoveWorktrees(dir, logger);
 
-        Assert.Single(logEntries);
-        Assert.Contains("has no .git file", logEntries[0]);
-        Assert.Contains("TestRepo", logEntries[0]);
+        Assert.Contains(logEntries, e => e.Contains("force-deleting"));
+        Assert.Contains(logEntries, e => e.Contains("TestRepo"));
+        Assert.False(Directory.Exists(worktreeDir), "Directory should be force-deleted");
     }
 
     [Fact]

--- a/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
@@ -897,10 +897,21 @@ public class PlanReaderService(
             if (!File.Exists(gitFile))
             {
                 var dirAge = DateTime.UtcNow - new DirectoryInfo(wtDir).CreationTimeUtc;
-                logger?.LogWarning(
-                    "Worktree directory has no .git file (created {Age} ago), skipping git removal: {Path}",
-                    dirAge, wtDir);
-                lifecycleLogger?.LogCleanupAttempt(planId, wtDir, "RemoveWorktrees", gitFileExists: false);
+                logger?.LogInformation(
+                    "Worktree directory has no .git file (created {Age} ago), force-deleting: {Path}",
+                    dirAge, Path.GetFileName(wtDir));
+                lifecycleLogger?.LogCleanupAttempt(planId, wtDir, "RemoveWorktrees(force)", gitFileExists: false);
+
+                try
+                {
+                    WorktreeCleanupService.ForceDeleteDirectory(wtDir, logger);
+                    lifecycleLogger?.LogCleanupSuccess(planId, wtDir);
+                }
+                catch (Exception ex)
+                {
+                    lifecycleLogger?.LogCleanupFailed(planId, wtDir, ex.Message);
+                    logger?.LogWarning(ex, "Failed to force-delete worktree directory {Dir}", Path.GetFileName(wtDir));
+                }
                 continue;
             }
 


### PR DESCRIPTION
# Summary

## Changes

Modified `PlanReaderService.RemoveWorktrees()` to immediately force-delete worktree directories that are missing their `.git` file, instead of logging a warning and skipping them. The log level was downgraded from `Warning` to `Information` since this is an expected scenario (not an error). Updated existing tests to verify the new force-delete behavior and corrected log message assertions.

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/Services/PlanReaderService.cs** — Changed missing-`.git`-file handling in `RemoveWorktrees()` from skip-with-warning to force-delete-with-info-log
- **src/tendril/Ivy.Tendril.Test/WorktreeCleanupServiceTests.cs** — Updated `RemoveWorktrees_ForceDeletes_Directory_Without_GitFile` and `RemoveWorktrees_Logs_Info_And_ForceDeletes_When_GitFile_Missing` tests to match new behavior

## Commits

- 9fa16d8b3 [03108] Force-delete worktree directories without .git files instead of skipping