### PR TITLE
[03156] Add rate limiting to Tendril password authentication

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/Auth/LoginRateLimiterTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/Auth/LoginRateLimiterTests.cs
@@ -1,0 +1,153 @@
+using Ivy.Tendril.Auth;
+
+namespace Ivy.Tendril.Test.Auth;
+
+public class LoginRateLimiterTests
+{
+    private static LoginRateLimiter CreateLimiter(int threshold = 3, double baseDelay = 1.0, double maxDelay = 60.0)
+    {
+        return new LoginRateLimiter(new LoginRateLimitConfig
+        {
+            Threshold = threshold,
+            BaseDelaySeconds = baseDelay,
+            MaxDelaySeconds = maxDelay
+        });
+    }
+
+    [Fact]
+    public void IsLoginAllowed_UnderThreshold_ReturnsTrue()
+    {
+        var limiter = CreateLimiter(threshold: 3);
+
+        limiter.RecordFailedAttempt("192.168.1.1");
+        Assert.True(limiter.IsLoginAllowed("192.168.1.1"));
+
+        limiter.RecordFailedAttempt("192.168.1.1");
+        Assert.True(limiter.IsLoginAllowed("192.168.1.1"));
+
+        limiter.RecordFailedAttempt("192.168.1.1");
+        Assert.True(limiter.IsLoginAllowed("192.168.1.1"));
+    }
+
+    [Fact]
+    public void IsLoginAllowed_OverThreshold_RequiresDelay()
+    {
+        var limiter = CreateLimiter(threshold: 3, baseDelay: 10.0);
+
+        for (var i = 0; i < 4; i++)
+            limiter.RecordFailedAttempt("192.168.1.1");
+
+        Assert.False(limiter.IsLoginAllowed("192.168.1.1"));
+    }
+
+    [Fact]
+    public void RecordFailedAttempt_IncrementsCounter()
+    {
+        var limiter = CreateLimiter(threshold: 1, baseDelay: 100.0);
+
+        limiter.RecordFailedAttempt("10.0.0.1");
+        Assert.True(limiter.IsLoginAllowed("10.0.0.1"));
+
+        limiter.RecordFailedAttempt("10.0.0.1");
+        Assert.False(limiter.IsLoginAllowed("10.0.0.1"));
+    }
+
+    [Fact]
+    public void RecordSuccessfulLogin_ResetsCounter()
+    {
+        var limiter = CreateLimiter(threshold: 1, baseDelay: 100.0);
+
+        limiter.RecordFailedAttempt("10.0.0.1");
+        limiter.RecordFailedAttempt("10.0.0.1");
+        Assert.False(limiter.IsLoginAllowed("10.0.0.1"));
+
+        limiter.RecordSuccessfulLogin("10.0.0.1");
+        Assert.True(limiter.IsLoginAllowed("10.0.0.1"));
+    }
+
+    [Fact]
+    public void GetRequiredDelay_ExponentialBackoff()
+    {
+        var limiter = CreateLimiter(threshold: 3, baseDelay: 1.0, maxDelay: 60.0);
+
+        for (var i = 0; i < 4; i++)
+            limiter.RecordFailedAttempt("10.0.0.1");
+
+        var delay4 = limiter.GetRequiredDelay("10.0.0.1");
+        Assert.True(delay4.TotalSeconds > 0 && delay4.TotalSeconds <= 1.0,
+            $"After 4 failures (1 over threshold), expected ~1s delay, got {delay4.TotalSeconds}s");
+
+        limiter.RecordFailedAttempt("10.0.0.1");
+        var delay5 = limiter.GetRequiredDelay("10.0.0.1");
+        Assert.True(delay5.TotalSeconds > 1.0 && delay5.TotalSeconds <= 2.0,
+            $"After 5 failures (2 over threshold), expected ~2s delay, got {delay5.TotalSeconds}s");
+
+        limiter.RecordFailedAttempt("10.0.0.1");
+        var delay6 = limiter.GetRequiredDelay("10.0.0.1");
+        Assert.True(delay6.TotalSeconds > 2.0 && delay6.TotalSeconds <= 4.0,
+            $"After 6 failures (3 over threshold), expected ~4s delay, got {delay6.TotalSeconds}s");
+
+        limiter.RecordFailedAttempt("10.0.0.1");
+        var delay7 = limiter.GetRequiredDelay("10.0.0.1");
+        Assert.True(delay7.TotalSeconds > 4.0 && delay7.TotalSeconds <= 8.0,
+            $"After 7 failures (4 over threshold), expected ~8s delay, got {delay7.TotalSeconds}s");
+    }
+
+    [Fact]
+    public void GetRequiredDelay_MaxCapRespected()
+    {
+        var limiter = CreateLimiter(threshold: 1, baseDelay: 1.0, maxDelay: 5.0);
+
+        for (var i = 0; i < 20; i++)
+            limiter.RecordFailedAttempt("10.0.0.1");
+
+        var delay = limiter.GetRequiredDelay("10.0.0.1");
+        Assert.True(delay.TotalSeconds <= 5.0,
+            $"Expected delay capped at 5s, got {delay.TotalSeconds}s");
+    }
+
+    [Fact]
+    public void CleanupOldEntries_RemovesStaleRecords()
+    {
+        var limiter = CreateLimiter(threshold: 1, baseDelay: 1.0, maxDelay: 1.0);
+
+        limiter.RecordFailedAttempt("10.0.0.1");
+        limiter.RecordFailedAttempt("10.0.0.1");
+
+        // Immediately after recording, the entry exists
+        Assert.False(limiter.IsLoginAllowed("10.0.0.1"));
+
+        // After a successful login, the entry is removed
+        limiter.RecordSuccessfulLogin("10.0.0.1");
+        Assert.True(limiter.IsLoginAllowed("10.0.0.1"));
+    }
+
+    [Fact]
+    public void MultipleIPs_IndependentTracking()
+    {
+        var limiter = CreateLimiter(threshold: 1, baseDelay: 100.0);
+
+        limiter.RecordFailedAttempt("10.0.0.1");
+        limiter.RecordFailedAttempt("10.0.0.1");
+        limiter.RecordFailedAttempt("10.0.0.2");
+
+        Assert.False(limiter.IsLoginAllowed("10.0.0.1"));
+        Assert.True(limiter.IsLoginAllowed("10.0.0.2"));
+    }
+
+    [Fact]
+    public void GetRequiredDelay_NoAttempts_ReturnsZero()
+    {
+        var limiter = CreateLimiter();
+
+        Assert.Equal(TimeSpan.Zero, limiter.GetRequiredDelay("unknown-ip"));
+    }
+
+    [Fact]
+    public void IsLoginAllowed_NewIP_ReturnsTrue()
+    {
+        var limiter = CreateLimiter();
+
+        Assert.True(limiter.IsLoginAllowed("new-ip"));
+    }
+}

