### PR TITLE
[03183] Add AnnotateBrokenFileLinks call in TrashApp

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/TrashApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/TrashApp.cs
@@ -91,8 +91,9 @@ public class TrashApp : ViewBase
                                 }
                             });
 
+            var annotatedContent = MarkdownHelper.AnnotateBrokenFileLinks(selected.Content);
             var scrollableContent = Layout.Vertical().Width(Size.Auto().Max(Size.Units(200)))
-                                    | new Markdown(selected.Content)
+                                    | new Markdown(annotatedContent)
                                         .DangerouslyAllowLocalFiles()
                                         .OnLinkClick(FileLinkHelper.CreateFileLinkClickHandler(openFile));
 


### PR DESCRIPTION
# Summary

## Changes

Added `MarkdownHelper.AnnotateBrokenFileLinks` call in TrashApp.cs before rendering markdown content, matching the pattern used in all other Tendril apps. Broken `file:///` links in trashed plans will now show warning indicators.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Apps/TrashApp.cs` — Added broken file link annotation before markdown rendering

## Commits

- 2b82dc981 [03183] Add AnnotateBrokenFileLinks call in TrashApp