### PR TITLE
[03182] Add ObjectDisposedException handling to RunStaleOutputWatchdog

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/JobServiceTimeoutTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/JobServiceTimeoutTests.cs
@@ -270,6 +270,26 @@ codingAgent: claude
     }
 
     [Fact]
+    public async Task RunStaleOutputWatchdog_HandlesDisposedCts_ExitsGracefully()
+    {
+        var service = CreateService(TimeSpan.FromMinutes(30), TimeSpan.FromSeconds(5));
+
+        var id = service.CreateTestJob("ExecutePlan", Path.GetTempPath());
+        var job = service.GetJob(id);
+        Assert.NotNull(job);
+
+        var cts = job.TimeoutCts!;
+        var watchdogTask = service.RunStaleOutputWatchdog(id, cts);
+
+        await Task.Delay(100);
+        cts.Dispose();
+
+        var completed = await Task.WhenAny(watchdogTask, Task.Delay(TimeSpan.FromSeconds(5)));
+        Assert.Equal(watchdogTask, completed);
+        Assert.True(watchdogTask.IsCompletedSuccessfully, "Watchdog should exit gracefully, not fault");
+    }
+
+    [Fact]
     public void ProcessId_CapturedOnJobItem()
     {
         var service = CreateService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));

--- a/src/tendril/Ivy.Tendril/Services/JobService.cs
+++ b/src/tendril/Ivy.Tendril/Services/JobService.cs
@@ -831,36 +831,40 @@ public class JobService : IJobService
             }
     }
 
-    private async Task RunStaleOutputWatchdog(string id, CancellationTokenSource timeoutCts)
+    internal async Task RunStaleOutputWatchdog(string id, CancellationTokenSource timeoutCts)
     {
         var checkInterval = TimeSpan.FromSeconds(60);
 
-        while (!timeoutCts.Token.IsCancellationRequested)
+        try
         {
-            try
+            while (!timeoutCts.Token.IsCancellationRequested)
             {
-                await Task.Delay(checkInterval, timeoutCts.Token);
-            }
-            catch (OperationCanceledException)
-            {
-                break;
-            }
-
-            if (!_jobs.TryGetValue(id, out var job) || job.Status != JobStatus.Running)
-                break;
-
-            if (job.LastOutputAt.HasValue)
-            {
-                var sinceLastOutput = DateTime.UtcNow - job.LastOutputAt.Value;
-                if (sinceLastOutput >= _staleOutputTimeout)
+                try
                 {
-                    // Stale output detected — signal via flag and cancel the timeout CTS
-                    // The main monitor (LaunchJob background task) will handle process kill and CompleteJob
-                    job.StaleOutputDetected = true;
-                    try { timeoutCts.Cancel(); } catch (ObjectDisposedException) { }
+                    await Task.Delay(checkInterval, timeoutCts.Token);
+                }
+                catch (OperationCanceledException)
+                {
                     break;
                 }
+
+                if (!_jobs.TryGetValue(id, out var job) || job.Status != JobStatus.Running)
+                    break;
+
+                if (job.LastOutputAt.HasValue)
+                {
+                    var sinceLastOutput = DateTime.UtcNow - job.LastOutputAt.Value;
+                    if (sinceLastOutput >= _staleOutputTimeout)
+                    {
+                        job.StaleOutputDetected = true;
+                        try { timeoutCts.Cancel(); } catch (ObjectDisposedException) { }
+                        break;
+                    }
+                }
             }
+        }
+        catch (ObjectDisposedException)
+        {
         }
     }
 


### PR DESCRIPTION
# Summary

## Changes

Added `ObjectDisposedException` handling to `RunStaleOutputWatchdog` in `JobService.cs` by wrapping the entire watchdog loop in an outer try-catch block (Option 1 from plan). This prevents unhandled exceptions when the CancellationTokenSource is disposed by `DisposeResources()` while the watchdog is still running. Added a test that directly invokes the watchdog, disposes the CTS mid-execution, and verifies graceful exit.

## API Changes

- `JobService.RunStaleOutputWatchdog(string id, CancellationTokenSource timeoutCts)` — changed from `private` to `internal` for testability (already covered by `InternalsVisibleTo("Ivy.Tendril.Test")`)

## Files Modified

- **src/tendril/Ivy.Tendril/Services/JobService.cs** — Added outer try-catch for ObjectDisposedException around watchdog loop, changed method visibility to internal
- **src/tendril/Ivy.Tendril.Test/JobServiceTimeoutTests.cs** — Added `RunStaleOutputWatchdog_HandlesDisposedCts_ExitsGracefully` test

## Commits

- b5122ee30 [03182] Add ObjectDisposedException handling to RunStaleOutputWatchdog