### PR TITLE
[03122] Check latest version of Tendril and show update notice in wallpaper app

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/VersionCheckServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/VersionCheckServiceTests.cs
@@ -1,0 +1,104 @@
+using System.Net;
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Test;
+
+public class VersionCheckServiceTests
+{
+    [Fact]
+    public void CurrentVersion_ReturnsAssemblyVersion()
+    {
+        var version = VersionCheckService.GetCurrentVersion();
+        Assert.NotNull(version);
+        Assert.NotEqual("0.0.0", version);
+        Assert.True(Version.TryParse(version, out _));
+    }
+
+    [Fact]
+    public async Task CheckForUpdates_WithNewerVersion_ReturnsHasUpdateTrue()
+    {
+        var factory = new FakeHttpClientFactory("""{"versions":["0.0.1","99.0.0"]}""");
+        var service = new VersionCheckService(factory);
+
+        var result = await service.CheckForUpdatesAsync();
+
+        Assert.True(result.HasUpdate);
+        Assert.Equal("99.0.0", result.LatestVersion);
+        Assert.NotNull(result.LastChecked);
+    }
+
+    [Fact]
+    public async Task CheckForUpdates_WithSameVersion_ReturnsHasUpdateFalse()
+    {
+        var currentVersion = VersionCheckService.GetCurrentVersion();
+        var factory = new FakeHttpClientFactory($$"""
+            {"versions":["{{currentVersion}}"]}
+            """);
+        var service = new VersionCheckService(factory);
+
+        var result = await service.CheckForUpdatesAsync();
+
+        Assert.False(result.HasUpdate);
+        Assert.Equal(currentVersion, result.LatestVersion);
+    }
+
+    [Fact]
+    public async Task CheckForUpdates_WithCachedResult_DoesNotCallApi()
+    {
+        var factory = new FakeHttpClientFactory("""{"versions":["99.0.0"]}""");
+        var service = new VersionCheckService(factory);
+
+        await service.CheckForUpdatesAsync();
+        await service.CheckForUpdatesAsync();
+
+        Assert.Equal(1, factory.CallCount);
+    }
+
+    [Fact]
+    public async Task CheckForUpdates_WithNetworkError_ReturnsNullLatestVersion()
+    {
+        var factory = new FakeHttpClientFactory(statusCode: HttpStatusCode.InternalServerError);
+        var service = new VersionCheckService(factory);
+
+        var result = await service.CheckForUpdatesAsync();
+
+        Assert.Null(result.LatestVersion);
+        Assert.False(result.HasUpdate);
+    }
+
+    [Fact]
+    public async Task CheckForUpdates_SkipsPreReleaseVersions()
+    {
+        var factory = new FakeHttpClientFactory("""{"versions":["1.0.0","99.0.0-pre-20260101"]}""");
+        var service = new VersionCheckService(factory);
+
+        var result = await service.CheckForUpdatesAsync();
+
+        Assert.Equal("1.0.0", result.LatestVersion);
+    }
+
+    private class FakeHttpClientFactory : IHttpClientFactory
+    {
+        private readonly HttpMessageHandler _handler;
+        public int CallCount { get; private set; }
+
+        public FakeHttpClientFactory(string? responseBody = null, HttpStatusCode statusCode = HttpStatusCode.OK)
+        {
+            _handler = new FakeHandler(this, responseBody ?? "", statusCode);
+        }
+
+        public HttpClient CreateClient(string name) => new(_handler, disposeHandler: false);
+
+        private class FakeHandler(FakeHttpClientFactory owner, string body, HttpStatusCode statusCode) : HttpMessageHandler
+        {
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                owner.CallCount++;
+                return Task.FromResult(new HttpResponseMessage(statusCode)
+                {
+                    Content = new StringContent(body)
+                });
+            }
+        }
+    }
+}

--- a/src/tendril/Ivy.Tendril/Apps/WallpaperApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/WallpaperApp.cs
@@ -11,8 +11,19 @@ public class WallpaperApp : ViewBase
         var jobService = UseService<IJobService>();
         var configService = UseService<IConfigService>();
         var countsService = UseService<IPlanCountsService>();
+        var versionService = UseService<IVersionCheckService>();
         var dialogOpen = UseState(false);
         var lastSelectedProjects = UseState<string[]>(["[Auto]"]);
+        var versionInfo = UseState<VersionInfo?>(null);
+
+        UseEffect(() =>
+        {
+            _ = Task.Run(async () =>
+            {
+                var info = await versionService.CheckForUpdatesAsync();
+                versionInfo.Set(info);
+            });
+        }, []);
 
         var counts = countsService.Current;
         var projectNames = configService.Projects.Select(p => p.Name).ToList();
@@ -35,6 +46,16 @@ public class WallpaperApp : ViewBase
                        .Icon(Icons.Plus, Align.Right)
                 )
         };
