### PR TITLE
[03123] Add Rerun dialog with clean option

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/RerunDialogTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/RerunDialogTests.cs
@@ -1,0 +1,106 @@
+using Ivy.Tendril.Apps.Review.Dialogs;
+
+namespace Ivy.Tendril.Test;
+
+public class RerunDialogTests
+{
+    [Fact]
+    public void CleanPlanState_DeletesArtifactsAndLogs()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"ivy-test-{Guid.NewGuid()}");
+        try
+        {
+            var planDir = Path.Combine(tempDir, "00001-TestPlan");
+            var artifactsDir = Path.Combine(planDir, "artifacts");
+            var logsDir = Path.Combine(planDir, "logs");
+            Directory.CreateDirectory(artifactsDir);
+            Directory.CreateDirectory(logsDir);
+            File.WriteAllText(Path.Combine(artifactsDir, "summary.md"), "test");
+            File.WriteAllText(Path.Combine(logsDir, "001.md"), "test");
+
+            RerunDialog.CleanPlanState(planDir);
+
+            Assert.False(Directory.Exists(artifactsDir));
+            Assert.False(Directory.Exists(logsDir));
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void CleanPlanState_HandlesNonExistentDirectories()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"ivy-test-{Guid.NewGuid()}");
+        try
+        {
+            var planDir = Path.Combine(tempDir, "00001-TestPlan");
+            Directory.CreateDirectory(planDir);
+
+            var ex = Record.Exception(() => RerunDialog.CleanPlanState(planDir));
+            Assert.Null(ex);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void CleanPlanState_PreservesOtherDirectories()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"ivy-test-{Guid.NewGuid()}");
+        try
+        {
+            var planDir = Path.Combine(tempDir, "00001-TestPlan");
+            var artifactsDir = Path.Combine(planDir, "artifacts");
+            var logsDir = Path.Combine(planDir, "logs");
+            var verificationDir = Path.Combine(planDir, "verification");
+            var revisionsDir = Path.Combine(planDir, "revisions");
+            Directory.CreateDirectory(artifactsDir);
+            Directory.CreateDirectory(logsDir);
+            Directory.CreateDirectory(verificationDir);
+            Directory.CreateDirectory(revisionsDir);
+
+            RerunDialog.CleanPlanState(planDir);
+
+            Assert.False(Directory.Exists(artifactsDir));
+            Assert.False(Directory.Exists(logsDir));
+            Assert.True(Directory.Exists(verificationDir));
+            Assert.True(Directory.Exists(revisionsDir));
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void CleanPlanState_DeletesNestedArtifacts()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"ivy-test-{Guid.NewGuid()}");
+        try
+        {
+            var planDir = Path.Combine(tempDir, "00001-TestPlan");
+            var screenshotsDir = Path.Combine(planDir, "artifacts", "screenshots");
+            var sampleDir = Path.Combine(planDir, "artifacts", "sample", "bin");
+            Directory.CreateDirectory(screenshotsDir);
+            Directory.CreateDirectory(sampleDir);
+            File.WriteAllText(Path.Combine(screenshotsDir, "img.png"), "test");
+            File.WriteAllText(Path.Combine(sampleDir, "app.dll"), "test");
+
+            RerunDialog.CleanPlanState(planDir);
+
+            Assert.False(Directory.Exists(Path.Combine(planDir, "artifacts")));
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+}

