### PR TITLE
[00043] Remove lodash manual chunk after DataTable lazy-load

### DIFF
--- a/src/frontend/vite.config.mjs
+++ b/src/frontend/vite.config.mjs
@@ -178,9 +178,6 @@ function manualChunks(id) {
   }
 
   // 3) Other stable vendor boundaries (loosely coupled to the rest of the app)
-  if (pkg === "lodash" || pkg === "lodash-es") {
-    return "vendor-lodash";
-  }
   if (pkg === "@microsoft/signalr") {
     return "vendor-signalr";
   }


### PR DESCRIPTION
## Summary

Removed the `vendor-lodash` manual chunk rule from `vite.config.mjs`. After plan 00032 lazy-loaded the DataTable widget, all lodash consumers (glide-data-grid and mermaid) are behind dynamic imports. Rollup now auto-splits lodash into async chunks, removing ~56 KB from the initial page load.

## Files Modified

- **src/frontend/vite.config.mjs** — Deleted the `if (pkg === "lodash" || pkg === "lodash-es")` block (3 lines) from the `manualChunks` function

## Commits

- b8dc47b77