### PR TITLE
[00102] Consume Ivy.NativeJsonDiff v2.0.0 in Ivy-Framework

### DIFF
--- a/src/Ivy.Benchmarks/Ivy.Benchmarks.csproj
+++ b/src/Ivy.Benchmarks/Ivy.Benchmarks.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
-    <PackageReference Include="Ivy.NativeJsonDiff" Version="1.0.1" />
+    <PackageReference Include="Ivy.NativeJsonDiff" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ivy.Benchmarks/JsonPatchBenchmark.cs
+++ b/src/Ivy.Benchmarks/JsonPatchBenchmark.cs
@@ -4,7 +4,7 @@ using System.Text.Json.JsonDiffPatch;
 using System.Text.Json.JsonDiffPatch.Diffs.Formatters;
 using BenchmarkDotNet.Attributes;
 using Ivy.Core;
-using NativeJsonDiffLib = Ivy.NativeJsonDiff.NativeJsonDiff;
+using Ivy.NativeJsonDiff;
 
 namespace Ivy.Benchmarks;
 
@@ -68,6 +68,6 @@ public class JsonPatchBenchmark
     [Benchmark]
     public JsonNode? NativeJsonDiff_ComputePatch()
     {
-        return NativeJsonDiffLib.ComputePatch(_oldBytes, _newBytes);
+        return JsonDiffer.ComputePatch(_oldBytes, _newBytes);
     }
 }

--- a/src/Ivy.Benchmarks/PayloadSizeAnalyzer.cs
+++ b/src/Ivy.Benchmarks/PayloadSizeAnalyzer.cs
@@ -4,7 +4,7 @@ using System.Text.Json.Nodes;
 using System.Text.Json.JsonDiffPatch;
 using System.Text.Json.JsonDiffPatch.Diffs.Formatters;
 using Ivy.Core;
-using NativeJsonDiffLib = Ivy.NativeJsonDiff.NativeJsonDiff;
+using Ivy.NativeJsonDiff;
 
 namespace Ivy.Benchmarks;
 
@@ -24,7 +24,7 @@ public static class PayloadSizeAnalyzer
         var csPatch = oldNode.Diff(newNode, new JsonPatchDeltaFormatter(), WidgetTree.JsonDiffOptions);
         var csPayload = csPatch!.ToJsonString();
         
-        var rustPatch = NativeJsonDiffLib.ComputePatch(oldBytes, newBytes);
+        var rustPatch = JsonDiffer.ComputePatch(oldBytes, newBytes);
         var rustPayload = rustPatch?.ToJsonString() ?? "NULL";
 
         Console.WriteLine($"\n[C# Original String]: {csPayload.Length} chars");

--- a/src/Ivy/Core/WidgetTree.cs
+++ b/src/Ivy/Core/WidgetTree.cs
@@ -5,7 +5,7 @@ using System.Text.Json.JsonDiffPatch;
 using System.Text.Json.Nodes;
 using Ivy.Core.Helpers;
 using Ivy.Core.Hooks;
-using NativeJsonDiffLib = Ivy.NativeJsonDiff.NativeJsonDiff;
+using Ivy.NativeJsonDiff;
 
 namespace Ivy.Core;
 
@@ -228,7 +228,7 @@ public class WidgetTree : IWidgetTree, IObservable<WidgetTreeChanged[]>
                 // [Native Patch Integration] Execute mathematically independent zero-allocation diffing via C/Rust!
                 var oldBytes = System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(previous);
                 var newBytes = System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(update);
-                patch = NativeJsonDiffLib.ComputePatch(oldBytes, newBytes);
+                patch = JsonDiffer.ComputePatch(oldBytes, newBytes);
             }
             else
             {

--- a/src/Ivy/Ivy.csproj
+++ b/src/Ivy/Ivy.csproj
@@ -72,7 +72,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="System.IO.Hashing" Version="10.0.5" />
     <PackageReference Include="Ivy.SystemTextJson.JsonDiffPatch" Version="2.0.4" />
-<PackageReference Include="Ivy.NativeJsonDiff" Version="1.0.1" />
+<PackageReference Include="Ivy.NativeJsonDiff" Version="2.0.0" />
 <PackageReference Include="Ivy.DesignSystem" Version="1.1.31" />
   </ItemGroup>
 

--- a/src/Ivy/packages.lock.json
+++ b/src/Ivy/packages.lock.json
@@ -64,9 +64,9 @@
       },
       "Ivy.NativeJsonDiff": {
         "type": "Direct",
-        "requested": "[1.0.0, )",
-        "resolved": "1.0.0",
-        "contentHash": "xtjtSJRA1MFilciXzW7LbadkUHA5BZahtQMdegd+e++ci4uJg1NwE6WIom/ufz6hsn6mG54nAMqPnhaF8JGL3w=="
+        "requested": "[2.0.0, )",
+        "resolved": "2.0.0",
+        "contentHash": "ZZgMZ+Q/i++tVP6igeW+LH+BF1GJqjOq6DwUNqiPoGGn2YC5fYz46jkA6loMNO6UCsb/GlFpIgb4rjAFJb2NtQ=="
       },
       "Ivy.SystemTextJson.JsonDiffPatch": {
         "type": "Direct",


### PR DESCRIPTION
# Summary

## Changes

Upgraded `Ivy.NativeJsonDiff` from v1.0.1 to v2.0.0 in both `Ivy.csproj` and `Ivy.Benchmarks.csproj`. Replaced the `using NativeJsonDiffLib = Ivy.NativeJsonDiff.NativeJsonDiff;` alias with `using Ivy.NativeJsonDiff;` and updated all `NativeJsonDiffLib.ComputePatch()` call sites to `JsonDiffer.ComputePatch()` to reflect the v2.0.0 class rename.

## API Changes

- `NativeJsonDiffLib.ComputePatch()` calls replaced with `JsonDiffer.ComputePatch()` (class renamed in v2.0.0)
- Using alias `NativeJsonDiffLib` removed, replaced with direct namespace import `using Ivy.NativeJsonDiff;`

## Files Modified

- **Package references:**
  - `src/Ivy/Ivy.csproj` — version 1.0.1 -> 2.0.0
  - `src/Ivy.Benchmarks/Ivy.Benchmarks.csproj` — version 1.0.1 -> 2.0.0
- **Using alias + call site updates:**
  - `src/Ivy/Core/WidgetTree.cs` — alias + line 231
  - `src/Ivy.Benchmarks/JsonPatchBenchmark.cs` — alias + line 71
  - `src/Ivy.Benchmarks/PayloadSizeAnalyzer.cs` — alias + line 27
- `src/Ivy/packages.lock.json` — updated lock file

## Commits

- `dba7814db` — [00102] Upgrade Ivy.NativeJsonDiff to v2.0.0 and adopt JsonDiffer class rename