### PR TITLE
[00001] Upgrade axios to >= 1.15.0 to fix CVE-2026-40175 (CRLF header injection)

### DIFF
--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -141,6 +141,7 @@
   "pnpm": {
     "overrides": {
       "@swc/helpers": "0.5.17",
+      "axios": "1.15.0",
       "dompurify": "3.3.2",
       "lodash-es": "4.18.1",
       "minimatch": "9.0.7",

--- a/src/frontend/pnpm-lock.yaml
+++ b/src/frontend/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   '@swc/helpers': 0.5.17
+  axios: 1.15.0
   dompurify: 3.3.2
   lodash-es: 4.18.1
   minimatch: 9.0.7
@@ -1974,8 +1975,8 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  axios@1.14.0:
-    resolution: {integrity: sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==}
+  axios@1.15.0:
+    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
 
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
@@ -5285,7 +5286,7 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  axios@1.14.0(debug@4.4.3):
+  axios@1.15.0(debug@4.4.3):
     dependencies:
       follow-redirects: 1.15.11(debug@4.4.3)
       form-data: 4.0.5
@@ -7237,7 +7238,7 @@ snapshots:
 
   vite-plugin-mkcert@1.17.10(@voidzero-dev/vite-plus-core@0.1.13(@types/node@24.10.0)(jiti@2.6.1)(typescript@5.9.3)(yaml@2.8.3)):
     dependencies:
-      axios: 1.14.0(debug@4.4.3)
+      axios: 1.15.0(debug@4.4.3)
       debug: 4.4.3
       picocolors: 1.1.1
       vite: '@voidzero-dev/vite-plus-core@0.1.13(@types/node@24.10.0)(jiti@2.6.1)(typescript@5.9.3)(yaml@2.8.3)'


### PR DESCRIPTION
## Summary

Added `"axios": "1.15.0"` to the `pnpm.overrides` block in `src/frontend/package.json` and regenerated `pnpm-lock.yaml`. This pins the transitive axios dependency (via `vite-plugin-mkcert`) to version 1.15.0, resolving CVE-2026-40175 (CRLF header injection, CVSS 9.9).

## API Changes

None.

## Files Modified

- `src/frontend/package.json` — added axios override to existing `pnpm.overrides` block
- `src/frontend/pnpm-lock.yaml` — regenerated lockfile reflecting axios 1.14.0 -> 1.15.0

## Commits

- c8746c731 [00001] Pin axios to 1.15.0 via pnpm.overrides to fix CVE-2026-40175