### PR TITLE
[03185] Extract shared CrashLog utility class

### DIFF
--- a/src/Ivy/Helpers/CrashLog.cs
+++ b/src/Ivy/Helpers/CrashLog.cs
@@ -1,0 +1,25 @@
+namespace Ivy.Helpers;
+
+public static class CrashLog
+{
+    private static readonly Lazy<string> LazyPath = new(() =>
+    {
+        var tendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME");
+        var logDir = !string.IsNullOrEmpty(tendrilHome) ? tendrilHome : Path.GetTempPath();
+        return Path.Combine(logDir, "crash.log");
+    });
+
+    public static string Path => LazyPath.Value;
+
+    public static void Write(string message)
+    {
+        try
+        {
+            File.AppendAllText(Path, message + Environment.NewLine);
+        }
+        catch
+        {
+            // Last-resort: don't let logging crash the process
+        }
+    }
+}

--- a/src/Ivy/Helpers/CrashLog.cs
+++ b/src/Ivy/Helpers/CrashLog.cs
@@ -5,8 +5,8 @@ public static class CrashLog
     private static readonly Lazy<string> LazyPath = new(() =>
     {
         var tendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME");
-        var logDir = !string.IsNullOrEmpty(tendrilHome) ? tendrilHome : Path.GetTempPath();
-        return Path.Combine(logDir, "crash.log");
+        var logDir = !string.IsNullOrEmpty(tendrilHome) ? tendrilHome : System.IO.Path.GetTempPath();
+        return System.IO.Path.Combine(logDir, "crash.log");
     });
 
     public static string Path => LazyPath.Value;

--- a/src/Ivy/Helpers/ProcessExtensions.cs
+++ b/src/Ivy/Helpers/ProcessExtensions.cs
@@ -67,7 +67,7 @@ public static class ProcessExtensions
         {
             process.Kill(true);
             if (!process.WaitForExit(5000))
-                WriteCrashLog($"[{DateTime.UtcNow:O}] Process {process.Id} did not exit within 5 seconds after Kill()");
+                CrashLog.Write($"[{DateTime.UtcNow:O}] Process {process.Id} did not exit within 5 seconds after Kill()");
         }
         catch (InvalidOperationException)
         {
@@ -75,7 +75,7 @@ public static class ProcessExtensions
         }
         catch (Exception ex)
         {
-            WriteCrashLog($"[{DateTime.UtcNow:O}] Exception killing process {process.Id}: {ex.GetType().Name}: {ex.Message}");
+            CrashLog.Write($"[{DateTime.UtcNow:O}] Exception killing process {process.Id}: {ex.GetType().Name}: {ex.Message}");
         }
     }
 
@@ -89,7 +89,7 @@ public static class ProcessExtensions
         }
         catch (OperationCanceledException)
         {
-            WriteCrashLog($"[{DateTime.UtcNow:O}] Process {process.Id} did not exit within 5 seconds after Kill()");
+            CrashLog.Write($"[{DateTime.UtcNow:O}] Process {process.Id} did not exit within 5 seconds after Kill()");
         }
         catch (InvalidOperationException)
         {
@@ -97,22 +97,7 @@ public static class ProcessExtensions
         }
         catch (Exception ex)
         {
-            WriteCrashLog($"[{DateTime.UtcNow:O}] Exception killing process {process.Id}: {ex.GetType().Name}: {ex.Message}");
-        }
-    }
-
-    private static void WriteCrashLog(string message)
-    {
-        try
-        {
-            var tendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME");
-            var logDir = !string.IsNullOrEmpty(tendrilHome) ? tendrilHome : Path.GetTempPath();
-            var path = Path.Combine(logDir, "crash.log");
-            File.AppendAllText(path, message + Environment.NewLine);
-        }
-        catch
-        {
-            // Last-resort: don't let logging crash the process
+            CrashLog.Write($"[{DateTime.UtcNow:O}] Exception killing process {process.Id}: {ex.GetType().Name}: {ex.Message}");
         }
     }
 }

--- a/src/tendril/Ivy.Tendril/Program.cs
+++ b/src/tendril/Ivy.Tendril/Program.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Ivy.Desktop;
+using Ivy.Helpers;
 using Ivy.Tendril.Commands;
 using Ivy.Tendril.Database;
 using Ivy.Tendril.Services;
@@ -52,8 +53,7 @@ public class Program
         if (hashExitCode >= 0)
             return hashExitCode;
 
-        var crashLogPath = GetCrashLogPath();
-        WriteCrashLog(crashLogPath, $"[{DateTime.UtcNow:O}] Tendril starting (PID {Environment.ProcessId}) | {GetMemoryStats()}");
+        CrashLog.Write($"[{DateTime.UtcNow:O}] Tendril starting (PID {Environment.ProcessId}) | {GetMemoryStats()}");
 
         // Install native console control handler FIRST — this catches CTRL_CLOSE_EVENT
         // (console window closed), CTRL_C_EVENT, CTRL_BREAK_EVENT, CTRL_LOGOFF_EVENT,
