### PR TITLE
[03163] Implement clickable plan:// links in markdown

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/MarkdownHelperTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/MarkdownHelperTests.cs
@@ -72,6 +72,60 @@ public class MarkdownHelperTests
     }
 
     [Fact]
+    public void AnnotateBrokenPlanLinks_ValidPlan_RemainsUnchanged()
+    {
+        var tempPlansDir = Path.Combine(Path.GetTempPath(), $"plans-{Guid.NewGuid()}");
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(tempPlansDir, "01234-TestPlan"));
+            var markdown = "[Plan 01234](plan://01234)";
+            var result = MarkdownHelper.AnnotateBrokenPlanLinks(markdown, tempPlansDir);
+            Assert.DoesNotContain("\u26a0\ufe0f", result);
+            Assert.Equal(markdown, result);
+        }
+        finally
+        {
+            Directory.Delete(tempPlansDir, true);
+        }
+    }
+
+    [Fact]
+    public void AnnotateBrokenPlanLinks_BrokenPlan_AddsWarningIndicator()
+    {
+        var tempPlansDir = Path.Combine(Path.GetTempPath(), $"plans-{Guid.NewGuid()}");
+        try
+        {
+            Directory.CreateDirectory(tempPlansDir);
+            var markdown = "[Plan 99999](plan://99999)";
+            var result = MarkdownHelper.AnnotateBrokenPlanLinks(markdown, tempPlansDir);
+            Assert.Contains("\u26a0\ufe0f", result);
+            Assert.Contains("[Plan 99999 \u26a0\ufe0f](plan://99999)", result);
+        }
+        finally
+        {
+            Directory.Delete(tempPlansDir, true);
+        }
+    }
+
+    [Fact]
+    public void AnnotateBrokenPlanLinks_PlanIdWithoutLeadingZeros_Works()
+    {
+        var tempPlansDir = Path.Combine(Path.GetTempPath(), $"plans-{Guid.NewGuid()}");
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(tempPlansDir, "00123-TestPlan"));
+            var markdown = "[Plan 123](plan://123)";
+            var result = MarkdownHelper.AnnotateBrokenPlanLinks(markdown, tempPlansDir);
+            Assert.DoesNotContain("\u26a0\ufe0f", result);
+            Assert.Equal(markdown, result);
+        }
+        finally
+        {
+            Directory.Delete(tempPlansDir, true);
+        }
+    }
+
+    [Fact]
     public void FindFilesInRepos_FindsMatchingFiles()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), $"ivy-test-{Guid.NewGuid()}");

--- a/src/tendril/Ivy.Tendril.Test/Services/FileLinkHelperTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/Services/FileLinkHelperTests.cs
@@ -41,6 +41,50 @@ public class FileLinkHelperTests
     }
 
     [Fact]
+    public void CreateFileLinkClickHandler_InvokesPlanCallback_WhenPlanUrlProvided()
+    {
+        var fileState = new TestState<string?>(null);
+        var planIdCaptured = 0;
+        var handler = FileLinkHelper.CreateFileLinkClickHandler(
+            fileState,
+            planId => planIdCaptured = planId);
+
+        handler("plan://03156");
+
+        Assert.Equal(3156, planIdCaptured);
+        Assert.Null(fileState.Value);
+    }
+
+    [Fact]
+    public void CreateFileLinkClickHandler_HandlesPlanIdWithLeadingZeros()
+    {
+        var fileState = new TestState<string?>(null);
+        var planIdCaptured = 0;
+        var handler = FileLinkHelper.CreateFileLinkClickHandler(
+            fileState,
+            planId => planIdCaptured = planId);
+
+        handler("plan://00123");
+
+        Assert.Equal(123, planIdCaptured);
+    }
+
+    [Fact]
+    public void CreateFileLinkClickHandler_IgnoresInvalidPlanIds()
+    {
+        var fileState = new TestState<string?>(null);
+        var callbackInvoked = false;
+        var handler = FileLinkHelper.CreateFileLinkClickHandler(
+            fileState,
+            _ => callbackInvoked = true);
+
+        handler("plan://notanumber");
+
+        Assert.False(callbackInvoked);
+        Assert.Null(fileState.Value);
+    }
+
+    [Fact]
     public void BuildFileLinkSheet_ReturnsNull_WhenFilePathIsNull()
     {
         var result = FileLinkHelper.BuildFileLinkSheet(null, () => { }, [], TestConfig);

--- a/src/tendril/Ivy.Tendril/Apps/Icebox/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Icebox/ContentView.cs
@@ -109,9 +109,21 @@ public class ContentView(
                 });
         else
             scrollableContent |=
