### PR TITLE
[03118] Add widget affix examples to input sample apps

### DIFF
--- a/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/NumberInputApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/NumberInputApp.cs
@@ -220,7 +220,22 @@ public class NumberInputPrefixSuffixTab : ViewBase
                  .Suffix("%")
                  .Precision(2)
                  .TestId("number-input-suffix-percent")
-               | Text.Monospaced(percentValue.Value.ToString("F2"));
+               | Text.Monospaced(percentValue.Value.ToString("F2"))
+
+               | Text.Block("Badge Prefix (currency)")
+               | priceValue
+                 .ToNumberInput()
+                 .Prefix(new Badge("USD", BadgeVariant.Info))
+                 .Precision(2)
+                 .TestId("number-input-prefix-badge")
+               | Text.Monospaced(priceValue.Value.ToString("F2"))
+
+               | Text.Block("Button Suffix (info)")
+               | temperatureValue
+                 .ToNumberInput()
+                 .Suffix(new Button("Info", () => { }, icon: Icons.Info).Ghost().Small())
+                 .TestId("number-input-suffix-button")
+               | Text.Monospaced(temperatureValue.Value.ToString());
     }
 }
 

--- a/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/NumberRangeInputApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/NumberRangeInputApp.cs
@@ -287,7 +287,17 @@ public class NumberRangeInputPrefixSuffixTab : ViewBase
                    .Prefix(Icons.Thermometer)
                    .Suffix("°C")
                    .TestId("numberrange-input-icon-prefix")
-               | Text.Monospaced($"{intRange.Value.Item1}°C - {intRange.Value.Item2}°C");
+               | Text.Monospaced($"{intRange.Value.Item1}°C - {intRange.Value.Item2}°C")
+
+               | Text.Block("Button Prefix + Badge Suffix")
+               | intRange
+                   .ToNumberRangeInput()
+                   .Min(0)
+                   .Max(100)
+                   .Prefix(new Button("Reset", () => { intRange.Value = (25, 75); }).Ghost().Small())
+                   .Suffix(new Badge($"{intRange.Value.Item2 - intRange.Value.Item1} range", BadgeVariant.Secondary))
+                   .TestId("numberrange-input-widget-affixes")
+               | Text.Monospaced($"Spread: {intRange.Value.Item2 - intRange.Value.Item1}");
     }
 }
 

--- a/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/TextInputApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/TextInputApp.cs
@@ -261,6 +261,16 @@ public class TextInputAffixes : ViewBase
                | textState.ToTextInput().Suffix(Icons.Mail)
                | textState.ToTextInput().Prefix(Icons.Mail).Suffix(Icons.Mail)
 
+               | Text.Monospaced("Button prefix/suffix")
+               | textState.ToTextInput().Prefix(new Button("Copy", () => { }, icon: Icons.Copy).Ghost().Small())
+               | textState.ToTextInput().Suffix(new Button("Clear", () => { textState.Value = ""; }).Ghost().Small())
+               | textState.ToTextInput().Prefix(new Button("Copy", () => { }, icon: Icons.Copy).Ghost().Small()).Suffix(new Button("Send").Ghost().Small())
+
+               | Text.Monospaced("Badge prefix/suffix")
+               | textState.ToTextInput().Prefix(new Badge("NEW", BadgeVariant.Success))
+               | textState.ToTextInput().Suffix(new Badge($"{textState.Value.Length} chars", BadgeVariant.Secondary))
+               | textState.ToTextInput().Prefix(new Badge("v2", BadgeVariant.Info)).Suffix(new Badge("OK", BadgeVariant.Success))
+
                | Text.Monospaced("Nullable with prefix/suffix")
                | nullableState.ToTextInput().Prefix("$").Placeholder("Amount")
                | nullableState.ToTextInput().Suffix("%").Placeholder("Percentage")


### PR DESCRIPTION
# Summary

## Changes

Added widget affix examples (Button and Badge) to the TextInput, NumberInput, and NumberRangeInput sample apps, demonstrating that the `Prefix()` and `Suffix()` methods accept any widget, not just strings and icons.

## API Changes

None.

## Files Modified

- **Sample apps:**
  - `src/Ivy.Samples.Shared/Apps/Widgets/Inputs/TextInputApp.cs` — Added "Button prefix/suffix" and "Badge prefix/suffix" rows to TextInputAffixes grid
  - `src/Ivy.Samples.Shared/Apps/Widgets/Inputs/NumberInputApp.cs` — Added "Badge Prefix (currency)" and "Button Suffix (info)" rows to NumberInputPrefixSuffixTab grid
  - `src/Ivy.Samples.Shared/Apps/Widgets/Inputs/NumberRangeInputApp.cs` — Added "Button Prefix + Badge Suffix" row to NumberRangeInputPrefixSuffixTab grid

## Commits

- 1cef3a727 [03118] Add widget affix examples to input sample apps