@@ -71,7 +71,7 @@ public class Program
                     6 => "CTRL_SHUTDOWN_EVENT",
                     _ => $"UNKNOWN({ctrlType})"
                 };
-                WriteCrashLog(crashLogPath,
+                CrashLog.Write(
                     $"[{DateTime.UtcNow:O}] ConsoleCtrlHandler: {name} (PID {Environment.ProcessId}) | {GetMemoryStats()}");
                 return false; // Let default handling proceed
             };
@@ -82,20 +82,20 @@ public class Program
         {
             var msg = $"[{DateTime.UtcNow:O}] FATAL UnhandledException (IsTerminating={e.IsTerminating}) | {GetMemoryStats()}\n  {e.ExceptionObject}";
             Console.WriteLine($"[FATAL] Unhandled exception: {e.ExceptionObject}");
-            WriteCrashLog(crashLogPath, msg);
+            CrashLog.Write(msg);
         };
 
         TaskScheduler.UnobservedTaskException += (_, e) =>
         {
             var msg = $"[{DateTime.UtcNow:O}] FATAL UnobservedTaskException | {GetMemoryStats()}\n  {e.Exception}";
             Console.WriteLine($"[FATAL] Unobserved task exception: {e.Exception}");
-            WriteCrashLog(crashLogPath, msg);
+            CrashLog.Write(msg);
             e.SetObserved();
         };
 
         AppDomain.CurrentDomain.ProcessExit += (_, _) =>
         {
-            WriteCrashLog(crashLogPath, $"[{DateTime.UtcNow:O}] ProcessExit event fired (PID {Environment.ProcessId}) | {GetMemoryStats()}");
+            CrashLog.Write($"[{DateTime.UtcNow:O}] ProcessExit event fired (PID {Environment.ProcessId}) | {GetMemoryStats()}");
         };
 
         // Periodic memory watchdog — logs a warning when working set exceeds 1 GB
@@ -109,7 +109,7 @@ public class Program
                 {
                     using var proc = Process.GetCurrentProcess();
                     if (proc.WorkingSet64 > warningThresholdBytes)
-                        WriteCrashLog(crashLogPath, $"[{DateTime.UtcNow:O}] MEMORY WARNING | {GetMemoryStats()}");
+                        CrashLog.Write($"[{DateTime.UtcNow:O}] MEMORY WARNING | {GetMemoryStats()}");
                 }
                 catch { /* best-effort */ }
             }
@@ -139,28 +139,7 @@ public class Program
         }
     }
 
-    private static string GetCrashLogPath()
-    {
-        var tendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME");
-        var logDir = !string.IsNullOrEmpty(tendrilHome) ? tendrilHome : Path.GetTempPath();
-        return Path.Combine(logDir, "crash.log");
-    }
-
-    internal static string CrashLogPath { get; } = GetCrashLogPath();
-
-    internal static void WriteCrashLog(string message) => WriteCrashLog(CrashLogPath, message);
-
-    private static void WriteCrashLog(string path, string message)
-    {
-        try
-        {
-            File.AppendAllText(path, message + Environment.NewLine);
-        }
-        catch
-        {
-            // Last-resort: don't let logging itself crash the process
-        }
-    }
+    internal static void WriteCrashLog(string message) => CrashLog.Write(message);
 
     private static string GetMemoryStats()
     {


### PR DESCRIPTION
# Summary

## Changes

Extracted duplicate crash logging logic from `ProcessExtensions.WriteCrashLog` and `Program.WriteCrashLog`/`GetCrashLogPath` into a new shared `Ivy.Helpers.CrashLog` static class. Both callsites now delegate to `CrashLog.Write`. The `Program.WriteCrashLog(string)` method is retained as a thin forwarding method for backward compatibility with external service callers (TendrilServer, JobService, PlanWatcherService, InboxWatcherService).

## API Changes

- **New class:** `Ivy.Helpers.CrashLog` (public static)
  - `CrashLog.Path` — gets the crash log file path (lazy-initialized from `TENDRIL_HOME` or temp)
  - `CrashLog.Write(string message)` — appends a message to the crash log, swallowing all exceptions
- **Removed:** `ProcessExtensions.WriteCrashLog(string)` (private, no external consumers)
- **Removed:** `Program.GetCrashLogPath()`, `Program.CrashLogPath`, `Program.WriteCrashLog(string, string)`
- **Retained:** `Program.WriteCrashLog(string)` now forwards to `CrashLog.Write`

## Files Modified

- **New:** `src/Ivy/Helpers/CrashLog.cs` — shared crash log utility
- **Modified:** `src/Ivy/Helpers/ProcessExtensions.cs` — replaced private `WriteCrashLog` with `CrashLog.Write`
- **Modified:** `src/tendril/Ivy.Tendril/Program.cs` — removed duplicate methods, replaced callsites with `CrashLog.Write`

## Commits

- 0f83aea84 [03185] Fix System.IO.Path collision in CrashLog utility
- 7bbade8b0 [03185] Extract shared CrashLog utility class