### PR TITLE
[03137] Extract shared test helper for IConfigService implementations

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/PlanContentHelpersTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/PlanContentHelpersTests.cs
@@ -1,5 +1,6 @@
 using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Test.TestHelpers;
 
 namespace Ivy.Tendril.Test;
 
@@ -169,38 +170,4 @@ public class PlanContentHelpersTests
         public int? GetCommitFileCount(string repoPath, string commitHash) => commitFiles?.Count;
     }
 
-    private class StubConfigService : IConfigService
-    {
-        public TendrilSettings Settings => new();
-        public string TendrilHome => "";
-        public string ConfigPath => "";
-        public string PlanFolder => "";
-        public List<ProjectConfig> Projects => [];
-        public List<LevelConfig> Levels => [];
-        public string[] LevelNames => [];
-        public EditorConfig Editor => new() { Command = "code", Label = "VS Code" };
-        public bool NeedsOnboarding => false;
-        public ConfigParseError? ParseError => null;
-        public ProjectConfig? GetProject(string name) => null;
-        public BadgeVariant GetBadgeVariant(string level) => BadgeVariant.Outline;
-        public Colors? GetProjectColor(string projectName) => null;
-        public void SaveSettings() { }
-        public void ReloadSettings() { }
-        public bool TryAutoHeal() => false;
-        public void ResetToDefaults() { }
-        public void RetryLoadConfig() { }
-#pragma warning disable CS0067
-        public event EventHandler? SettingsReloaded;
-#pragma warning restore CS0067
-        public void SetPendingCodingAgent(string name) { }
-        public string? GetPendingCodingAgent() => null;
-        public void SetPendingTendrilHome(string path) { }
-        public string? GetPendingTendrilHome() => null;
-        public void SetPendingProject(ProjectConfig project) { }
-        public ProjectConfig? GetPendingProject() => null;
-        public void SetPendingVerificationDefinitions(List<VerificationConfig> definitions) { }
-        public List<VerificationConfig>? GetPendingVerificationDefinitions() => null;
-        public void CompleteOnboarding(string tendrilHome) { }
-        public void OpenInEditor(string path) { }
-    }
 }

--- a/src/tendril/Ivy.Tendril.Test/Services/FileLinkHelperTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/Services/FileLinkHelperTests.cs
@@ -1,10 +1,11 @@
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Test.TestHelpers;
 
 namespace Ivy.Tendril.Test.Services;
 
 public class FileLinkHelperTests
 {
-    private static readonly IConfigService TestConfig = new TestConfigService();
+    private static readonly IConfigService TestConfig = new StubConfigService();
 
     [Fact]
     public void CreateFileLinkClickHandler_CapturesFilePath_WhenFileUrlProvided()
@@ -96,42 +97,6 @@ public class FileLinkHelperTests
             "/nonexistent/file.txt", () => { }, [], TestConfig);
         Assert.NotNull(result);
         Assert.IsType<Sheet>(result);
-    }
-
-    private class TestConfigService : IConfigService
-    {
-        public TendrilSettings Settings => new();
-        public string TendrilHome => "";
-        public string ConfigPath => "";
-        public string PlanFolder => "";
-        public List<ProjectConfig> Projects => [];
-        public List<LevelConfig> Levels => [];
-        public string[] LevelNames => [];
-        public EditorConfig Editor => new() { Command = "code", Label = "VS Code" };
-        public bool NeedsOnboarding => false;
-        public ConfigParseError? ParseError => null;
-
-        public ProjectConfig? GetProject(string name) => null;
-        public BadgeVariant GetBadgeVariant(string level) => BadgeVariant.Outline;
-        public Colors? GetProjectColor(string projectName) => null;
-        public void SaveSettings() { }
-        public void ReloadSettings() { }
-        public bool TryAutoHeal() => false;
-        public void ResetToDefaults() { }
-        public void RetryLoadConfig() { }
-#pragma warning disable CS0067
-        public event EventHandler? SettingsReloaded;
-#pragma warning restore CS0067
-        public void SetPendingCodingAgent(string name) { }
-        public string? GetPendingCodingAgent() => null;
-        public void SetPendingTendrilHome(string path) { }
-        public string? GetPendingTendrilHome() => null;
-        public void SetPendingProject(ProjectConfig project) { }
-        public ProjectConfig? GetPendingProject() => null;
-        public void SetPendingVerificationDefinitions(List<VerificationConfig> definitions) { }
-        public List<VerificationConfig>? GetPendingVerificationDefinitions() => null;
-        public void CompleteOnboarding(string tendrilHome) { }
-        public void OpenInEditor(string path) { }
     }
 
     private class TestState<T> : IState<T>

