### PR TITLE
[03184] Improve login UI to show rate limit feedback

### DIFF
--- a/src/Ivy.Test/Auth/LoginResultTests.cs
+++ b/src/Ivy.Test/Auth/LoginResultTests.cs
@@ -1,0 +1,36 @@
+namespace Ivy.Test.Auth;
+
+public class LoginResultTests
+{
+    [Fact]
+    public void Success_HasToken()
+    {
+        var token = new AuthToken("access", "refresh");
+        var result = LoginResult.Success(token);
+
+        Assert.Equal(LoginStatus.Success, result.Status);
+        Assert.Same(token, result.Token);
+        Assert.Null(result.RetryAfter);
+    }
+
+    [Fact]
+    public void InvalidCredentials_NoToken()
+    {
+        var result = LoginResult.InvalidCredentials();
+
+        Assert.Equal(LoginStatus.InvalidCredentials, result.Status);
+        Assert.Null(result.Token);
+        Assert.Null(result.RetryAfter);
+    }
+
+    [Fact]
+    public void RateLimited_HasRetryAfter()
+    {
+        var delay = TimeSpan.FromSeconds(30);
+        var result = LoginResult.RateLimited(delay);
+
+        Assert.Equal(LoginStatus.RateLimited, result.Status);
+        Assert.Null(result.Token);
+        Assert.Equal(delay, result.RetryAfter);
+    }
+}

--- a/src/Ivy/Auth/AuthService.cs
+++ b/src/Ivy/Auth/AuthService.cs
@@ -31,19 +31,19 @@ public class AuthService : AuthTokenHandlerService, IAuthService
         _serviceProvider = serviceProvider;
     }
 
-    public async Task<AuthToken?> LoginAsync(string email, string password, CancellationToken cancellationToken)
+    public async Task<LoginResult> LoginAsync(string email, string password, CancellationToken cancellationToken)
     {
         var oldSession = _authSession.TakeSnapshot();
 
-        var token = await TimeoutHelper.WithTimeoutAsync(ct =>
+        var result = await TimeoutHelper.WithTimeoutAsync(ct =>
             _authProvider.LoginAsync(_authSession, email, password, ct), cancellationToken);
-        _authSession.AuthToken = token;
+        _authSession.AuthToken = result.Token;
 
         if (_authSession.HasChangedSince(oldSession))
         {
             SetAuthCookies(reloadPage: _authSession.AuthToken != oldSession.AuthToken);
         }
-        return token;
+        return result;
     }
 
     public async Task<Uri> GetOAuthUriAsync(AuthOption option, WebhookEndpoint callback, CancellationToken cancellationToken)

--- a/src/Ivy/Auth/BasicAuthProvider.cs
+++ b/src/Ivy/Auth/BasicAuthProvider.cs
@@ -34,14 +34,14 @@ public class BasicAuthProvider : BasicAuthTokenHandler, IAuthProvider
         }
     }
 
-    public Task<AuthToken?> LoginAsync(IAuthSession authSession, string user, string password, CancellationToken cancellationToken)
+    public Task<LoginResult> LoginAsync(IAuthSession authSession, string user, string password, CancellationToken cancellationToken)
     {
         var found = _users.Any(u => u.user == user && PasswordMatches(user, password, u.hash));
-        if (!found) return Task.FromResult<AuthToken?>(null);
+        if (!found) return Task.FromResult(LoginResult.InvalidCredentials());
 
         var now = DateTimeOffset.UtcNow;
         var authToken = CreateToken(user, now, now.ToUnixTimeSeconds());
-        return Task.FromResult<AuthToken?>(authToken);
+        return Task.FromResult(LoginResult.Success(authToken));
     }
 
     private bool PasswordMatches(string username, string password, string hash)

