### PR TITLE
[03142] Add InboxController Web API

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/InboxControllerTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/InboxControllerTests.cs
@@ -1,0 +1,168 @@
+using Ivy.Tendril.Controllers;
+using Ivy.Tendril.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+// ReSharper disable UnusedAutoPropertyAccessor.Local
+
+namespace Ivy.Tendril.Test;
+
+public class InboxControllerTests
+{
+    [Fact]
+    public void PostPlan_ValidRequest_ReturnsOkWithJobId()
+    {
+        var jobService = new StubJobService();
+        var configService = new ConfigService(new TendrilSettings(), "/tmp");
+        var controller = CreateController(jobService, configService);
+
+        var result = controller.PostPlan(new CreatePlanRequest("Fix a bug", "Tendril"));
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        Assert.Equal(200, ok.StatusCode);
+        Assert.Single(jobService.StartedJobs);
+        Assert.Equal("MakePlan", jobService.StartedJobs[0].Type);
+    }
+
+    [Fact]
+    public void PostPlan_EmptyDescription_ReturnsBadRequest()
+    {
+        var jobService = new StubJobService();
+        var configService = new ConfigService(new TendrilSettings(), "/tmp");
+        var controller = CreateController(jobService, configService);
+
+        var result = controller.PostPlan(new CreatePlanRequest(""));
+
+        Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Empty(jobService.StartedJobs);
+    }
+
+    [Fact]
+    public void PostPlan_WithAuthentication_ValidKey_ReturnsOk()
+    {
+        var jobService = new StubJobService();
+        var settings = new TendrilSettings { Api = new ApiSettings { ApiKey = "secret-123" } };
+        var configService = new ConfigService(settings, "/tmp");
+        var controller = CreateController(jobService, configService, apiKey: "secret-123");
+
+        var result = controller.PostPlan(new CreatePlanRequest("Add feature"));
+
+        Assert.IsType<OkObjectResult>(result);
+        Assert.Single(jobService.StartedJobs);
+    }
+
+    [Fact]
+    public void PostPlan_WithAuthentication_InvalidKey_ReturnsUnauthorized()
+    {
+        var jobService = new StubJobService();
+        var settings = new TendrilSettings { Api = new ApiSettings { ApiKey = "secret-123" } };
+        var configService = new ConfigService(settings, "/tmp");
+        var controller = CreateController(jobService, configService, apiKey: "wrong-key");
+
+        var result = controller.PostPlan(new CreatePlanRequest("Add feature"));
+
+        Assert.IsType<UnauthorizedObjectResult>(result);
+        Assert.Empty(jobService.StartedJobs);
+    }
+
+    [Fact]
+    public void PostPlan_WithAuthentication_MissingKey_ReturnsUnauthorized()
+    {
+        var jobService = new StubJobService();
+        var settings = new TendrilSettings { Api = new ApiSettings { ApiKey = "secret-123" } };
+        var configService = new ConfigService(settings, "/tmp");
+        var controller = CreateController(jobService, configService);
+
+        var result = controller.PostPlan(new CreatePlanRequest("Add feature"));
+
+        Assert.IsType<UnauthorizedObjectResult>(result);
+        Assert.Empty(jobService.StartedJobs);
+    }
+
+    [Fact]
+    public void PostPlan_NoAuthConfigured_AllowsAccess()
+    {
+        var jobService = new StubJobService();
+        var configService = new ConfigService(new TendrilSettings(), "/tmp");
+        var controller = CreateController(jobService, configService);
+
+        var result = controller.PostPlan(new CreatePlanRequest("Do something"));
+
+        Assert.IsType<OkObjectResult>(result);
+        Assert.Single(jobService.StartedJobs);
+    }
+
+    [Fact]
+    public void PostPlan_WithSourcePath_PassesItToJobService()
+    {
+        var jobService = new StubJobService();
+        var configService = new ConfigService(new TendrilSettings(), "/tmp");
+        var controller = CreateController(jobService, configService);
+
+        var result = controller.PostPlan(new CreatePlanRequest("Fix bug", "Tendril", @"D:\Tests\Session1"));
+
+        Assert.IsType<OkObjectResult>(result);
+        var job = Assert.Single(jobService.StartedJobs);
+        Assert.Contains("-SourcePath", job.Args);
+        Assert.Contains(@"D:\Tests\Session1", job.Args);
+    }
+
+    [Fact]
+    public void PostPlan_NullProject_DefaultsToAuto()
+    {
+        var jobService = new StubJobService();
+        var configService = new ConfigService(new TendrilSettings(), "/tmp");
+        var controller = CreateController(jobService, configService);
+
+        var result = controller.PostPlan(new CreatePlanRequest("Some task"));
+
+        Assert.IsType<OkObjectResult>(result);
+        var job = Assert.Single(jobService.StartedJobs);
+        Assert.Contains("[Auto]", job.Args);
+    }
+
+    private static InboxController CreateController(
+        IJobService jobService,
+        IConfigService configService,
+        string? apiKey = null)
+    {
+        var controller = new InboxController(jobService, configService);
+        var httpContext = new DefaultHttpContext();
+        if (apiKey != null)
+            httpContext.Request.Headers["X-Api-Key"] = apiKey;
+        controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        return controller;
+    }
+
+    private class StubJobService : IJobService
+    {
+        public List<(string Type, string[] Args)> StartedJobs { get; } = new();
+
+        public string StartJob(string type, string[] args, string? inboxFilePath)
+        {
+            var id = $"job-{StartedJobs.Count + 1}";
+            StartedJobs.Add((type, args));
+            return id;
+        }
+
+        public string StartJob(string type, params string[] args)
+        {
+            return StartJob(type, args, null);
+        }
+
+        public void CompleteJob(string id, int? exitCode, bool timedOut = false, bool staleOutput = false) { }
+        public void StopJob(string id) { }
+        public void DeleteJob(string id) { }
+        public void ClearCompletedJobs() { }
+        public void ClearFailedJobs() { }
+        public List<Ivy.Tendril.Apps.Jobs.JobItem> GetJobs() => new();
+        public Ivy.Tendril.Apps.Jobs.JobItem? GetJob(string id) => null;
+        public bool IsInboxFileTracked(string filePath) => false;
+        public void Dispose() { }
+
+#pragma warning disable CS0067
+        public event Action? JobsChanged;
+        public event Action<JobNotification>? NotificationReady;
+#pragma warning restore CS0067
+    }
+}

