### PR TITLE
[00032] Lazy-load DataTable widget to auto-split apache-arrow from main bundle

### DIFF
--- a/src/frontend/src/widgets/widgetMap.ts
+++ b/src/frontend/src/widgets/widgetMap.ts
@@ -87,7 +87,6 @@ import {
   VideoPlayerWidget,
   RichTextBlockWidget,
 } from "@/widgets/primitives";
-import { DataTable } from "@/widgets/dataTables";
 import { TableWidget, TableRowWidget, TableCellWidget } from "@/widgets/tables";
 import { SmartSearch } from "@/docs-internal/SmartSearch";
 import { lazyWithRetry } from "@/lib/lazyWithRetry";
@@ -227,7 +226,7 @@ export const widgetMap = {
   "Ivy.TableCell": TableCellWidget,
 
   // DataTables
-  "Ivy.DataTable": DataTable,
+  "Ivy.DataTable": lazyWithRetry(() => import("@/widgets/dataTables/DataTableWidget")),
 
   // Lists
   "Ivy.List": ListWidget,

--- a/src/frontend/vite.config.mjs
+++ b/src/frontend/vite.config.mjs
@@ -184,9 +184,6 @@ function manualChunks(id) {
   if (pkg === "lodash" || pkg === "lodash-es") {
     return "vendor-lodash";
   }
-  if (pkg === "apache-arrow") {
-    return "vendor-apache-arrow";
-  }
   if (pkg === "@microsoft/signalr") {
     return "vendor-signalr";
   }


### PR DESCRIPTION
## Summary

Converted `DataTable` from a static import to a lazy-loaded widget in `widgetMap.ts` using the existing `lazyWithRetry()` pattern. Removed the `vendor-apache-arrow` manual chunk rule from `vite.config.mjs` since Rollup will now auto-split apache-arrow into an async chunk via the dynamic import boundary.

## API Changes

None.

## Files Modified

- **src/frontend/src/widgets/widgetMap.ts** — Removed static `DataTable` import; changed registration to use `lazyWithRetry(() => import("@/widgets/dataTables/DataTableWidget"))`
- **src/frontend/vite.config.mjs** — Removed `apache-arrow` manual chunk rule (lines 187-189)

## Commits

- `4c3ed922e` — [00032] Lazy-load DataTable widget to auto-split apache-arrow from main bundle