### PR TITLE
[03158] Change branch naming to tendril/<planid>-<title> format

### DIFF
--- a/src/tendril/Ivy.Tendril.TeamIvyConfig/Hooks/CleanupWorktrees.ps1
+++ b/src/tendril/Ivy.Tendril.TeamIvyConfig/Hooks/CleanupWorktrees.ps1
@@ -68,7 +68,8 @@ foreach ($planFolder in $planFolders) {
         if ($originalRepo) {
             try {
                 Push-Location $originalRepo
-                $branchName = "plan-$planId-$repoName"
+                $safeTitle = if ($planFolder.Name -match '^\d+-(.+)') { $Matches[1] } else { "Unknown" }
+                $branchName = "tendril/$planId-$safeTitle"
                 git worktree remove $wtDir.FullName --force 2>&1 | Out-Null
                 git branch -D $branchName 2>&1 | Out-Null
                 Pop-Location

--- a/src/tendril/Ivy.Tendril.Test/WorktreeLifecycleLoggerTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/WorktreeLifecycleLoggerTests.cs
@@ -23,7 +23,7 @@ public class WorktreeLifecycleLoggerTests : IDisposable
     [Fact]
     public void LogCreation_WritesFormattedEntry()
     {
-        _logger.LogCreation("03058", @"D:\Repos\MyRepo", @"D:\Plans\03058\worktrees\MyRepo", "plan-03058-MyRepo");
+        _logger.LogCreation("03058", @"D:\Repos\MyRepo", @"D:\Plans\03058\worktrees\MyRepo", "tendril/03058-TestPlan");
 
         var logFile = Path.Combine(_tempDir, "Logs", "worktrees.log");
         Assert.True(File.Exists(logFile));
@@ -32,7 +32,7 @@ public class WorktreeLifecycleLoggerTests : IDisposable
         Assert.Contains("[03058]", content);
         Assert.Contains("[Creation]", content);
         Assert.Contains("repo=\"D:\\Repos\\MyRepo\"", content);
-        Assert.Contains("branch=\"plan-03058-MyRepo\"", content);
+        Assert.Contains("branch=\"tendril/03058-TestPlan\"", content);
     }
 
     [Fact]

--- a/src/tendril/Ivy.Tendril/Promptwares/CleanupPlan/CleanupPlan.ps1
+++ b/src/tendril/Ivy.Tendril/Promptwares/CleanupPlan/CleanupPlan.ps1
@@ -46,7 +46,8 @@ foreach ($wtDir in $worktreeDirs) {
         # Remove worktree via git
         try {
             Push-Location $originalRepo
-            $branchName = "plan-$planId-$repoName"
+            $safeTitle = if ($planFolderName -match '^\d+-(.+)') { $Matches[1] } else { "Unknown" }
+            $branchName = "tendril/$planId-$safeTitle"
             git worktree remove $wtDir.FullName --force 2>&1 | Write-Host
             git branch -D $branchName 2>&1 | Write-Host
             Pop-Location

--- a/src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
+++ b/src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
@@ -223,8 +223,13 @@ For each repo listed in `plan.yaml` `repos` (or the project's repos from `config
 3. If the worktree or branch already exists from a prior execution, remove it first. A prior run may have left a **stale directory** (the filesystem tree still exists but git no longer tracks it as a worktree — there's no `.git` file at the worktree root). In that case `git worktree remove` will fail with "is not a working tree"; you must also `rm -rf` the directory. **Do all three unconditionally** so the next `git worktree add` starts from a clean slate:
 
 ```bash
+PLAN_FOLDER_NAME=$(basename "<PlanFolder>")
+PLAN_ID=$(echo "$PLAN_FOLDER_NAME" | grep -oP '^\d+')
+SAFE_TITLE=$(echo "$PLAN_FOLDER_NAME" | sed 's/^[0-9]\+-//')
+BRANCH_NAME="tendril/$PLAN_ID-$SAFE_TITLE"
+
 git worktree remove "<PlanFolder>/worktrees/<repo-folder-name>" --force 2>/dev/null
-git branch -D "plan-<planId>-<repo-folder-name>" 2>/dev/null
+git branch -D "$BRANCH_NAME" 2>/dev/null
 rm -rf "<PlanFolder>/worktrees/<repo-folder-name>"
 ```
 
@@ -235,7 +240,11 @@ rm -rf "<PlanFolder>/worktrees/<repo-folder-name>"
 ```bash
 cd <original-repo-path>
 git fetch origin
-git worktree add "<PlanFolder>/worktrees/<repo-folder-name>" -b "plan-<planId>-<repo-folder-name>" "origin/<default-branch>"
+PLAN_FOLDER_NAME=$(basename "<PlanFolder>")
+PLAN_ID=$(echo "$PLAN_FOLDER_NAME" | grep -oP '^\d+')
+SAFE_TITLE=$(echo "$PLAN_FOLDER_NAME" | sed 's/^[0-9]\+-//')
+BRANCH_NAME="tendril/$PLAN_ID-$SAFE_TITLE"
+git worktree add "<PlanFolder>/worktrees/<repo-folder-name>" -b "$BRANCH_NAME" "origin/<default-branch>"
 ```
 
 Example:
@@ -243,7 +252,7 @@ Example:
 ```bash
 cd <RepoPath>
 git fetch origin
-git worktree add "<PlanFolder>/worktrees/<RepoName>" -b "plan-<PlanId>-<RepoName>" origin/master
+git worktree add "<PlanFolder>/worktrees/<RepoName>" -b "tendril/<PlanId>-<SafeTitle>" origin/master
 ```
 
 **Important:** Always branch from `origin/<default-branch>`, not local HEAD. This ensures the PR only contains the plan's commits, not any unpushed local work.

--- a/src/tendril/Ivy.Tendril/Promptwares/MakePr/Program.md
+++ b/src/tendril/Ivy.Tendril/Promptwares/MakePr/Program.md
@@ -47,7 +47,7 @@ Before processing, read `plan.yaml` and check the `state` field:
 
 Check `<PlanFolder>/worktrees/` for each repo worktree.
 
-> **Worktree already removed:** If the worktrees/ directory is empty (worktree was already cleaned up), fall back to `plan.yaml` to get the repo path and branch name (format: `plan-<planId>-<repo-folder-name>`). The commit objects may still exist in the original repo's object store. Use `git cat-file -t <sha>` to verify, then create or force-update the local branch: `git branch -f <branch-name> <sha>` (use `-f` because the branch may already exist from a WIP auto-commit) and push from the original repo path.
+> **Worktree already removed:** If the worktrees/ directory is empty (worktree was already cleaned up), fall back to `plan.yaml` to get the repo path and branch name (format: `tendril/<planId>-<SafeTitle>`, where SafeTitle is extracted from the plan folder name: e.g. `03158-ChangeBranchNaming` → `ChangeBranchNaming`). The commit objects may still exist in the original repo's object store. Use `git cat-file -t <sha>` to verify, then create or force-update the local branch: `git branch -f <branch-name> <sha>` (use `-f` because the branch may already exist from a WIP auto-commit) and push from the original repo path.
 >
 > **Commit lost (object GC'd):** If `git cat-file -t <sha>` fails, the commit was garbage-collected after worktree removal. In this case: (1) check if the change is already on main, (2) if not, recreate the change from the plan revision — create a new branch from main, apply the changes as described in the revision, commit with the standard `[<planId>] <title>` message, and push. Update `plan.yaml` commits list with the new commit hash.
 
@@ -193,8 +193,12 @@ For each repo where the PR was merged:
 
 ```bash
 cd <original-repo-path>
+PLAN_FOLDER_NAME=$(basename "<PlanFolder>")
+PLAN_ID=$(echo "$PLAN_FOLDER_NAME" | grep -oP '^\d+')
+SAFE_TITLE=$(echo "$PLAN_FOLDER_NAME" | sed 's/^[0-9]\+-//')
+BRANCH_NAME="tendril/$PLAN_ID-$SAFE_TITLE"
 git worktree remove "<PlanFolder>/worktrees/<repo-folder-name>" --force
-git branch -D "plan-<planId>-<repo-folder-name>" 2>/dev/null
+git branch -D "$BRANCH_NAME" 2>/dev/null
 ```
 
 If **all** worktrees were cleaned up, remove the now-empty `worktrees/` directory:


### PR DESCRIPTION
# Summary

## Changes

Changed the git branch naming convention from `plan-<planId>-<repoName>` to `tendril/<planId>-<SafeTitle>` across all promptwares and cleanup scripts. The SafeTitle is extracted from the plan folder name (e.g., `03158-ChangeBranchNaming` yields `ChangeBranchNaming`), providing better namespacing under the `tendril/` prefix and more descriptive branch names.

## API Changes

None. This is a convention change in documentation and internal scripts.

## Files Modified

- **ExecutePlan/Program.md** — Updated cleanup, creation, and example code blocks to use new `tendril/<planId>-<SafeTitle>` branch format
- **MakePr/Program.md** — Updated fallback branch name format and cleanup code block
- **CleanupPlan/CleanupPlan.ps1** — Changed branch name construction to extract SafeTitle from plan folder name
- **CleanupWorktrees.ps1** — Changed branch name construction to extract SafeTitle from plan folder name
- **WorktreeLifecycleLoggerTests.cs** — Updated test data to use `tendril/03058-TestPlan` branch format

## Commits

- 4f4189374 [03158] Change branch naming from plan-<id>-<repo> to tendril/<id>-<title>