--- a/src/Ivy/Auth/DefaultAuthApp.cs
+++ b/src/Ivy/Auth/DefaultAuthApp.cs
@@ -74,11 +74,19 @@ public class PasswordEmailFlowView(IState<string?> errorMessage) : ViewBase
                 loading.Set(true);
                 errorMessage.Set((string?)null);
 
-                await auth.LoginAsync(model.User, model.Password);
+                var result = await auth.LoginAsync(model.User, model.Password);
 
-                if (auth.GetCurrentToken() == null)
+                switch (result.Status)
                 {
-                    errorMessage.Set("Login failed. Please check your credentials.");
+                    case LoginStatus.Success:
+                        break;
+                    case LoginStatus.InvalidCredentials:
+                        errorMessage.Set("Login failed. Please check your credentials.");
+                        break;
+                    case LoginStatus.RateLimited:
+                        var seconds = (int)Math.Ceiling(result.RetryAfter!.Value.TotalSeconds);
+                        errorMessage.Set($"Too many login attempts. Please try again in {seconds} second{(seconds == 1 ? "" : "s")}.");
+                        break;
                 }
             }
             catch (Exception ex)

--- a/src/Ivy/Auth/IAuthProvider.cs
+++ b/src/Ivy/Auth/IAuthProvider.cs
@@ -20,7 +20,7 @@ public static class AuthProviderHelpers
 
 public interface IAuthProvider : IAuthTokenHandler
 {
-    Task<AuthToken?> LoginAsync(IAuthSession authSession, string email, string password, CancellationToken cancellationToken = default);
+    Task<LoginResult> LoginAsync(IAuthSession authSession, string email, string password, CancellationToken cancellationToken = default);
 
     Task LogoutAsync(IAuthSession authSession, CancellationToken cancellationToken = default);
 

--- a/src/Ivy/Auth/IAuthService.cs
+++ b/src/Ivy/Auth/IAuthService.cs
@@ -6,7 +6,7 @@ namespace Ivy;
 
 public interface IAuthService : IAuthTokenHandlerService
 {
-    Task<AuthToken?> LoginAsync(string email, string password, CancellationToken cancellationToken = default);
+    Task<LoginResult> LoginAsync(string email, string password, CancellationToken cancellationToken = default);
 
     Task<Uri> GetOAuthUriAsync(AuthOption option, WebhookEndpoint callback, CancellationToken cancellationToken = default);
 

--- a/src/Ivy/Auth/LoginResult.cs
+++ b/src/Ivy/Auth/LoginResult.cs
@@ -1,0 +1,48 @@
+// ReSharper disable once CheckNamespace
+namespace Ivy;
+
+public class LoginResult
+{
+    public AuthToken? Token { get; init; }
+    public LoginStatus Status { get; init; }
+    public TimeSpan? RetryAfter { get; init; }
+
+    private LoginResult() { }
+
+    public static LoginResult Success(AuthToken token)
+    {
+        return new LoginResult
+        {
+            Token = token,
+            Status = LoginStatus.Success,
+            RetryAfter = null
+        };
+    }
+
+    public static LoginResult InvalidCredentials()
+    {
+        return new LoginResult
+        {
+            Token = null,
+            Status = LoginStatus.InvalidCredentials,
+            RetryAfter = null
+        };
+    }
+
+    public static LoginResult RateLimited(TimeSpan retryAfter)
+    {
+        return new LoginResult
+        {
+            Token = null,
+            Status = LoginStatus.RateLimited,
+            RetryAfter = retryAfter
+        };
+    }
+}
+
+public enum LoginStatus
+{
+    Success,
+    InvalidCredentials,
+    RateLimited
+}

--- a/src/Ivy/Core/Auth/CheckedAuthProvider.cs
+++ b/src/Ivy/Core/Auth/CheckedAuthProvider.cs
@@ -7,7 +7,7 @@ public class CheckedAuthProvider(IAuthProvider innerAuthProvider) : CheckedAuthT
 {
     private readonly IAuthProvider _innerAuthProvider = innerAuthProvider;
 
-    public Task<AuthToken?> LoginAsync(IAuthSession authSession, string email, string password, CancellationToken cancellationToken = default)
+    public Task<LoginResult> LoginAsync(IAuthSession authSession, string email, string password, CancellationToken cancellationToken = default)
     {
         authSession = authSession.WithCheckedAccess()
             .WithSessionDataAccess(AuthSessionAccessMode.ReadWrite)

--- a/src/auth/Ivy.Auth.Auth0/Auth0AuthProvider.cs
+++ b/src/auth/Ivy.Auth.Auth0/Auth0AuthProvider.cs
@@ -25,7 +25,7 @@ public class Auth0AuthProvider : Auth0AuthTokenHandler, IAuthProvider
     {
     }
 
-    public async Task<AuthToken?> LoginAsync(IAuthSession authSession, string email, string password, CancellationToken cancellationToken)
+    public async Task<LoginResult> LoginAsync(IAuthSession authSession, string email, string password, CancellationToken cancellationToken)
     {
         var request = new ResourceOwnerTokenRequest
         {
@@ -39,7 +39,7 @@ public class Auth0AuthProvider : Auth0AuthTokenHandler, IAuthProvider
         };
 
         var response = await AuthClient.GetTokenAsync(request, cancellationToken);
-        return new AuthToken(response.AccessToken, response.RefreshToken);
+        return LoginResult.Success(new AuthToken(response.AccessToken, response.RefreshToken));
     }
 
     public Task<Uri> GetOAuthUriAsync(IAuthSession authSession, AuthOption option, WebhookEndpoint callback, CancellationToken cancellationToken)

--- a/src/auth/Ivy.Auth.Authelia/AutheliaAuthProvider.cs
+++ b/src/auth/Ivy.Auth.Authelia/AutheliaAuthProvider.cs
@@ -14,21 +14,19 @@ public class AutheliaAuthProvider : AutheliaAuthTokenHandler, IAuthProvider
     {
     }
 
-    public async Task<AuthToken?> LoginAsync(IAuthSession authSession, string username, string password, CancellationToken cancellationToken)
+    public async Task<LoginResult> LoginAsync(IAuthSession authSession, string username, string password, CancellationToken cancellationToken)
     {
         var payload = new { username, password };
         var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
         var response = await HttpClient.PostAsync("/api/firstfactor", content, cancellationToken);
         if (response.IsSuccessStatusCode)
         {
-            // Return the "authelia_session" cookie value as our token.
             var cookies = CookieContainer.GetCookies(new Uri(BaseUrl));
             var session = cookies["authelia_session"]?.Value;
-            return session != null
-                ? new AuthToken(session)
-                : null;
+            if (session != null)
+                return LoginResult.Success(new AuthToken(session));
         }
-        return null;
+        return LoginResult.InvalidCredentials();
     }
 
     public async Task LogoutAsync(IAuthSession authSession, CancellationToken cancellationToken)

--- a/src/auth/Ivy.Auth.Clerk/ClerkAuthProvider.cs
+++ b/src/auth/Ivy.Auth.Clerk/ClerkAuthProvider.cs
@@ -59,7 +59,7 @@ public class ClerkAuthProvider : ClerkAuthTokenHandler, IAuthProvider
         => ex.Errors?.Any(e => e.Code == "session_exists") == true;
 
 
-    public async Task<AuthToken?> LoginAsync(IAuthSession authSession, string email, string password, CancellationToken cancellationToken = default)
+    public async Task<LoginResult> LoginAsync(IAuthSession authSession, string email, string password, CancellationToken cancellationToken = default)
     {
         try
         {
@@ -76,7 +76,7 @@ public class ClerkAuthProvider : ClerkAuthTokenHandler, IAuthProvider
                 var restoredToken = await TryRestoreExistingSessionAsync(authSession, credentials, cancellationToken);
                 if (restoredToken != null)
                 {
-                    return restoredToken;
+                    return LoginResult.Success(restoredToken);
                 }
 
                 await frontendClient.RemoveAllSessionsAsync(credentials, cancellationToken);
@@ -85,7 +85,7 @@ public class ClerkAuthProvider : ClerkAuthTokenHandler, IAuthProvider
 
             if (signInResponse.Response?.CreatedSessionId is not { } sessionId)
             {
-                return null;
+                return LoginResult.InvalidCredentials();
             }
 
             var newToken = await frontendClient.CreateSessionTokenAsync(sessionId, credentials, cancellationToken);
@@ -95,11 +95,11 @@ public class ClerkAuthProvider : ClerkAuthTokenHandler, IAuthProvider
                 throw new Exception("New JWT from Clerk is invalid.");
             }
 
-            return new AuthToken(newToken.Jwt!);
+            return LoginResult.Success(new AuthToken(newToken.Jwt!));
         }
         catch (Exception)
         {
-            return null;
+            return LoginResult.InvalidCredentials();
         }
     }
 

--- a/src/auth/Ivy.Auth.GitHub/GitHubAuthProvider.cs
+++ b/src/auth/Ivy.Auth.GitHub/GitHubAuthProvider.cs
@@ -33,7 +33,7 @@ public class GitHubAuthProvider : GitHubAuthTokenHandler, IAuthProvider
     }
 
     /// <summary>Not supported - use OAuth flow</summary>
-    public Task<AuthToken?> LoginAsync(IAuthSession authSession, string email, string password, CancellationToken cancellationToken = default)
+    public Task<LoginResult> LoginAsync(IAuthSession authSession, string email, string password, CancellationToken cancellationToken = default)
     {
         throw new NotSupportedException("GitHub authentication only supports OAuth flow. Use GetOAuthUriAsync and HandleOAuthCallbackAsync instead.");
     }

--- a/src/auth/Ivy.Auth.MicrosoftEntra/MicrosoftEntraAuthProvider.cs
+++ b/src/auth/Ivy.Auth.MicrosoftEntra/MicrosoftEntraAuthProvider.cs
@@ -21,7 +21,7 @@ public class MicrosoftEntraAuthProvider : MicrosoftEntraAuthTokenHandler, IAuthP
     {
     }
 
-    public Task<AuthToken?> LoginAsync(IAuthSession authSession, string email, string password, CancellationToken cancellationToken)
+    public Task<LoginResult> LoginAsync(IAuthSession authSession, string email, string password, CancellationToken cancellationToken)
         => throw new InvalidOperationException("Microsoft Entra login with email/password is not supported");
 
     public async Task<Uri> GetOAuthUriAsync(IAuthSession authSession, AuthOption option, WebhookEndpoint callback, CancellationToken cancellationToken)

--- a/src/auth/Ivy.Auth.Sliplane/SliplaneAuthProvider.cs
+++ b/src/auth/Ivy.Auth.Sliplane/SliplaneAuthProvider.cs
@@ -27,7 +27,7 @@ public class SliplaneAuthProvider : SliplaneAuthTokenHandler, IAuthProvider
     }
 
     /// <summary>Not supported — Sliplane only supports OAuth flow</summary>
-    public Task<AuthToken?> LoginAsync(IAuthSession authSession, string email, string password, CancellationToken cancellationToken = default)
+    public Task<LoginResult> LoginAsync(IAuthSession authSession, string email, string password, CancellationToken cancellationToken = default)
     {
         throw new NotSupportedException("Sliplane authentication only supports OAuth flow. Use GetOAuthUriAsync and HandleOAuthCallbackAsync instead.");
     }

--- a/src/auth/Ivy.Auth.Supabase/SupabaseAuthProvider.cs
+++ b/src/auth/Ivy.Auth.Supabase/SupabaseAuthProvider.cs
@@ -26,12 +26,12 @@ public class SupabaseAuthProvider : SupabaseAuthTokenHandler, IAuthProvider
     {
     }
 
-    public async Task<AuthToken?> LoginAsync(IAuthSession authSession, string email, string password, CancellationToken cancellationToken)
+    public async Task<LoginResult> LoginAsync(IAuthSession authSession, string email, string password, CancellationToken cancellationToken)
     {
         var session = await Client.Auth.SignIn(email, password)
             .WaitAsync(cancellationToken);
         var authToken = MakeAuthToken(session);
-        return authToken;
+        return authToken != null ? LoginResult.Success(authToken) : LoginResult.InvalidCredentials();
     }
 
     public async Task<Uri> GetOAuthUriAsync(IAuthSession authSession, AuthOption option, WebhookEndpoint callback, CancellationToken cancellationToken)

--- a/src/tendril/Ivy.Tendril.Test/Auth/TendrilAuthProviderTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/Auth/TendrilAuthProviderTests.cs
@@ -63,27 +63,29 @@ public class TendrilAuthProviderTests
     }
 
     [Fact]
