### PR TITLE
[03167] Fix monospace font in markdown code blocks

### DIFF
--- a/src/frontend/src/index.css
+++ b/src/frontend/src/index.css
@@ -143,9 +143,9 @@ ivy-widget {
     --radius-boxes: var(--radius-boxes);
     --radius-fields: var(--radius-fields);
     --radius-selectors: var(--radius-selectors);
-    --font-sans: var(--font-sans);
-    --font-mono: var(--font-mono);
-    --font-serif: var(--font-serif);
+    --font-family-sans: var(--font-sans);
+    --font-family-mono: var(--font-mono);
+    --font-family-serif: var(--font-serif);
     --shadow-2xs: var(--shadow-2xs);
     --shadow-xs: var(--shadow-xs);
     --shadow-sm: var(--shadow-sm);


### PR DESCRIPTION
## Problem

Markdown code blocks in the Tendril UI are no longer rendering in a monospaced font. Instead, code appears in a proportional font, making it difficult to read structured code where alignment matters (e.g., PowerShell variables like `$script:ConfigPath`).

**Root cause:** Tailwind CSS v4 requires font family utility classes to use the `--font-family-*` namespace. The current configuration in `src/frontend/src/index.css` defines `--font-mono: var(--font-mono)` at line 147, but Tailwind v4 expects `--font-family-mono` for the `font-mono` utility class to work.

## Solution

Update `src/frontend/src/index.css` to use the Tailwind CSS v4 font family namespace.

In the `@theme inline` block (around line 146-148), change:

```css
/* Before */
--font-sans: var(--font-sans);
--font-mono: var(--font-mono);
--font-serif: var(--font-serif);
```

To:

```css
/* After */
--font-family-sans: var(--font-sans);
--font-family-mono: var(--font-mono);
--font-family-serif: var(--font-serif);
```

This maps Tailwind's `font-sans`, `font-mono`, and `font-serif` utility classes to the CSS variables defined in `:root` using the correct Tailwind v4 namespace convention.

## Commits

- 7005e3fbc [03167] Fix monospace font in markdown code blocks