### PR TITLE
[00033] Lazy-load framer-motion widgets to remove vendor-framer-motion manualChunk

### DIFF
--- a/src/frontend/src/widgets/widgetMap.ts
+++ b/src/frontend/src/widgets/widgetMap.ts
@@ -2,12 +2,10 @@ import { LoadingScreen } from "@/components/LoadingScreen";
 import {
   ArticleWidget,
   BadgeWidget,
-  ButtonWidget,
   CardWidget,
   ChatLoadingWidget,
   ChatMessageWidget,
   ChatStatusWidget,
-  ChatWidget,
   DropDownMenuWidget,
   ExpandableWidget,
   ProgressWidget,
@@ -40,7 +38,6 @@ import {
   ReadOnlyInputWidget,
   ColorInputWidget,
   IconInputWidget,
-  FeedbackInputWidget,
   AsyncSelectInputWidget,
   DateRangeInputWidget,
   FileInputWidget,
@@ -130,7 +127,11 @@ export const widgetMap = {
 
   // Widgets
   "Ivy.Article": ArticleWidget,
-  "Ivy.Button": ButtonWidget,
+  "Ivy.Button": lazyWithRetry(() =>
+    import("@/widgets/button/ButtonWidget").then((m) => ({
+      default: m.ButtonWidget,
+    })),
+  ),
   "Ivy.Progress": ProgressWidget,
   "Ivy.StackedProgress": StackedProgressWidget,
   "Ivy.Tooltip": TooltipWidget,
@@ -141,7 +142,11 @@ export const widgetMap = {
   "Ivy.Badge": BadgeWidget,
   "Ivy.Breadcrumbs": BreadcrumbsWidget,
   "Ivy.Expandable": ExpandableWidget,
-  "Ivy.Chat": ChatWidget,
+  "Ivy.Chat": lazyWithRetry(() =>
+    import("@/widgets/chat/ChatWidget").then((m) => ({
+      default: m.ChatWidget,
+    })),
+  ),
   "Ivy.ChatMessage": ChatMessageWidget,
   "Ivy.ChatLoading": ChatLoadingWidget,
   "Ivy.ChatStatus": ChatStatusWidget,
@@ -192,7 +197,11 @@ export const widgetMap = {
   "Ivy.ReadOnlyInput": ReadOnlyInputWidget,
   "Ivy.ColorInput": ColorInputWidget,
   "Ivy.IconInput": IconInputWidget,
-  "Ivy.FeedbackInput": FeedbackInputWidget,
+  "Ivy.FeedbackInput": lazyWithRetry(() =>
+    import("@/widgets/inputs/FeedbackInputWidget").then((m) => ({
+      default: m.FeedbackInputWidget,
+    })),
+  ),
   "Ivy.AsyncSelectInput": AsyncSelectInputWidget,
   "Ivy.DateRangeInput": DateRangeInputWidget,
   "Ivy.FileInput": FileInputWidget,

--- a/src/frontend/vite.config.mjs
+++ b/src/frontend/vite.config.mjs
@@ -178,9 +178,6 @@ function manualChunks(id) {
   }
 
   // 3) Other stable vendor boundaries (loosely coupled to the rest of the app)
-  if (pkg === "framer-motion") {
-    return "vendor-framer-motion";
-  }
   if (pkg === "lodash" || pkg === "lodash-es") {
     return "vendor-lodash";
   }


### PR DESCRIPTION
## Summary

Converted ButtonWidget, ChatWidget, and FeedbackInputWidget from static imports to `lazyWithRetry` dynamic imports in `widgetMap.ts`. Removed the `vendor-framer-motion` manualChunk rule from `vite.config.mjs`, allowing Rollup to auto-split framer-motion into an async chunk (`features-animation-*.js`).

## API Changes

None.

## Files Modified

- **Frontend build config:**
  - `src/frontend/vite.config.mjs` — removed `vendor-framer-motion` manualChunk rule
- **Widget map:**
  - `src/frontend/src/widgets/widgetMap.ts` — converted 3 static widget imports to lazy-loaded dynamic imports

## Commits

- `84dc6ec87` — [00033] Lazy-load framer-motion widgets and remove vendor-framer-motion manualChunk