### PR TITLE
[03113] Improve Drafts Empty State UX

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Plans/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Plans/ContentView.cs
@@ -167,10 +167,12 @@ public class ContentView(
         if (_selectedPlan is null)
         {
             if (_allPlans.Count == 0)
-                return Layout.Vertical().AlignContent(Align.Center).Height(Size.Full()).Gap(2)
-                       | new Icon(Icons.Inbox).Large().Color(Colors.Gray)
-                       | Text.Muted("No draft plans yet")
-                       | new NewPlanButton();
+                return Layout.Vertical().AlignContent(Align.Center).Height(Size.Full()).Gap(4).Padding(8)
+                       | new Icon(Icons.Feather).Large().Color(Colors.Gray)
+                       | Text.H3("No draft plans yet")
+                       | Text.Muted("Create your first plan to start tracking implementation work")
+                       | new NewPlanButton()
+                       | Text.Muted("or press Ctrl+Alt+N").Small();
 
             return Layout.Vertical().AlignContent(Align.Center).Height(Size.Full())
                    | Text.Muted("Select a plan from the sidebar");


### PR DESCRIPTION
# Summary

## Changes

Enhanced the Drafts empty state in ContentView.cs with a more informative and visually appealing design. Replaced the Inbox icon with the correct Feather icon (matching the Drafts app definition), upgraded the plain muted text to an H3 heading with a descriptive subtitle, and added a keyboard shortcut hint below the New Plan button. Improved spacing with larger gap and padding values.

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/Apps/Plans/ContentView.cs** — Updated empty state rendering (lines 169-174)

## Commits

- d568d0cbf [03113] Improve Drafts Empty State UX