### PR TITLE
[03181] Add structured logging to JobService monitor task

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/JobServiceTimeoutTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/JobServiceTimeoutTests.cs
@@ -2,6 +2,8 @@ using System.Diagnostics;
 using Ivy.Helpers;
 using Ivy.Tendril.Apps.Jobs;
 using Ivy.Tendril.Services;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 
@@ -9,11 +11,13 @@ namespace Ivy.Tendril.Test;
 
 public class JobServiceTimeoutTests
 {
-    private static JobService CreateService(TimeSpan jobTimeout, TimeSpan staleOutputTimeout)
+    private static JobService CreateService(
+        TimeSpan jobTimeout,
+        TimeSpan staleOutputTimeout,
+        ILogger<JobService>? logger = null)
     {
-        // Clear sync context so notifications fire synchronously during tests
         SynchronizationContext.SetSynchronizationContext(null);
-        return new JobService(jobTimeout, staleOutputTimeout);
+        return new JobService(jobTimeout, staleOutputTimeout, logger: logger);
     }
 
     [Fact]
@@ -294,5 +298,50 @@ codingAgent: claude
 
         process.WaitForExit();
         service.CompleteJob(id, 0);
+    }
+
+    [Fact]
+    public void Constructor_AcceptsLogger()
+    {
+        var logger = NullLogger<JobService>.Instance;
+        var service = CreateService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10), logger);
+
+        var id = service.CreateTestJob("ExecutePlan", Path.GetTempPath());
+        service.CompleteJob(id, 0);
+
+        var job = service.GetJob(id);
+        Assert.NotNull(job);
+        Assert.Equal(JobStatus.Completed, job.Status);
+    }
+
+    [Fact]
+    public void Constructor_WithCapturingLogger_DoesNotThrow()
+    {
+        var logEntries = new List<(LogLevel Level, string Message)>();
+        var logger = new CapturingLogger<JobService>(logEntries);
+        var service = CreateService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10), logger);
+
+        var id = service.CreateTestJob("ExecutePlan", Path.GetTempPath());
+        service.CompleteJob(id, 0);
+
+        var job = service.GetJob(id);
+        Assert.NotNull(job);
+        Assert.Equal(JobStatus.Completed, job.Status);
+    }
+}
+
+internal sealed class CapturingLogger<T>(List<(LogLevel Level, string Message)> entries) : ILogger<T>
+{
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter)
+    {
+        entries.Add((logLevel, formatter(state, exception)));
     }
 }

--- a/src/tendril/Ivy.Tendril/Services/JobService.cs
+++ b/src/tendril/Ivy.Tendril/Services/JobService.cs
@@ -6,6 +6,8 @@ using Ivy.Helpers;
 using Ivy.Tendril.Apps;
 using Ivy.Tendril.Apps.Jobs;
 using Ivy.Tendril.Apps.Plans;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 
@@ -69,10 +71,12 @@ public class JobService : IJobService
     private readonly SynchronizationContext? _syncContext;
     private readonly ITelemetryService? _telemetryService;
     private readonly IWorktreeLifecycleLogger? _worktreeLifecycleLogger;
