### PR TITLE
[00132] Add Prefix/Suffix slot support to SelectInput

### DIFF
--- a/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/SelectInputApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/SelectInputApp.cs
@@ -21,7 +21,8 @@ public class SelectInputApp : SampleBase
             new Tab("Nullable & Edge Cases", new SelectInputAdvancedExample()),
             new Tab("Advanced Props", new SelectInputAdvancedPropsExample()),
             new Tab("Ghost", new SelectInputGhostExample()),
-            new Tab("Descriptions", new SelectInputDescriptionsExample())
+            new Tab("Descriptions", new SelectInputDescriptionsExample()),
+            new Tab("Affixes", new SelectInputAffixesExample())
         ).Variant(TabsVariant.Content)
         ;
     }
@@ -642,5 +643,37 @@ public class SelectInputRadioExample : ViewBase
                     | Text.Monospaced("String options")
                     | notificationFrequency.ToSelectInput(frequencyOptions).Radio()
                         .WithField().Label("Notification frequency"));
+    }
+}
+
+public class SelectInputAffixesExample : ViewBase
+{
+    private enum Currency { USD, EUR, GBP, JPY }
+
+    public override object? Build()
+    {
+        var currencyState = UseState(Currency.USD);
+        var currencyOptions = typeof(Currency).ToOptions();
+
+        return Layout.Grid().Columns(4)
+               | null!
+               | Text.Monospaced("Prefix only")
+               | Text.Monospaced("Suffix only")
+               | Text.Monospaced("Both")
+
+               | Text.Monospaced("Text prefix/suffix")
+               | currencyState.ToSelectInput(currencyOptions).Prefix("$")
+               | currencyState.ToSelectInput(currencyOptions).Suffix("USD")
+               | currencyState.ToSelectInput(currencyOptions).Prefix("$").Suffix("USD")
+
+               | Text.Monospaced("Icon prefix/suffix")
+               | currencyState.ToSelectInput(currencyOptions).Prefix(Icons.Mail)
+               | currencyState.ToSelectInput(currencyOptions).Suffix(Icons.Mail)
+               | currencyState.ToSelectInput(currencyOptions).Prefix(Icons.Mail).Suffix(Icons.Mail)
+
+               | Text.Monospaced("Button prefix/suffix")
+               | currencyState.ToSelectInput(currencyOptions).Prefix(new Button("Copy", () => { }, icon: Icons.Copy).Ghost().Small())
+               | currencyState.ToSelectInput(currencyOptions).Suffix(new Button("Go").Ghost().Small())
+               | currencyState.ToSelectInput(currencyOptions).Prefix(new Button("Copy", () => { }, icon: Icons.Copy).Ghost().Small()).Suffix(new Button("Go").Ghost().Small());
     }
 }

--- a/src/Ivy.Test/InputWidgetTests.cs
+++ b/src/Ivy.Test/InputWidgetTests.cs
@@ -217,6 +217,30 @@ public class InputWidgetTests
 
 public class InputPrefixSuffixSlotTests
 {
+    private class MockState<T>(T value) : IState<T>
+    {
+        private readonly Subject<T> _subject = new();
+        public T Value { get; set; } = value;
+
+        [OverloadResolutionPriority(1)]
+        public T Set(T value) { Value = value; return Value; }
+        public T Set(Func<T, T> setter) { Value = setter(Value); return Value; }
+        public T Reset() => Set(default(T)!);
+        public Type GetStateType() => typeof(T);
+
+        public IDisposable Subscribe(IObserver<T> observer)
+        {
+            observer.OnNext(Value);
+            return _subject.Subscribe(observer);
+        }
+
+        public void Dispose() => _subject.Dispose();
+        public IDisposable SubscribeAny(Action action) => _subject.Subscribe(_ => action());
+        public IDisposable SubscribeAny(Action<object?> action) => _subject.Subscribe(x => action(x));
+        public IEffectTrigger ToTrigger() => EffectTrigger.OnStateChange(this);
+        public object? GetValueAsObject() => Value;
+    }
+
     private static Slot? FindSlot(WidgetBase widget, string name)
         => widget.Children.OfType<Slot>().FirstOrDefault(s => s.Name == name);
 

--- a/src/Ivy.Test/InputWidgetTests.cs
+++ b/src/Ivy.Test/InputWidgetTests.cs
@@ -320,4 +320,44 @@ public class InputPrefixSuffixSlotTests
         Assert.NotNull(slot);
         Assert.Equal("USD", slot!.Children[0]);
     }