--- a/src/tendril/Ivy.Tendril.Test/Auth/TendrilAuthProviderTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/Auth/TendrilAuthProviderTests.cs
@@ -7,7 +7,7 @@ namespace Ivy.Tendril.Test.Auth;
 
 public class TendrilAuthProviderTests
 {
-    private static AuthConfig CreateAuthConfig(string password = "test-password")
+    private static AuthConfig CreateAuthConfig(string password = "test-password", LoginRateLimitConfig? rateLimit = null)
     {
         var secret = GenerateSecret();
         var secretBytes = Convert.FromBase64String(secret);
@@ -27,7 +27,7 @@ public class TendrilAuthProviderTests
             HashLength = 32
         });
 
-        return new AuthConfig { Password = hash, HashSecret = secret };
+        return new AuthConfig { Password = hash, HashSecret = secret, RateLimit = rateLimit };
     }
 
     private static string GenerateSecret()
@@ -115,5 +115,84 @@ public class TendrilAuthProviderTests
 
         Assert.Single(options);
         Assert.Equal(Ivy.AuthFlow.EmailPassword, options[0].Flow);
+    }
+
+    [Fact]
+    public async Task LoginAsync_RateLimited_ReturnsNull()
+    {
+        var rateLimit = new LoginRateLimitConfig { Threshold = 1, BaseDelaySeconds = 100.0 };
+        var auth = CreateAuthConfig("test-pass", rateLimit);
+        var provider = CreateProvider(auth);
+
+        // Two failed attempts to exceed threshold
+        await provider.LoginAsync(null!, "anyone", "wrong", CancellationToken.None);
+        await provider.LoginAsync(null!, "anyone", "wrong", CancellationToken.None);
+
+        // Even correct password should be blocked
+        var token = await provider.LoginAsync(null!, "anyone", "test-pass", CancellationToken.None);
+        Assert.Null(token);
+    }
+
+    [Fact]
+    public async Task LoginAsync_FailedAttempts_TriggersRateLimit()
+    {
+        var rateLimit = new LoginRateLimitConfig { Threshold = 2, BaseDelaySeconds = 100.0 };
+        var auth = CreateAuthConfig("test-pass", rateLimit);
+        var provider = CreateProvider(auth);
+
+        // First 2 attempts are under threshold
+        var t1 = await provider.LoginAsync(null!, "anyone", "wrong", CancellationToken.None);
+        Assert.Null(t1);
+        var t2 = await provider.LoginAsync(null!, "anyone", "wrong", CancellationToken.None);
+        Assert.Null(t2);
+
+        // 3rd attempt exceeds threshold — rate limited
+        var t3 = await provider.LoginAsync(null!, "anyone", "wrong", CancellationToken.None);
+        Assert.Null(t3);
+
+        // Correct password is also blocked
+        var t4 = await provider.LoginAsync(null!, "anyone", "test-pass", CancellationToken.None);
+        Assert.Null(t4);
+    }
+
+    [Fact]
+    public async Task LoginAsync_SuccessfulLogin_ClearsRateLimit()
+    {
+        var rateLimit = new LoginRateLimitConfig { Threshold = 2, BaseDelaySeconds = 0.0 };
+        var auth = CreateAuthConfig("test-pass", rateLimit);
+        var provider = CreateProvider(auth);
+
+        // Fail a few times
+        await provider.LoginAsync(null!, "anyone", "wrong", CancellationToken.None);
+        await provider.LoginAsync(null!, "anyone", "wrong", CancellationToken.None);
+
+        // Successful login resets counter
+        var token = await provider.LoginAsync(null!, "anyone", "test-pass", CancellationToken.None);
+        Assert.NotNull(token);
+
+        // Subsequent login should work (counter was reset)
+        var token2 = await provider.LoginAsync(null!, "anyone", "test-pass", CancellationToken.None);
+        Assert.NotNull(token2);
+    }
+
+    [Fact]
+    public async Task LoginAsync_CustomRateLimitConfig_Respected()
+    {
+        var rateLimit = new LoginRateLimitConfig { Threshold = 1, BaseDelaySeconds = 100.0, MaxDelaySeconds = 200.0 };
+        var auth = CreateAuthConfig("test-pass", rateLimit);
+        var provider = CreateProvider(auth);
+
+        // 1 failure is under threshold
+        await provider.LoginAsync(null!, "anyone", "wrong", CancellationToken.None);
+        var t1 = await provider.LoginAsync(null!, "anyone", "test-pass", CancellationToken.None);
+        Assert.NotNull(t1);
+
+        // After success, counter is reset. Fail again to trigger rate limit.
+        await provider.LoginAsync(null!, "anyone", "wrong", CancellationToken.None);
+        await provider.LoginAsync(null!, "anyone", "wrong", CancellationToken.None);
+
+        // Now blocked
+        var t2 = await provider.LoginAsync(null!, "anyone", "test-pass", CancellationToken.None);
+        Assert.Null(t2);
     }
 }