-    public async Task LoginAsync_CorrectPassword_ReturnsToken()
+    public async Task LoginAsync_CorrectPassword_ReturnsSuccess()
     {
         var auth = CreateAuthConfig("login-test");
         var provider = CreateProvider(auth);
 
-        var token = await provider.LoginAsync(null!, "anyone", "login-test", CancellationToken.None);
+        var result = await provider.LoginAsync(null!, "anyone", "login-test", CancellationToken.None);
 
-        Assert.NotNull(token);
-        Assert.False(string.IsNullOrEmpty(token.AccessToken));
-        Assert.False(string.IsNullOrEmpty(token.RefreshToken));
+        Assert.Equal(LoginStatus.Success, result.Status);
+        Assert.NotNull(result.Token);
+        Assert.False(string.IsNullOrEmpty(result.Token.AccessToken));
+        Assert.False(string.IsNullOrEmpty(result.Token.RefreshToken));
     }
 
     [Fact]
-    public async Task LoginAsync_IncorrectPassword_ReturnsNull()
+    public async Task LoginAsync_IncorrectPassword_ReturnsInvalidCredentials()
     {
         var auth = CreateAuthConfig("login-test");
         var provider = CreateProvider(auth);
 
-        var token = await provider.LoginAsync(null!, "anyone", "bad-password", CancellationToken.None);
+        var result = await provider.LoginAsync(null!, "anyone", "bad-password", CancellationToken.None);
 
-        Assert.Null(token);
+        Assert.Equal(LoginStatus.InvalidCredentials, result.Status);
+        Assert.Null(result.Token);
     }
 
     [Fact]