+
+    [Fact]
+    public void SelectInput_Prefix_AddsPrefixSlot()
+    {
+        var state = new MockState<string>("a");
+        var input = state.ToSelectInput().Prefix("$");
+        var slot = FindSlot(input, "Prefix");
+        Assert.NotNull(slot);
+        Assert.Equal("$", slot!.Children[0]);
+    }
+
+    [Fact]
+    public void SelectInput_Suffix_AddsSuffixSlot()
+    {
+        var state = new MockState<string>("a");
+        var input = state.ToSelectInput().Suffix(".00");
+        var slot = FindSlot(input, "Suffix");
+        Assert.NotNull(slot);
+        Assert.Equal(".00", slot!.Children[0]);
+    }
+
+    [Fact]
+    public void SelectInput_PrefixAndSuffix_Coexist()
+    {
+        var state = new MockState<string>("a");
+        var input = state.ToSelectInput().Prefix("$").Suffix("USD");
+        Assert.NotNull(FindSlot(input, "Prefix"));
+        Assert.NotNull(FindSlot(input, "Suffix"));
+    }
+
+    [Fact]
+    public void SelectInput_Prefix_AcceptsWidgetContent()
+    {
+        var state = new MockState<string>("a");
+        var button = new Button("Click");
+        var input = state.ToSelectInput().Prefix(button);
+        var slot = FindSlot(input, "Prefix");
+        Assert.NotNull(slot);
+        Assert.Same(button, slot!.Children[0]);
+    }
 }

--- a/src/Ivy/Widgets/Inputs/SelectInput.cs
+++ b/src/Ivy/Widgets/Inputs/SelectInput.cs
@@ -263,4 +263,17 @@ public static class SelectInputExtensions
         return new SelectInput<string[]>(state, options.ToOptions(), placeholder ?? "Select options...", disabled, variant, true);
     }
 
+    private static object[] WithSlot(SelectInputBase widget, string slotName, object? value)
+    {
+        var others = widget.Children.Where(c => c is not Slot s || s.Name != slotName);
+        var result = value != null ? others.Append(new Slot(slotName, value)) : others;
+        return result.ToArray();
+    }
+
+    public static SelectInputBase Prefix(this SelectInputBase widget, object prefix)
+        => widget with { Children = WithSlot(widget, "Prefix", prefix) };
+
+    public static SelectInputBase Suffix(this SelectInputBase widget, object suffix)
+        => widget with { Children = WithSlot(widget, "Suffix", suffix) };
+
 }

