### PR TITLE
[03135] [Regression] Add tooltip value formatting to cartesian charts

### DIFF
--- a/src/frontend/src/widgets/charts/AreaChartWidget.tsx
+++ b/src/frontend/src/widgets/charts/AreaChartWidget.tsx
@@ -12,6 +12,7 @@ import {
   generateYAxis,
   getColors,
   getTransformValueFn,
+  formatTooltipValue,
 } from "./sharedUtils";
 import { getHeight, getWidth } from "@/lib/styles";
 import { useThemeWithMonitoring } from "@/components/theme-provider";
@@ -186,12 +187,26 @@ const AreaChartWidget: React.FC<AreaChartWidgetProps> = ({
     () => ({
       grid: generateEChartGrid(cartesianGrid, !!toolbox && toolbox.enabled !== false, yAxis, xAxis),
       color: chartColors,
-      tooltip: generateTooltip(tooltip, "cross", {
-        foreground: themeColors.foreground,
-        fontSans: themeColors.fontSans,
-        background: themeColors.background,
-        mutedForeground: themeColors.mutedForeground,
-      }),
+      tooltip: {
+        ...generateTooltip(tooltip, "cross", {
+          foreground: themeColors.foreground,
+          fontSans: themeColors.fontSans,
+          background: themeColors.background,
+          mutedForeground: themeColors.mutedForeground,
+        }),
+        formatter: (params: any) => {
+          if (Array.isArray(params)) {
+            return params
+              .map((p) => {
+                const value = formatTooltipValue(p.value[isVertical ? 0 : 1], tooltip);
+                return `${p.marker} ${p.seriesName}: <strong>${value}</strong>`;
+              })
+              .join("<br/>");
+          }
+          const value = formatTooltipValue(params.value[isVertical ? 0 : 1], tooltip);
+          return `${params.marker} ${params.seriesName}: <strong>${value}</strong>`;
+        },
+      },
       legend: generateEChartLegend(legend, {
         foreground: themeColors.foreground,
         fontSans: themeColors.fontSans,

--- a/src/frontend/src/widgets/charts/BarChartWidget.tsx
+++ b/src/frontend/src/widgets/charts/BarChartWidget.tsx
@@ -11,6 +11,7 @@ import {
   generateXAxis,
   generateYAxis,
   getColors,
+  formatTooltipValue,
 } from "./sharedUtils";
 import { useThemeWithMonitoring } from "@/components/theme-provider";
 import { getHeight, getWidth } from "@/lib/styles";
@@ -240,12 +241,26 @@ const BarChartWidget: React.FC<BarChartWidgetProps> = ({
         foreground: themeColors.foreground,
         fontSans: themeColors.fontSans,
       }),
-      tooltip: generateTooltip(tooltip, "shadow", {
-        foreground: themeColors.foreground,
-        fontSans: themeColors.fontSans,
-        background: themeColors.background,
-        mutedForeground: themeColors.mutedForeground,
-      }),
+      tooltip: {
+        ...generateTooltip(tooltip, "shadow", {
+          foreground: themeColors.foreground,
+          fontSans: themeColors.fontSans,
+          background: themeColors.background,
+          mutedForeground: themeColors.mutedForeground,
+        }),
+        formatter: (params: any) => {
+          if (Array.isArray(params)) {
+            return params
+              .map((p) => {
+                const value = formatTooltipValue(p.value[isVertical ? 0 : 1], tooltip);
+                return `${p.marker} ${p.seriesName}: <strong>${value}</strong>`;
+              })
+              .join("<br/>");
+          }
+          const value = formatTooltipValue(params.value[isVertical ? 0 : 1], tooltip);
+          return `${params.marker} ${params.seriesName}: <strong>${value}</strong>`;
+        },
+      },
       toolbox: generateEChartToolbox(toolbox),
     }),
     [

--- a/src/frontend/src/widgets/charts/LineChartWidget.tsx
+++ b/src/frontend/src/widgets/charts/LineChartWidget.tsx
@@ -14,6 +14,7 @@ import {
   getColors,
   getTransformValueFn,
   generateEChartToolbox,
+  formatTooltipValue,
 } from "./sharedUtils";
 import { getChartThemeColors } from "./styles";
 import { LineChartWidgetProps, ChartType } from "./chartTypes";
@@ -100,12 +101,26 @@ const LineChartWidget: React.FC<LineChartWidgetProps> = ({
         },
         cartesianGrid,
       ),
-      tooltip: generateTooltip(tooltip, "shadow", {
-        foreground: themeColors.foreground,
-        fontSans: themeColors.fontSans,
-        background: themeColors.background,
-        mutedForeground: themeColors.mutedForeground,
-      }),
+      tooltip: {
+        ...generateTooltip(tooltip, "shadow", {
+          foreground: themeColors.foreground,
+          fontSans: themeColors.fontSans,
+          background: themeColors.background,
+          mutedForeground: themeColors.mutedForeground,
+        }),
+        formatter: (params: any) => {
+          if (Array.isArray(params)) {
+            return params
+              .map((p) => {
+                const value = formatTooltipValue(p.value[isVertical ? 0 : 1], tooltip);
+                return `${p.marker} ${p.seriesName}: <strong>${value}</strong>`;
+              })
+              .join("<br/>");
+          }
+          const value = formatTooltipValue(params.value[isVertical ? 0 : 1], tooltip);
+          return `${params.marker} ${params.seriesName}: <strong>${value}</strong>`;
+        },
+      },
       toolbox: generateEChartToolbox(toolbox),
       legend: generateEChartLegend(legend, {
         foreground: themeColors.foreground,

--- a/src/frontend/src/widgets/charts/ScatterChartWidget.tsx
+++ b/src/frontend/src/widgets/charts/ScatterChartWidget.tsx
@@ -10,6 +10,7 @@ import {
   generateTextStyle,
   getColors,
   generateEChartToolbox,
+  formatTooltipValue,
 } from "./sharedUtils";
 import { getChartThemeColors, type ChartThemeColors } from "./styles";
 import {
@@ -378,12 +379,19 @@ const ScatterChartWidget: React.FC<ScatterChartWidgetProps> = ({
         mutedForeground: themeColors.mutedForeground,
         fontSans: themeColors.fontSans,
       }),
-      tooltip: generateTooltip(tooltip, "item", {
-        foreground: themeColors.foreground,
-        fontSans: themeColors.fontSans,
-        background: themeColors.background,
-        mutedForeground: themeColors.mutedForeground,
-      }),
+      tooltip: {
+        ...generateTooltip(tooltip, "item", {
+          foreground: themeColors.foreground,
+          fontSans: themeColors.fontSans,
+          background: themeColors.background,
+          mutedForeground: themeColors.mutedForeground,
+        }),
+        formatter: (params: any) => {
+          const xValue = formatTooltipValue(params.value[0], tooltip);
+          const yValue = formatTooltipValue(params.value[1], tooltip);
+          return `${params.marker} ${params.seriesName}<br/>X: ${xValue}<br/>Y: <strong>${yValue}</strong>`;
+        },
+      },
       toolbox: generateEChartToolbox(toolbox),
       legend: generateEChartLegend(legend, {
         foreground: themeColors.foreground,


### PR DESCRIPTION
# Summary

## Changes

Restored tooltip value formatting to cartesian charts (Bar, Line, Area, Scatter) by adding custom tooltip `formatter` callbacks that use the existing `formatTooltipValue()` helper. This applies `ChartTooltip.ValueFormat` to tooltip values, matching the pattern already used in non-cartesian charts (Pie, Funnel, Sankey).

## API Changes

None. No new public APIs — this restores existing `ChartTooltip.ValueFormat` behavior to cartesian chart tooltips.

## Files Modified

- **Chart widgets (tooltip formatting):**
  - `src/frontend/src/widgets/charts/LineChartWidget.tsx` — added `formatTooltipValue` import and custom tooltip formatter
  - `src/frontend/src/widgets/charts/BarChartWidget.tsx` — added `formatTooltipValue` import and custom tooltip formatter
  - `src/frontend/src/widgets/charts/AreaChartWidget.tsx` — added `formatTooltipValue` import and custom tooltip formatter
  - `src/frontend/src/widgets/charts/ScatterChartWidget.tsx` — added `formatTooltipValue` import and custom tooltip formatter (X+Y format)

---

## Commits

- ec969b993 [03135] Add tooltip value formatting to cartesian charts