### PR TITLE
[03161] Job timeouts have stopped working

### DIFF
--- a/src/Ivy.Test/Helpers/ProcessExtensionsTests.cs
+++ b/src/Ivy.Test/Helpers/ProcessExtensionsTests.cs
@@ -134,4 +134,26 @@ public class ProcessExtensionsTests
         Assert.False(result);
         Assert.True(process!.HasExited);
     }
+
+    [Fact]
+    public async Task WaitForExitOrKillAsync_PostKillTimeout_CompletesWithinReasonableTime()
+    {
+        using var process = Process.Start(new ProcessStartInfo
+        {
+            FileName = OperatingSystem.IsWindows() ? "cmd.exe" : "/bin/sh",
+            Arguments = OperatingSystem.IsWindows() ? "/c ping -n 120 127.0.0.1 >nul" : "-c \"sleep 120\"",
+            UseShellExecute = false,
+            CreateNoWindow = true
+        });
+
+        var sw = Stopwatch.StartNew();
+        using var cts = new CancellationTokenSource(100);
+        var result = await process.WaitForExitOrKillAsync(cts.Token);
+        sw.Stop();
+
+        Assert.False(result);
+        Assert.True(process!.HasExited);
+        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(10),
+            $"Post-kill should complete within 10s (5s kill timeout + margin), took {sw.Elapsed}");
+    }
 }

--- a/src/Ivy/Helpers/ProcessExtensions.cs
+++ b/src/Ivy/Helpers/ProcessExtensions.cs
@@ -14,12 +14,7 @@ public static class ProcessExtensions
         if (process is null) return true;
         if (!process.WaitForExit(timeoutMs))
         {
-            try
-            {
-                process.Kill(true);
-                process.WaitForExit(); // Ensure HasExited is true
-            }
-            catch { /* already exited */ }
+            KillProcess(process);
             return false;
         }
         return true;
@@ -41,12 +36,7 @@ public static class ProcessExtensions
         }
         catch (OperationCanceledException)
         {
-            try
-            {
-                process.Kill(true);
-                await process.WaitForExitAsync(); // Ensure HasExited is true
-            }
-            catch { /* already exited */ }
+            await KillProcessAsync(process);
             return false;
         }
     }
@@ -66,13 +56,48 @@ public static class ProcessExtensions
         }
         catch (OperationCanceledException)
         {
-            try
-            {
-                process.Kill(true);
-                await process.WaitForExitAsync(); // Ensure HasExited is true
-            }
-            catch { /* already exited */ }
+            await KillProcessAsync(process);
             return false;
+        }
+    }
+
+    private static void KillProcess(Process process)
+    {
+        try
+        {
+            process.Kill(true);
+            if (!process.WaitForExit(5000))
+                Debug.WriteLine($"Process {process.Id} did not exit within 5 seconds after Kill()");
+        }
+        catch (InvalidOperationException)
+        {
+            // Process already exited
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Exception killing process {process.Id}: {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    private static async Task KillProcessAsync(Process process)
+    {
+        try
+        {
+            process.Kill(true);
+            using var killTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            await process.WaitForExitAsync(killTimeout.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            Debug.WriteLine($"Process {process.Id} did not exit within 5 seconds after Kill()");
+        }
+        catch (InvalidOperationException)
+        {
+            // Process already exited
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Exception killing process {process.Id}: {ex.GetType().Name}: {ex.Message}");
         }
     }
 }

--- a/src/tendril/Ivy.Tendril.Test/JobServiceTimeoutTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/JobServiceTimeoutTests.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+using Ivy.Helpers;
 using Ivy.Tendril.Apps.Jobs;
 using Ivy.Tendril.Services;
 using YamlDotNet.Serialization;
@@ -222,6 +224,57 @@ codingAgent: claude
         Assert.Contains("\"type\":\"heartbeat\"", heartbeatLine);
         Assert.DoesNotContain("\"type\":\"heartbeat\"", normalLine);
 
+        service.CompleteJob(id, 0);
+    }
+
+    [Fact]
+    public async Task RealProcess_KilledAfterTimeout()
+    {
+        using var process = Process.Start(new ProcessStartInfo
+        {
+            FileName = OperatingSystem.IsWindows() ? "cmd.exe" : "/bin/sh",
+            Arguments = OperatingSystem.IsWindows() ? "/c ping -n 120 127.0.0.1 >nul" : "-c \"sleep 120\"",
+            UseShellExecute = false,
+            CreateNoWindow = true
+        });
+        Assert.NotNull(process);
+        Assert.False(process.HasExited);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        var sw = Stopwatch.StartNew();
+        var result = await process.WaitForExitOrKillAsync(cts.Token);
+        sw.Stop();
+
+        Assert.False(result);
+        Assert.True(process.HasExited);
+        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(15),
+            $"Process should be killed within timeout + kill grace period, took {sw.Elapsed}");
+    }
+
+    [Fact]
+    public void ProcessId_CapturedOnJobItem()
+    {
+        var service = CreateService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
+        var id = service.CreateTestJob("ExecutePlan", Path.GetTempPath());
+        var job = service.GetJob(id);
+        Assert.NotNull(job);
+
+        using var process = Process.Start(new ProcessStartInfo
+        {
+            FileName = OperatingSystem.IsWindows() ? "cmd.exe" : "/bin/sh",
+            Arguments = OperatingSystem.IsWindows() ? "/c exit 0" : "-c \"exit 0\"",
+            UseShellExecute = false,
+            CreateNoWindow = true
+        });
+        Assert.NotNull(process);
+
+        job.Process = process;
+        job.ProcessId = process.Id;
+
+        Assert.NotNull(job.ProcessId);
+        Assert.True(job.ProcessId > 0);
+
+        process.WaitForExit();
         service.CompleteJob(id, 0);
     }
 }

