### PR TITLE
[00030] Route dropdown menu shortcuts through formatShortcutForDisplay

### DIFF
--- a/src/frontend/src/widgets/dropDownMenu/DropDownMenuWidget.tsx
+++ b/src/frontend/src/widgets/dropDownMenu/DropDownMenuWidget.tsx
@@ -19,6 +19,7 @@ import { MenuItem } from "@/types/widgets";
 import Icon from "@/components/Icon";
 import { camelCase } from "@/lib/utils";
 import { getColor } from "@/lib/styles";
+import { formatShortcutForDisplay } from "@/lib/shortcut";
 import { Densities } from "@/types/density";
 
 const EMPTY_ARRAY: never[] = [];
@@ -81,7 +82,9 @@ const DropDownMenuItemGroup = ({ items, onItemClick, iconSize }: DropDownMenuIte
           {item.icon && <Icon name={item.icon} size={iconSize} style={colorStyle} />}
           {item.label}
           {item.checked && <span className="ml-auto">✓</span>}
-          {item.shortcut && <DropdownMenuShortcut>{item.shortcut}</DropdownMenuShortcut>}
+          {item.shortcut && (
+            <DropdownMenuShortcut>{formatShortcutForDisplay(item.shortcut)}</DropdownMenuShortcut>
+          )}
         </DropdownMenuItem>
       );
     }
@@ -98,7 +101,9 @@ const DropDownMenuItemGroup = ({ items, onItemClick, iconSize }: DropDownMenuIte
           {item.icon && <Icon name={item.icon} size={iconSize} style={colorStyle} />}
           {item.label}
           {item.checked && <span className="ml-auto">●</span>}
-          {item.shortcut && <DropdownMenuShortcut>{item.shortcut}</DropdownMenuShortcut>}
+          {item.shortcut && (
+            <DropdownMenuShortcut>{formatShortcutForDisplay(item.shortcut)}</DropdownMenuShortcut>
+          )}
         </DropdownMenuItem>
       );
     }
@@ -110,7 +115,9 @@ const DropDownMenuItemGroup = ({ items, onItemClick, iconSize }: DropDownMenuIte
           <DropdownMenuSubTrigger disabled={item.disabled} style={colorStyle}>
             {item.icon && <Icon name={item.icon} size={iconSize} style={colorStyle} />}
             {item.label}
-            {item.shortcut && <DropdownMenuShortcut>{item.shortcut}</DropdownMenuShortcut>}
+            {item.shortcut && (
+              <DropdownMenuShortcut>{formatShortcutForDisplay(item.shortcut)}</DropdownMenuShortcut>
+            )}
           </DropdownMenuSubTrigger>
           <DropdownMenuPortal>
             <DropdownMenuSubContent className="m-2">
@@ -135,7 +142,9 @@ const DropDownMenuItemGroup = ({ items, onItemClick, iconSize }: DropDownMenuIte
       >
         {item.icon && <Icon name={item.icon} size={iconSize} style={colorStyle} />}
         {item.label}
-        {item.shortcut && <DropdownMenuShortcut>{item.shortcut}</DropdownMenuShortcut>}
+        {item.shortcut && (
+          <DropdownMenuShortcut>{formatShortcutForDisplay(item.shortcut)}</DropdownMenuShortcut>
+        )}
       </DropdownMenuItem>
     );
   });


### PR DESCRIPTION
## Changes

Routed all 4 dropdown menu shortcut renders in `DropDownMenuWidget.tsx` through the `formatShortcutForDisplay` function from `@/lib/shortcut`. This ensures keyboard shortcuts in dropdown menus display with proper symbols (e.g., backspace symbol, command symbol on Mac) consistent with other UI surfaces like `ButtonWidget`.

## API Changes

None.

## Files Modified

- **src/frontend/src/widgets/dropDownMenu/DropDownMenuWidget.tsx** — Added import of `formatShortcutForDisplay` and wrapped all 4 `item.shortcut` renders (Checkbox, Radio, Submenu, Default variants) through the formatter.

## Commits

- `7819bda0c` — [00030] Route dropdown menu shortcuts through formatShortcutForDisplay