@@ -118,7 +120,7 @@ public class TendrilAuthProviderTests
     }
 
     [Fact]
-    public async Task LoginAsync_RateLimited_ReturnsNull()
+    public async Task LoginAsync_RateLimited_ReturnsRateLimitedWithRetryAfter()
     {
         var rateLimit = new LoginRateLimitConfig { Threshold = 1, BaseDelaySeconds = 100.0 };
         var auth = CreateAuthConfig("test-pass", rateLimit);
@@ -129,8 +131,11 @@ public class TendrilAuthProviderTests
         await provider.LoginAsync(null!, "anyone", "wrong", CancellationToken.None);
 
         // Even correct password should be blocked
-        var token = await provider.LoginAsync(null!, "anyone", "test-pass", CancellationToken.None);
-        Assert.Null(token);
+        var result = await provider.LoginAsync(null!, "anyone", "test-pass", CancellationToken.None);
+        Assert.Equal(LoginStatus.RateLimited, result.Status);
+        Assert.Null(result.Token);
+        Assert.NotNull(result.RetryAfter);
+        Assert.True(result.RetryAfter.Value.TotalSeconds > 0);
     }
 
     [Fact]
@@ -142,17 +147,17 @@ public class TendrilAuthProviderTests
 
         // First 2 attempts are under threshold
         var t1 = await provider.LoginAsync(null!, "anyone", "wrong", CancellationToken.None);
