### PR TITLE
[03155] Add Gemini health check to SoftwareCheckStepView

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Onboarding/SoftwareCheckStepView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Onboarding/SoftwareCheckStepView.cs
@@ -25,10 +25,10 @@ public class SoftwareCheckStepView(
                                     checkResults.Value["gemini"]);
 
         var ghHealthy = healthResults.Value?.GetValueOrDefault("gh") == HealthCheckStatus.Authenticated;
-        var anyAgentHealthy = (healthResults.Value != null
-                               && (healthResults.Value.GetValueOrDefault("claude") == HealthCheckStatus.Authenticated
-                                   || healthResults.Value.GetValueOrDefault("codex") == HealthCheckStatus.Authenticated))
-                              || (checkResults.Value != null && checkResults.Value.GetValueOrDefault("gemini"));
+        var anyAgentHealthy = healthResults.Value != null
+                              && (healthResults.Value.GetValueOrDefault("claude") == HealthCheckStatus.Authenticated
+                                  || healthResults.Value.GetValueOrDefault("codex") == HealthCheckStatus.Authenticated
+                                  || healthResults.Value.GetValueOrDefault("gemini") == HealthCheckStatus.Authenticated);
 
         var allRequiredPassed = checkResults.Value != null
                                 && checkResults.Value["gh"] && ghHealthy
@@ -133,11 +133,15 @@ public class SoftwareCheckStepView(
             // verify --max-turns is still a recognized flag (`claude --help | grep max-turns`).
             var claudeHealthTask = results["claude"] ? CheckHealth("claude", "-p \"ping\" --max-turns 1") : null;
             var codexHealthTask = results["codex"] ? CheckHealth("codex", "login status") : null;
+            // Gemini CLI has no non-interactive auth check command. Running `gemini -p` opens a browser
+            // when unauthenticated (see plan 03037). Instead, check for ~/.gemini/oauth_creds.json.
+            var geminiHealthTask = results["gemini"] ? CheckGeminiAuth() : null;
 
             var pendingTasks = new List<(string key, Task<HealthCheckStatus> task)>();
             if (ghHealthTask != null) pendingTasks.Add(("gh", ghHealthTask));
             if (claudeHealthTask != null) pendingTasks.Add(("claude", claudeHealthTask));
             if (codexHealthTask != null) pendingTasks.Add(("codex", codexHealthTask));
+            if (geminiHealthTask != null) pendingTasks.Add(("gemini", geminiHealthTask));
 
             var health = new Dictionary<string, HealthCheckStatus?>();
 
@@ -230,6 +234,32 @@ public class SoftwareCheckStepView(
         {
             return HealthCheckStatus.CheckFailed;
         }
+    }
+
+    private static Task<HealthCheckStatus> CheckGeminiAuth()
+    {
+        return Task.Run(() =>
+        {
+            try
+            {
+                var homeDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+                var oauthCredsPath = Path.Combine(homeDir, ".gemini", "oauth_creds.json");
+
+                if (File.Exists(oauthCredsPath))
+                {
+                    var fileInfo = new FileInfo(oauthCredsPath);
+                    return fileInfo.Length > 0
+                        ? HealthCheckStatus.Authenticated
+                        : HealthCheckStatus.NotAuthenticated;
+                }
+
+                return HealthCheckStatus.NotAuthenticated;
+            }
+            catch
+            {
+                return HealthCheckStatus.CheckFailed;
+            }
+        });
     }
 
     private static async Task<bool> CheckProcess(string fileName, string arguments, int timeoutMs)


### PR DESCRIPTION
# Summary

## Changes

Added a Gemini authentication health check to `SoftwareCheckStepView` that verifies auth status by checking for `~/.gemini/oauth_creds.json` instead of running `gemini -p` (which opens a browser when unauthenticated). Updated the `anyAgentHealthy` logic to include Gemini in the proper health check evaluation rather than falling back to the installation-only check.

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/Apps/Onboarding/SoftwareCheckStepView.cs** — Added `CheckGeminiAuth()` method, wired Gemini health task into the pending tasks collection, and fixed `anyAgentHealthy` to use Gemini health status instead of installation-only fallback.

## Commits

- e76ca2bc8 [03155] Add Gemini health check to SoftwareCheckStepView