### PR TITLE
[03139] Cache GetRepos() calls in CreateIssue and ImportIssues dialogs

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Plans/Dialogs/CreateIssueDialog.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Plans/Dialogs/CreateIssueDialog.cs
@@ -88,8 +88,7 @@ public class CreateIssueDialog(
                 {
                     if (_selectedRepoState.Value is { } repo)
                     {
-                        var availableRepos = githubService.GetRepos();
-                        var selectedRepo = availableRepos.FirstOrDefault(r => r.DisplayName == repo);
+                        var selectedRepo = repos.FirstOrDefault(r => r.DisplayName == repo);
                         if (selectedRepo != null)
                         {
                             var repoPath = selectedRepo.FullName;


### PR DESCRIPTION
# Summary

## Changes

Eliminated a redundant `githubService.GetRepos()` call in the `CreateIssueDialog` OnClick handler by reusing the `repos` variable already cached in the `Build()` method body. The `ImportIssuesDialog` already had the optimal caching pattern and required no changes. The plan's approach of caching at the very top of `Build()` was not feasible due to the Ivy analyzer's IVYHOOK005 rule requiring hooks before non-hook statements.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Apps/Plans/Dialogs/CreateIssueDialog.cs` — Replaced `var availableRepos = githubService.GetRepos()` in OnClick with reference to existing `repos` variable

---

## Commits

- 1b29fad5c [03139] Use cached repos in CreateIssueDialog OnClick handler