### PR TITLE
[00017] Use backspace symbol in kbd/shortcut display instead of full word

### DIFF
--- a/src/frontend/src/lib/shortcut.test.ts
+++ b/src/frontend/src/lib/shortcut.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { formatShortcutForDisplay } from "./shortcut";
+
+describe("formatShortcutForDisplay", () => {
+  it("renders Backspace as ⌫", () => {
+    const result = formatShortcutForDisplay("Backspace");
+    expect(result).toContain("⌫");
+  });
+
+  it("renders Delete as ⌦", () => {
+    const result = formatShortcutForDisplay("Delete");
+    expect(result).toContain("⌦");
+  });
+
+  it("renders Enter as ↵", () => {
+    const result = formatShortcutForDisplay("Enter");
+    expect(result).toContain("↵");
+  });
+
+  it("renders Escape as Esc", () => {
+    const result = formatShortcutForDisplay("Escape");
+    expect(result).toContain("Esc");
+  });
+
+  it("renders Ctrl+Backspace with both modifier and ⌫", () => {
+    const result = formatShortcutForDisplay("Ctrl+Backspace");
+    expect(result).toContain("⌫");
+    // Should have 3 parts: modifier, "+", symbol
+    expect(result.length).toBe(3);
+  });
+
+  it("renders regular key A as A", () => {
+    const result = formatShortcutForDisplay("A");
+    expect(result).toContain("A");
+  });
+
+  it("returns empty array for undefined input", () => {
+    const result = formatShortcutForDisplay(undefined);
+    expect(result).toEqual([]);
+  });
+
+  it("renders Tab as ⇥", () => {
+    const result = formatShortcutForDisplay("Tab");
+    expect(result).toContain("⇥");
+  });
+
+  it("renders arrow keys as symbols", () => {
+    expect(formatShortcutForDisplay("ArrowUp")).toContain("↑");
+    expect(formatShortcutForDisplay("ArrowDown")).toContain("↓");
+    expect(formatShortcutForDisplay("ArrowLeft")).toContain("←");
+    expect(formatShortcutForDisplay("ArrowRight")).toContain("→");
+  });
+});

--- a/src/frontend/src/lib/shortcut.ts
+++ b/src/frontend/src/lib/shortcut.ts
@@ -85,12 +85,30 @@ export const formatShortcutForDisplay = (shortcutStr?: string): React.ReactNode[
   const parts = shortcutStr.split("+").map((p) => p.trim());
   const result: React.ReactNode[] = [];
 
+  const keySymbols: Record<string, string> = {
+    backspace: "⌫",
+    delete: "⌦",
+    enter: "↵",
+    return: "↵",
+    escape: "Esc",
+    tab: "⇥",
+    space: "␣",
+    arrowup: "↑",
+    arrowdown: "↓",
+    arrowleft: "←",
+    arrowright: "→",
+    ...(isMac ? { shift: "⇧", alt: "⌥", option: "⌥" } : {}),
+  };
+
   parts.forEach((part, index) => {
     if (index > 0) {
       result.push("+");
     }
 
-    if (
+    const symbol = keySymbols[part.toLowerCase()];
+    if (symbol) {
+      result.push(symbol);
+    } else if (
       isMac &&
       (part.toLowerCase() === "ctrl" ||
         part.toLowerCase() === "cmd" ||


### PR DESCRIPTION
## Changes

Added a `keySymbols` mapping to `formatShortcutForDisplay` in `shortcut.ts` that converts special key names (Backspace, Delete, Enter, Escape, Tab, Space, arrow keys) to their standard Unicode symbols (⌫, ⌦, ↵, Esc, ⇥, ␣, ↑↓←→). On macOS, Shift and Alt/Option are also mapped to ⇧ and ⌥. Created unit tests for the new mappings.

## API Changes

None. This is a display-only change — the `formatShortcutForDisplay` function signature is unchanged.

## Files Modified

- **src/frontend/src/lib/shortcut.ts** — Added `keySymbols` lookup map and symbol resolution before the fallback case in `formatShortcutForDisplay`
- **src/frontend/src/lib/shortcut.test.ts** — New test file with unit tests for key symbol rendering

## Commits

- de9034bb1 — [00017] Add key symbol mapping for shortcut display