### PR TITLE
[00055] Use shared densityText constant in table variants

### DIFF
--- a/src/frontend/src/components/ui/table/table-variant.ts
+++ b/src/frontend/src/components/ui/table/table-variant.ts
@@ -19,9 +19,9 @@ export const tableHeadSizeVariant = cva("w-full caption-bottom", {
 export const tableCellSizeVariant = cva("align-middle", {
   variants: {
     density: {
-      Small: "p-1 text-xs",
-      Medium: "p-2 text-sm",
-      Large: "p-3 text-base",
+      Small: `p-1 ${densityText.Small}`,
+      Medium: `p-2 ${densityText.Medium}`,
+      Large: `p-3 ${densityText.Large}`,
     },
   },
   defaultVariants: {
@@ -32,9 +32,9 @@ export const tableCellSizeVariant = cva("align-middle", {
 export const tableSizeVariant = cva("", {
   variants: {
     density: {
-      Small: "text-xs",
-      Medium: "text-sm",
-      Large: "text-base",
+      Small: densityText.Small,
+      Medium: densityText.Medium,
+      Large: densityText.Large,
     },
   },
   defaultVariants: {


### PR DESCRIPTION
## Summary

Replaced hardcoded `text-xs/text-sm/text-base` class strings in `tableCellSizeVariant` and `tableSizeVariant` with the shared `densityText` constant from `density-scale.ts`. This completes the density text extraction started in plan 00046, ensuring all table variants use the same centralized text-size scale.

## API Changes

None.

## Files Modified

- `src/frontend/src/components/ui/table/table-variant.ts` — Updated `tableCellSizeVariant` to use template literals with `densityText`, and `tableSizeVariant` to reference `densityText` directly.

## Commits

- d1fc50013