### PR TITLE
[03114] Add Error Handling to SetTendrilHome Method

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/ConfigServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/ConfigServiceTests.cs
@@ -843,13 +843,15 @@ editor:
         {
             service.SetTendrilHome(tempDir);
 
-            // SetTendrilHome silently catches errors, so test via constructor-like reload
-            // Write malformed config and retry
-            File.WriteAllText(Path.Combine(tempDir, "config.yaml"), "invalid: yaml: [unclosed");
-            service.RetryLoadConfig();
+            // SetTendrilHome detects the error and auto-heals, clearing ParseError
+            // Verify error was detected by checking backup exists
+            var backupFiles = Directory.GetFiles(tempDir, "config.yaml.broken.*.bak");
+            Assert.NotEmpty(backupFiles);
 
-            Assert.NotNull(service.ParseError);
-            Assert.Contains(tempDir, service.ParseError.FilePath);
+            // Verify auto-healed config is valid
+            var yaml = File.ReadAllText(Path.Combine(tempDir, "config.yaml"));
+            var settings = YamlHelper.Deserializer.Deserialize<TendrilSettings>(yaml);
+            Assert.NotNull(settings);
         }
         finally
         {
@@ -867,7 +869,6 @@ editor:
         try
         {
             service.SetTendrilHome(tempDir);
-            service.RetryLoadConfig();
 
             var backupFiles = Directory.GetFiles(tempDir, "config.yaml.broken.*.bak");
             Assert.NotEmpty(backupFiles);
@@ -878,6 +879,35 @@ editor:
         finally
         {
             Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void SetTendrilHome_Should_Handle_Malformed_Config_Gracefully()
+    {
+        var validYaml = "codingAgent: testAgent\njobTimeout: 99";
+        var validDir = CreateTempConfigFile(validYaml);
+        var malformedDir = CreateTempConfigFile("invalid: yaml: [unclosed");
+        var service = new ConfigService(new TendrilSettings());
+
+        try
+        {
+            service.SetTendrilHome(validDir);
+            Assert.Equal("testAgent", service.Settings.CodingAgent);
+
+            service.SetTendrilHome(malformedDir);
+
+            // Error should have been detected and auto-healed
+            var backupFiles = Directory.GetFiles(malformedDir, "config.yaml.broken.*.bak");
+            Assert.NotEmpty(backupFiles);
+
+            // Settings should be valid (auto-healed minimal config)
+            Assert.NotNull(service.Settings);
+        }
+        finally
+        {
+            Directory.Delete(validDir, true);
+            Directory.Delete(malformedDir, true);
         }
     }
 
@@ -986,6 +1016,9 @@ jobTimeout: 30
         try
         {
             service.SetTendrilHome(tempDir);
+
+            // Write malformed config again (autohealing replaced the original)
+            File.WriteAllText(Path.Combine(tempDir, "config.yaml"), "broken: [yaml");
             service.RetryLoadConfig();
             Assert.NotNull(service.ParseError);
 
@@ -1011,6 +1044,9 @@ jobTimeout: 30
         try
         {
             service.SetTendrilHome(tempDir);
+
+            // Write malformed config again (autohealing replaced the original)
+            File.WriteAllText(Path.Combine(tempDir, "config.yaml"), "broken: [yaml");
             service.RetryLoadConfig();
             Assert.NotNull(service.ParseError);
 

--- a/src/tendril/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/tendril/Ivy.Tendril/Services/ConfigService.cs
@@ -603,9 +603,16 @@ public class ConfigService : IConfigService
                 var loadedSettings = YamlHelper.Deserializer.Deserialize<TendrilSettings>(yaml);
                 if (loadedSettings != null) Settings = loadedSettings;
             }
-            catch
+            catch (Exception ex)
             {
-                // Malformed config.yaml — keep existing settings rather than crashing.
+                Console.Error.WriteLine($"Failed to load Tendril config from new path '{ConfigPath}': {ex}");
+                ParseError = new ConfigParseError(ex.Message, ConfigPath, ex);
+                BackupBrokenConfig();
+
+                if (TryAutoHeal())
+                {
+                    ParseError = null;
+                }
             }
         }
 


### PR DESCRIPTION
# Summary

## Changes

Added error handling to `ConfigService.SetTendrilHome()` to match the constructor's behavior: on malformed config.yaml, the method now sets `ParseError`, backs up the broken config, and attempts autohealing via `TryAutoHeal()`. Updated existing tests that relied on the old silent-failure behavior to account for autohealing (which always succeeds by writing a minimal valid config).

## API Changes

None. The `SetTendrilHome()` method signature is unchanged. Behavior change: it now sets `ParseError` and calls `BackupBrokenConfig()`/`TryAutoHeal()` on parse failure instead of silently swallowing the exception.

## Files Modified

- **src/tendril/Ivy.Tendril/Services/ConfigService.cs** — Updated catch block in `SetTendrilHome()` to set `ParseError`, backup broken config, and attempt autohealing
- **src/tendril/Ivy.Tendril.Test/ConfigServiceTests.cs** — Updated 3 existing tests and added 1 new test to verify the new error handling behavior

## Commits

- [03114] Add error handling to SetTendrilHome method (47eb0f9cd)