### PR TITLE
[00073] Bump Ivy.NativeJsonDiff to 1.0.1 in Ivy-Framework

### DIFF
--- a/src/Ivy.Benchmarks/Ivy.Benchmarks.csproj
+++ b/src/Ivy.Benchmarks/Ivy.Benchmarks.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
-    <PackageReference Include="Ivy.NativeJsonDiff" Version="1.0.0" />
+    <PackageReference Include="Ivy.NativeJsonDiff" Version="1.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ivy/Ivy.csproj
+++ b/src/Ivy/Ivy.csproj
@@ -72,7 +72,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="System.IO.Hashing" Version="10.0.5" />
     <PackageReference Include="Ivy.SystemTextJson.JsonDiffPatch" Version="2.0.4" />
-<PackageReference Include="Ivy.NativeJsonDiff" Version="1.0.0" />
+<PackageReference Include="Ivy.NativeJsonDiff" Version="1.0.1" />
 <PackageReference Include="Ivy.DesignSystem" Version="1.1.31" />
   </ItemGroup>
 


### PR DESCRIPTION
## Problem

Ivy-Framework references `Ivy.NativeJsonDiff` version **1.0.0** in two csproj files, but version **1.0.1** has been published. The Framework should consume the latest patch release.

## Solution

Bump the `Ivy.NativeJsonDiff` package version from `1.0.0` to `1.0.1` in both csproj files:

- `src/Ivy/Ivy.csproj`
- `src/Ivy.Benchmarks/Ivy.Benchmarks.csproj`

No API changes — the class name is unchanged in v1.0.1, so all existing `using` aliases remain valid.

## Commits

- `c12a81b` [00073] Bump Ivy.NativeJsonDiff to 1.0.1 in Ivy-Framework