### PR TITLE
[00127] StackedProgress does not respect max width — overflows container bounds

### DIFF
--- a/src/frontend/src/widgets/stackedProgress/StackedProgressWidget.tsx
+++ b/src/frontend/src/widgets/stackedProgress/StackedProgressWidget.tsx
@@ -56,22 +56,25 @@ export const StackedProgressWidget: React.FC<StackedProgressWidgetProps> = ({
       <div
         className="bg-neutral/10"
         style={{
+          minWidth: 0,
+          maxWidth: "100%",
           ...getWidth(width),
           height: `${barHeight}px`,
           borderRadius: rounded ? `${barHeight / 2}px` : undefined,
+          overflow: "hidden",
         }}
       />
     );
   }
 
   const containerStyles: React.CSSProperties = {
+    minWidth: 0,
+    maxWidth: "100%",
     ...getWidth(width),
     height: `${barHeight}px`,
     display: "flex",
     overflow: "hidden",
     borderRadius: rounded ? `${barHeight / 2}px` : undefined,
-    minWidth: 0,
-    maxWidth: "100%",
   };
 
   const handleSelect = (index: number) => {
@@ -89,7 +92,13 @@ export const StackedProgressWidget: React.FC<StackedProgressWidgetProps> = ({
     <TooltipProvider>
       <div
         className="flex flex-col gap-1"
-        style={{ ...getWidth(width), height: "fit-content", minWidth: 0, maxWidth: "100%" }}
+        style={{
+          minWidth: 0,
+          maxWidth: "100%",
+          ...getWidth(width),
+          height: "fit-content",
+          overflow: "hidden",
+        }}
       >
         <div className="bg-neutral/10" style={containerStyles}>
           {segments.map((segment, index) => {


### PR DESCRIPTION
## Problem

Stacked progress bar does not respect its max width. In Tendril it extends out of its bounds.

## Solution

Fix StackedProgress max-width overflow by reordering CSS properties to ensure container bounds are respected.

## Commits

- `9848db39f` [00127] Fix StackedProgress max-width overflow by reordering CSS properties