### PR TITLE
[03120] Replace Debug.WriteLine with Logger in PlanReaderService.RecoverStuckPlans

### DIFF
--- a/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
@@ -76,8 +76,7 @@ public class PlanReaderService(
             }
             catch (Exception ex)
             {
-                Debug.WriteLine(
-                    $"Failed to recover plan {Path.GetFileName(dir)}: {ex.Message}");
+                _logger.LogWarning(ex, "Failed to recover plan in {Folder}", Path.GetFileName(dir));
             }
     }
 


### PR DESCRIPTION
# Summary

## Changes

Replaced `Debug.WriteLine` with `_logger.LogWarning` in `PlanReaderService.RecoverStuckPlans()` to make plan recovery failures visible in production logs. The call now uses structured logging with the exception parameter for stack trace capture.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Services/PlanReaderService.cs` — changed exception handler in `RecoverStuckPlans()` from `Debug.WriteLine` to `_logger.LogWarning`

---

## Commits

- e897f378b [03120] Replace Debug.WriteLine with Logger in PlanReaderService.RecoverStuckPlans