### PR TITLE
[00122] Add build warning for unconditional Ivy project references in Docker-consumed projects

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,4 +2,17 @@
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
+
+  <!--
+    Guard: when IvyPackageVersion is set (Docker/NuGet builds), no project should
+    have an unconditional ProjectReference to Ivy.csproj. Projects must use the
+    conditional IvyPackageVersion pattern instead.
+  -->
+  <Target Name="WarnUnconditionalIvyProjectRef"
+          BeforeTargets="ResolveProjectReferences"
+          Condition="'$(IvyPackageVersion)' != ''">
+    <Warning Code="IVY001"
+             Text="Project '$(MSBuildProjectName)' has a ProjectReference to Ivy.csproj but IvyPackageVersion is set. Use the conditional IvyPackageVersion pattern (PackageReference when set, ProjectReference when empty)."
+             Condition="'%(ProjectReference.Filename)' == 'Ivy' And '%(ProjectReference.Extension)' == '.csproj'" />
+  </Target>
 </Project>


### PR DESCRIPTION
## Changes

Added an MSBuild target `WarnUnconditionalIvyProjectRef` to `src/Directory.Build.props` that emits warning IVY001 when a project has a `ProjectReference` to `Ivy.csproj` while `IvyPackageVersion` is set. Since `TreatWarningsAsErrors` is already enabled, this effectively fails the build in Docker/NuGet contexts.

Note: Part 1 of the plan (fixing `Ivy.Docs.Helpers.csproj` to use the conditional pattern) was already completed by plan 00089 (commit d3a74823a).

## API Changes

None.

## Files Modified

- **src/Directory.Build.props** — Added `WarnUnconditionalIvyProjectRef` target that uses `%(ProjectReference.Filename)` and `%(ProjectReference.Extension)` metadata for path-agnostic detection of unconditional Ivy project references.

## Commits

- 0ac1bfa94 — [00122] Add MSBuild warning for unconditional Ivy project references