### PR TITLE
[00084] Update StartAsync cross-reference for consistency with BuildAsync update

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/05_Other/Hallucinations.md
+++ b/src/Ivy.Docs.Shared/Docs/05_Other/Hallucinations.md
@@ -3186,7 +3186,7 @@ server.UseWebApplication(app =>
 await server.RunAsync();
 ```
 
-The `Server` class does not have `StartAsync()` or `WaitForShutdownAsync()`. The agent confused ASP.NET Core's `IHost.StartAsync()` / `IHost.WaitForShutdownAsync()` pattern with Ivy's `Server` API. Use `server.RunAsync()` for the full lifecycle. See also: `Server.OnReady / Server.OnStartup` and `Server.BuildAsync()` entries.
+The `Server` class does not have `StartAsync()` or `WaitForShutdownAsync()`. The agent confused ASP.NET Core's `IHost.StartAsync()` / `IHost.WaitForShutdownAsync()` pattern with Ivy's `Server` API. Use `server.RunAsync()` for the full lifecycle. For DI access, `server.Services` (public `IServiceCollection`) is available directly; for runtime service resolution, use `server.UseWebApplication(app => ...)` to access `app.Services`. See also: `Server.OnReady / Server.OnStartup` and `Server.BuildAsync()` entries.
 
 **Found In:**
 2235e1c1-ab1e-4313-be50-995daa1be1f9


### PR DESCRIPTION
## Summary

Updated the closing paragraph of the `Server.StartAsync() / Server.WaitForShutdownAsync()` hallucination entry in Hallucinations.md to mention `server.Services` as a direct DI access path, consistent with the BuildAsync entry updated by plan 00069.

## API Changes

None.

## Files Modified

- `src/Ivy.Docs.Shared/Docs/05_Other/Hallucinations.md` — Updated StartAsync entry cross-reference text (line 3189)

## Commits

- b7939932a