--- a/src/tendril/Ivy.Tendril/Apps/Jobs/Models.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Jobs/Models.cs
@@ -42,6 +42,7 @@ public record JobItem
 
     // Process handle for non-interactive execution
     public Process? Process { get; set; }
+    public int? ProcessId { get; set; }
     public string? StatusMessage { get; set; }
     public ConcurrentQueue<string> OutputLines { get; set; } = new();
     public DateTime? LastOutputAt { get; set; }

--- a/src/tendril/Ivy.Tendril/Services/JobService.cs
+++ b/src/tendril/Ivy.Tendril/Services/JobService.cs
@@ -714,6 +714,7 @@ public class JobService : IJobService
         process.BeginOutputReadLine();
         process.BeginErrorReadLine();
         job.Process = process;
+        job.ProcessId = process.Id;
 
         // Monitor for completion in background with timeout and stale output detection
         var cts = new CancellationTokenSource(_jobTimeout);


### PR DESCRIPTION
# Summary

## Changes

Fixed job timeouts by adding a 5-second timeout to the post-Kill `WaitForExitAsync()` call in `ProcessExtensions`, which was previously waiting indefinitely and causing hung jobs. Replaced silent catch-all exception handlers with specific catches and `Debug.WriteLine` logging for Kill failures. Added `ProcessId` tracking to `JobItem` for debugging.

## API Changes

- `JobItem.ProcessId` (`int?`) — new property on `Ivy.Tendril.Apps.Jobs.JobItem` that captures the OS process ID for debugging timeout issues

## Files Modified

- **src/Ivy/Helpers/ProcessExtensions.cs** — Extracted `KillProcess`/`KillProcessAsync` helpers with 5-second timeout and diagnostic logging
- **src/tendril/Ivy.Tendril/Apps/Jobs/Models.cs** — Added `ProcessId` property to `JobItem`
- **src/tendril/Ivy.Tendril/Services/JobService.cs** — Capture `process.Id` after `Start()`
- **src/Ivy.Test/Helpers/ProcessExtensionsTests.cs** — Added post-kill timeout completion test
- **src/tendril/Ivy.Tendril.Test/JobServiceTimeoutTests.cs** — Added real-process kill test and ProcessId capture test

## Commits

- 5b8baadc5 [03161] Add tests for post-kill timeout and process ID tracking
- b943236a5 [03161] Fix job timeouts by adding post-kill timeout and logging