### PR TITLE
[03121] Move worktree cleanup from ExecutePlan to after MakePr

### DIFF
--- a/src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/ExecutePlan.ps1
+++ b/src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/ExecutePlan.ps1
@@ -154,16 +154,4 @@ finally {
     Stop-Heartbeat $heartbeat
     Pop-Location
     Remove-Item $promptFile -ErrorAction SilentlyContinue
-
-    if (-not $env:KEEP_WORKTREES) {
-        Write-Host "Cleaning up worktrees..." -ForegroundColor Gray
-        try {
-            $cleanupScript = Join-Path $PSScriptRoot "Tools" "Cleanup-Worktrees.ps1"
-            & $cleanupScript -PlanPath $PlanPath
-        } catch {
-            Write-Warning "Worktree cleanup failed (non-fatal): $_"
-        }
-    } else {
-        Write-Host "KEEP_WORKTREES is set - skipping worktree cleanup" -ForegroundColor Gray
-    }
 }

--- a/src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
+++ b/src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
@@ -507,18 +507,17 @@ After all verifications pass:
 
 3. Run `git status` in every worktree. If there are any uncommitted files (from verification fixes, generated files, etc.), commit or discard them. The worktrees must be completely clean before finishing.
 
-### 8.5. Clean Up Worktrees
+### 8.5. Worktree Lifecycle
 
-After all verifications pass and the worktrees are clean, the launcher script automatically removes all worktree directories to free disk space.
+Worktrees are **not** cleaned up by ExecutePlan. They remain on disk so that MakePr can push branches and create PRs directly from the worktree.
 
-**Worktree cleanup includes:**
-1. Deregister each worktree from git via `git worktree remove --force`
-2. Force-delete the worktree directory (with Windows `rmdir /s /q` fallback for locked files)
-3. Remove the parent `worktrees/` directory
+**Cleanup happens later, in two places:**
+1. **MakePr Step 5** — cleans up worktrees after PRs are created and (for yolo-rule repos) merged.
+2. **WorktreeCleanupService** — safety net that runs every 30 minutes and removes worktrees for plans in terminal states (Completed, Failed, Skipped) after a 10-minute grace period.
 
-**Git branches are preserved** — MakePr uses the `plan-<ID>-<repo>` branch to create pull requests. Only the worktree filesystem directories are removed.
+**Git branches are preserved** until MakePr consumes them — only the worktree filesystem directories are removed.
 
-**Debugging tip:** To keep worktrees for manual inspection after failure, set the `KEEP_WORKTREES=1` environment variable before running ExecutePlan. The WorktreeCleanupService will still clean them up after the grace period (10 minutes + 30 minute cycle).
+**Debugging tip:** To keep worktrees for manual inspection after failure, set the `KEEP_WORKTREES=1` environment variable. The WorktreeCleanupService will still clean them up after the grace period.
 
 ### 9. Plan State
 


### PR DESCRIPTION
# Summary

## Changes

Removed worktree cleanup from ExecutePlan.ps1's `finally` block so worktrees remain available for MakePr to push branches and create PRs. Updated Program.md Step 8.5 to document the new lifecycle where cleanup is deferred to MakePr and WorktreeCleanupService.

## API Changes

None.

## Files Modified

- **ExecutePlan.ps1** — Removed the `if (-not $env:KEEP_WORKTREES)` cleanup block (lines 158-168) from the `finally` clause
- **Program.md** — Rewrote Step 8.5 from "Clean Up Worktrees" to "Worktree Lifecycle" documenting when/where cleanup now happens

## Commits

- 5f332e022 [03121] Remove worktree cleanup from ExecutePlan launcher