--- a/src/tendril/Ivy.Tendril/Auth/LoginRateLimiter.cs
+++ b/src/tendril/Ivy.Tendril/Auth/LoginRateLimiter.cs
@@ -1,0 +1,95 @@
+using System.Collections.Concurrent;
+
+namespace Ivy.Tendril.Auth;
+
+public class LoginRateLimiter
+{
+    private readonly ConcurrentDictionary<string, LoginAttemptRecord> _attempts = new();
+    private readonly TimeSpan _cleanupInterval = TimeSpan.FromMinutes(5);
+    private readonly LoginRateLimitConfig _config;
+    private DateTime _lastCleanup = DateTime.UtcNow;
+
+    public LoginRateLimiter(LoginRateLimitConfig config)
+    {
+        _config = config;
+    }
+
+    public bool IsLoginAllowed(string ipAddress)
+    {
+        CleanupOldEntries();
+
+        if (!_attempts.TryGetValue(ipAddress, out var record))
+            return true;
+
+        var timeSinceLastAttempt = DateTime.UtcNow - record.LastAttempt;
+        var requiredDelay = CalculateRequiredDelay(record.FailedAttempts);
+
+        return timeSinceLastAttempt >= requiredDelay;
+    }
+
+    public void RecordFailedAttempt(string ipAddress)
+    {
+        _attempts.AddOrUpdate(
+            ipAddress,
+            _ => new LoginAttemptRecord(1, DateTime.UtcNow),
+            (_, existing) => new LoginAttemptRecord(existing.FailedAttempts + 1, DateTime.UtcNow));
+    }
+
+    public void RecordSuccessfulLogin(string ipAddress)
+    {
+        _attempts.TryRemove(ipAddress, out _);
+    }
+
+    public TimeSpan GetRequiredDelay(string ipAddress)
+    {
+        if (!_attempts.TryGetValue(ipAddress, out var record))
+            return TimeSpan.Zero;
+
+        var timeSinceLastAttempt = DateTime.UtcNow - record.LastAttempt;
+        var requiredDelay = CalculateRequiredDelay(record.FailedAttempts);
+        var remaining = requiredDelay - timeSinceLastAttempt;
+
+        return remaining > TimeSpan.Zero ? remaining : TimeSpan.Zero;
+    }
+
+    // min(baseDelay * 2^(attempts - threshold), maxDelay)
+    private TimeSpan CalculateRequiredDelay(int failedAttempts)
+    {
+        if (failedAttempts <= _config.Threshold)
+            return TimeSpan.Zero;
+
+        var exponent = failedAttempts - _config.Threshold;
+        var delaySeconds = _config.BaseDelaySeconds * Math.Pow(2, exponent - 1);
+        var cappedDelay = Math.Min(delaySeconds, _config.MaxDelaySeconds);
+
+        return TimeSpan.FromSeconds(cappedDelay);
+    }
+
+    private void CleanupOldEntries()
+    {
+        if (DateTime.UtcNow - _lastCleanup < _cleanupInterval)
+            return;
+
+        _lastCleanup = DateTime.UtcNow;
+        var cutoff = DateTime.UtcNow - TimeSpan.FromSeconds(_config.MaxDelaySeconds) - _cleanupInterval;
+
+        var keysToRemove = _attempts
+            .Where(kvp => kvp.Value.LastAttempt < cutoff)
+            .Select(kvp => kvp.Key)
+            .ToList();
+
+        foreach (var key in keysToRemove)
+        {
+            _attempts.TryRemove(key, out _);
+        }
+    }
+
+    private sealed record LoginAttemptRecord(int FailedAttempts, DateTime LastAttempt);
+}
+
+public record LoginRateLimitConfig
+{
+    public int Threshold { get; init; } = 3;
+    public double BaseDelaySeconds { get; init; } = 1.0;
+    public double MaxDelaySeconds { get; init; } = 60.0;
+}

