### PR TITLE
[00003] Fix missing slash in basePath URL construction for auth redirects

### DIFF
--- a/src/Ivy.Test/BasePathFilterTests.cs
+++ b/src/Ivy.Test/BasePathFilterTests.cs
@@ -1,0 +1,89 @@
+using System.Xml.Linq;
+using Ivy.Core.Server.HtmlPipeline;
+using Ivy.Core.Server.HtmlPipeline.Filters;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Ivy.Test;
+
+public class BasePathFilterTests
+{
+    private static XDocument CreateHtmlDocument()
+    {
+        return XDocument.Parse("<html><head></head><body></body></html>");
+    }
+
+    private static HtmlPipelineContext CreateContext(string? basePath)
+    {
+        var args = new ServerArgs { BasePath = basePath };
+        return new HtmlPipelineContext
+        {
+            ServerArgs = args,
+            Services = new ServiceCollection().BuildServiceProvider()
+        };
+    }
+
+    [Fact]
+    public void Process_NoBasePath_InjectsBaseHrefSlash()
+    {
+        var doc = CreateHtmlDocument();
+        var filter = new BasePathFilter();
+        filter.Process(CreateContext(null), doc);
+
+        var head = doc.Root!.Element("head")!;
+        var baseEl = head.Element("base");
+        Assert.NotNull(baseEl);
+        Assert.Equal("/", baseEl.Attribute("href")!.Value);
+    }
+
+    [Fact]
+    public void Process_WithBasePath_InjectsLeadingSlashInMetaTag()
+    {
+        var doc = CreateHtmlDocument();
+        var filter = new BasePathFilter();
+        filter.Process(CreateContext("/ivy"), doc);
+
+        var head = doc.Root!.Element("head")!;
+        var meta = head.Elements("meta").FirstOrDefault(m => m.Attribute("name")?.Value == "ivy-path-base");
+        Assert.NotNull(meta);
+        Assert.Equal("/ivy", meta.Attribute("content")!.Value);
+    }
+
+    [Fact]
+    public void Process_WithBasePathNoLeadingSlash_StillGetsLeadingSlash()
+    {
+        var doc = CreateHtmlDocument();
+        var filter = new BasePathFilter();
+        filter.Process(CreateContext("ivy"), doc);
+
+        var head = doc.Root!.Element("head")!;
+        var meta = head.Elements("meta").FirstOrDefault(m => m.Attribute("name")?.Value == "ivy-path-base");
+        Assert.NotNull(meta);
+        Assert.Equal("/ivy", meta.Attribute("content")!.Value);
+    }
+
+    [Fact]
+    public void Process_WithBasePathTrailingSlash_TrimsTrailingSlash()
+    {
+        var doc = CreateHtmlDocument();
+        var filter = new BasePathFilter();
+        filter.Process(CreateContext("/studio/"), doc);
+
+        var head = doc.Root!.Element("head")!;
+        var meta = head.Elements("meta").FirstOrDefault(m => m.Attribute("name")?.Value == "ivy-path-base");
+        Assert.NotNull(meta);
+        Assert.Equal("/studio", meta.Attribute("content")!.Value);
+    }
+
+    [Fact]
+    public void Process_WithBasePath_BaseHrefHasTrailingSlash()
+    {
+        var doc = CreateHtmlDocument();
+        var filter = new BasePathFilter();
+        filter.Process(CreateContext("/ivy"), doc);
+
+        var head = doc.Root!.Element("head")!;
+        var baseEl = head.Element("base");
+        Assert.NotNull(baseEl);
+        Assert.Equal("/ivy/", baseEl.Attribute("href")!.Value);
+    }
+}

