### PR TITLE
[03125] Remove obsolete KEEP_WORKTREES documentation

### DIFF
--- a/src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
+++ b/src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
@@ -517,7 +517,7 @@ Worktrees are **not** cleaned up by ExecutePlan. They remain on disk so that Mak
 
 **Git branches are preserved** until MakePr consumes them — only the worktree filesystem directories are removed.
 
-**Debugging tip:** To keep worktrees for manual inspection after failure, set the `KEEP_WORKTREES=1` environment variable. The WorktreeCleanupService will still clean them up after the grace period.
+**Manual inspection:** If you need to inspect worktrees after failure, check the plan folder's `worktrees/` directory before MakePr runs. After PR creation, worktrees are cleaned up automatically. You can also temporarily pause WorktreeCleanupService if needed for extended debugging.
 
 ### 9. Plan State
 


### PR DESCRIPTION
# Summary

## Changes

Replaced the obsolete `KEEP_WORKTREES=1` debugging tip in ExecutePlan/Program.md Step 8.5 with accurate guidance on inspecting worktrees before MakePr cleanup. The `KEEP_WORKTREES` environment variable was removed from ExecutePlan.ps1 in plan 03121 and is no longer checked by any code.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/Program.md` — replaced misleading KEEP_WORKTREES debugging tip with current worktree inspection guidance

## Commits

- 62ec7930e [03125] Remove obsolete KEEP_WORKTREES documentation