### PR TITLE
[03165] Remove unnecessary Folder directive from Tendril csproj

### DIFF
--- a/src/tendril/Ivy.Tendril/Ivy.Tendril.csproj
+++ b/src/tendril/Ivy.Tendril/Ivy.Tendril.csproj
@@ -63,9 +63,6 @@
       <OutputItemType>Analyzer</OutputItemType>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Apps" />
-  </ItemGroup>
 
   <ItemGroup>
     <None Update="example.config.yaml">


### PR DESCRIPTION
# Summary

## Changes

Removed the unnecessary `<ItemGroup><Folder Include="Apps" /></ItemGroup>` directive from `Ivy.Tendril.csproj` (lines 66-68). This directive was originally added to make the empty `Apps/` folder visible in Solution Explorer, but the folder now contains many files and subdirectories, making it redundant.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Ivy.Tendril.csproj` — Removed 3-line `<Folder Include="Apps" />` ItemGroup

## Commits

- c935b5b4f [03165] Remove unnecessary Folder directive from Ivy.Tendril.csproj