--- a/src/Ivy.Test/WebhookEndpointTests.cs
+++ b/src/Ivy.Test/WebhookEndpointTests.cs
@@ -1,0 +1,76 @@
+using Ivy.Core;
+
+namespace Ivy.Test;
+
+public class WebhookEndpointTests
+{
+    [Fact]
+    public void BuildWebhookBaseUrl_NoBasePath_ReturnsUrlWithoutBasePath()
+    {
+        var result = WebhookEndpoint.BuildWebhookBaseUrl("https", "example.com");
+        Assert.Equal("https://example.com/ivy/webhook", result);
+    }
+
+    [Fact]
+    public void BuildWebhookBaseUrl_WithLeadingSlash_ReturnsCorrectUrl()
+    {
+        var result = WebhookEndpoint.BuildWebhookBaseUrl("https", "example.com", "/ivy");
+        Assert.Equal("https://example.com/ivy/ivy/webhook", result);
+    }
+
+    [Fact]
+    public void BuildWebhookBaseUrl_WithoutLeadingSlash_ReturnsCorrectUrl()
+    {
+        var result = WebhookEndpoint.BuildWebhookBaseUrl("https", "example.com", "ivy");
+        Assert.Equal("https://example.com/ivy/ivy/webhook", result);
+    }
+
+    [Fact]
+    public void BuildWebhookBaseUrl_WithTrailingSlash_ReturnsCorrectUrl()
+    {
+        var result = WebhookEndpoint.BuildWebhookBaseUrl("https", "example.com", "/ivy/");
+        Assert.Equal("https://example.com/ivy/ivy/webhook", result);
+    }
+
+    [Fact]
+    public void BuildAuthCallbackBaseUrl_NoBasePath_ReturnsUrlWithoutBasePath()
+    {
+        var result = WebhookEndpoint.BuildAuthCallbackBaseUrl("https", "example.com");
+        Assert.Equal("https://example.com/ivy/auth/callback", result);
+    }
+
+    [Fact]
+    public void BuildAuthCallbackBaseUrl_WithLeadingSlash_ReturnsCorrectUrl()
+    {
+        var result = WebhookEndpoint.BuildAuthCallbackBaseUrl("https", "example.com", "/ivy");
+        Assert.Equal("https://example.com/ivy/ivy/auth/callback", result);
+    }
+
+    [Fact]
+    public void BuildAuthCallbackBaseUrl_WithoutLeadingSlash_ReturnsCorrectUrl()
+    {
+        var result = WebhookEndpoint.BuildAuthCallbackBaseUrl("https", "example.com", "ivy");
+        Assert.Equal("https://example.com/ivy/ivy/auth/callback", result);
+    }
+
+    [Fact]
+    public void BuildAuthCallbackBaseUrl_WithTrailingSlash_ReturnsCorrectUrl()
+    {
+        var result = WebhookEndpoint.BuildAuthCallbackBaseUrl("https", "example.com", "/ivy/");
+        Assert.Equal("https://example.com/ivy/ivy/auth/callback", result);
+    }
+
+    [Fact]
+    public void BuildWebhookBaseUrl_NullBasePath_ReturnsUrlWithoutBasePath()
+    {
+        var result = WebhookEndpoint.BuildWebhookBaseUrl("https", "sliplane.app", null);
+        Assert.Equal("https://sliplane.app/ivy/webhook", result);
+    }
+
+    [Fact]
+    public void BuildAuthCallbackBaseUrl_NullBasePath_ReturnsUrlWithoutBasePath()
+    {
+        var result = WebhookEndpoint.BuildAuthCallbackBaseUrl("https", "sliplane.app", null);
+        Assert.Equal("https://sliplane.app/ivy/auth/callback", result);
+    }
+}

--- a/src/Ivy/Core/Server/AppHub.cs
+++ b/src/Ivy/Core/Server/AppHub.cs
@@ -64,7 +64,7 @@ public class AppHub(
         var basePath = server.Args?.BasePath;
         if (httpContext.Request.Headers.TryGetValue("X-Forwarded-Prefix", out var forwardedPrefix) && !string.IsNullOrEmpty(forwardedPrefix.ToString()))
         {
-            basePath = forwardedPrefix.ToString().Trim('/');
+            basePath = "/" + forwardedPrefix.ToString().Trim('/');
         }
 
         var requestHost = httpContext.Request.Host.Value!;
@@ -116,7 +116,7 @@ public class AppHub(
             var basePath = server.Args?.BasePath;
             if (httpContext.Request.Headers.TryGetValue("X-Forwarded-Prefix", out var forwardedPrefix) && !string.IsNullOrEmpty(forwardedPrefix.ToString()))
             {
-                basePath = forwardedPrefix.ToString().Trim('/');
+                basePath = "/" + forwardedPrefix.ToString().Trim('/');
             }
 
             var machineId = AppRouter.GetMachineId(httpContext);

--- a/src/Ivy/Core/Server/HtmlPipeline/Filters/BasePathFilter.cs
+++ b/src/Ivy/Core/Server/HtmlPipeline/Filters/BasePathFilter.cs
@@ -30,7 +30,7 @@ public class BasePathFilter : IHtmlFilter
         }
         else
         {
-            var trimmed = basePath.TrimEnd('/');
+            var trimmed = "/" + basePath.Trim('/');
             head.AddFirst(new XElement("meta",
                 new XAttribute("name", "ivy-path-base"),
                 new XAttribute("content", trimmed)));

--- a/src/Ivy/Core/WebhookEndpoint.cs
+++ b/src/Ivy/Core/WebhookEndpoint.cs
@@ -22,10 +22,10 @@ public record WebhookEndpoint
     }
 
     public static string BuildWebhookBaseUrl(string scheme, string host, string? basePath = null)
-        => basePath != null ? $"{scheme}://{host}/{basePath.TrimStart('/')}/ivy/webhook" : $"{scheme}://{host}/ivy/webhook";
+        => basePath != null ? $"{scheme}://{host}/{basePath.Trim('/')}/ivy/webhook" : $"{scheme}://{host}/ivy/webhook";
 
     public static string BuildAuthCallbackBaseUrl(string scheme, string host, string? basePath = null)
-        => basePath != null ? $"{scheme}://{host}/{basePath.TrimStart('/')}/ivy/auth/callback" : $"{scheme}://{host}/ivy/auth/callback";
+        => basePath != null ? $"{scheme}://{host}/{basePath.Trim('/')}/ivy/auth/callback" : $"{scheme}://{host}/ivy/auth/callback";
 
     public Uri GetUri(bool includeIdInPath = true) => includeIdInPath
         ? new Uri($"{BaseUrl}/{Id}")

--- a/src/Ivy/Core/WebhookEndpoint.cs
+++ b/src/Ivy/Core/WebhookEndpoint.cs
@@ -22,10 +22,10 @@ public record WebhookEndpoint
     }
 
     public static string BuildWebhookBaseUrl(string scheme, string host, string? basePath = null)