-                new Markdown(MarkdownHelper.AnnotateBrokenFileLinks(_selectedPlan.LatestRevisionContent))
+                new Markdown(MarkdownHelper.AnnotateBrokenPlanLinks(
+                        MarkdownHelper.AnnotateBrokenFileLinks(_selectedPlan.LatestRevisionContent),
+                        _planService.PlansDirectory))
                     .DangerouslyAllowLocalFiles()
-                    .OnLinkClick(FileLinkHelper.CreateFileLinkClickHandler(openFile));
+                    .OnLinkClick(FileLinkHelper.CreateFileLinkClickHandler(openFile, planId =>
+                    {
+                        var planFolder = Directory.GetDirectories(_planService.PlansDirectory, $"{planId:D5}-*")
+                            .FirstOrDefault();
+                        if (planFolder != null)
+                        {
+                            var plan = _planService.GetPlanByFolder(planFolder);
+                            if (plan != null)
+                                _selectedPlanState.Set(plan);
+                        }
+                    }));
 
         var actionBar = Layout.Horizontal().AlignContent(Align.Center).Gap(2).Padding(1)
                         | new Button("Delete").Icon(Icons.Trash).Outline().OnClick(() => deleteDialogOpen.Set(true))

--- a/src/tendril/Ivy.Tendril/Apps/JobsApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/JobsApp.cs
@@ -286,7 +286,9 @@ public class JobsApp : ViewBase
 
             var sheetContent = string.IsNullOrEmpty(content)
                 ? Text.P("Plan not found or empty.")
-                : (object)new Markdown(MarkdownHelper.AnnotateBrokenFileLinks(content))
+                : (object)new Markdown(MarkdownHelper.AnnotateBrokenPlanLinks(
+                        MarkdownHelper.AnnotateBrokenFileLinks(content),
+                        planService.PlansDirectory))
                     .DangerouslyAllowLocalFiles()
                     .OnLinkClick(FileLinkHelper.CreateFileLinkClickHandler(openFile));
 