--- a/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -38,6 +38,7 @@ public class ContentView(
         var suggestChangesOpen = UseState(false);
         var suggestChangesText = UseState("");
         var customPrOpen = UseState(false);
+        var rerunDialogOpen = UseState(false);
 
         var githubService = UseService<IGithubService>();
         var assigneesQuery = UseQuery<string[], string>(
@@ -463,14 +464,14 @@ public class ContentView(
         // Discard confirmation dialog
         content |= new DiscardPlanDialog(discardDialogOpen, _selectedPlan, _planService, _refreshPlans);
 
+        // Rerun dialog
+        content |= new RerunDialog(rerunDialogOpen, _selectedPlan, _jobService, _planService, _refreshPlans);
+
         // Action bar
         var actionBar = Layout.Horizontal().AlignContent(Align.Center).Gap(2).Padding(1)
                         | new Button("Rerun").Icon(Icons.RotateCw).Outline().ShortcutKey("r").OnClick(() =>
                         {
-                            _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Building);
-                            _jobService.StartJob("ExecutePlan", _selectedPlan.FolderPath, "-Note",
-                                "User requested you to execute this plan another time. Go through all code, verifications and artifacts one more time.");
-                            _refreshPlans();
+                            rerunDialogOpen.Set(true);
                         })
                         | new Button("Suggest Changes").Icon(Icons.MessageSquare).Outline().OnClick(() =>
                         {

--- a/src/tendril/Ivy.Tendril/Apps/Review/Dialogs/RerunDialog.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Review/Dialogs/RerunDialog.cs
@@ -1,0 +1,78 @@
+using Ivy.Tendril.Apps.Plans;
+using Ivy.Tendril.Services;
+using Microsoft.Extensions.Logging;
+
+namespace Ivy.Tendril.Apps.Review.Dialogs;
+
+public class RerunDialog(
+    IState<bool> dialogOpen,
+    PlanFile selectedPlan,
+    IJobService jobService,
+    IPlanReaderService planService,
+    Action refreshPlans) : ViewBase
+{
+    private readonly IState<bool> _dialogOpen = dialogOpen;
+    private readonly IJobService _jobService = jobService;
+    private readonly IPlanReaderService _planService = planService;
+    private readonly Action _refreshPlans = refreshPlans;
+    private readonly PlanFile _selectedPlan = selectedPlan;
+
+    public override object? Build()
+    {
+        var logger = UseService<ILogger<RerunDialog>>();
+
+        if (!_dialogOpen.Value) return null;
+
+        return new Dialog(
+            _ => _dialogOpen.Set(false),
+            new DialogHeader($"Rerun Plan #{_selectedPlan.Id}"),
+            new DialogBody(
+                Text.P("How would you like to rerun this plan?")
+            ),
+            new DialogFooter(
+                new Button("Cancel").Outline().ShortcutKey("Escape").OnClick(() => _dialogOpen.Set(false)),
+                new Button("Rerun from Scratch").Warning().OnClick(() =>
+                {
+                    _dialogOpen.Set(false);
+                    _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Building);
+                    _refreshPlans();
+
+                    var folderPath = _selectedPlan.FolderPath;
+                    Task.Run(() =>
+                    {
+                        CleanPlanState(folderPath, logger);
+                        _jobService.StartJob("ExecutePlan", folderPath, "-Note",
+                            "User requested a clean rerun. All artifacts, logs, and worktrees have been cleaned. Execute this plan from scratch.");
+                    });
+                }),
+                new Button("Rerun with Current").Primary().ShortcutKey("Enter").AutoFocus().OnClick(() =>
+                {
+                    _dialogOpen.Set(false);
+                    _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Building);
+                    _jobService.StartJob("ExecutePlan", _selectedPlan.FolderPath, "-Note",
+                        "User requested you to execute this plan another time. Go through all code, verifications and artifacts one more time.");
+                    _refreshPlans();
+                })
+            )
+        ).Width(Size.Rem(40));
+    }
+
+    internal static void CleanPlanState(string planFolderPath, ILogger? logger = null)
+    {
+        var artifactsDir = Path.Combine(planFolderPath, "artifacts");
+        if (Directory.Exists(artifactsDir))
+        {
+            logger?.LogInformation("Cleaning artifacts directory: {Path}", artifactsDir);
+            WorktreeCleanupService.ForceDeleteDirectory(artifactsDir, logger);
+        }
+
+        var logsDir = Path.Combine(planFolderPath, "logs");
+        if (Directory.Exists(logsDir))
+        {
+            logger?.LogInformation("Cleaning logs directory: {Path}", logsDir);
+            WorktreeCleanupService.ForceDeleteDirectory(logsDir, logger);
+        }
+
+        PlanReaderService.RemoveWorktrees(planFolderPath, logger);
+    }
+}


### PR DESCRIPTION
# Summary

## Changes

Added a Rerun dialog to the Review app that replaces the direct "Rerun" button handler. Users now get three options: Cancel, Rerun from Scratch (cleans artifacts, logs, and worktrees before re-executing), and Rerun with Current (preserves existing state). The "Rerun from Scratch" option runs cleanup in a background task before starting ExecutePlan.

## API Changes

- New class `RerunDialog` in `Ivy.Tendril.Apps.Review.Dialogs` — dialog component with Cancel, Rerun from Scratch, and Rerun with Current buttons
- New static method `RerunDialog.CleanPlanState(string planFolderPath, ILogger? logger)` — deletes artifacts/, logs/, and removes worktrees for a plan folder

## Files Modified

- **New:** `src/tendril/Ivy.Tendril/Apps/Review/Dialogs/RerunDialog.cs` — dialog with three-option rerun flow
- **Modified:** `src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs` — replaced direct rerun handler with dialog open, added RerunDialog to content
- **New:** `src/tendril/Ivy.Tendril.Test/RerunDialogTests.cs` — 4 tests for CleanPlanState cleanup logic

## Commits

- 25a190b3f [03123] Add Rerun dialog with clean option