### PR TITLE
[00100] Clean up inputs/ sub-barrel re-exports

### DIFF
--- a/src/frontend/src/widgets/inputs/code/index.ts
+++ b/src/frontend/src/widgets/inputs/code/index.ts
@@ -1,3 +1,0 @@
-export { CodeInputWidget } from "./CodeInputWidget";
-export { dbml } from "./dbml-language";
-export { createIvyCodeTheme } from "./theme";


### PR DESCRIPTION
## Summary

Deleted the unused `inputs/code/index.ts` sub-barrel file. This file re-exported `CodeInputWidget`, `dbml`, and `createIvyCodeTheme` but had zero external consumers — all imports already used direct paths to the source files.

## API Changes

None.

## Files Modified

- **Deleted:** `src/frontend/src/widgets/inputs/code/index.ts` — dead sub-barrel with no consumers

## Commits

- `8723b0295` [00100] Delete unused inputs/code/index.ts sub-barrel