--- a/src/tendril/Ivy.Tendril/Apps/Plans/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Plans/ContentView.cs
@@ -224,9 +224,21 @@ public class ContentView(
         {
             var planLayout = Layout.Vertical();
             if (_selectedPlan.Status == PlanStatus.Failed) planLayout |= BuildFailureCallout(_selectedPlan);
-            planLayout |= new Markdown(MarkdownHelper.AnnotateBrokenFileLinks(_selectedPlan.LatestRevisionContent))
+            var annotatedContent = MarkdownHelper.AnnotateBrokenFileLinks(_selectedPlan.LatestRevisionContent);
+            annotatedContent = MarkdownHelper.AnnotateBrokenPlanLinks(annotatedContent, _planService.PlansDirectory);
+            planLayout |= new Markdown(annotatedContent)
                 .DangerouslyAllowLocalFiles()
-                .OnLinkClick(FileLinkHelper.CreateFileLinkClickHandler(openFile));
+                .OnLinkClick(FileLinkHelper.CreateFileLinkClickHandler(openFile, planId =>
+                {
+                    var planFolder = Directory.GetDirectories(_planService.PlansDirectory, $"{planId:D5}-*")
+                        .FirstOrDefault();
+                    if (planFolder != null)
+                    {
+                        var plan = _planService.GetPlanByFolder(planFolder);
+                        if (plan != null)
+                            _selectedPlanState.Set(plan);
+                    }
+                }));
             planTabContent = planLayout;
         }
 

--- a/src/tendril/Ivy.Tendril/Apps/PullRequestApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/PullRequestApp.cs
@@ -133,7 +133,9 @@ public class PullRequestApp : ViewBase
 
             var sheetContent = string.IsNullOrEmpty(content)
                 ? Text.P("Plan not found or empty.")
-                : (object)new Markdown(MarkdownHelper.AnnotateBrokenFileLinks(content))
+                : (object)new Markdown(MarkdownHelper.AnnotateBrokenPlanLinks(
+                        MarkdownHelper.AnnotateBrokenFileLinks(content),
+                        planService.PlansDirectory))
                     .DangerouslyAllowLocalFiles()
                     .OnLinkClick(FileLinkHelper.CreateFileLinkClickHandler(openFile));
 

--- a/src/tendril/Ivy.Tendril/Apps/Recommendations/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Recommendations/ContentView.cs
@@ -148,7 +148,9 @@ public class ContentView(
 
             var sheetContent = string.IsNullOrEmpty(content)
                 ? Text.P("Plan not found or empty.")
-                : (object)new Markdown(MarkdownHelper.AnnotateBrokenFileLinks(content))
+                : (object)new Markdown(MarkdownHelper.AnnotateBrokenPlanLinks(
+                        MarkdownHelper.AnnotateBrokenFileLinks(content),
+                        _planService.PlansDirectory))
                     .DangerouslyAllowLocalFiles()
                     .OnLinkClick(FileLinkHelper.CreateFileLinkClickHandler(openFile));
 

--- a/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -247,9 +247,21 @@ public class ContentView(
         var planData = planContentQuery.Value;
 
         // Plan tab content (not dependent on query — uses in-memory data)
-        var planTabContent = new Markdown(MarkdownHelper.AnnotateBrokenFileLinks(_selectedPlan.LatestRevisionContent))
+        var reviewAnnotated = MarkdownHelper.AnnotateBrokenFileLinks(_selectedPlan.LatestRevisionContent);
+        reviewAnnotated = MarkdownHelper.AnnotateBrokenPlanLinks(reviewAnnotated, _planService.PlansDirectory);
+        var planTabContent = new Markdown(reviewAnnotated)
             .DangerouslyAllowLocalFiles()
-            .OnLinkClick(FileLinkHelper.CreateFileLinkClickHandler(openFile));
+            .OnLinkClick(FileLinkHelper.CreateFileLinkClickHandler(openFile, planId =>
+            {
+                var planFolder = Directory.GetDirectories(_planService.PlansDirectory, $"{planId:D5}-*")
+                    .FirstOrDefault();
+                if (planFolder != null)
+                {
+                    var plan = _planService.GetPlanByFolder(planFolder);
+                    if (plan != null)
+                        _selectedPlanState.Set(plan);
+                }
+            }));
 
         if (planContentQuery.Loading)
         {

--- a/src/tendril/Ivy.Tendril/Promptwares/.shared/Plans.md
+++ b/src/tendril/Ivy.Tendril/Promptwares/.shared/Plans.md
@@ -157,5 +157,6 @@ Each revision can include `## Verification` with checkboxes from `config.yaml`:
 ## Notes
 
 - **Local file links in plans:** `[Button.cs](file:///path/to/...)` so VS Code opens the path; keep the path as link text.
+- **Plan references:** `[Plan 03156](plan://03156)` to link to other plans. The link handler will navigate to that plan in the Plans app. The plan ID can be 5 digits (e.g., `plan://03156`) or without leading zeros (e.g., `plan://3156`).
 - Images: normal markdown `![alt](url)`.
 - **Diagrams:** Graphviz/DOT (```dot / ```graphviz) or Mermaid (```mermaid). **Prefer DOT** for layout. Use only when a diagram really helps.

--- a/src/tendril/Ivy.Tendril/Services/FileLinkHelper.cs
+++ b/src/tendril/Ivy.Tendril/Services/FileLinkHelper.cs
@@ -6,7 +6,9 @@ public static class FileLinkHelper
 {
     private static readonly string[] ImageExtensions = [".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp"];
 
-    public static Action<string> CreateFileLinkClickHandler(IState<string?> openFileState)
+    public static Action<string> CreateFileLinkClickHandler(
+        IState<string?> openFileState,
+        Action<int>? onPlanClick = null)
     {
         return url =>
         {
@@ -14,6 +16,12 @@ public static class FileLinkHelper
             {
                 var filePath = url.Substring("file:///".Length);
                 openFileState.Set(filePath);
+            }
+            else if (url.StartsWith("plan://", StringComparison.OrdinalIgnoreCase))
+            {
+                var planIdStr = url.Substring("plan://".Length);
+                if (int.TryParse(planIdStr, out var planId))
+                    onPlanClick?.Invoke(planId);
             }
         };
     }

--- a/src/tendril/Ivy.Tendril/Services/MarkdownHelper.cs
+++ b/src/tendril/Ivy.Tendril/Services/MarkdownHelper.cs
@@ -8,6 +8,10 @@ public static class MarkdownHelper
         @"\[([^\]]*)\]\((file:///[^)]+)\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
+    private static readonly Regex PlanLinkRegex = new(
+        @"\[([^\]]*)\]\((plan://(\d{1,5}))\)",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
     /// <summary>
     ///     Annotates broken file:/// links in markdown content with a warning indicator.
     ///     Valid links are left unchanged.
@@ -24,6 +28,29 @@ public static class MarkdownHelper
             var filePath = url.Substring("file:///".Length);
 
             if (File.Exists(filePath))
+                return match.Value;
+
+            return $"[{linkText} \u26a0\ufe0f]({url})";
+        });
+    }
+
+    public static string AnnotateBrokenPlanLinks(string markdownContent, string plansDirectory)
+    {
+        if (string.IsNullOrEmpty(markdownContent))
+            return markdownContent;
+
+        return PlanLinkRegex.Replace(markdownContent, match =>
+        {
+            var linkText = match.Groups[1].Value;
+            var url = match.Groups[2].Value;
+            var planId = match.Groups[3].Value;
+
+            var paddedId = planId.PadLeft(5, '0');
+
+            var planExists = Directory.Exists(plansDirectory) &&
+                             Directory.GetDirectories(plansDirectory, $"{paddedId}-*").Length > 0;
+
+            if (planExists)
                 return match.Value;
 
             return $"[{linkText} \u26a0\ufe0f]({url})";


### PR DESCRIPTION
# Summary

## Changes

Added `plan://` protocol link support to the markdown rendering system, following the existing `file:///` pattern. Plan links like `[Plan 03156](plan://03156)` are now clickable and navigate to the referenced plan. Broken plan links (referencing non-existent plan IDs) are annotated with a warning emoji.

## API Changes

- `MarkdownHelper.AnnotateBrokenPlanLinks(string markdownContent, string plansDirectory)` — new static method that validates `plan://` links and annotates broken ones
- `FileLinkHelper.CreateFileLinkClickHandler(IState<string?> openFileState, Action<int>? onPlanClick = null)` — added optional `onPlanClick` callback parameter (backward-compatible)
- `MarkdownHelper.PlanLinkRegex` — new private regex field for matching `[text](plan://digits)` patterns

## Files Modified

**Core services:**
- `Services/MarkdownHelper.cs` — Added `PlanLinkRegex` and `AnnotateBrokenPlanLinks` method
- `Services/FileLinkHelper.cs` — Extended `CreateFileLinkClickHandler` with `onPlanClick` parameter

**Call sites (plan link annotation + navigation):**
- `Apps/Plans/ContentView.cs` — Full plan navigation on click
- `Apps/Review/ContentView.cs` — Full plan navigation on click
- `Apps/Icebox/ContentView.cs` — Full plan navigation on click
- `Apps/JobsApp.cs` — Plan link annotation only
- `Apps/Recommendations/ContentView.cs` — Plan link annotation only
- `Apps/PullRequestApp.cs` — Plan link annotation only

**Documentation:**
- `Promptwares/.shared/Plans.md` — Added `plan://` link format documentation

**Tests:**
- `Ivy.Tendril.Test/MarkdownHelperTests.cs` — 3 new tests for plan link annotation
- `Ivy.Tendril.Test/Services/FileLinkHelperTests.cs` — 3 new tests for plan click handling

## Commits

- 2b7aee91a [03163] Implement clickable plan:// links in markdown