### PR TITLE
[03154] Refactor Windows KillProcessUsingPort to use GetPidsOnPort pattern

### DIFF
--- a/src/Ivy/Helpers/ProcessHelper.cs
+++ b/src/Ivy/Helpers/ProcessHelper.cs
@@ -39,39 +39,37 @@ public static class ProcessHelper
 
     private static void KillProcessUsingPortWindows(int port)
     {
-        using var netstat = new Process
+        var pids = GetPidsOnPort("netstat", "-ano", output =>
         {
-            StartInfo = new ProcessStartInfo
+            var results = new List<int>();
+            var lines = output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries);
+            var regex = new Regex(@"\s+");
+
+            foreach (var line in lines)
             {
-                FileName = "netstat",
-                Arguments = "-ano",
-                RedirectStandardOutput = true,
-                UseShellExecute = false,
-                CreateNoWindow = true
+                if (!line.Trim().StartsWith("TCP"))
+                    continue;
+                var parts = regex.Split(line.Trim());
+                if (parts.Length < 5)
+                    continue;
+                string localAddress = parts[1];
+                string pidStr = parts[4];
+                int colonIndex = localAddress.LastIndexOf(':');
+                if (colonIndex == -1)
+                    continue;
+                if (!int.TryParse(localAddress[(colonIndex + 1)..], out int linePort) || linePort != port)
+                    continue;
+                if (int.TryParse(pidStr, out int pid) && pid != 0)
+                    results.Add(pid);
             }
-        };
-        netstat.Start();
-        string output = netstat.StandardOutput.ReadToEnd();
-        netstat.WaitForExitOrKill(10000);
 
-        var lines = output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries);
-        var regex = new Regex(@"\s+");
+            return results;
+        });
 
-        foreach (var line in lines)
+        if (pids == null) return;
+
+        foreach (var pid in pids)
         {
-            if (!line.Trim().StartsWith("TCP"))
-                continue;
-            var parts = regex.Split(line.Trim());
-            if (parts.Length < 5)
-                continue;
-            string localAddress = parts[1];
-            string pidStr = parts[4];
-            int colonIndex = localAddress.LastIndexOf(':');
-            if (colonIndex == -1)
-                continue;
-            if (!int.TryParse(localAddress[(colonIndex + 1)..], out int linePort) || linePort != port) continue;
-            if (!int.TryParse(pidStr, out int pid)) continue;
-            if (pid == 0) continue;
             try
             {
                 using var proc = Process.GetProcessById(pid);
@@ -79,7 +77,7 @@ public static class ProcessHelper
             }
             catch (Exception)
             {
-                //ignore
+                // ignore - process may have already exited
             }
         }
     }


### PR DESCRIPTION
# Summary

## Changes

Refactored `KillProcessUsingPortWindows` in `ProcessHelper.cs` to use the existing `GetPidsOnPort` helper method instead of inline `Process` creation and output parsing. The Windows path now follows the same pattern as the Unix path, with a port-filtering lambda passed to `GetPidsOnPort`. Used `List<int>` instead of `yield return` since C# does not support iterator blocks in lambdas.

## API Changes

None.

## Files Modified

- **src/Ivy/Helpers/ProcessHelper.cs** — Replaced inline netstat process creation and parsing in `KillProcessUsingPortWindows` with a call to `GetPidsOnPort` using an inline parser lambda.

## Commits

- 701216ebf [03154] Refactor KillProcessUsingPortWindows to use GetPidsOnPort