### PR TITLE
[03140] Apply error-tuple pattern to GetPrStatusesAsync / FetchPrStatusesFromGhCliAsync

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/GithubServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/GithubServiceTests.cs
@@ -166,6 +166,19 @@ public class GithubServiceTests
     }
 
     [Fact]
+    public async Task GetPrStatusesAsync_Returns_Error_When_Command_Fails()
+    {
+        var configService = new ConfigService(new TendrilSettings());
+        var githubService = new GithubService(configService);
+
+        var (statuses, error) = await githubService.GetPrStatusesAsync(
+            "nonexistent-owner-xyz-000", "nonexistent-repo-xyz-000");
+
+        Assert.Empty(statuses);
+        Assert.NotNull(error);
+    }
+
+    [Fact]
     public async Task GetLabelsAsync_Returns_Error_When_Command_Fails()
     {
         var configService = new ConfigService(new TendrilSettings());

--- a/src/tendril/Ivy.Tendril/Services/GithubService.cs
+++ b/src/tendril/Ivy.Tendril/Services/GithubService.cs
@@ -64,7 +64,7 @@ public class GithubService(IConfigService config) : IGithubService
         return (labels, error);
     }
 
-    public async Task<Dictionary<string, string>> GetPrStatusesAsync(string owner, string repo)
+    public async Task<(Dictionary<string, string> statuses, string? error)> GetPrStatusesAsync(string owner, string repo)
     {
         return await FetchPrStatusesFromGhCliAsync(owner, repo);
     }
@@ -231,7 +231,7 @@ public class GithubService(IConfigService config) : IGithubService
         }
     }
 
-    private static async Task<Dictionary<string, string>> FetchPrStatusesFromGhCliAsync(string owner, string repo)
+    private static async Task<(Dictionary<string, string> statuses, string? error)> FetchPrStatusesFromGhCliAsync(string owner, string repo)
     {
         try
         {
@@ -247,7 +247,9 @@ public class GithubService(IConfigService config) : IGithubService
             };
 
             using var process = Process.Start(psi);
-            if (process is null) return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            if (process is null)
+                return (new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+                        "GitHub CLI (gh) is not available. Please install it from https://cli.github.com/");
 
             var output = await process.StandardOutput.ReadToEndAsync();
             var stderr = await process.StandardError.ReadToEndAsync();
@@ -255,9 +257,11 @@ public class GithubService(IConfigService config) : IGithubService
 
             if (process.ExitCode != 0)
             {
-                Console.Error.WriteLine(
-                    $"[GithubService] gh pr list failed for {owner}/{repo}: {stderr}");
-                return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                Console.Error.WriteLine($"[GithubService] gh pr list failed for {owner}/{repo}: {stderr}");
+                var errorMsg = !string.IsNullOrWhiteSpace(stderr)
+                    ? stderr.Trim()
+                    : $"GitHub CLI exited with code {process.ExitCode}";
+                return (new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase), errorMsg);
             }
 
             var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
@@ -279,13 +283,13 @@ public class GithubService(IConfigService config) : IGithubService
                 }
             }
 
-            return result;
+            return (result, null);
         }
         catch (Exception ex)
         {
-            Console.Error.WriteLine(
-                $"[GithubService] Failed to fetch PR statuses for {owner}/{repo}: {ex.Message}");
-            return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            Console.Error.WriteLine($"[GithubService] Failed to fetch PR statuses for {owner}/{repo}: {ex.Message}");
+            return (new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+                    $"Failed to fetch PR statuses: {ex.Message}");
         }
     }
 

--- a/src/tendril/Ivy.Tendril/Services/IGithubService.cs
+++ b/src/tendril/Ivy.Tendril/Services/IGithubService.cs
@@ -13,6 +13,6 @@ public interface IGithubService
     List<RepoConfig> GetRepos();
     Task<(List<string> assignees, string? error)> GetAssigneesAsync(string owner, string repo);
     Task<(List<string> labels, string? error)> GetLabelsAsync(string owner, string repo);
-    Task<Dictionary<string, string>> GetPrStatusesAsync(string owner, string repo);
+    Task<(Dictionary<string, string> statuses, string? error)> GetPrStatusesAsync(string owner, string repo);
     Task<(List<GitHubIssue> issues, string? error)> SearchIssuesAsync(string owner, string repo, string? query, string? assignee, string[]? labels);
 }

--- a/src/tendril/Ivy.Tendril/Services/PrStatusSyncService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PrStatusSyncService.cs
@@ -77,7 +77,14 @@ public class PrStatusSyncService : IStartable, IDisposable
 
                 try
                 {
-                    var statuses = await _githubService.GetPrStatusesAsync(parts[0], parts[1]);
+                    var (statuses, error) = await _githubService.GetPrStatusesAsync(parts[0], parts[1]);
+
+                    if (error is not null)
+                    {
+                        _logger.LogWarning("Failed to fetch PR statuses for {Repo}: {Error}", ownerRepo, error);
+                        continue;
+                    }
+
                     foreach (var url in urls)
                     {
                         var resolvedStatus = statuses.GetValueOrDefault(url, "Open");


### PR DESCRIPTION
# Summary

## Changes

Applied the error-tuple pattern to `GetPrStatusesAsync` and `FetchPrStatusesFromGhCliAsync` in `GithubService`, matching the pattern established in plan 03097 for `FetchAssigneesFromGhCliAsync` and `FetchLabelsFromGhCliAsync`. The caller in `PrStatusSyncService` now properly logs GitHub CLI failures and skips the repo instead of silently using an empty dictionary.

## API Changes

- `IGithubService.GetPrStatusesAsync` return type changed from `Task<Dictionary<string, string>>` to `Task<(Dictionary<string, string> statuses, string? error)>`
- `GithubService.FetchPrStatusesFromGhCliAsync` (private) return type changed to match
- `PrStatusSyncService.RunSyncAsync` now deconstructs the error tuple and logs warnings on failure

## Files Modified

- `src/tendril/Ivy.Tendril/Services/IGithubService.cs` — Updated interface signature
- `src/tendril/Ivy.Tendril/Services/GithubService.cs` — Updated both `GetPrStatusesAsync` and `FetchPrStatusesFromGhCliAsync` to return error tuples
- `src/tendril/Ivy.Tendril/Services/PrStatusSyncService.cs` — Updated caller to handle error tuple with logging
- `src/tendril/Ivy.Tendril.Test/GithubServiceTests.cs` — Added `GetPrStatusesAsync_Returns_Error_When_Command_Fails` test

## Commits

- ee9d68ec9 [03140] Apply error-tuple pattern to GetPrStatusesAsync / FetchPrStatusesFromGhCliAsync