### PR TITLE
[00046] Extract shared density height/padding constants

### DIFF
--- a/src/frontend/src/components/ui/density-scale.ts
+++ b/src/frontend/src/components/ui/density-scale.ts
@@ -1,0 +1,19 @@
+/** Base density scale — used by table-head, expandable trigger, and as reference for offset scales */
+export const densityHeight = {
+  Small: "h-8",
+  Medium: "h-10",
+  Large: "h-12",
+} as const;
+
+/** One step above base — available for components needing a larger scale */
+export const densityHeightLg = {
+  Small: "h-10",
+  Medium: "h-12",
+  Large: "h-14",
+} as const;
+
+export const densityText = {
+  Small: "text-xs",
+  Medium: "text-sm",
+  Large: "text-base",
+} as const;

--- a/src/frontend/src/components/ui/expandable/expandable-variant.ts
+++ b/src/frontend/src/components/ui/expandable/expandable-variant.ts
@@ -1,13 +1,14 @@
 import { cva } from "class-variance-authority";
+import { densityHeight } from "../density-scale";
 
 export const expandableTriggerVariant = cva(
   "w-full flex justify-between items-center cursor-pointer hover:bg-accent/50 rounded-box transition-colors disabled:cursor-not-allowed disabled:hover:bg-transparent overflow-hidden box-border shrink-0",
   {
     variants: {
       density: {
-        Small: "h-8 px-2 py-1 gap-2",
-        Medium: "h-10 px-3 py-2 gap-3",
-        Large: "h-12 px-4 py-3 gap-4",
+        Small: `${densityHeight.Small} px-2 py-1 gap-2`,
+        Medium: `${densityHeight.Medium} px-3 py-2 gap-3`,
+        Large: `${densityHeight.Large} px-4 py-3 gap-4`,
       },
     },
     defaultVariants: {

--- a/src/frontend/src/components/ui/table/table-variant.ts
+++ b/src/frontend/src/components/ui/table/table-variant.ts
@@ -1,12 +1,13 @@
 import { cva } from "class-variance-authority";
+import { densityHeight, densityText } from "../density-scale";
 
 // Size variants for TableHead padding
 export const tableHeadSizeVariant = cva("w-full caption-bottom", {
   variants: {
     density: {
-      Small: "h-8 px-1 text-xs",
-      Medium: "h-10 px-2 text-sm",
-      Large: "h-12 px-3 text-base",
+      Small: `${densityHeight.Small} px-1 ${densityText.Small}`,
+      Medium: `${densityHeight.Medium} px-2 ${densityText.Medium}`,
+      Large: `${densityHeight.Large} px-3 ${densityText.Large}`,
     },
   },
   defaultVariants: {

--- a/src/tendril/Ivy.Tendril.TeamIvyConfig/Promptwares/IvyFrameworkVerification/Memory/IvyFrameworkGotchas.md
+++ b/src/tendril/Ivy.Tendril.TeamIvyConfig/Promptwares/IvyFrameworkVerification/Memory/IvyFrameworkGotchas.md
@@ -622,6 +622,21 @@ Number columns had `type: undefined` because `ColType.Number` (enum 0) was strip
 ✅ **`UseState(() => ImmutableArray<FileUpload<byte[]>>.Empty)`** — explicitly initialize with `.Empty`
 📝 **Why**: `default(ImmutableArray<T>)` has a null backing array (unlike `List<T>` which is just empty). The `UseState<T>()` overload without initializer uses `default(T)`, which for `ImmutableArray` produces an unusable instance. Always use the `Func<T>` overload with `.Empty`.
 
+## Ivy Server Always Uses HTTPS
+
+### Health check and Playwright must use HTTPS
+❌ **`http.get(\`http://localhost:\${port}\`)`** — connection refused or no response; Ivy binds to HTTPS only
+✅ **`https.get(\`https://localhost:\${port}\`, { rejectUnauthorized: false })`** — use `https` module with self-signed cert bypass
+✅ **`ignoreHTTPSErrors: true`** in Playwright config `use` block — required for all page navigation
+📝 **Why**: Ivy's `Server` class configures Kestrel with HTTPS by default (dev certificate). There is no HTTP endpoint. All `waitForServer` health checks, `page.goto()`, and WebSocket connections must use `https://` / `wss://`.
+
+## TableBuilder.Header() Requires Label Parameter
+
+### `.Header(expr)` is not valid — second arg is mandatory
+❌ **`products.ToTable().Header(p => p.Name)`** — CS7036: no argument for required parameter `label`
+✅ **`products.ToTable().Header(p => p.Name, "Name")`** — always provide the display label
+📝 **Why**: `TableBuilder<T>.Header(Expression<Func<T, object>>, string)` has `label` as a required parameter, not optional. Unlike DataTable which auto-derives column names, the simple Table widget requires explicit labels.
+
 ## Future Gotchas
 
 As we encounter more issues, add them with:


### PR DESCRIPTION
## Summary

Created a shared `density-scale.ts` module exporting `densityHeight`, `densityHeightLg`, and `densityText` constants for the Small/Medium/Large density scale. Updated `table-variant.ts` and `expandable-variant.ts` to import and use these shared constants instead of hardcoded Tailwind class strings, making future scale adjustments a single-point change.

Note: The plan originally described expandable trigger heights as `h-10/h-12/h-14` ("one step above base"), but plan 00022 had already adjusted them to match the base table-head scale (`h-8/h-10/h-12`). Both files now use `densityHeight` (the base scale). The `densityHeightLg` constant is exported for future use.

## API Changes

New exports from `src/frontend/src/components/ui/density-scale.ts`:
- `densityHeight` — `{ Small: "h-8", Medium: "h-10", Large: "h-12" }`
- `densityHeightLg` — `{ Small: "h-10", Medium: "h-12", Large: "h-14" }`
- `densityText` — `{ Small: "text-xs", Medium: "text-sm", Large: "text-base" }`

## Files Modified

- **New:** `src/frontend/src/components/ui/density-scale.ts` — shared density constants
- **Modified:** `src/frontend/src/components/ui/table/table-variant.ts` — imports `densityHeight` and `densityText`
- **Modified:** `src/frontend/src/components/ui/expandable/expandable-variant.ts` — imports `densityHeight`

## Commits

- `65ed2ecd0` — Extract shared density height/padding/text constants into density-scale.ts
- `ff6287370` — Update IvyFrameworkVerification gotchas from visual verification