--- a/src/tendril/Ivy.Tendril/Controllers/InboxController.cs
+++ b/src/tendril/Ivy.Tendril/Controllers/InboxController.cs
@@ -1,0 +1,54 @@
+using Ivy.Tendril.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Ivy.Tendril.Controllers;
+
+[ApiController]
+[Route("api/inbox")]
+public class InboxController : ControllerBase
+{
+    private readonly IConfigService _configService;
+    private readonly IJobService _jobService;
+
+    public InboxController(IJobService jobService, IConfigService configService)
+    {
+        _jobService = jobService;
+        _configService = configService;
+    }
+
+    [HttpPost]
+    public IActionResult PostPlan([FromBody] CreatePlanRequest request)
+    {
+        var apiKey = _configService.Settings.Api?.ApiKey;
+        if (!string.IsNullOrEmpty(apiKey))
+        {
+            var providedKey = Request.Headers["X-Api-Key"].FirstOrDefault();
+            if (string.IsNullOrEmpty(providedKey) || providedKey != apiKey)
+                return Unauthorized(new { error = "Invalid or missing API key" });
+        }
+
+        if (string.IsNullOrWhiteSpace(request.Description))
+            return BadRequest(new { error = "Description is required" });
+
+        try
+        {
+            var project = request.Project ?? "[Auto]";
+            var args = new List<string> { "-Description", request.Description, "-Project", project };
+            if (!string.IsNullOrEmpty(request.SourcePath))
+                args.AddRange(["-SourcePath", request.SourcePath]);
+
+            var jobId = _jobService.StartJob("MakePlan", args.ToArray(), null);
+            return Ok(new { jobId, status = "Started", message = "Plan creation job started successfully" });
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(500, new { error = $"Failed to start plan creation: {ex.Message}" });
+        }
+    }
+}
+
+public record CreatePlanRequest(
+    string Description,
+    string? Project = null,
+    string? SourcePath = null
+);

--- a/src/tendril/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/tendril/Ivy.Tendril/Services/ConfigService.cs
@@ -111,6 +111,11 @@ public record LlmConfig
     public string Model { get; set; } = "gpt-4o-mini";
 }
 
+public record ApiSettings
+{
+    public string? ApiKey { get; set; }
+}
+
 public class TendrilSettings
 {
     public string CodingAgent { get; set; } = "claude";
@@ -122,6 +127,7 @@ public class TendrilSettings
     public string PlanTemplate { get; set; } = "";
     public EditorConfig Editor { get; set; } = new();
     public LlmConfig? Llm { get; set; }
+    public ApiSettings? Api { get; set; }
     public Dictionary<string, PromptwareConfig> Promptwares { get; set; } = new();
     public List<AgentConfig> CodingAgents { get; set; } = new();
     public bool Telemetry { get; set; } = true;


### PR DESCRIPTION
# Summary

## Changes

Added a new `InboxController` API controller exposing a `POST /api/inbox` endpoint that allows creating plans programmatically via HTTP. The endpoint accepts a JSON body with `Description`, optional `Project`, and optional `SourcePath` fields. Optional API key authentication is supported via the `X-Api-Key` header, configured through a new `api.apiKey` setting in `config.yaml`.

## API Changes

- **New endpoint:** `POST /api/inbox` — creates a plan via `IJobService.StartJob("MakePlan", ...)`
- **New record:** `CreatePlanRequest(string Description, string? Project, string? SourcePath)` in `Ivy.Tendril.Controllers`
- **New record:** `ApiSettings { ApiKey }` in `Ivy.Tendril.Services`
- **New property:** `TendrilSettings.Api` (`ApiSettings?`) — optional API configuration section

## Files Modified

**Created:**
- `src/tendril/Ivy.Tendril/Controllers/InboxController.cs` — API controller with POST endpoint and auth
- `src/tendril/Ivy.Tendril.Test/InboxControllerTests.cs` — 8 unit tests

**Modified:**
- `src/tendril/Ivy.Tendril/Services/ConfigService.cs` — added `ApiSettings` record and `Api` property to `TendrilSettings`

## Commits

- [03142] Add InboxController Web API with optional API key auth (4fa59b2f7)