--- a/src/frontend/src/widgets/inputs/SelectMultiVariant.tsx
+++ b/src/frontend/src/widgets/inputs/SelectMultiVariant.tsx
@@ -196,20 +196,21 @@ export const SelectMultiVariant: React.FC<SelectInputWidgetProps> = ({
   return (
     <div className="flex items-center gap-2 w-full" style={styles}>
       {hasAffixes ? (
-        <div className={cn(
-          "relative flex flex-1 items-stretch rounded-field border border-input bg-transparent shadow-sm transition-colors dark:bg-white/5 dark:border-white/10",
-          invalid && "border-destructive",
-          (disabled || loading) && "cursor-not-allowed opacity-50",
-          ghost && "border-transparent shadow-none bg-transparent dark:border-transparent dark:bg-transparent",
-        )}>
+        <div
+          className={cn(
+            "relative flex flex-1 items-stretch rounded-field border border-input bg-transparent shadow-sm transition-colors dark:bg-white/5 dark:border-white/10",
+            invalid && "border-destructive",
+            (disabled || loading) && "cursor-not-allowed opacity-50",
+            ghost &&
+              "border-transparent shadow-none bg-transparent dark:border-transparent dark:bg-transparent",
+          )}
+        >
           {hasPrefix && (
             <div className="flex items-center px-3 bg-muted text-muted-foreground border-r border-input rounded-tl-[var(--radius-fields)] rounded-bl-[var(--radius-fields)]">
               {prefixContent}
             </div>
           )}
-          <div className="flex-1 relative w-full">
-            {multiSelectorContent}
-          </div>
+          <div className="flex-1 relative w-full">{multiSelectorContent}</div>
           {hasSuffix && (
             <div className="flex items-center px-3 bg-muted text-muted-foreground border-l border-input rounded-tr-[var(--radius-fields)] rounded-br-[var(--radius-fields)]">
               {suffixContent}
@@ -217,9 +218,7 @@ export const SelectMultiVariant: React.FC<SelectInputWidgetProps> = ({
           )}
         </div>
       ) : (
-        <div className="flex-1 relative w-full">
-          {multiSelectorContent}
-        </div>
+        <div className="flex-1 relative w-full">{multiSelectorContent}</div>
       )}
     </div>
   );

--- a/src/frontend/src/widgets/inputs/SelectMultiVariant.tsx
+++ b/src/frontend/src/widgets/inputs/SelectMultiVariant.tsx
@@ -31,6 +31,7 @@ export const SelectMultiVariant: React.FC<SelectInputWidgetProps> = ({
   width,
   events = EMPTY_ARRAY,
   autoFocus,
+  slots,
 }) => {
   const validOptions = options.filter(
     (option) => option.value != null && option.value.toString().trim() !== "",
@@ -118,67 +119,108 @@ export const SelectMultiVariant: React.FC<SelectInputWidgetProps> = ({
 
   const styles = getWidth(width);
 
-  return (
-    <div className="flex items-center gap-2 w-full" style={styles}>
-      <div className="flex-1 relative w-full">
-        <MultipleSelector
-          value={selectedMultiSelectOptions}
-          defaultOptions={multiSelectOptions}
-          onValueChange={handleMultiSelectChange}
-          placeholder={placeholder}
-          disabled={disabled || loading}
-          className={cn("w-full", ghost && "ghost")}
-          invalid={!!invalid}
-          hidePlaceholderWhenSelected
-          density={density}
-          ghost={ghost}
-          onBlur={handleBlur}
-          onFocus={handleFocus}
-          data-testid={dataTestId}
-          showActions={showActions && selectMany}
-          maxSelections={maxSelections}
-          minSelections={minSelections}
-          onNullableClear={nullable ? () => eventHandler("OnChange", id, [null]) : undefined}
-          autoFocus={autoFocus}
-        />
-        {(selectedMultiSelectOptions.length > 0 && !disabled) || invalid || loading ? (
-          <div className={selectIconContainerVariant({ density })} style={{ zIndex: 2 }}>
-            {loading && (
-              <div className="pointer-events-auto flex items-center h-6 p-1">
-                <Loader2 className="h-4 w-4 animate-spin text-muted-foreground text-opacity-50" />
-              </div>
-            )}
-            {selectedMultiSelectOptions.length > 0 && !disabled && (
-              <button
-                type="button"
-                tabIndex={-1}
-                aria-label="Clear All"
-                onClick={(e) => {
+  const prefixContent = slots?.Prefix;
+  const suffixContent = slots?.Suffix;
+  const hasPrefix = (prefixContent?.length ?? 0) > 0;
+  const hasSuffix = (suffixContent?.length ?? 0) > 0;
+  const hasAffixes = hasPrefix || hasSuffix;
+
+  const multiSelectorContent = (
+    <>
+      <MultipleSelector
+        value={selectedMultiSelectOptions}
+        defaultOptions={multiSelectOptions}
+        onValueChange={handleMultiSelectChange}
+        placeholder={placeholder}
+        disabled={disabled || loading}
+        className={cn(
+          "w-full",
+          ghost && "ghost",
+          hasAffixes && "border-0 shadow-none",
+          hasPrefix && "rounded-l-none",
+          hasSuffix && "rounded-r-none",
+        )}
+        invalid={!!invalid}
+        hidePlaceholderWhenSelected
+        density={density}
+        ghost={ghost}
+        onBlur={handleBlur}
+        onFocus={handleFocus}
+        data-testid={dataTestId}
+        showActions={showActions && selectMany}
+        maxSelections={maxSelections}
+        minSelections={minSelections}
+        onNullableClear={nullable ? () => eventHandler("OnChange", id, [null]) : undefined}
+        autoFocus={autoFocus}
+      />
+      {(selectedMultiSelectOptions.length > 0 && !disabled) || invalid || loading ? (
+        <div className={selectIconContainerVariant({ density })} style={{ zIndex: 2 }}>
+          {loading && (
+            <div className="pointer-events-auto flex items-center h-6 p-1">
+              <Loader2 className="h-4 w-4 animate-spin text-muted-foreground text-opacity-50" />
+            </div>
+          )}
+          {selectedMultiSelectOptions.length > 0 && !disabled && (
+            <button
+              type="button"
+              tabIndex={-1}
+              aria-label="Clear All"
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                logger.debug("Select input clear button clicked (MultiSelect)", { id });
+                eventHandler("OnChange", id, [null]);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
                   e.preventDefault();
                   e.stopPropagation();
-                  logger.debug("Select input clear button clicked (MultiSelect)", { id });
                   eventHandler("OnChange", id, [null]);
-                }}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    eventHandler("OnChange", id, [null]);
-                  }
-                }}
-                className="pointer-events-auto p-1 rounded hover:bg-accent focus:outline-none cursor-pointer flex items-center h-6"
-              >
-                <X className={xIconVariant({ density })} />
-              </button>
-            )}
-            {invalid && (
-              <div className="pointer-events-auto flex items-center h-6 p-1">
-                <InvalidIcon message={invalid} />
-              </div>
-            )}
+                }
+              }}
+              className="pointer-events-auto p-1 rounded hover:bg-accent focus:outline-none cursor-pointer flex items-center h-6"
+            >
+              <X className={xIconVariant({ density })} />
+            </button>
+          )}
+          {invalid && (
+            <div className="pointer-events-auto flex items-center h-6 p-1">
+              <InvalidIcon message={invalid} />
+            </div>
+          )}
+        </div>
+      ) : null}
+    </>
+  );
+
+  return (
+    <div className="flex items-center gap-2 w-full" style={styles}>
+      {hasAffixes ? (
+        <div className={cn(
+          "relative flex flex-1 items-stretch rounded-field border border-input bg-transparent shadow-sm transition-colors dark:bg-white/5 dark:border-white/10",
+          invalid && "border-destructive",
+          (disabled || loading) && "cursor-not-allowed opacity-50",
+          ghost && "border-transparent shadow-none bg-transparent dark:border-transparent dark:bg-transparent",
+        )}>
+          {hasPrefix && (
+            <div className="flex items-center px-3 bg-muted text-muted-foreground border-r border-input rounded-tl-[var(--radius-fields)] rounded-bl-[var(--radius-fields)]">
+              {prefixContent}
+            </div>
+          )}
+          <div className="flex-1 relative w-full">
+            {multiSelectorContent}
           </div>
-        ) : null}
-      </div>
+          {hasSuffix && (
+            <div className="flex items-center px-3 bg-muted text-muted-foreground border-l border-input rounded-tr-[var(--radius-fields)] rounded-br-[var(--radius-fields)]">
+              {suffixContent}
+            </div>
+          )}
+        </div>
+      ) : (
+        <div className="flex-1 relative w-full">
+          {multiSelectorContent}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/frontend/src/widgets/inputs/SelectSingleVariant.tsx
+++ b/src/frontend/src/widgets/inputs/SelectSingleVariant.tsx
@@ -40,6 +40,7 @@ export const SelectSingleVariant: React.FC<SelectInputWidgetProps> = ({
   width,
   events = EMPTY_ARRAY,
   autoFocus,
+  slots,
 }) => {
   const hasAutoFocusedRef = useRef(false);
   useEffect(() => {
@@ -124,6 +125,12 @@ export const SelectSingleVariant: React.FC<SelectInputWidgetProps> = ({
   const hasValue = stringValue !== undefined;
   const styles = getWidth(width);
 
+  const prefixContent = slots?.Prefix;
+  const suffixContent = slots?.Suffix;
+  const hasPrefix = (prefixContent?.length ?? 0) > 0;
+  const hasSuffix = (suffixContent?.length ?? 0) > 0;
+  const hasAffixes = hasPrefix || hasSuffix;
+
   const handleOpenChange = (newOpen: boolean) => {
     setIsOpen(newOpen);
     if (newOpen) {
@@ -150,6 +157,9 @@ export const SelectSingleVariant: React.FC<SelectInputWidgetProps> = ({
         !hasValue && "text-muted-foreground",
         ghost &&
           "border-transparent shadow-none bg-transparent hover:bg-accent hover:text-accent-foreground dark:border-transparent dark:bg-transparent dark:hover:bg-accent dark:hover:text-accent-foreground",
+        hasAffixes && "border-0 shadow-none focus-visible:ring-0 focus-visible:ring-offset-0",
+        hasPrefix && "rounded-l-none",
+        hasSuffix && "rounded-r-none",
       )}
       density={density}
       onBlur={handleTriggerBlur}
@@ -199,101 +209,129 @@ export const SelectSingleVariant: React.FC<SelectInputWidgetProps> = ({
     </SelectTrigger>
   );
 
+  const selectContent = (
+    <Select
+      key={`${id}-${stringValue ?? "null"}`}
+      disabled={disabled}
+      value={stringValue}
+      onValueChange={handleValueChange}
+      open={isOpen}
+      onOpenChange={handleOpenChange}
+      data-testid={dataTestId}
+    >
+      {isEllipsed && selectedLabel ? (
+        <TooltipProvider>
+          <Tooltip delayDuration={300} open={isOpen ? false : undefined}>
+            <TooltipTrigger asChild>{selectTriggerElement}</TooltipTrigger>
+            <TooltipContent className="bg-popover text-popover-foreground shadow-md max-w-sm">
+              <div className="whitespace-pre-wrap break-words">{selectedLabel}</div>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      ) : (
+        selectTriggerElement
+      )}
+      <SelectContent density={density}>
+        {searchable && (
+          <div className="p-2 border-b">
+            <div className="relative">
+              <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+              <Input
+                type="text"
+                placeholder="Search..."
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+                onKeyDown={(e) => e.stopPropagation()}
+                onClick={(e) => e.stopPropagation()}
+                className="pl-9 h-9"
+                disabled={disabled || loading}
+              />
+            </div>
+          </div>
+        )}
+        {loading ? (
+          <div className="flex justify-center p-4">
+            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+          </div>
+        ) : filteredOptions.length === 0 ? (
+          <div className="p-4 text-center text-sm text-muted-foreground">
+            {emptyMessage || "No options available"}
+          </div>
+        ) : (
+          Object.entries(groupedOptions).map(([group, options], index) => (
+            <React.Fragment key={group}>
+              {index > 0 && <SelectSeparator />}
+              <SelectGroup>
+                {group !== "default" && <SelectLabel>{group}</SelectLabel>}
+                {options.map((option) => (
+                  <SelectItem
+                    key={option.value}
+                    value={option.value.toString()}
+                    textValue={option.label}
+                    density={density}
+                    disabled={disabled || loading || option.disabled}
+                  >
+                    {option.tooltip ? (
+                      <TooltipProvider>
+                        <Tooltip delayDuration={300}>
+                          <TooltipTrigger asChild>
+                            <div className="flex items-center gap-2">
+                              {option.icon && (
+                                <Icon name={option.icon} className="h-4 w-4 flex-shrink-0" />
+                              )}
+                              {option.label}
+                            </div>
+                          </TooltipTrigger>
+                          <TooltipContent>{option.tooltip}</TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
+                    ) : (
+                      <div className="flex items-center gap-2">
+                        {option.icon && (
+                          <Icon name={option.icon} className="h-4 w-4 flex-shrink-0" />
+                        )}
+                        {option.label}
+                      </div>
+                    )}
+                  </SelectItem>
+                ))}
+              </SelectGroup>
+            </React.Fragment>
+          ))
+        )}
+      </SelectContent>
+    </Select>
+  );
+
   return (
     <div className="flex items-center gap-2 w-full" style={styles}>
-      <div className="flex-1 relative w-full">
-        <Select
-          key={`${id}-${stringValue ?? "null"}`}
-          disabled={disabled}
-          value={stringValue}
-          onValueChange={handleValueChange}
-          open={isOpen}
-          onOpenChange={handleOpenChange}
-          data-testid={dataTestId}
-        >
-          {isEllipsed && selectedLabel ? (
-            <TooltipProvider>
-              <Tooltip delayDuration={300} open={isOpen ? false : undefined}>
-                <TooltipTrigger asChild>{selectTriggerElement}</TooltipTrigger>
-                <TooltipContent className="bg-popover text-popover-foreground shadow-md max-w-sm">
-                  <div className="whitespace-pre-wrap break-words">{selectedLabel}</div>
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-          ) : (
-            selectTriggerElement
+      {hasAffixes ? (
+        <div className={cn(
+          "relative flex flex-1 items-stretch rounded-field border border-input bg-transparent shadow-sm transition-colors dark:bg-white/5 dark:border-white/10",
+          isOpen && "ring-1 ring-ring",
+          invalid && "border-destructive",
+          disabled && "cursor-not-allowed opacity-50",
+          ghost && "border-transparent shadow-none bg-transparent dark:border-transparent dark:bg-transparent",
+        )}>
+          {hasPrefix && (
+            <div className="flex items-center px-3 bg-muted text-muted-foreground border-r border-input rounded-tl-[var(--radius-fields)] rounded-bl-[var(--radius-fields)]">
+              {prefixContent}
+            </div>
           )}
-          <SelectContent density={density}>
-            {searchable && (
-              <div className="p-2 border-b">
-                <div className="relative">
-                  <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
-                  <Input
-                    type="text"
-                    placeholder="Search..."
-                    value={searchTerm}
-                    onChange={(e) => setSearchTerm(e.target.value)}
-                    onKeyDown={(e) => e.stopPropagation()}
-                    onClick={(e) => e.stopPropagation()}
-                    className="pl-9 h-9"
-                    disabled={disabled || loading}
-                  />
-                </div>
-              </div>
-            )}
-            {loading ? (
-              <div className="flex justify-center p-4">
-                <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
-              </div>
-            ) : filteredOptions.length === 0 ? (
-              <div className="p-4 text-center text-sm text-muted-foreground">
-                {emptyMessage || "No options available"}
-              </div>
-            ) : (
-              Object.entries(groupedOptions).map(([group, options], index) => (
-                <React.Fragment key={group}>
-                  {index > 0 && <SelectSeparator />}
-                  <SelectGroup>
-                    {group !== "default" && <SelectLabel>{group}</SelectLabel>}
-                    {options.map((option) => (
-                      <SelectItem
-                        key={option.value}
-                        value={option.value.toString()}
-                        textValue={option.label}
-                        density={density}
-                        disabled={disabled || loading || option.disabled}
-                      >
-                        {option.tooltip ? (
-                          <TooltipProvider>
-                            <Tooltip delayDuration={300}>
-                              <TooltipTrigger asChild>
-                                <div className="flex items-center gap-2">
-                                  {option.icon && (
-                                    <Icon name={option.icon} className="h-4 w-4 flex-shrink-0" />
-                                  )}
-                                  {option.label}
-                                </div>
-                              </TooltipTrigger>
-                              <TooltipContent>{option.tooltip}</TooltipContent>
-                            </Tooltip>
-                          </TooltipProvider>
-                        ) : (
-                          <div className="flex items-center gap-2">
-                            {option.icon && (
-                              <Icon name={option.icon} className="h-4 w-4 flex-shrink-0" />
-                            )}
-                            {option.label}
-                          </div>
-                        )}
-                      </SelectItem>
-                    ))}
-                  </SelectGroup>
-                </React.Fragment>
-              ))
-            )}
-          </SelectContent>
-        </Select>
-      </div>
+          <div className="flex-1 relative w-full">
+            {selectContent}
+          </div>
+          {hasSuffix && (
+            <div className="flex items-center px-3 bg-muted text-muted-foreground border-l border-input rounded-tr-[var(--radius-fields)] rounded-br-[var(--radius-fields)]">
+              {suffixContent}
+            </div>
+          )}
+        </div>
+      ) : (
+        <div className="flex-1 relative w-full">
+          {selectContent}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/frontend/src/widgets/inputs/SelectSingleVariant.tsx
+++ b/src/frontend/src/widgets/inputs/SelectSingleVariant.tsx
@@ -306,21 +306,22 @@ export const SelectSingleVariant: React.FC<SelectInputWidgetProps> = ({
   return (
     <div className="flex items-center gap-2 w-full" style={styles}>
       {hasAffixes ? (
-        <div className={cn(
-          "relative flex flex-1 items-stretch rounded-field border border-input bg-transparent shadow-sm transition-colors dark:bg-white/5 dark:border-white/10",
-          isOpen && "ring-1 ring-ring",
-          invalid && "border-destructive",
-          disabled && "cursor-not-allowed opacity-50",
-          ghost && "border-transparent shadow-none bg-transparent dark:border-transparent dark:bg-transparent",
-        )}>
+        <div
+          className={cn(
+            "relative flex flex-1 items-stretch rounded-field border border-input bg-transparent shadow-sm transition-colors dark:bg-white/5 dark:border-white/10",
+            isOpen && "ring-1 ring-ring",
+            invalid && "border-destructive",
+            disabled && "cursor-not-allowed opacity-50",
+            ghost &&
+              "border-transparent shadow-none bg-transparent dark:border-transparent dark:bg-transparent",
+          )}
+        >
           {hasPrefix && (
             <div className="flex items-center px-3 bg-muted text-muted-foreground border-r border-input rounded-tl-[var(--radius-fields)] rounded-bl-[var(--radius-fields)]">
               {prefixContent}
             </div>
           )}
-          <div className="flex-1 relative w-full">
-            {selectContent}
-          </div>
+          <div className="flex-1 relative w-full">{selectContent}</div>
           {hasSuffix && (
             <div className="flex items-center px-3 bg-muted text-muted-foreground border-l border-input rounded-tr-[var(--radius-fields)] rounded-br-[var(--radius-fields)]">
               {suffixContent}
@@ -328,9 +329,7 @@ export const SelectSingleVariant: React.FC<SelectInputWidgetProps> = ({
           )}
         </div>
       ) : (
-        <div className="flex-1 relative w-full">
-          {selectContent}
-        </div>
+        <div className="flex-1 relative w-full">{selectContent}</div>
       )}
     </div>
   );

--- a/src/frontend/src/widgets/inputs/select-types.ts
+++ b/src/frontend/src/widgets/inputs/select-types.ts
@@ -38,4 +38,5 @@ export interface SelectInputWidgetProps {
   width?: string;
   events?: string[];
   autoFocus?: boolean;
+  slots?: { Prefix?: React.ReactNode[]; Suffix?: React.ReactNode[] };
 }


### PR DESCRIPTION
## Summary

Added Prefix/Suffix slot support to SelectInput, following the exact same pattern used by TextInput. This enables `.Prefix(object)` and `.Suffix(object)` extension methods on `SelectInputBase`, with corresponding frontend rendering in both single-select and multi-select variants.

## API Changes

- `SelectInputExtensions.Prefix(this SelectInputBase widget, object prefix)` — new extension method
- `SelectInputExtensions.Suffix(this SelectInputBase widget, object suffix)` — new extension method
- `SelectInputWidgetProps.slots` — new optional prop in frontend types (`{ Prefix?: React.ReactNode[]; Suffix?: React.ReactNode[] }`)

## Files Modified

- **C# Backend:**
  - `src/Ivy/Widgets/Inputs/SelectInput.cs` — Added `WithSlot`, `Prefix`, `Suffix` methods to `SelectInputExtensions`

- **Frontend Types:**
  - `src/frontend/src/widgets/inputs/select-types.ts` — Added `slots` prop to `SelectInputWidgetProps`

- **Frontend Rendering:**
  - `src/frontend/src/widgets/inputs/SelectSingleVariant.tsx` — Added affix container wrapping with prefix/suffix rendering
  - `src/frontend/src/widgets/inputs/SelectMultiVariant.tsx` — Added affix container wrapping with prefix/suffix rendering

- **Tests:**
  - `src/Ivy.Test/InputWidgetTests.cs` — Added 4 tests in `InputPrefixSuffixSlotTests` for SelectInput slots; added `MockState<T>` helper class

- **Samples:**
  - `src/Ivy.Samples.Shared/Apps/Widgets/Inputs/SelectInputApp.cs` — Added "Affixes" tab with `SelectInputAffixesExample`

## Commits

- `31f3e78c6` — Initial implementation
- `59b98cbd8` — Added `MockState<T>` to `InputPrefixSuffixSlotTests`
- `f88e59dc0` — Frontend formatting fixes