-        => basePath != null ? $"{scheme}://{host}{basePath}/ivy/webhook" : $"{scheme}://{host}/ivy/webhook";
+        => basePath != null ? $"{scheme}://{host}/{basePath.TrimStart('/')}/ivy/webhook" : $"{scheme}://{host}/ivy/webhook";
 
     public static string BuildAuthCallbackBaseUrl(string scheme, string host, string? basePath = null)
-        => basePath != null ? $"{scheme}://{host}{basePath}/ivy/auth/callback" : $"{scheme}://{host}/ivy/auth/callback";
+        => basePath != null ? $"{scheme}://{host}/{basePath.TrimStart('/')}/ivy/auth/callback" : $"{scheme}://{host}/ivy/auth/callback";
 
     public Uri GetUri(bool includeIdInPath = true) => includeIdInPath
         ? new Uri($"{BaseUrl}/{Id}")

--- a/src/Ivy/Server.cs
+++ b/src/Ivy/Server.cs
@@ -119,7 +119,7 @@ public class Server
 
         if (_args.BasePath == null && Environment.GetEnvironmentVariable("BASE_PATH") is { } basePath)
         {
-            _args = _args with { BasePath = basePath };
+            _args = _args with { BasePath = "/" + basePath.TrimStart('/') };
         }
 
         _args = _args with

--- a/src/frontend/src/lib/utils.test.ts
+++ b/src/frontend/src/lib/utils.test.ts
@@ -955,6 +955,52 @@ describe("getIvyHost", () => {
       expect(utils.getIvyHost()).toBe("https://example.com");
     });
   });
+
+  describe("with ivy-path-base meta tag (base path behind reverse proxy)", () => {
+    const setIvyBasePathMeta = (value: string) => {
+      const meta = document.createElement("meta");
+      meta.setAttribute("name", "ivy-path-base");
+      meta.setAttribute("content", value);
+      document.head.appendChild(meta);
+    };
+
+    it("appends base path with leading slash to origin", () => {
+      setIvyBasePathMeta("/studio");
+      expect(utils.getIvyHost()).toBe(defaultOrigin + "/studio");
+    });
+
+    it("appends base path to meta host origin", () => {
+      const originalOrigin = window.location.origin;
+      Object.defineProperty(window, "location", {
+        value: {
+          ...window.location,
+          origin: "https://example.com",
+          hostname: "example.com",
+        },
+        writable: true,
+        configurable: true,
+      });
+      try {
+        setIvyHostMeta("https://example.com");
+        setIvyBasePathMeta("/ivy");
+        expect(utils.getIvyHost()).toBe("https://example.com/ivy");
+      } finally {
+        Object.defineProperty(window, "location", {
+          value: {
+            ...window.location,
+            origin: originalOrigin,
+          },
+          writable: true,
+          configurable: true,
+        });
+      }
+    });
+
+    it("returns origin without base path when no base path meta", () => {
+      // No ivy-path-base meta tag set
+      expect(utils.getIvyHost()).toBe(defaultOrigin);
+    });
+  });
 });
 
 const mediaValidationCases = [


### PR DESCRIPTION
## Changes

Fixed missing slash in basePath URL construction that caused malformed OAuth redirect URLs when deployed behind a reverse proxy with a base path (e.g. `sliplane.appivy/` instead of `sliplane.app/ivy/`). Normalized basePath to always include a leading slash at the point of storage and added defensive guards in URL construction methods.

## API Changes

None. All changes are internal normalization — no public API surface changed.

## Files Modified

**Bug fix (basePath normalization):**
- `src/Ivy/Core/Server/AppHub.cs` — Both `X-Forwarded-Prefix` read sites now prepend `/` after trimming
- `src/Ivy/Server.cs` — `BASE_PATH` env var normalization adds leading `/`
- `src/Ivy/Core/WebhookEndpoint.cs` — `BuildWebhookBaseUrl` and `BuildAuthCallbackBaseUrl` use `TrimStart('/')` with explicit `/` separator
- `src/Ivy/Core/Server/HtmlPipeline/Filters/BasePathFilter.cs` — Meta tag content now uses `"/" + basePath.Trim('/')` to ensure leading slash

**Tests:**
- `src/Ivy.Test/WebhookEndpointTests.cs` — New: 10 tests covering all basePath variants for webhook and auth callback URL builders
- `src/Ivy.Test/BasePathFilterTests.cs` — New: 5 tests covering BasePathFilter HTML output with various basePath formats
- `src/frontend/src/lib/utils.test.ts` — Added 3 tests for `getIvyHost()` with `ivy-path-base` meta tag

## Commits

- `7de79f7c3`
- `858fe98ed`
- `e7699c3ec`