### PR TITLE
[03151] Add 'doctor plans' subcommand to Tendril CLI

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/DoctorCommandPlansTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/DoctorCommandPlansTests.cs
@@ -1,0 +1,149 @@
+using Ivy.Tendril.Commands;
+
+namespace Ivy.Tendril.Test;
+
+public class DoctorCommandPlansTests : IDisposable
+{
+    private readonly string _plansDir;
+
+    public DoctorCommandPlansTests()
+    {
+        _plansDir = Path.Combine(Path.GetTempPath(), $"tendril-doctor-plans-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_plansDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_plansDir))
+            try { Directory.Delete(_plansDir, true); }
+            catch { /* best effort */ }
+    }
+
+    private string CreatePlan(string folderName, string? yamlContent = null)
+    {
+        var planDir = Path.Combine(_plansDir, folderName);
+        Directory.CreateDirectory(planDir);
+        if (yamlContent != null)
+            File.WriteAllText(Path.Combine(planDir, "plan.yaml"), yamlContent);
+        return planDir;
+    }
+
+    private static readonly string ValidYaml = """
+        state: Completed
+        project: TestProject
+        title: Test Plan
+        repos: []
+        commits: []
+        """;
+
+    [Fact]
+    public void DoctorPlans_HealthyPlan_ReturnsOK()
+    {
+        CreatePlan("00001-HealthyPlan", ValidYaml);
+
+        var results = DoctorCommand.ScanPlans(_plansDir);
+
+        Assert.Single(results);
+        Assert.Equal("00001", results[0].Id);
+        Assert.Equal("HealthyPlan", results[0].Title);
+        Assert.Equal("Completed", results[0].State);
+        Assert.Equal(0, results[0].Worktrees);
+        Assert.Equal("OK", results[0].Health);
+        Assert.True(results[0].IsHealthy);
+    }
+
+    [Fact]
+    public void DoctorPlans_MissingYaml_ReportsError()
+    {
+        CreatePlan("00002-MissingYaml");
+
+        var results = DoctorCommand.ScanPlans(_plansDir);
+
+        Assert.Single(results);
+        Assert.False(results[0].IsHealthy);
+        Assert.Contains("YAML:Missing", results[0].Health);
+        Assert.Equal("Unknown", results[0].State);
+    }
+
+    [Fact]
+    public void DoctorPlans_InvalidYaml_ReportsError()
+    {
+        CreatePlan("00003-InvalidYaml", "title: OnlyTitle\nrepos: []\n");
+
+        var results = DoctorCommand.ScanPlans(_plansDir);
+
+        Assert.Single(results);
+        Assert.False(results[0].IsHealthy);
+        Assert.Contains("YAML:Invalid structure", results[0].Health);
+    }
+
+    [Fact]
+    public void DoctorPlans_WithWorktrees_CountsCorrectly()
+    {
+        var planDir = CreatePlan("00004-WithWorktrees", ValidYaml);
+        var wtDir = Path.Combine(planDir, "worktrees");
+        Directory.CreateDirectory(Path.Combine(wtDir, "RepoA"));
+        Directory.CreateDirectory(Path.Combine(wtDir, "RepoB"));
+
+        var results = DoctorCommand.ScanPlans(_plansDir);
+
+        Assert.Single(results);
+        Assert.Equal(2, results[0].Worktrees);
+        Assert.True(results[0].IsHealthy);
+    }
+
+    [Fact]
+    public void DoctorPlans_NestedWorktree_DetectsIssue()
+    {
+        var planDir = CreatePlan("00005-NestedWt", ValidYaml);
+        var wtRepoDir = Path.Combine(planDir, "worktrees", "SomeRepo");
+        Directory.CreateDirectory(wtRepoDir);
+        File.WriteAllText(Path.Combine(wtRepoDir, ".git"), "gitdir: /some/path");
+
+        var results = DoctorCommand.ScanPlans(_plansDir);
+
+        Assert.Single(results);
+        Assert.False(results[0].IsHealthy);
+        Assert.Contains("NestedWorktree", results[0].Health);
+    }
+
+    [Fact]
+    public void DoctorPlans_UnhealthyFlag_FiltersResults()
+    {
+        CreatePlan("00010-Healthy", ValidYaml);
+        CreatePlan("00011-Broken");
+
+        var allResults = DoctorCommand.ScanPlans(_plansDir);
+        var filtered = allResults.Where(r => !r.IsHealthy).ToList();
+
+        Assert.Equal(2, allResults.Count);
+        Assert.Single(filtered);
+        Assert.Equal("00011", filtered[0].Id);
+    }
+
+    [Fact]
+    public void CheckYamlHealth_EmptyFile_ReportsEmpty()
+    {
+        var path = Path.Combine(_plansDir, "empty.yaml");
+        File.WriteAllText(path, "");
+
+        var (healthy, error, state) = DoctorCommand.CheckYamlHealth(path);
+
+        Assert.False(healthy);
+        Assert.Equal("Empty", error);
+        Assert.Equal("Unknown", state);
+    }
+
+    [Fact]
+    public void CheckYamlHealth_ValidFile_ExtractsState()
+    {
+        var path = Path.Combine(_plansDir, "valid.yaml");
+        File.WriteAllText(path, ValidYaml);
+
+        var (healthy, error, state) = DoctorCommand.CheckYamlHealth(path);
+
+        Assert.True(healthy);
+        Assert.Null(error);
+        Assert.Equal("Completed", state);
+    }
+}

--- a/src/tendril/Ivy.Tendril/Commands/DoctorCommand.cs
+++ b/src/tendril/Ivy.Tendril/Commands/DoctorCommand.cs
@@ -31,6 +31,10 @@ public static class DoctorCommand
     public static int Handle(string[] args)
     {
         if (args.Length == 0 || args[0] != "doctor") return -1;
+
+        if (args.Length > 1 && args[1] == "plans")
+            return DoctorPlans(args.Skip(2).ToArray());
+
         return RunAsync().GetAwaiter().GetResult();
     }
 
@@ -444,5 +448,181 @@ public static class DoctorCommand
         Console.ForegroundColor = color;
         Console.WriteLine(value);
         Console.ResetColor();
+    }
+
+    // --- doctor plans subcommand ---
+
+    internal record PlanHealthResult(
+        string Id,
+        string Title,
+        string State,
+        int Worktrees,
+        string Health,
+        bool IsHealthy
+    );
+
+    internal static int DoctorPlans(string[] args)
+    {
+        var showOnlyUnhealthy = args.Contains("--unhealthy");
+
+        var tendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME")?.Trim();
+        if (string.IsNullOrEmpty(tendrilHome))
+        {
+            Console.Error.WriteLine("TENDRIL_HOME is not set.");
+            return 1;
+        }
+
+        var plansDir = Path.Combine(tendrilHome, "Plans");
+        if (!Directory.Exists(plansDir))
+        {
+            Console.Error.WriteLine($"Plans directory not found: {plansDir}");
+            return 1;
+        }
+
+        Console.WriteLine($"Scanning plans in: {plansDir}");
+        Console.WriteLine();
+
+        var allResults = ScanPlans(plansDir);
+        var results = showOnlyUnhealthy
+            ? allResults.Where(r => !r.IsHealthy).ToList()
+            : allResults;
+
+        PrintPlansTable(results);
+        PrintPlansSummary(allResults);
+
+        return allResults.Any(r => !r.IsHealthy) ? 1 : 0;
+    }
+
+    internal static List<PlanHealthResult> ScanPlans(string plansDir)
+    {
+        var results = new List<PlanHealthResult>();
+
+        var planDirs = Directory.GetDirectories(plansDir)
+            .Where(d => System.Text.RegularExpressions.Regex.IsMatch(Path.GetFileName(d), @"^\d{5}-"))
+            .OrderBy(d => Path.GetFileName(d))
+            .ToList();
+
+        foreach (var dir in planDirs)
+        {
+            var folderName = Path.GetFileName(dir);
+            var match = System.Text.RegularExpressions.Regex.Match(folderName, @"^(\d{5})-(.+)$");
+            var id = match.Success ? match.Groups[1].Value : folderName;
+            var title = match.Success ? match.Groups[2].Value : "";
+
+            var yamlPath = Path.Combine(dir, "plan.yaml");
+            var (yamlHealthy, yamlError, state) = CheckYamlHealth(yamlPath);
+            var worktreeCount = CountWorktrees(dir);
+            var hasNestedWorktree = DetectNestedWorktrees(dir);
+
+            var healthIssues = new List<string>();
+            if (!yamlHealthy)
+                healthIssues.Add($"YAML:{yamlError}");
+            if (hasNestedWorktree)
+                healthIssues.Add("NestedWorktree");
+
+            var health = healthIssues.Count == 0 ? "OK" : string.Join(",", healthIssues);
+
+            results.Add(new PlanHealthResult(id, title, state, worktreeCount, health, healthIssues.Count == 0));
+        }
+
+        return results;
+    }
+
+    internal static (bool Healthy, string? Error, string State) CheckYamlHealth(string yamlPath)
+    {
+        if (!File.Exists(yamlPath))
+            return (false, "Missing", "Unknown");
+
+        try
+        {
+            var content = File.ReadAllText(yamlPath);
+            if (string.IsNullOrWhiteSpace(content))
+                return (false, "Empty", "Unknown");
+
+            if (!content.Contains("state:") || !content.Contains("project:"))
+                return (false, "Invalid structure", "Unknown");
+
+            var state = "Unknown";
+            var stateMatch = System.Text.RegularExpressions.Regex.Match(content, @"state:\s*(\S+)");
+            if (stateMatch.Success)
+                state = stateMatch.Groups[1].Value;
+
+            return (true, null, state);
+        }
+        catch (Exception ex)
+        {
+            return (false, $"Parse error: {ex.Message}", "Unknown");
+        }
+    }
+
+    internal static int CountWorktrees(string planPath)
+    {
+        var worktreesPath = Path.Combine(planPath, "worktrees");
+        if (!Directory.Exists(worktreesPath))
+            return 0;
+
+        return Directory.GetDirectories(worktreesPath).Length;
+    }
+
+    internal static bool DetectNestedWorktrees(string planPath)
+    {
+        var worktreesPath = Path.Combine(planPath, "worktrees");
+        if (!Directory.Exists(worktreesPath))
+            return false;
+
+        foreach (var subDir in Directory.GetDirectories(worktreesPath))
+        {
+            var gitPath = Path.Combine(subDir, ".git");
+            if (File.Exists(gitPath) || Directory.Exists(gitPath))
+                return true;
+        }
+
+        return false;
+    }
+
+    internal static void PrintPlansTable(IEnumerable<PlanHealthResult> results)
+    {
+        const int idWidth = 5;
+        const int planWidth = 33;
+        const int stateWidth = 10;
+        const int wtWidth = 10;
+
+        Console.WriteLine(
+            $"{"Id".PadRight(idWidth)}  {"Plan".PadRight(planWidth)}  {"State".PadRight(stateWidth)}  {"Worktrees".PadRight(wtWidth)}  Health");
+        Console.WriteLine(
+            $"{new string('-', idWidth)}  {new string('-', planWidth)}  {new string('-', stateWidth)}  {new string('-', wtWidth)}  ------");
+
+        foreach (var r in results)
+        {
+            var truncatedTitle = r.Title.Length > planWidth
+                ? r.Title[..(planWidth - 3)] + "..."
+                : r.Title;
+
+            Console.Write($"{r.Id.PadRight(idWidth)}  {truncatedTitle.PadRight(planWidth)}  {r.State.PadRight(stateWidth)}  {r.Worktrees.ToString().PadRight(wtWidth)}  ");
+
+            if (r.IsHealthy)
+            {
+                Console.ForegroundColor = ConsoleColor.Green;
+                Console.WriteLine("OK");
+            }
+            else
+            {
+                Console.ForegroundColor = ConsoleColor.Red;
+                Console.WriteLine(r.Health);
+            }
+
+            Console.ResetColor();
+        }
+    }
+
+    internal static void PrintPlansSummary(List<PlanHealthResult> allResults)
+    {
+        Console.WriteLine();
+        Console.WriteLine("Summary:");
+        Console.WriteLine($"  Total plans: {allResults.Count}");
+        Console.WriteLine($"  Healthy: {allResults.Count(r => r.IsHealthy)}");
+        Console.WriteLine($"  Unhealthy: {allResults.Count(r => !r.IsHealthy)}");
+        Console.WriteLine($"  With worktrees: {allResults.Count(r => r.Worktrees > 0)}");
+        Console.WriteLine($"  Nested worktrees: {allResults.Count(r => r.Health.Contains("NestedWorktree"))}");
     }
 }

