### PR TITLE
[00010] Lazy-load vendor-mermaid chunk via dynamic import to reduce initial page load

### DIFF
--- a/src/frontend/vite.config.mjs
+++ b/src/frontend/vite.config.mjs
@@ -191,12 +191,7 @@ function manualChunks(id) {
     return "vendor-echarts";
   }
 
-  // 5) Mermaid (large, dynamically imported; keep package + internals together)
-  if (pkg === "mermaid" || pkg.startsWith("@mermaid-js/")) {
-    return "vendor-mermaid";
-  }
-
-  // 6) Other stable vendor boundaries (loosely coupled to the rest of the app)
+  // 5) Other stable vendor boundaries (loosely coupled to the rest of the app)
   if (pkg === "framer-motion") {
     return "vendor-framer-motion";
   }

--- a/src/frontend/vite.config.mjs
+++ b/src/frontend/vite.config.mjs
@@ -208,7 +208,6 @@ function manualChunks(id) {
   return undefined;
 }
 
-
 export default defineConfig({
   base: "./",
   staged: {


### PR DESCRIPTION
## Summary

Removed the `vendor-mermaid` manual chunk grouping from `vite.config.mjs`. Since Mermaid is already lazy-loaded via dynamic `import()` in `MermaidRenderer`, this override was unnecessary. Rollup can now split mermaid internals into smaller parallel-loadable chunks naturally.

## API Changes

None.

## Files Modified

- **src/frontend/vite.config.mjs** — Removed mermaid `manualChunks` case (lines 194-197), renumbered subsequent comment from `// 6)` to `// 5)`

## Commits

- 274afaef1 — [00010] Remove mermaid from manualChunks grouping in vite config
- 266f37ac9 — [00010] Fix formatting in vite.config.mjs