### PR TITLE
[03129] Surface errors in CreateIssueDialog and Review ContentView

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Plans/Dialogs/CreateIssueDialog.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Plans/Dialogs/CreateIssueDialog.cs
@@ -22,15 +22,27 @@ public class CreateIssueDialog(
     public override object? Build()
     {
         var githubService = UseService<IGithubService>();
+        var assigneesError = UseState<string?>(null);
+        var labelsError = UseState<string?>(null);
+
         var assigneesQuery = UseQuery<string[], string>(
             _selectedRepoState.Value ?? "",
             async (repoName, _) =>
             {
-                if (string.IsNullOrEmpty(repoName)) return Array.Empty<string>();
+                if (string.IsNullOrEmpty(repoName))
+                {
+                    assigneesError.Set(null);
+                    return Array.Empty<string>();
+                }
                 var repos = githubService.GetRepos();
                 var selectedRepo = repos.FirstOrDefault(r => r.DisplayName == repoName);
-                if (selectedRepo is null) return Array.Empty<string>();
-                var (assignees, _) = await githubService.GetAssigneesAsync(selectedRepo.Owner, selectedRepo.Name);
+                if (selectedRepo is null)
+                {
+                    assigneesError.Set(null);
+                    return Array.Empty<string>();
+                }
+                var (assignees, error) = await githubService.GetAssigneesAsync(selectedRepo.Owner, selectedRepo.Name);
+                assigneesError.Set(error);
                 return assignees.ToArray();
             },
             initialValue: Array.Empty<string>()
@@ -40,15 +52,30 @@ public class CreateIssueDialog(
             _selectedRepoState.Value ?? "",
             async (repoName, _) =>
             {
-                if (string.IsNullOrEmpty(repoName)) return Array.Empty<string>();
+                if (string.IsNullOrEmpty(repoName))
+                {
+                    labelsError.Set(null);
+                    return Array.Empty<string>();
+                }
                 var repos = githubService.GetRepos();
                 var selectedRepo = repos.FirstOrDefault(r => r.DisplayName == repoName);
-                if (selectedRepo is null) return Array.Empty<string>();
-                var (labels, _) = await githubService.GetLabelsAsync(selectedRepo.Owner, selectedRepo.Name);
+                if (selectedRepo is null)
+                {
+                    labelsError.Set(null);
+                    return Array.Empty<string>();
+                }
+                var (labels, error) = await githubService.GetLabelsAsync(selectedRepo.Owner, selectedRepo.Name);
+                labelsError.Set(error);
                 return labels.ToArray();
             },
             initialValue: Array.Empty<string>()
         );
+
+        UseEffect(() =>
+        {
+            assigneesError.Set(null);
+            labelsError.Set(null);
+        }, _selectedRepoState);
 
         if (!_dialogOpen.Value) return null;
 
@@ -63,6 +90,8 @@ public class CreateIssueDialog(
                 _issueCommentState.Set("");
                 _issueAssigneeState.Set(null);
                 _issueLabelsState.Set(Array.Empty<string>());
+                assigneesError.Set(null);
+                labelsError.Set(null);
                 _dialogOpen.Set(false);
             },
             new DialogHeader($"Create GitHub Issue #{_selectedPlan.Id}"),
@@ -74,6 +103,12 @@ public class CreateIssueDialog(
                     .Nullable().WithField().Label("Assignee")
                 | _issueLabelsState.ToSelectInput(labels.ToOptions())
                     .Placeholder("Select labels...").WithField().Label("Labels")
+                | (assigneesError.Value is { } assigneeErr
+                    ? Text.Danger(assigneeErr).Small()
+                    : null)
+                | (labelsError.Value is { } labelErr
+                    ? Text.Danger(labelErr).Small()
+                    : null)
                 | _issueCommentState.ToTextInput().Multiline().WithField().Label("Comment")
             ),
             new DialogFooter(
@@ -82,6 +117,8 @@ public class CreateIssueDialog(
                     _issueCommentState.Set("");
                     _issueAssigneeState.Set(null);
                     _issueLabelsState.Set(Array.Empty<string>());
+                    assigneesError.Set(null);
+                    labelsError.Set(null);
                     _dialogOpen.Set(false);
                 }),
                 new Button("Create Issue").Primary().OnClick(() =>
@@ -103,6 +140,8 @@ public class CreateIssueDialog(
                     _issueCommentState.Set("");
                     _issueAssigneeState.Set(null);
                     _issueLabelsState.Set(Array.Empty<string>());
+                    assigneesError.Set(null);
+                    labelsError.Set(null);
                     _dialogOpen.Set(false);
                 })
             )

--- a/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -40,17 +40,31 @@ public class ContentView(
         var customPrOpen = UseState(false);
 
         var githubService = UseService<IGithubService>();
+        var assigneesError = UseState<string?>(null);
         var assigneesQuery = UseQuery<string[], string>(
             _selectedPlan?.Project ?? "",
             async (_, _) =>
             {
-                if (_selectedPlan is null) return Array.Empty<string>();
+                if (_selectedPlan is null)
+                {
+                    assigneesError.Set(null);
+                    return Array.Empty<string>();
+                }
                 var repos = _selectedPlan.GetEffectiveRepoPaths(_config);
                 var repoPath = repos.FirstOrDefault();
-                if (repoPath is null) return Array.Empty<string>();
+                if (repoPath is null)
+                {
+                    assigneesError.Set(null);
+                    return Array.Empty<string>();
+                }
                 var repoConfig = GithubService.GetRepoConfigFromPath(repoPath);
-                if (repoConfig is null) return Array.Empty<string>();
-                var (assignees, _) = await githubService.GetAssigneesAsync(repoConfig.Owner, repoConfig.Name);
+                if (repoConfig is null)
+                {
+                    assigneesError.Set(null);
+                    return Array.Empty<string>();
+                }
+                var (assignees, error) = await githubService.GetAssigneesAsync(repoConfig.Owner, repoConfig.Name);
+                assigneesError.Set(error);
                 return assignees.ToArray();
             },
             initialValue: Array.Empty<string>()
@@ -458,7 +472,7 @@ public class ContentView(
         content |= new SuggestChangesDialog(suggestChangesOpen, suggestChangesText, _selectedPlan, _jobService,
             _planService, _refreshPlans);
         content |= new CustomPrDialog(customPrOpen, _selectedPlan, _jobService, _planService, _refreshPlans,
-            assigneesQuery);
+            assigneesQuery, assigneesError);
 
         // Discard confirmation dialog
         content |= new DiscardPlanDialog(discardDialogOpen, _selectedPlan, _planService, _refreshPlans);

--- a/src/tendril/Ivy.Tendril/Apps/Review/Dialogs/CustomPrDialog.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Review/Dialogs/CustomPrDialog.cs
@@ -11,8 +11,10 @@ public class CustomPrDialog(
     IJobService jobService,
     IPlanReaderService planService,
     Action refreshPlans,
-    QueryResult<string[]> assigneesQuery) : ViewBase
+    QueryResult<string[]> assigneesQuery,
+    IState<string?> assigneesError) : ViewBase
 {
+    private readonly IState<string?> _assigneesError = assigneesError;
     private readonly QueryResult<string[]> _assigneesQuery = assigneesQuery;
     private readonly IState<bool> _dialogOpen = dialogOpen;
     private readonly IJobService _jobService = jobService;
@@ -54,6 +56,9 @@ public class CustomPrDialog(
                 | customPrIncludeArtifacts.ToBoolInput("Include Artifacts")
                 | customPrAssignee.ToSelectInput((_assigneesQuery.Value ?? Array.Empty<string>()).ToOptions())
                     .Nullable().WithField().Label("Assignee")
+                | (_assigneesError.Value is { } err
+                    ? Text.Danger(err).Small()
+                    : null)
                 | customPrComment.ToTextareaInput("Comment").Rows(3)
             ),
             new DialogFooter(


### PR DESCRIPTION
# Summary

## Changes

Applied the error-tuple handling pattern from `ImportIssuesDialog` to `CreateIssueDialog` and Review `ContentView`/`CustomPrDialog`. Both components now capture GitHub API errors from `GetAssigneesAsync` and `GetLabelsAsync` (where applicable) and display them via `Text.Danger` widgets, instead of silently discarding errors with `_`.

## API Changes

- `CustomPrDialog` constructor gained a new `IState<string?> assigneesError` parameter.

## Files Modified

- **CreateIssueDialog.cs** — Added error state variables, error capture in UseQuery callbacks, error display in dialog body, error reset on close/repo change.
- **ContentView.cs** — Added assigneesError state, error capture in UseQuery callback, passes error to CustomPrDialog.
- **CustomPrDialog.cs** — Accepts assigneesError parameter, displays error after assignee select input.

## Commits

- 614017fc9 [03129] Surface errors in CreateIssueDialog and Review ContentView