--- a/src/tendril/Ivy.Tendril.Test/TestHelpers/StubConfigService.cs
+++ b/src/tendril/Ivy.Tendril.Test/TestHelpers/StubConfigService.cs
@@ -1,0 +1,39 @@
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Test.TestHelpers;
+
+public class StubConfigService : IConfigService
+{
+    public TendrilSettings Settings => new();
+    public string TendrilHome => "";
+    public string ConfigPath => "";
+    public string PlanFolder => "";
+    public List<ProjectConfig> Projects => [];
+    public List<LevelConfig> Levels => [];
+    public string[] LevelNames => [];
+    public EditorConfig Editor => new() { Command = "code", Label = "VS Code" };
+    public bool NeedsOnboarding => false;
+    public ConfigParseError? ParseError => null;
+
+    public ProjectConfig? GetProject(string name) => null;
+    public BadgeVariant GetBadgeVariant(string level) => BadgeVariant.Outline;
+    public Colors? GetProjectColor(string projectName) => null;
+    public void SaveSettings() { }
+    public void ReloadSettings() { }
+    public bool TryAutoHeal() => false;
+    public void ResetToDefaults() { }
+    public void RetryLoadConfig() { }
+#pragma warning disable CS0067
+    public event EventHandler? SettingsReloaded;
+#pragma warning restore CS0067
+    public void SetPendingCodingAgent(string name) { }
+    public string? GetPendingCodingAgent() => null;
+    public void SetPendingTendrilHome(string path) { }
+    public string? GetPendingTendrilHome() => null;
+    public void SetPendingProject(ProjectConfig project) { }
+    public ProjectConfig? GetPendingProject() => null;
+    public void SetPendingVerificationDefinitions(List<VerificationConfig> definitions) { }
+    public List<VerificationConfig>? GetPendingVerificationDefinitions() => null;
+    public void CompleteOnboarding(string tendrilHome) { }
+    public void OpenInEditor(string path) { }
+}


### PR DESCRIPTION
# Summary

## Changes

Extracted the duplicate `IConfigService` no-op implementations from `FileLinkHelperTests.TestConfigService` and `PlanContentHelpersTests.StubConfigService` into a single shared `TestHelpers/StubConfigService` class. Both test files now reference the shared class, eliminating 33 lines of duplication.

## API Changes

- New public class: `Ivy.Tendril.Test.TestHelpers.StubConfigService` (implements `IConfigService` with no-op defaults)
- Removed: private `TestConfigService` class from `FileLinkHelperTests`
- Removed: private `StubConfigService` class from `PlanContentHelpersTests`

## Files Modified

- **New:** `src/tendril/Ivy.Tendril.Test/TestHelpers/StubConfigService.cs` — shared no-op IConfigService implementation
- **Modified:** `src/tendril/Ivy.Tendril.Test/Services/FileLinkHelperTests.cs` — replaced private TestConfigService with shared StubConfigService
- **Modified:** `src/tendril/Ivy.Tendril.Test/PlanContentHelpersTests.cs` — replaced private StubConfigService with shared StubConfigService

## Commits

- fc560119d