### PR TITLE
[03180] Migrate promptware Program.md files to use Get-ConfigYaml helper

### DIFF
--- a/src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
+++ b/src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
@@ -13,7 +13,7 @@ The firmware header contains:
 - **Note** (optional) — Additional instructions from the reviewer. If present, follow these instructions in addition to the plan.
 
 Read the plan structure in `../.shared/Plans.md`.
-Read `config.yaml` from the `TENDRIL_CONFIG` environment variable (absolute path to config.yaml) for project repos and context.
+Use the `Get-ConfigYaml` helper from Utils.ps1 to read project configuration (project repos and context) with caching.
 
 The launcher script sets the working directory to the project's primary repo.
 

--- a/src/tendril/Ivy.Tendril/Promptwares/ExpandPlan/Program.md
+++ b/src/tendril/Ivy.Tendril/Promptwares/ExpandPlan/Program.md
@@ -9,7 +9,7 @@ The firmware header contains:
 - **CurrentTime** — current UTC timestamp
 
 Read the plan structure in `../.shared/Plans.md`.
-Read `config.yaml` from the `TENDRIL_CONFIG` environment variable (absolute path to config.yaml).
+Use the `Get-ConfigYaml` helper from Utils.ps1 to read project configuration with caching.
 
 ## Execution Steps
 

--- a/src/tendril/Ivy.Tendril/Promptwares/MakePlan/Program.md
+++ b/src/tendril/Ivy.Tendril/Promptwares/MakePlan/Program.md
@@ -15,7 +15,7 @@ The firmware header contains these key values:
 - **SourcePath** (optional) — absolute path to the source that generated this plan (e.g. test working directory)
 
 Read the plan folder structure in `../.shared/Plans.md`.
-Read the project configuration from the `TENDRIL_CONFIG` environment variable (absolute path to config.yaml).
+Use the `Get-ConfigYaml` helper from Utils.ps1 to read project configuration with caching.
 
 ## Execution Steps
 
@@ -34,7 +34,7 @@ Flags can be combined (e.g., `task description [YOLO] [FORCE]` or `task descript
 
 ### 1.5. Load Project Context
 
-Read `config.yaml` (at the path from `TENDRIL_CONFIG` environment variable) to understand all available projects, their repos, and context.
+Use `Get-ConfigYaml` to understand all available projects, their repos, and context.
 
 **If `Project` is set to a specific project name** (not `Auto`):
 - Find that project in `config.yaml` and use its repos and context to scope your research

--- a/src/tendril/Ivy.Tendril/Promptwares/MakePr/Program.md
+++ b/src/tendril/Ivy.Tendril/Promptwares/MakePr/Program.md
@@ -13,7 +13,7 @@ The firmware header contains:
 - **CurrentTime** — current UTC timestamp
 
 Read the plan structure in `../.shared/Plans.md`.
-Read `config.yaml` from the `TENDRIL_CONFIG` environment variable (absolute path to config.yaml) for project repos and their `prRule` setting.
+Use the `Get-ConfigYaml` helper from Utils.ps1 to read project configuration (project repos and their `prRule` setting) with caching.
 
 ## PR Rules (from config.yaml per repo)
 
@@ -32,7 +32,7 @@ Before processing, read `plan.yaml` and check the `state` field:
 
 - Read `plan.yaml` from the plan folder (project, commits, repos)
 - Read the latest revision for the plan title and description
-- Read config.yaml to find the `prRule` for each repo
+- Use `Get-ConfigYaml` to find the `prRule` for each repo
 - **Check for custom options:** If `<PlanFolder>/.custom-pr-options.yaml` exists, read it. The file contains:
   ```yaml
   merge: true/false

--- a/src/tendril/Ivy.Tendril/Promptwares/SplitPlan/Program.md
+++ b/src/tendril/Ivy.Tendril/Promptwares/SplitPlan/Program.md
@@ -9,7 +9,7 @@ The firmware header contains:
 - **CurrentTime** — current UTC timestamp
 
 Read the plan structure in `../.shared/Plans.md`.
-Read `config.yaml` from the `TENDRIL_CONFIG` environment variable (absolute path to config.yaml) for available projects and their repos.
+Use the `Get-ConfigYaml` helper from Utils.ps1 to read project configuration (available projects and their repos) with caching.
 
 The plans directory path can be derived from the plan folder's parent directory.
 

--- a/src/tendril/Ivy.Tendril/Promptwares/UpdatePlan/Program.md
+++ b/src/tendril/Ivy.Tendril/Promptwares/UpdatePlan/Program.md
@@ -9,7 +9,7 @@ The firmware header contains:
 - **CurrentTime** — current UTC timestamp
 
 Read the plan structure in `../.shared/Plans.md`.
-Read `config.yaml` from the `TENDRIL_CONFIG` environment variable (absolute path to config.yaml).
+Use the `Get-ConfigYaml` helper from Utils.ps1 to read project configuration with caching.
 
 ## Execution Steps
 
@@ -31,7 +31,7 @@ If no `>>` lines exist, report "No comments found" and stop.
 
 For each question in the `>>` lines:
 1. Read relevant source files to find the answer
-2. Read `config.yaml` (from `TENDRIL_CONFIG` environment variable) for project context if needed
+2. Use `Get-ConfigYaml` for project context if needed
 
 ### 3.5. Resolve Answered Questions
 


### PR DESCRIPTION
# Summary

## Changes

Updated 9 references across 6 promptware Program.md files to instruct LLM agents to use the cached `Get-ConfigYaml` helper from Utils.ps1 instead of parsing config.yaml directly via the `TENDRIL_CONFIG` environment variable. This aligns agent instructions with the caching implementation from plan 03166.

## API Changes

None.

## Files Modified

- **MakePlan/Program.md** — 2 references updated (lines 18, 37)
- **ExpandPlan/Program.md** — 1 reference updated (line 12)
- **SplitPlan/Program.md** — 1 reference updated (line 12)
- **UpdatePlan/Program.md** — 2 references updated (lines 12, 34)
- **ExecutePlan/Program.md** — 1 reference updated (line 16)
- **MakePr/Program.md** — 2 references updated (lines 16, 35)

## Commits

- 5a2f5468b [03180] Migrate promptware Program.md files to use Get-ConfigYaml helper