### PR TITLE
[03136] Extract shared plan creation dialog logic

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/WallpaperApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/WallpaperApp.cs
@@ -1,5 +1,5 @@
-using Ivy.Tendril.Apps.Plans.Dialogs;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Views;
 
 namespace Ivy.Tendril.Apps;
 
@@ -8,12 +8,8 @@ public class WallpaperApp : ViewBase
 {
     public override object Build()
     {
-        var jobService = UseService<IJobService>();
-        var configService = UseService<IConfigService>();
         var countsService = UseService<IPlanCountsService>();
         var versionService = UseService<IVersionCheckService>();
-        var dialogOpen = UseState(false);
-        var lastSelectedProjects = UseState<string[]>(["[Auto]"]);
         var versionInfo = UseState<VersionInfo?>(null);
 
         UseEffect(() =>
@@ -26,7 +22,6 @@ public class WallpaperApp : ViewBase
         }, []);
 
         var counts = countsService.Current;
-        var projectNames = configService.Projects.Select(p => p.Name).ToList();
 
         var hasActivity = counts.Drafts > 0 || counts.ActiveJobs > 0 || counts.Reviews > 0;
 
@@ -41,9 +36,10 @@ public class WallpaperApp : ViewBase
                    | new Image("/tendril/assets/Tendril.svg").Width(Size.Units(30)).Height(Size.Auto())
                    | Text.H2(heading)
                    | Text.Muted(subtitle)
-                   | new Button(buttonLabel, () => dialogOpen.Set(true))
-                       .Variant(ButtonVariant.Primary)
-                       .Icon(Icons.Plus, Align.Right)
+                   | new CreatePlanDialogLauncher(
+                       open => new Button(buttonLabel, open)
+                           .Variant(ButtonVariant.Primary)
+                           .Icon(Icons.Plus, Align.Right))
                 )
         };
 
@@ -55,19 +51,6 @@ public class WallpaperApp : ViewBase
                         | Text.Block($"Tendril v{versionInfo.Value.LatestVersion} is available!")
                         | Text.Muted($"You're running v{versionInfo.Value.CurrentVersion}")
                         | Text.Muted("Run: tendril --version && dotnet tool update -g Ivy.Tendril"))
-            ));
-
-        if (dialogOpen.Value)
-            elements.Add(new CreatePlanDialog(
-                projectNames,
-                (description, projects, priority) =>
-                {
-                    lastSelectedProjects.Set(projects);
-                    var project = string.Join(",", projects);
-                    jobService.StartJob("MakePlan", "-Description", $"{description} [FORCE]", "-Project", project, "-Priority", priority.ToString());
-                },
-                () => dialogOpen.Set(false),
-                lastSelectedProjects.Value
             ));
 
         return new Fragment(elements.ToArray());

--- a/src/tendril/Ivy.Tendril/Views/CreatePlanDialogLauncher.cs
+++ b/src/tendril/Ivy.Tendril/Views/CreatePlanDialogLauncher.cs
@@ -1,0 +1,37 @@
+using Ivy.Tendril.Apps.Plans.Dialogs;
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Views;
+
+public class CreatePlanDialogLauncher(Func<Action, object> renderTrigger) : ViewBase
+{
+    public override object Build()
+    {
+        var jobService = UseService<IJobService>();
+        var configService = UseService<IConfigService>();
+        var dialogOpen = UseState(false);
+        var lastSelectedProjects = UseState<string[]>(["[Auto]"]);
+
+        var projectNames = configService.Projects.Select(p => p.Name).ToList();
+
+        var elements = new List<object>
+        {
+            renderTrigger(() => dialogOpen.Set(true))
+        };
+
+        if (dialogOpen.Value)
+            elements.Add(new CreatePlanDialog(
+                projectNames,
+                (description, projects, priority) =>
+                {
+                    lastSelectedProjects.Set(projects);
+                    var project = string.Join(",", projects);
+                    jobService.StartJob("MakePlan", "-Description", $"{description} [FORCE]", "-Project", project, "-Priority", priority.ToString());
+                },
+                () => dialogOpen.Set(false),
+                lastSelectedProjects.Value
+            ));
+
+        return new Fragment(elements.ToArray());
+    }
+}

--- a/src/tendril/Ivy.Tendril/Views/NewPlanButton.cs
+++ b/src/tendril/Ivy.Tendril/Views/NewPlanButton.cs
@@ -1,42 +1,15 @@
-using Ivy.Tendril.Apps.Plans.Dialogs;
-using Ivy.Tendril.Services;
-
 namespace Ivy.Tendril.Views;
 
 public class NewPlanButton : ViewBase
 {
     public override object Build()
     {
-        var jobService = UseService<IJobService>();
-        var configService = UseService<IConfigService>();
-        var dialogOpen = UseState(false);
-        var lastSelectedProjects = UseState<string[]>(["[Auto]"]);
-
-        var projectNames = configService.Projects.Select(p => p.Name).ToList();
-
-        var elements = new List<object>
-        {
-            new Button("New Plan")
+        return new CreatePlanDialogLauncher(
+            open => new Button("New Plan")
                 .Icon(Icons.Plus)
                 .Width(Size.Full())
                 .Variant(ButtonVariant.Primary)
-                .OnClick(() => dialogOpen.Set(true))
-                .ShortcutKey("CTRL+ALT+N")
-        };
-
-        if (dialogOpen.Value)
-            elements.Add(new CreatePlanDialog(
-                projectNames,
-                (description, projects, priority) =>
-                {
-                    lastSelectedProjects.Set(projects);
-                    var project = string.Join(",", projects);
-                    jobService.StartJob("MakePlan", "-Description", $"{description} [FORCE]", "-Project", project, "-Priority", priority.ToString());
-                },
-                () => dialogOpen.Set(false),
-                lastSelectedProjects.Value
-            ));
-
-        return new Fragment(elements.ToArray());
+                .OnClick(open)
+                .ShortcutKey("CTRL+ALT+N"));
     }
 }


### PR DESCRIPTION
# Summary

## Changes

Extracted duplicated CreatePlanDialog state management and wiring from `WallpaperApp` and `NewPlanButton` into a new reusable `CreatePlanDialogLauncher` ViewBase component. Both consumers now delegate dialog logic to the launcher, passing only their custom trigger button via a render function.

## API Changes

- **New class:** `Ivy.Tendril.Views.CreatePlanDialogLauncher` — ViewBase that accepts a `Func<Action, object>` render function for the trigger element, and encapsulates all dialog state (open/close, last selected projects), service resolution (IJobService, IConfigService), and MakePlan job invocation.

## Files Modified

- **Created**: `src/tendril/Ivy.Tendril/Views/CreatePlanDialogLauncher.cs` — new reusable component
- **Modified**: `src/tendril/Ivy.Tendril/Apps/WallpaperApp.cs` — replaced inline dialog logic with `CreatePlanDialogLauncher`
- **Modified**: `src/tendril/Ivy.Tendril/Views/NewPlanButton.cs` — simplified to a single `CreatePlanDialogLauncher` invocation

## Commits

- 1d41649e5 [03136] Extract shared plan creation dialog logic into CreatePlanDialogLauncher