### PR TITLE
[00154] Remove stale src/RustServer/ build artifacts directory

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -431,3 +431,6 @@ worktrees/
 # Nested Plans artifacts (belt-and-suspenders)
 **/worktrees/**/Plans/
 
+# Stale Rust build artifacts (RustServer removed in plan 00130)
+RustServer/
+


### PR DESCRIPTION
## Summary

Added `RustServer/` to `src/.gitignore` to prevent stale Rust build artifacts from being accidentally committed. The `src/RustServer/` directory only contained untracked build artifacts (`target/`) in local clones — no tracked files existed on `origin/main`, so no file deletion was needed in the worktree.

## API Changes

None.

## Files Modified

- `src/.gitignore` — Added `RustServer/` ignore entry with comment referencing plan 00130

## Commits

- `629f2e937` — [00154] Remove stale src/RustServer/ build artifacts directory