### PR TITLE
[03152] Tendril: Fix project selector Auto exclusivity

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Plans/Dialogs/CreatePlanDialog.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Plans/Dialogs/CreatePlanDialog.cs
@@ -1,0 +1,68 @@
+using Ivy.Core.Hooks;
+
+namespace Ivy.Tendril.Apps.Plans.Dialogs;
+
+public class CreatePlanDialog(
+    List<string> projectNames,
+    Action<string, string[], int> onCreatePlan,
+    Action onClose,
+    string[]? defaultProjects = null) : ViewBase
+{
+    private readonly string[] _defaultProjects = defaultProjects ?? ["Auto"];
+    private readonly Action _onClose = onClose;
+    private readonly Action<string, string[], int> _onCreatePlan = onCreatePlan;
+    private readonly List<string> _projectNames = projectNames;
+
+    internal static readonly List<string> PriorityOptions = ["Normal (0)", "High (1)", "Urgent (2)"];
+
+    internal static int ParsePriority(string option) =>
+        int.TryParse(option.AsSpan(option.LastIndexOf('(') + 1, 1), out var v) ? v : 0;
+
+    public override object Build()
+    {
+        var createPlanText = UseState("");
+        var selectedProjects = UseState(_defaultProjects);
+        var selectedPriority = UseState("Normal (0)");
+
+        var exclusiveProjects = new ConvertedState<string[], string[]>(
+            selectedProjects,
+            forward: v => v,
+            backward: newValue =>
+            {
+                var current = selectedProjects.Value;
+                if (newValue.Contains("Auto") && !current.Contains("Auto"))
+                    return ["Auto"];
+                if (newValue.Contains("Auto") && newValue.Any(p => p != "Auto"))
+                    return newValue.Where(p => p != "Auto").ToArray();
+                return newValue;
+            }
+        );
+
+        var options = new List<string> { "Auto" };
+        options.AddRange(_projectNames);
+
+        return new Dialog(
+            _ => _onClose(),
+            new DialogHeader("Create New Plan"),
+            new DialogBody(
+                Layout.Vertical()
+                | exclusiveProjects.ToSelectInput(options).Variant(SelectInputVariant.Toggle).WithLabel("Select project(s)")
+                | selectedPriority.ToSelectInput(PriorityOptions).Variant(SelectInputVariant.Toggle).WithLabel("Priority")
+                | createPlanText.ToTextareaInput("Enter task description...").Rows(6).AutoFocus().WithField()
+                    .Label("Describe the task for the new plan")
+            ),
+            new DialogFooter(
+                new Button("Cancel").Outline().OnClick(() => _onClose()),
+                new Button("Create").Primary().ShortcutKey("Ctrl+Enter").OnClick(() =>
+                {
+                    if (!string.IsNullOrWhiteSpace(createPlanText.Value))
+                    {
+                        var projects = selectedProjects.Value.Any() ? selectedProjects.Value : ["Auto"];
+                        _onCreatePlan(createPlanText.Value, projects, ParsePriority(selectedPriority.Value));
+                        _onClose();
+                    }
+                })
+            )
+        ).Width(Size.Rem(30));
+    }
+}


### PR DESCRIPTION
# Summary

## Changes

Restored `CreatePlanDialog.cs` (accidentally deleted during merge conflict resolution in plan 00078) and added mutual exclusivity logic for the "Auto" project option. When a user selects "Auto", all specific projects are deselected; when a specific project is selected while "Auto" is active, "Auto" is removed. Uses `ConvertedState<string[], string[]>` to intercept SelectInput value changes before they reach the underlying state, avoiding re-render loops.

## API Changes

None. The `CreatePlanDialog` class signature is unchanged from the version deleted in the merge conflict. The `ConvertedState` wrapper is an internal implementation detail.

## Files Modified

- **Restored:** `src/tendril/Ivy.Tendril/Apps/Plans/Dialogs/CreatePlanDialog.cs` — full file restoration with exclusivity logic added

## Commits

- 74c93123b [03152] Restore CreatePlanDialog and add Auto exclusivity logic