### PR TITLE
[03138] Simplify worktree cleanup duplicate logic

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/WorktreeCleanupServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/WorktreeCleanupServiceTests.cs
@@ -290,6 +290,25 @@ public class WorktreeCleanupServiceTests : IDisposable
     }
 
     [Fact]
+    public void CleanupPlanWorktrees_FallbackRemoves_DirectoryMissedByRemoveWorktrees()
+    {
+        var dir = CreatePlan("10003-TestFallback", "Completed", DateTime.UtcNow.AddHours(-2));
+        var worktreeDir = Path.Combine(dir, "worktrees", "TestRepo");
+        Directory.CreateDirectory(worktreeDir);
+        File.WriteAllText(Path.Combine(worktreeDir, ".git"),
+            "gitdir: /nonexistent/repo/.git/worktrees/TestRepo");
+        File.WriteAllText(Path.Combine(worktreeDir, "file.txt"), "test");
+
+        var logEntries = new List<string>();
+        var logger = new CapturingLogger(logEntries);
+
+        WorktreeCleanupService.CleanupPlanWorktrees(dir, logger);
+
+        Assert.False(Directory.Exists(worktreeDir), "Fallback should delete directory missed by RemoveWorktrees");
+        Assert.Contains(logEntries, e => e.Contains("still exists after RemoveWorktrees"));
+    }
+
+    [Fact]
     public void CleanupPlanWorktrees_ForceDeletes_DeepNodeModulesPath()
     {
         // Simulates the real-world failure: cleanup must succeed over a deeply nested

--- a/src/tendril/Ivy.Tendril/Services/WorktreeCleanupService.cs
+++ b/src/tendril/Ivy.Tendril/Services/WorktreeCleanupService.cs
@@ -152,20 +152,14 @@ public class WorktreeCleanupService : IStartable, IDisposable
 
         PlanReaderService.RemoveWorktrees(planFolderPath, logger, lifecycleLogger);
 
+        // Safety net: RemoveWorktrees should have removed all directories
         foreach (var wtDir in Directory.GetDirectories(worktreesDir))
         {
-            var gitFile = Path.Combine(wtDir, ".git");
-            var gitFileExists = File.Exists(gitFile);
+            logger?.LogWarning(
+                "Worktree directory still exists after RemoveWorktrees (this should not happen): {Path}",
+                Path.GetFileName(wtDir));
 
-            if (!gitFileExists)
-            {
-                var dirAge = DateTime.UtcNow - new DirectoryInfo(wtDir).CreationTimeUtc;
-                logger?.LogWarning(
-                    "Force-deleting orphaned worktree directory (no .git file, created {Age} ago): {Path}",
-                    dirAge, Path.GetFileName(wtDir));
-            }
-
-            lifecycleLogger?.LogCleanupAttempt(planId, wtDir, $"TerminalState({planYaml.State})", gitFileExists);
+            lifecycleLogger?.LogCleanupAttempt(planId, wtDir, "CleanupPlanWorktrees(fallback)", gitFileExists: false);
 
             try
             {


### PR DESCRIPTION
# Summary

## Changes

Simplified the duplicate worktree cleanup fallback in `WorktreeCleanupService.CleanupPlanWorktrees()`. Removed the `.git` file existence check and conditional orphan warning that duplicated logic already handled by `PlanReaderService.RemoveWorktrees()` (added in plan 03108). The remaining loop now serves as a pure safety net for directories that `RemoveWorktrees` unexpectedly fails to delete.

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/Services/WorktreeCleanupService.cs** — Simplified the fallback loop in `CleanupPlanWorktrees()` (lines 153-180): removed `.git` check, updated warning message, simplified lifecycle logger reason
- **src/tendril/Ivy.Tendril.Test/WorktreeCleanupServiceTests.cs** — Added `CleanupPlanWorktrees_FallbackRemoves_DirectoryMissedByRemoveWorktrees` test

## Commits

- 1175bbc24 [03138] Simplify worktree cleanup duplicate logic in CleanupPlanWorktrees