+    private readonly ILogger<JobService> _logger;
     private int _counter;
 
     public JobService(
         IConfigService configService,
+        ILogger<JobService>? logger = null,
         ModelPricingService? modelPricingService = null,
         IPlanReaderService? planReaderService = null,
         ITelemetryService? telemetryService = null,
@@ -82,6 +86,7 @@ public class JobService : IJobService
     {
         _syncContext = SynchronizationContext.Current;
         _configService = configService;
+        _logger = logger ?? NullLogger<JobService>.Instance;
         _modelPricingService = modelPricingService;
         _planReaderService = planReaderService;
         _telemetryService = telemetryService;
@@ -106,9 +111,11 @@ public class JobService : IJobService
         int maxConcurrentJobs = 5,
         IPlanReaderService? planReaderService = null,
         ITelemetryService? telemetryService = null,
-        IPlanDatabaseService? database = null)
+        IPlanDatabaseService? database = null,
+        ILogger<JobService>? logger = null)
     {
         _syncContext = SynchronizationContext.Current;
+        _logger = logger ?? NullLogger<JobService>.Instance;
         _jobTimeout = jobTimeout;
         _staleOutputTimeout = staleOutputTimeout;
         _maxConcurrentJobs = maxConcurrentJobs;
@@ -722,26 +729,38 @@ public class JobService : IJobService
 
         Task.Run(async () =>
         {
+            _logger.LogDebug("Job {JobId}: Monitor task started", id);
+
             try
             {
                 if (await process.WaitForExitOrKillAsync(cts.Token))
                 {
                     if (_jobs.TryGetValue(id, out var j) && j.StaleOutputDetected)
+                    {
+                        _logger.LogInformation("Job {JobId}: Process exited, stale output detected", id);
                         CompleteJob(id, null, timedOut: true, staleOutput: true);
+                    }
                     else
+                    {
+                        _logger.LogInformation("Job {JobId}: Process exited with code {ExitCode}", id, process.ExitCode);
                         CompleteJob(id, process.ExitCode);
+                    }
                 }
                 else
                 {
+                    _logger.LogWarning("Job {JobId}: Process killed after timeout", id);
                     CompleteJob(id, null, timedOut: true);
                 }
+
+                _logger.LogDebug("Job {JobId}: Monitor task completed normally", id);
             }
             catch (ObjectDisposedException)
             {
-                // CTS was disposed — job is already being completed elsewhere (CompleteJob/StopJob).
+                _logger.LogDebug("Job {JobId}: Monitor task exiting (CTS disposed, job completed elsewhere)", id);
             }
             catch (Exception ex)
             {
+                _logger.LogError(ex, "Job {JobId}: Monitor task exception", id);
                 Program.WriteCrashLog($"[{DateTime.UtcNow:O}] JobService process monitor exception for job {id}: {ex}");
                 CompleteJob(id, null, timedOut: false);
             }

--- a/src/tendril/Ivy.Tendril/TendrilServer.cs
+++ b/src/tendril/Ivy.Tendril/TendrilServer.cs
@@ -109,6 +109,7 @@ public static class TendrilServer
             var cfg = sp.GetRequiredService<IConfigService>();
             return new JobService(
                 cfg,
+                sp.GetRequiredService<ILogger<JobService>>(),
                 sp.GetRequiredService<ModelPricingService>(),
                 sp.GetRequiredService<IPlanReaderService>(),
                 sp.GetRequiredService<ITelemetryService>(),


### PR DESCRIPTION
# Summary

## Changes

Added structured logging to the JobService monitor task using `ILogger<JobService>`. The monitor task now logs lifecycle events at appropriate levels: Debug for start/completion/CTS disposal, Information for exit code and stale output detection, Warning for timeout kills, and Error for unexpected exceptions. Both JobService constructors accept an optional `ILogger<JobService>` parameter with `NullLogger` fallback, ensuring backward compatibility with all existing call sites.

## API Changes

- `JobService(IConfigService, ...)` — new optional `ILogger<JobService>? logger` parameter (2nd position)
- `JobService(TimeSpan, TimeSpan, ...)` — new optional `ILogger<JobService>? logger` parameter (last position)

## Files Modified

- **Core implementation:**
  - `src/tendril/Ivy.Tendril/Services/JobService.cs` — added logger field, constructor params, and structured logging in monitor task
  - `src/tendril/Ivy.Tendril/TendrilServer.cs` — inject `ILogger<JobService>` via DI

- **Tests:**
  - `src/tendril/Ivy.Tendril.Test/JobServiceTimeoutTests.cs` — added logger parameter to `CreateService`, new tests for logger wiring, `CapturingLogger<T>` helper

## Commits

- c72b293b6 [03181] Add structured logging to JobService monitor task