### PR TITLE
[00013] Review vendor-echarts and vendor-codemirror manualChunks — remove if Rollup handles them naturally

### DIFF
--- a/src/frontend/vite.config.mjs
+++ b/src/frontend/vite.config.mjs
@@ -177,21 +177,7 @@ function manualChunks(id) {
     return "vendor-react";
   }
 
-  // 3) CodeMirror + Lezer
-  if (
-    pkg.startsWith("@codemirror/") ||
-    pkg.startsWith("@lezer/") ||
-    pkg === "@uiw/react-codemirror"
-  ) {
-    return "vendor-codemirror";
-  }
-
-  // 4) Charts
-  if (pkg === "echarts" || pkg === "echarts-for-react" || pkg === "zrender") {
-    return "vendor-echarts";
-  }
-
-  // 5) Other stable vendor boundaries (loosely coupled to the rest of the app)
+  // 3) Other stable vendor boundaries (loosely coupled to the rest of the app)
   if (pkg === "framer-motion") {
     return "vendor-framer-motion";
   }


### PR DESCRIPTION
## Summary

### Changes

Removed the `vendor-codemirror` and `vendor-echarts` manual chunk rules from the `manualChunks` function in `vite.config.mjs`. Both package families (ECharts and CodeMirror) are only reachable through dynamically-imported widget entry points, so Rollup's automatic code-splitting handles them without manual overrides. Renumbered remaining comment sections accordingly.

### API Changes

None.

### Files Modified

- **src/frontend/vite.config.mjs** — Removed `vendor-codemirror` block (CodeMirror + Lezer grouping) and `vendor-echarts` block (Charts grouping) from `manualChunks()`. Renumbered `// 5) Other stable vendor boundaries` to `// 3)`.

## Commits

- `9c5c73cc7` — [00013] Remove vendor-echarts and vendor-codemirror manualChunks from vite config