--- a/src/tendril/Ivy.Tendril/Promptwares/MakePlan/Tools/Doctor-Plans.ps1
+++ b/src/tendril/Ivy.Tendril/Promptwares/MakePlan/Tools/Doctor-Plans.ps1
@@ -1,3 +1,4 @@
+# Reference implementation for DoctorCommand.DoctorPlans()
 #!/usr/bin/env pwsh
 <#
 .SYNOPSIS


### PR DESCRIPTION
# Summary

## Changes

Added `doctor plans` subcommand to the Tendril CLI by extending `DoctorCommand.cs`. The implementation ports the PowerShell `Doctor-Plans.ps1` prototype to C#, scanning all plan directories for YAML health, worktree counts, and nested worktree detection. Supports `--unhealthy` flag to filter output.

## API Changes

- `DoctorCommand.Handle()` now routes `doctor plans` to `DoctorPlans()` method
- New `DoctorPlans(string[] args)` — entry point for the plans subcommand
- New `ScanPlans(string plansDir)` — scans plan directories and returns health results
- New `CheckYamlHealth(string yamlPath)` — validates plan.yaml existence and structure
- New `CountWorktrees(string planPath)` — counts worktree subdirectories
- New `DetectNestedWorktrees(string planPath)` — detects `.git` files inside worktrees
- New `PlanHealthResult` record — data model for plan health scan results
- New `PrintPlansTable()` / `PrintPlansSummary()` — table/summary output formatters

## Files Modified

- **src/tendril/Ivy.Tendril/Commands/DoctorCommand.cs** — Added `DoctorPlans()` and all supporting methods
- **src/tendril/Ivy.Tendril.Test/DoctorCommandPlansTests.cs** — New test file with 8 test cases
- **src/tendril/Ivy.Tendril/Promptwares/MakePlan/Tools/Doctor-Plans.ps1** — Added reference comment

## Commits

- da9ebb6b0 [03151] Add 'doctor plans' subcommand to Tendril CLI