### PR TITLE
[03164] Replace Debug.WriteLine with crash log in ProcessExtensions kill-failure diagnostics

### DIFF
--- a/src/Ivy/Helpers/ProcessExtensions.cs
+++ b/src/Ivy/Helpers/ProcessExtensions.cs
@@ -67,7 +67,7 @@ public static class ProcessExtensions
         {
             process.Kill(true);
             if (!process.WaitForExit(5000))
-                Debug.WriteLine($"Process {process.Id} did not exit within 5 seconds after Kill()");
+                WriteCrashLog($"[{DateTime.UtcNow:O}] Process {process.Id} did not exit within 5 seconds after Kill()");
         }
         catch (InvalidOperationException)
         {
@@ -75,7 +75,7 @@ public static class ProcessExtensions
         }
         catch (Exception ex)
         {
-            Debug.WriteLine($"Exception killing process {process.Id}: {ex.GetType().Name}: {ex.Message}");
+            WriteCrashLog($"[{DateTime.UtcNow:O}] Exception killing process {process.Id}: {ex.GetType().Name}: {ex.Message}");
         }
     }
 
@@ -89,7 +89,7 @@ public static class ProcessExtensions
         }
         catch (OperationCanceledException)
         {
-            Debug.WriteLine($"Process {process.Id} did not exit within 5 seconds after Kill()");
+            WriteCrashLog($"[{DateTime.UtcNow:O}] Process {process.Id} did not exit within 5 seconds after Kill()");
         }
         catch (InvalidOperationException)
         {
@@ -97,7 +97,22 @@ public static class ProcessExtensions
         }
         catch (Exception ex)
         {
-            Debug.WriteLine($"Exception killing process {process.Id}: {ex.GetType().Name}: {ex.Message}");
+            WriteCrashLog($"[{DateTime.UtcNow:O}] Exception killing process {process.Id}: {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    private static void WriteCrashLog(string message)
+    {
+        try
+        {
+            var tendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME");
+            var logDir = !string.IsNullOrEmpty(tendrilHome) ? tendrilHome : Path.GetTempPath();
+            var path = Path.Combine(logDir, "crash.log");
+            File.AppendAllText(path, message + Environment.NewLine);
+        }
+        catch
+        {
+            // Last-resort: don't let logging crash the process
         }
     }
 }


### PR DESCRIPTION
# Summary

## Changes

Replaced four `Debug.WriteLine` calls in `ProcessExtensions.cs` with a self-contained `WriteCrashLog` helper that appends timestamped messages to Tendril's `crash.log` file. This ensures kill-failure diagnostics (post-kill timeout warnings and exception details) are captured in production, where `Debug.WriteLine` output is invisible.

Because `ProcessExtensions` lives in the shared `Ivy` project which cannot reference `Ivy.Tendril` (circular dependency), the `WriteCrashLog` method was implemented directly in `ProcessExtensions` — it writes to the same `TENDRIL_HOME/crash.log` path used by `Tendril.Program.WriteCrashLog`.

## API Changes

None. All changes are internal to private methods.

## Files Modified

- **src/Ivy/Helpers/ProcessExtensions.cs** — Replaced 4 `Debug.WriteLine` calls with `WriteCrashLog`; added private `WriteCrashLog` helper method

## Commits

- 047f35550 [03164] Replace Debug.WriteLine with crash log in ProcessExtensions