### PR TITLE
[00021] Expandable app could use a layout tabs

### DIFF
--- a/src/Ivy.Samples.Shared/Apps/Widgets/ExpandableApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/ExpandableApp.cs
@@ -110,29 +110,36 @@ public class ExpandableApp : SampleBase
             .Ghost()
             .Icon(Icons.Ghost);
 
-        return Layout.Vertical()
-            | Text.H2("Original Basic Expandable")
-            | basicExpandable
-            | Text.H2("Expandable with Icon")
-            | iconExpandable
-            | Text.H2("Expandable with Icon + Density Variations")
-            | smallIconExpandable
-            | mediumIconExpandable
-            | largeIconExpandable
-            | Text.H2("Density Variations")
-            | Text.Block("Use the Density helpers (Small / Medium / Large) to match the density of the surrounding layout.")
-            | smallDensityExpandable
-            | mediumDensityExpandable
-            | largeDensityExpandable
-            | Text.H2("Problematic Case - Switch in Header")
-            | Text.Block("Nested switches should not be blocked by the expandable:")
-            | Text.Block($"Switch states: {headerSwitchState1.Value}, {headerSwitchState2.Value}, {headerSwitchState3.Value}, {headerSwitchState4.Value}")
-            | switchInHeaderExpandable1
-            | switchInHeaderExpandable2
-            | switchInHeaderExpandable3
-            | switchInHeaderExpandable4
-            | Text.H2("Ghost Variant")
-            | ghostExpandable
-            | ghostWithIconExpandable;
+        return Layout.Tabs(
+            new Tab("Basic",
+                Layout.Vertical()
+                | basicExpandable
+                | iconExpandable
+            ),
+            new Tab("Density",
+                Layout.Vertical()
+                | Text.Block("Use the Density helpers (Small / Medium / Large) to match the density of the surrounding layout.")
+                | smallDensityExpandable
+                | mediumDensityExpandable
+                | largeDensityExpandable
+                | smallIconExpandable
+                | mediumIconExpandable
+                | largeIconExpandable
+            ),
+            new Tab("Switch in Header",
+                Layout.Vertical()
+                | Text.Block("Nested switches should not be blocked by the expandable:")
+                | Text.Block($"Switch states: {headerSwitchState1.Value}, {headerSwitchState2.Value}, {headerSwitchState3.Value}, {headerSwitchState4.Value}")
+                | switchInHeaderExpandable1
+                | switchInHeaderExpandable2
+                | switchInHeaderExpandable3
+                | switchInHeaderExpandable4
+            ),
+            new Tab("Ghost",
+                Layout.Vertical()
+                | ghostExpandable
+                | ghostWithIconExpandable
+            )
+        );
     }
 }


### PR DESCRIPTION
## Summary

Refactored `ExpandableApp.BuildSample()` to use `Layout.Tabs(...)` instead of a single `Layout.Vertical()` stack. The existing expandable demos are now organized into four tabs: Basic, Density, Switch in Header, and Ghost.

## Files Modified

- `src/Ivy.Samples.Shared/Apps/Widgets/ExpandableApp.cs` — Replaced top-level `Layout.Vertical()` return with `Layout.Tabs(...)` containing 4 tabs, each wrapping its content in a `Layout.Vertical()`.

## Commits

- 43bd19286