-        Assert.Null(t1);
+        Assert.Equal(LoginStatus.InvalidCredentials, t1.Status);
         var t2 = await provider.LoginAsync(null!, "anyone", "wrong", CancellationToken.None);
-        Assert.Null(t2);
+        Assert.Equal(LoginStatus.InvalidCredentials, t2.Status);
 
         // 3rd attempt exceeds threshold — rate limited
         var t3 = await provider.LoginAsync(null!, "anyone", "wrong", CancellationToken.None);
-        Assert.Null(t3);
+        Assert.Equal(LoginStatus.RateLimited, t3.Status);
 
         // Correct password is also blocked
         var t4 = await provider.LoginAsync(null!, "anyone", "test-pass", CancellationToken.None);
-        Assert.Null(t4);
+        Assert.Equal(LoginStatus.RateLimited, t4.Status);
     }
 
     [Fact]
@@ -167,12 +172,14 @@ public class TendrilAuthProviderTests
         await provider.LoginAsync(null!, "anyone", "wrong", CancellationToken.None);
 
         // Successful login resets counter
-        var token = await provider.LoginAsync(null!, "anyone", "test-pass", CancellationToken.None);
-        Assert.NotNull(token);
+        var result = await provider.LoginAsync(null!, "anyone", "test-pass", CancellationToken.None);
+        Assert.Equal(LoginStatus.Success, result.Status);
+        Assert.NotNull(result.Token);
 
         // Subsequent login should work (counter was reset)