--- a/src/tendril/Ivy.Tendril/Auth/TendrilAuthProvider.cs
+++ b/src/tendril/Ivy.Tendril/Auth/TendrilAuthProvider.cs
@@ -11,8 +11,10 @@ public class TendrilAuthProvider : BasicAuthTokenHandler, IAuthProvider
 {
     private readonly string _passwordHash;
     private readonly byte[] _hashSecret;
+    private readonly LoginRateLimiter _rateLimiter;
+    private readonly IHttpContextAccessor? _httpContextAccessor;
 
-    public TendrilAuthProvider(IConfigService configService)
+    public TendrilAuthProvider(IConfigService configService, IHttpContextAccessor? httpContextAccessor = null)
         : base(BuildConfiguration(configService))
     {
         var auth = configService.Settings.Auth
@@ -28,12 +30,25 @@ public class TendrilAuthProvider : BasicAuthTokenHandler, IAuthProvider
         {
             throw new InvalidOperationException("Auth:HashSecret is not a valid base64 string");
         }
+
+        _httpContextAccessor = httpContextAccessor;
+        _rateLimiter = new LoginRateLimiter(auth.RateLimit ?? new LoginRateLimitConfig());
     }
 
     public Task<AuthToken?> LoginAsync(IAuthSession authSession, string user, string password, CancellationToken cancellationToken)
     {
-        if (!PasswordMatches(password))
+        var ipAddress = _httpContextAccessor?.HttpContext?.Connection.RemoteIpAddress?.ToString() ?? "global";
+
+        if (!_rateLimiter.IsLoginAllowed(ipAddress))
             return Task.FromResult<AuthToken?>(null);
+
+        if (!PasswordMatches(password))
+        {
+            _rateLimiter.RecordFailedAttempt(ipAddress);
+            return Task.FromResult<AuthToken?>(null);
+        }
+
+        _rateLimiter.RecordSuccessfulLogin(ipAddress);
 
         var now = DateTimeOffset.UtcNow;
         var authToken = CreateToken("tendril", now, now.ToUnixTimeSeconds());

--- a/src/tendril/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/tendril/Ivy.Tendril/Services/ConfigService.cs
@@ -115,6 +115,7 @@ public record AuthConfig
 {
     public string Password { get; set; } = "";
     public string HashSecret { get; set; } = "";
+    public Auth.LoginRateLimitConfig? RateLimit { get; set; }
 }
 
 public record ApiSettings

--- a/src/tendril/Ivy.Tendril/TendrilServer.cs
+++ b/src/tendril/Ivy.Tendril/TendrilServer.cs
@@ -28,6 +28,7 @@ public static class TendrilServer
 
         if (configService.Settings.Auth != null)
         {
+            server.Services.AddHttpContextAccessor();
             server.UseAuth<Auth.TendrilAuthProvider>();
         }
 


### PR DESCRIPTION
# Summary

## Changes

Added a `LoginRateLimiter` service with exponential backoff to protect Tendril's password authentication against brute-force attacks. The rate limiter tracks failed login attempts per client identifier and enforces configurable delays after a threshold is exceeded. Integrated into `TendrilAuthProvider` with `IHttpContextAccessor` for IP-based tracking, falling back to a global key for WebSocket-based login flows.

## API Changes

- New class `LoginRateLimiter` — tracks failed attempts and enforces exponential backoff delays
- New record `LoginRateLimitConfig` — configures `Threshold` (default 3), `BaseDelaySeconds` (default 1.0), `MaxDelaySeconds` (default 60.0)
- `AuthConfig.RateLimit` — new optional `LoginRateLimitConfig?` property for configuring rate limiting via config.yaml
- `TendrilAuthProvider` constructor — added optional `IHttpContextAccessor?` parameter (backward compatible)

## Files Modified

**New files:**
- `src/tendril/Ivy.Tendril/Auth/LoginRateLimiter.cs` — rate limiter service and config
- `src/tendril/Ivy.Tendril.Test/Auth/LoginRateLimiterTests.cs` — 10 unit tests

**Modified:**
- `src/tendril/Ivy.Tendril/Auth/TendrilAuthProvider.cs` — integrated rate limiter into login flow
- `src/tendril/Ivy.Tendril/Services/ConfigService.cs` — added RateLimit to AuthConfig
- `src/tendril/Ivy.Tendril/TendrilServer.cs` — registered IHttpContextAccessor in DI
- `src/tendril/Ivy.Tendril.Test/Auth/TendrilAuthProviderTests.cs` — 4 new rate limiting integration tests

## Commits

- ad999739d [03156] Add rate limiting to Tendril password authentication