### PR TITLE
[03189] Clean up stale <Folder Include> directives in .csproj files

### DIFF
--- a/src/Ivy.Docs.Shared/Ivy.Docs.Shared.csproj
+++ b/src/Ivy.Docs.Shared/Ivy.Docs.Shared.csproj
@@ -63,10 +63,6 @@
     <InternalsVisibleTo Include="Ivy.Docs.Test" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Generated/" />
-  </ItemGroup>
-
   <!-- enable ivy analyzer for docs -->
   <ItemGroup>
     <ProjectReference Include="../Ivy.Analyser/Ivy.Analyser.csproj">

--- a/src/Ivy.Test/Ivy.Test.csproj
+++ b/src/Ivy.Test/Ivy.Test.csproj
@@ -28,9 +28,5 @@
   <ItemGroup>
     <ProjectReference Include="../Ivy/Ivy.csproj" />
   </ItemGroup>
-  
-  <ItemGroup>
-    <Folder Include="DataTables\" />
-  </ItemGroup>
 
 </Project>

--- a/src/Ivy/Ivy.csproj
+++ b/src/Ivy/Ivy.csproj
@@ -88,12 +88,6 @@
     <ProjectReference Include="../Ivy.Agent.Filter/Ivy.Agent.Filter.csproj" />
   </ItemGroup>
   
-  <ItemGroup>
-    <Folder Include="Core/Apps/" />
-    <Folder Include="Core/Auth/" />
-    <Folder Include="Properties/" />
-  </ItemGroup>
-
   <!-- Frontend source files for incremental build detection -->
   <ItemGroup>
     <FrontendSourceFiles Include="../frontend/src/**/*" />

--- a/src/tendril/Ivy.Tendril.Docs/Ivy.Tendril.Docs.csproj
+++ b/src/tendril/Ivy.Tendril.Docs/Ivy.Tendril.Docs.csproj
@@ -45,10 +45,6 @@
         <Watch Remove="Docs/**/*" />
     </ItemGroup>
 
-    <ItemGroup>
-        <Folder Include="Generated/" />
-    </ItemGroup>
-
     <!-- enable ivy analyzer -->
     <ItemGroup>
         <ProjectReference Include="../../Ivy.Analyser/Ivy.Analyser.csproj">

--- a/src/widgets/Ivy.Widgets.Xterm/Ivy.Widgets.Xterm.csproj
+++ b/src/widgets/Ivy.Widgets.Xterm/Ivy.Widgets.Xterm.csproj
@@ -44,10 +44,6 @@
     <None Include=".samples\**\*" CopyToOutputDirectory="Never" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include=".samples\.console\" />
-  </ItemGroup>
-
   <Import Project="..\..\Ivy\Build\Ivy.ExternalWidget.targets" />
 
 </Project>


### PR DESCRIPTION
# Summary

## Changes

Removed 7 stale `<Folder Include>` directives from 5 .csproj files. Each referenced folder now contains files, making the directives unnecessary. Empty `<ItemGroup>` blocks left behind were also removed.

## API Changes

None.

## Files Modified

- `src/widgets/Ivy.Widgets.Xterm/Ivy.Widgets.Xterm.csproj` — removed `<Folder Include=".samples\.console\" />`
- `src/Ivy.Docs.Shared/Ivy.Docs.Shared.csproj` — removed `<Folder Include="Generated/" />`
- `src/Ivy.Test/Ivy.Test.csproj` — removed `<Folder Include="DataTables\" />`
- `src/Ivy/Ivy.csproj` — removed `<Folder Include="Core/Apps/" />`, `<Folder Include="Core/Auth/" />`, `<Folder Include="Properties/" />`
- `src/tendril/Ivy.Tendril.Docs/Ivy.Tendril.Docs.csproj` — removed `<Folder Include="Generated/" />`

## Commits

- bd4be86e4 [03189] Clean up stale <Folder Include> directives in .csproj files