-        var token2 = await provider.LoginAsync(null!, "anyone", "test-pass", CancellationToken.None);
-        Assert.NotNull(token2);
+        var result2 = await provider.LoginAsync(null!, "anyone", "test-pass", CancellationToken.None);
+        Assert.Equal(LoginStatus.Success, result2.Status);
+        Assert.NotNull(result2.Token);
     }
 
     [Fact]
@@ -185,7 +192,8 @@ public class TendrilAuthProviderTests
         // 1 failure is under threshold
         await provider.LoginAsync(null!, "anyone", "wrong", CancellationToken.None);
         var t1 = await provider.LoginAsync(null!, "anyone", "test-pass", CancellationToken.None);
-        Assert.NotNull(t1);
+        Assert.Equal(LoginStatus.Success, t1.Status);
+        Assert.NotNull(t1.Token);
 
         // After success, counter is reset. Fail again to trigger rate limit.
         await provider.LoginAsync(null!, "anyone", "wrong", CancellationToken.None);
@@ -193,6 +201,7 @@ public class TendrilAuthProviderTests
 
         // Now blocked
         var t2 = await provider.LoginAsync(null!, "anyone", "test-pass", CancellationToken.None);
-        Assert.Null(t2);
+        Assert.Equal(LoginStatus.RateLimited, t2.Status);
+        Assert.Null(t2.Token);
     }
 }

--- a/src/tendril/Ivy.Tendril/Auth/TendrilAuthProvider.cs
+++ b/src/tendril/Ivy.Tendril/Auth/TendrilAuthProvider.cs
@@ -35,24 +35,27 @@ public class TendrilAuthProvider : BasicAuthTokenHandler, IAuthProvider
         _rateLimiter = new LoginRateLimiter(auth.RateLimit ?? new LoginRateLimitConfig());
     }
 