+
+        if (versionInfo.Value?.HasUpdate == true)
+            elements.Insert(0, new Card(
+                Layout.Horizontal().Gap(2).AlignContent(Align.Center)
+                    | Icons.Info
+                    | (Layout.Vertical().Gap(1)
+                        | Text.Block($"Tendril v{versionInfo.Value.LatestVersion} is available!")
+                        | Text.Muted($"You're running v{versionInfo.Value.CurrentVersion}")
+                        | Text.Muted("Run: tendril --version && dotnet tool update -g Ivy.Tendril"))
+            ));
 
         if (dialogOpen.Value)
             elements.Add(new CreatePlanDialog(

--- a/src/tendril/Ivy.Tendril/Services/IVersionCheckService.cs
+++ b/src/tendril/Ivy.Tendril/Services/IVersionCheckService.cs
@@ -1,0 +1,12 @@
+namespace Ivy.Tendril.Services;
+
+public interface IVersionCheckService
+{
+    Task<VersionInfo> CheckForUpdatesAsync();
+}
+
+public record VersionInfo(
+    string CurrentVersion,
+    string? LatestVersion,
+    bool HasUpdate,
+    DateTime? LastChecked);

--- a/src/tendril/Ivy.Tendril/Services/VersionCheckService.cs
+++ b/src/tendril/Ivy.Tendril/Services/VersionCheckService.cs
@@ -1,0 +1,79 @@
+using System.Text.Json;
+
+namespace Ivy.Tendril.Services;
+
+public class VersionCheckService(IHttpClientFactory httpClientFactory) : IVersionCheckService
+{
+    private static readonly TimeSpan CacheDuration = TimeSpan.FromMinutes(15);
+
+    private VersionInfo? _cachedResult;
+    private DateTime _lastCheckTime = DateTime.MinValue;
+
+    public async Task<VersionInfo> CheckForUpdatesAsync()
+    {
+        if (_cachedResult != null && DateTime.UtcNow - _lastCheckTime < CacheDuration)
+            return _cachedResult;
+
+        var currentVersion = GetCurrentVersion();
+        string? latestVersion = null;
+
+        try
+        {
+            latestVersion = await FetchLatestVersionAsync();
+        }
+        catch
+        {
+            // Network failure — return null latest version
+        }
+
+        var hasUpdate = latestVersion != null
+            && Version.TryParse(currentVersion, out var current)
+            && Version.TryParse(latestVersion, out var latest)
+            && latest > current;
+
+        var now = DateTime.UtcNow;
+        _cachedResult = new VersionInfo(currentVersion, latestVersion, hasUpdate, now);
+        _lastCheckTime = now;
+
+        return _cachedResult;
+    }
+
+    internal static string GetCurrentVersion()
+    {
+        var version = typeof(Program).Assembly.GetName().Version;
+        return version?.ToString(3) ?? "0.0.0";
+    }
+
+    private async Task<string?> FetchLatestVersionAsync()
+    {
+        using var client = httpClientFactory.CreateClient();
+        client.Timeout = TimeSpan.FromSeconds(10);
+
+        var response = await client.GetAsync("https://api.nuget.org/v3-flatcontainer/ivy.tendril/index.json");
+        response.EnsureSuccessStatusCode();
+
+        var json = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(json);
+
+        if (!doc.RootElement.TryGetProperty("versions", out var versions))
+            return null;
+
+        Version? highest = null;
+        string? highestString = null;
+
+        foreach (var v in versions.EnumerateArray())
+        {
+            var versionString = v.GetString();
+            if (versionString == null) continue;
+            if (versionString.Contains('-')) continue; // skip pre-release
+
+            if (Version.TryParse(versionString, out var parsed) && (highest == null || parsed > highest))
+            {
+                highest = parsed;
+                highestString = versionString;
+            }
+        }
+
+        return highestString;
+    }
+}

--- a/src/tendril/Ivy.Tendril/TendrilServer.cs
+++ b/src/tendril/Ivy.Tendril/TendrilServer.cs
@@ -20,6 +20,8 @@ public static class TendrilServer
 #endif
         server.SetMetaTitle("Ivy Tendril");
 
+        server.Services.AddHttpClient();
+
         var configService = new ConfigService();
         server.Services.AddSingleton<IConfigService>(configService);
         server.Services.AddSingleton<ConfigService>(configService);
@@ -40,6 +42,9 @@ public static class TendrilServer
                     new OpenAIClientOptions { Endpoint = new Uri(endpoint) });
                 return client.GetChatClient(llm.Model).AsIChatClient();
             });
+
+        server.Services.AddSingleton<VersionCheckService>();
+        server.Services.AddSingleton<IVersionCheckService>(sp => sp.GetRequiredService<VersionCheckService>());
 
         server.Services.AddSingleton<OnboardingSetupService>();
         server.Services.AddSingleton<IOnboardingSetupService>(sp => sp.GetRequiredService<OnboardingSetupService>());


### PR DESCRIPTION
# Summary

## Changes

Added a version check system that queries the NuGet.org API for the latest published Ivy.Tendril version and displays an update notice in the WallpaperApp when a newer stable version is available. Results are cached for 15 minutes to avoid excessive API calls.

## API Changes

- New interface `IVersionCheckService` with method `CheckForUpdatesAsync()` returning `VersionInfo`
- New record `VersionInfo(string CurrentVersion, string? LatestVersion, bool HasUpdate, DateTime? LastChecked)`
- New class `VersionCheckService` implementing `IVersionCheckService`
- `IHttpClientFactory` now registered in DI container via `AddHttpClient()`

## Files Modified

- **New:** `src/tendril/Ivy.Tendril/Services/IVersionCheckService.cs` — interface and VersionInfo record
- **New:** `src/tendril/Ivy.Tendril/Services/VersionCheckService.cs` — NuGet API check with caching
- **Modified:** `src/tendril/Ivy.Tendril/TendrilServer.cs` — service and HttpClient registration
- **Modified:** `src/tendril/Ivy.Tendril/Apps/WallpaperApp.cs` — update notice card UI
- **New:** `src/tendril/Ivy.Tendril.Test/VersionCheckServiceTests.cs` — 6 unit tests

## Commits

- d29a7d4d1 [03122] Add version check service and update notice in WallpaperApp