### PR TITLE
[00072] Re-enable StackedProgress OnSelect handler in Dashboard

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Dashboard2App.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Dashboard2App.cs
@@ -106,7 +106,13 @@ public class Dashboard2App : ViewBase
                 )
                 .Selected(selectedProject.Value != null
                     ? projectData.FindIndex(p => p.Project == selectedProject.Value)
-                    : null);
+                    : null)
+                .OnSelect(e =>
+                {
+                    var clickedProject = projectData[e.Value].Project;
+                    selectedProject.Set(selectedProject.Value == clickedProject ? null : clickedProject);
+                    return ValueTask.CompletedTask;
+                });
 
         // Hourly cost & tokens combined bar chart
         var hourlyBurn = planService.GetHourlyTokenBurn(projectFilter: selectedProject.Value);


### PR DESCRIPTION
## Summary

Added an `.OnSelect()` handler to the `StackedProgress` widget in `Dashboard2App.cs`. Clicking a project segment now toggles the `selectedProject` state, which filters both the dashboard data table and the hourly token burn chart. Clicking the same segment again deselects it.

## Files Modified

- `src/tendril/Ivy.Tendril/Apps/Dashboard2App.cs` — Added `.OnSelect()` handler to StackedProgress widget chain

## Commits

- `17e44e708` — Re-enable StackedProgress OnSelect handler in Dashboard