-    public Task<AuthToken?> LoginAsync(IAuthSession authSession, string user, string password, CancellationToken cancellationToken)
+    public Task<LoginResult> LoginAsync(IAuthSession authSession, string user, string password, CancellationToken cancellationToken)
     {
         var ipAddress = _httpContextAccessor?.HttpContext?.Connection.RemoteIpAddress?.ToString() ?? "global";
 
         if (!_rateLimiter.IsLoginAllowed(ipAddress))
-            return Task.FromResult<AuthToken?>(null);
+        {
+            var retryAfter = _rateLimiter.GetRequiredDelay(ipAddress);
+            return Task.FromResult(LoginResult.RateLimited(retryAfter));
+        }
 
         if (!PasswordMatches(password))
         {
             _rateLimiter.RecordFailedAttempt(ipAddress);
-            return Task.FromResult<AuthToken?>(null);
+            return Task.FromResult(LoginResult.InvalidCredentials());
         }
 
         _rateLimiter.RecordSuccessfulLogin(ipAddress);
 
         var now = DateTimeOffset.UtcNow;
         var authToken = CreateToken("tendril", now, now.ToUnixTimeSeconds());
-        return Task.FromResult<AuthToken?>(authToken);
+        return Task.FromResult(LoginResult.Success(authToken));
     }
 
     public Task LogoutAsync(IAuthSession authSession, CancellationToken cancellationToken)


### PR DESCRIPTION
# Summary

## Changes

Introduced a `LoginResult` type to replace `AuthToken?` returns from `IAuthProvider.LoginAsync` and `IAuthService.LoginAsync`, enabling the UI to distinguish between invalid credentials and rate-limited login attempts. Updated all 10 IAuthProvider implementations and the DefaultAuthApp to display a "Too many login attempts. Please try again in X seconds." message when rate-limited.

## API Changes

- New class `LoginResult` with static factories: `Success(AuthToken)`, `InvalidCredentials()`, `RateLimited(TimeSpan)`
- New enum `LoginStatus` with values: `Success`, `InvalidCredentials`, `RateLimited`
- `IAuthProvider.LoginAsync` return type changed from `Task<AuthToken?>` to `Task<LoginResult>`
- `IAuthService.LoginAsync` return type changed from `Task<AuthToken?>` to `Task<LoginResult>`

## Files Modified

- **New types:**
  - `src/Ivy/Auth/LoginResult.cs` — LoginResult class and LoginStatus enum

- **Core interfaces and services:**
  - `src/Ivy/Auth/IAuthProvider.cs` — LoginAsync return type
  - `src/Ivy/Auth/IAuthService.cs` — LoginAsync return type
  - `src/Ivy/Auth/AuthService.cs` — Forward LoginResult, set token from result
  - `src/Ivy/Core/Auth/CheckedAuthProvider.cs` — LoginAsync return type

- **Provider implementations:**
  - `src/Ivy/Auth/BasicAuthProvider.cs`
  - `src/tendril/Ivy.Tendril/Auth/TendrilAuthProvider.cs` — Returns RateLimited with RetryAfter
  - `src/auth/Ivy.Auth.Auth0/Auth0AuthProvider.cs`
  - `src/auth/Ivy.Auth.Authelia/AutheliaAuthProvider.cs`
  - `src/auth/Ivy.Auth.Clerk/ClerkAuthProvider.cs`
  - `src/auth/Ivy.Auth.GitHub/GitHubAuthProvider.cs`
  - `src/auth/Ivy.Auth.MicrosoftEntra/MicrosoftEntraAuthProvider.cs`
  - `src/auth/Ivy.Auth.Sliplane/SliplaneAuthProvider.cs`
  - `src/auth/Ivy.Auth.Supabase/SupabaseAuthProvider.cs`

- **UI:**
  - `src/Ivy/Auth/DefaultAuthApp.cs` — Switch on LoginStatus for specific error messages

- **Tests:**
  - `src/Ivy.Test/Auth/LoginResultTests.cs` — 3 new tests for LoginResult factories
  - `src/tendril/Ivy.Tendril.Test/Auth/TendrilAuthProviderTests.cs` — Updated to verify LoginResult statuses

## Commits

- 81af42481 [03184] Add LoginResult type and update auth stack for rate limit feedback