### PR TITLE
[03178] Connection secret presets not auto-loaded into IConfiguration

### DIFF
--- a/src/Ivy.Tests/ServerConfigurationTests.cs
+++ b/src/Ivy.Tests/ServerConfigurationTests.cs
@@ -1,0 +1,75 @@
+using Microsoft.Extensions.Configuration;
+
+namespace Ivy.Tests;
+
+public class TestConnectionWithPresets : IConnection, IHaveSecrets
+{
+    public string GetContext(string connectionPath) => "";
+    public string GetNamespace() => "Test";
+    public string GetName() => "TestConnection";
+    public string GetConnectionType() => "Test";
+    public ConnectionEntity[] GetEntities() => [];
+    public void RegisterServices(Server server) { }
+    public Task<(bool ok, string? message)> TestConnection(IConfiguration config) => Task.FromResult((true, (string?)null));
+
+    public Secret[] GetSecrets() =>
+    [
+        new Secret("Test:ApiKey", "preset-api-key-123"),
+        new Secret("Test:Endpoint", "https://preset.example.com/"),
+    ];
+}
+
+public class TestConnectionWithoutSecrets : IConnection
+{
+    public string GetContext(string connectionPath) => "";
+    public string GetNamespace() => "Test";
+    public string GetName() => "NoSecrets";
+    public string GetConnectionType() => "Test";
+    public ConnectionEntity[] GetEntities() => [];
+    public void RegisterServices(Server server) { }
+    public Task<(bool ok, string? message)> TestConnection(IConfiguration config) => Task.FromResult((true, (string?)null));
+}
+
+public class ServerConfigurationTests
+{
+    [Fact]
+    public void AddConnectionsFromAssembly_LoadsSecretPresetsIntoConfiguration()
+    {
+        var server = new Server(new ServerArgs());
+
+        server.AddConnectionsFromAssembly(typeof(ServerConfigurationTests).Assembly);
+
+        Assert.Equal("preset-api-key-123", server.Configuration["Test:ApiKey"]);
+        Assert.Equal("https://preset.example.com/", server.Configuration["Test:Endpoint"]);
+    }
+
+    [Fact]
+    public void AddConnectionsFromAssembly_PresetsAreOverriddenByEnvironmentVariables()
+    {
+        var server = new Server(new ServerArgs());
+
+        Environment.SetEnvironmentVariable("Test__ApiKey", "env-override-key");
+        try
+        {
+            server.AddConnectionsFromAssembly(typeof(ServerConfigurationTests).Assembly);
+
+            Assert.Equal("env-override-key", server.Configuration["Test:ApiKey"]);
+            Assert.Equal("https://preset.example.com/", server.Configuration["Test:Endpoint"]);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("Test__ApiKey", null);
+        }
+    }
+
+    [Fact]
+    public void AddConnectionsFromAssembly_WithNoPresets_DoesNotRebuildConfiguration()
+    {
+        var server = new Server(new ServerArgs());
+        var originalConfig = server.Configuration;
+
+        server.AddConnectionsFromAssembly(typeof(int).Assembly);
+
+        Assert.Same(originalConfig, server.Configuration);
+    }
+}

--- a/src/Ivy/Server.cs
+++ b/src/Ivy/Server.cs
@@ -179,11 +179,43 @@ public class Server
         assembly ??= Assembly.GetEntryAssembly();
 
         var connections = assembly!.GetLoadableTypes()
-            .Where(t => t.IsClass && typeof(IConnection).IsAssignableFrom(t));
+            .Where(t => t.IsClass && typeof(IConnection).IsAssignableFrom(t))
+            .Select(t => (IConnection)Activator.CreateInstance(t)!)
+            .ToList();
 
-        foreach (var type in connections)
+        var presets = new Dictionary<string, string?>();
+        foreach (var connection in connections)
         {
-            var connection = (IConnection)Activator.CreateInstance(type)!;
+            if (connection is IHaveSecrets secretProvider)
+            {
+                foreach (var secret in secretProvider.GetSecrets())
+                {
+                    if (secret.Preset != null && !presets.ContainsKey(secret.Key))
+                    {
+                        presets[secret.Key] = secret.Preset;
+                    }
+                }
+            }
+        }
+
+        if (presets.Count > 0)
+        {
+            var builder = new ConfigurationBuilder()
+                .AddInMemoryCollection(presets)
+                .AddEnvironmentVariables()
+                .SetBasePath(Directory.GetCurrentDirectory())
+                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true);
+
+            if (Assembly.GetEntryAssembly() is { } entryAssembly)
+            {
+                builder.AddUserSecrets(entryAssembly);
+            }
+
+            Configuration = builder.Build();
+        }
+
+        foreach (var connection in connections)
+        {
             connection.RegisterServices(this);
         }
     }

--- a/src/Ivy/Server.cs
+++ b/src/Ivy/Server.cs
@@ -12,7 +12,6 @@ using Ivy.Core.Server.Middleware;
 using Ivy.Core.Server.Formatters;
 using MessagePack;
 using MessagePack.Resolvers;
-using MessagePack.Formatters;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http; //do not remove - used in RELEASE
@@ -1210,7 +1209,7 @@ public static class WebApplicationExtensions
         // {
         //     context.Response.Headers["ivy-version"] = version;
         // }
-        
+
         // Determine HTTP status code based on app routing
         var server = app.Services.GetRequiredService<Server>();
         var httpStatusCode = GetHttpStatusCodeForRequest(server, context);


### PR DESCRIPTION
# Summary

## Changes

Modified `Server.AddConnectionsFromAssembly()` to collect secret presets from connections implementing `IHaveSecrets` and inject them as lowest-priority in-memory configuration sources before calling `RegisterServices()`. This ensures preset values from `GetSecrets()` are available via `IConfiguration` without requiring manual user-secrets setup.

## API Changes

None — no public API surface changes. The existing `AddConnectionsFromAssembly()` method signature is unchanged; it now additionally populates `Configuration` with preset values.

## Files Modified

- **src/Ivy/Server.cs** — `AddConnectionsFromAssembly()` now collects presets from `IHaveSecrets` connections and rebuilds `Configuration` with in-memory presets as lowest-priority source
- **src/Ivy.Tests/ServerConfigurationTests.cs** — New test class with 3 tests verifying preset loading, environment variable override, and no-op when no presets exist

## Commits

- e3e1e6df3 [03178] Fix formatting in Server.cs
- bb39a78de [03178] Inject connection secret presets into IConfiguration