### PR TITLE
[03146] Fix Rerun plan in Jobs creating New Plan item

### DIFF
--- a/src/tendril/Ivy.Tendril/Database/Migrations/Migration_009_JobsArgs.cs
+++ b/src/tendril/Ivy.Tendril/Database/Migrations/Migration_009_JobsArgs.cs
@@ -1,0 +1,20 @@
+using Microsoft.Data.Sqlite;
+
+namespace Ivy.Tendril.Database.Migrations;
+
+public class Migration_009_JobsArgs : IMigration
+{
+    public int Version => 9;
+    public string Description => "Add Args column to Jobs table";
+
+    public void Apply(SqliteConnection connection)
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "ALTER TABLE Jobs ADD COLUMN Args TEXT;";
+        cmd.ExecuteNonQuery();
+
+        using var setVersionCmd = connection.CreateCommand();
+        setVersionCmd.CommandText = "PRAGMA user_version = 9;";
+        setVersionCmd.ExecuteNonQuery();
+    }
+}

--- a/src/tendril/Ivy.Tendril/Services/PlanDatabaseService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanDatabaseService.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using Ivy.Tendril.Apps.Jobs;
 using Ivy.Tendril.Apps.Plans;
@@ -878,8 +879,8 @@ public class PlanDatabaseService : IPlanDatabaseService
         {
             using var cmd = _connection.CreateCommand();
             cmd.CommandText = """
-                              INSERT OR REPLACE INTO Jobs (Id, Type, PlanFile, Project, Status, Provider, SessionId, StartedAt, CompletedAt, DurationSeconds, Cost, Tokens, StatusMessage)
-                              VALUES (@id, @type, @planFile, @project, @status, @provider, @sessionId, @startedAt, @completedAt, @durationSeconds, @cost, @tokens, @statusMessage)
+                              INSERT OR REPLACE INTO Jobs (Id, Type, PlanFile, Project, Status, Provider, SessionId, StartedAt, CompletedAt, DurationSeconds, Cost, Tokens, StatusMessage, Args)
+                              VALUES (@id, @type, @planFile, @project, @status, @provider, @sessionId, @startedAt, @completedAt, @durationSeconds, @cost, @tokens, @statusMessage, @args)
                               """;
             cmd.Parameters.AddWithValue("@id", job.Id);
             cmd.Parameters.AddWithValue("@type", job.Type);
@@ -896,6 +897,7 @@ public class PlanDatabaseService : IPlanDatabaseService
             cmd.Parameters.AddWithValue("@cost", job.Cost.HasValue ? (double)job.Cost.Value : DBNull.Value);
             cmd.Parameters.AddWithValue("@tokens", (object?)job.Tokens ?? DBNull.Value);
             cmd.Parameters.AddWithValue("@statusMessage", (object?)job.StatusMessage ?? DBNull.Value);
+            cmd.Parameters.AddWithValue("@args", job.Args.Length > 0 ? JsonSerializer.Serialize(job.Args) : (object)DBNull.Value);
             cmd.ExecuteNonQuery();
         }
         finally
@@ -946,7 +948,10 @@ public class PlanDatabaseService : IPlanDatabaseService
                         : reader.GetInt32(reader.GetOrdinal("Tokens")),
                     StatusMessage = reader.IsDBNull(reader.GetOrdinal("StatusMessage"))
                         ? null
-                        : reader.GetString(reader.GetOrdinal("StatusMessage"))
+                        : reader.GetString(reader.GetOrdinal("StatusMessage")),
+                    Args = reader.IsDBNull(reader.GetOrdinal("Args"))
+                        ? []
+                        : JsonSerializer.Deserialize<string[]>(reader.GetString(reader.GetOrdinal("Args"))) ?? []
                 });
             return jobs;
         }


### PR DESCRIPTION
# Summary

## Changes

Added database persistence for job Args so that rerunning a MakePlan job preserves the original task description instead of falling back to "New Plan". Created Migration_009_JobsArgs to add an `Args TEXT` column to the Jobs table, and updated `UpsertJob`/`GetRecentJobs` in PlanDatabaseService to serialize/deserialize Args as JSON.

## API Changes

None.

## Files Modified

- **New:** `src/tendril/Ivy.Tendril/Database/Migrations/Migration_009_JobsArgs.cs` — migration adding Args column
- **Modified:** `src/tendril/Ivy.Tendril/Services/PlanDatabaseService.cs` — UpsertJob now persists Args as JSON; GetRecentJobs now reads Args back

## Commits

- 70ed30dc0 [03146] Persist job Args in database for Rerun support