### PR TITLE
[00150] Auto-generate ResponsiveExtensions value-type overloads to eliminate boilerplate

### DIFF
--- a/src/Ivy.Tests/Shared/ResponsiveTests.cs
+++ b/src/Ivy.Tests/Shared/ResponsiveTests.cs
@@ -119,4 +119,115 @@ public class ResponsiveTests
         Assert.Equal("16,16,16,16", root.GetProperty("desktop").GetString());
         Assert.False(root.TryGetProperty("default", out _));
     }
+
+    [Theory]
+    [InlineData(Breakpoint.Mobile)]
+    [InlineData(Breakpoint.Tablet)]
+    [InlineData(Breakpoint.Desktop)]
+    [InlineData(Breakpoint.Wide)]
+    public void Int_At_SetsCorrectBreakpoint(Breakpoint bp)
+    {
+        var responsive = 42.At(bp);
+        AssertBreakpoint(responsive, bp, 42);
+    }
+
+    [Theory]
+    [InlineData(Breakpoint.Mobile)]
+    [InlineData(Breakpoint.Tablet)]
+    [InlineData(Breakpoint.Desktop)]
+    [InlineData(Breakpoint.Wide)]
+    public void Int_And_SetsCorrectBreakpoint(Breakpoint bp)
+    {
+        var responsive = 1.At(Breakpoint.Mobile).And(bp, 99);
+        Assert.Equal(99, GetBreakpointValue(responsive, bp));
+    }
+
+    [Theory]
+    [InlineData(Breakpoint.Mobile)]
+    [InlineData(Breakpoint.Tablet)]
+    [InlineData(Breakpoint.Desktop)]
+    [InlineData(Breakpoint.Wide)]
+    public void Orientation_At_SetsCorrectBreakpoint(Breakpoint bp)
+    {
+        var responsive = Orientation.Horizontal.At(bp);
+        AssertBreakpoint(responsive, bp, Orientation.Horizontal);
+    }
+
+    [Theory]
+    [InlineData(Breakpoint.Mobile)]
+    [InlineData(Breakpoint.Tablet)]
+    [InlineData(Breakpoint.Desktop)]
+    [InlineData(Breakpoint.Wide)]
+    public void Density_At_SetsCorrectBreakpoint(Breakpoint bp)
+    {
+        var responsive = Density.Small.At(bp);
+        AssertBreakpoint(responsive, bp, Density.Small);
+    }
+
+    [Theory]
+    [InlineData(Breakpoint.Mobile)]
+    [InlineData(Breakpoint.Tablet)]
+    [InlineData(Breakpoint.Desktop)]
+    [InlineData(Breakpoint.Wide)]
+    public void Bool_At_SetsCorrectBreakpoint(Breakpoint bp)
+    {
+        var responsive = true.At(bp);
+        AssertBreakpoint(responsive, bp, true);
+    }
+
+    [Theory]
+    [InlineData(Breakpoint.Mobile)]
+    [InlineData(Breakpoint.Tablet)]
+    [InlineData(Breakpoint.Desktop)]
+    [InlineData(Breakpoint.Wide)]
+    public void Thickness_At_SetsCorrectBreakpoint(Breakpoint bp)
+    {
+        var responsive = new Thickness(8).At(bp);
+        AssertBreakpoint(responsive, bp, new Thickness(8));
+    }
+
+    [Fact]
+    public void AllValueTypes_At_And_Chain()
+    {
+        var intR = 1.At(Breakpoint.Mobile).And(Breakpoint.Desktop, 2);
+        Assert.Equal(1, intR.Mobile);
+        Assert.Equal(2, intR.Desktop);
+
+        var orientR = Orientation.Horizontal.At(Breakpoint.Tablet).And(Breakpoint.Wide, Orientation.Vertical);
+        Assert.Equal(Orientation.Horizontal, orientR.Tablet);
+        Assert.Equal(Orientation.Vertical, orientR.Wide);
+
+        var densityR = Density.Small.At(Breakpoint.Mobile).And(Breakpoint.Desktop, Density.Large);
+        Assert.Equal(Density.Small, densityR.Mobile);
+        Assert.Equal(Density.Large, densityR.Desktop);
+
+        var boolR = true.At(Breakpoint.Mobile).And(Breakpoint.Desktop, false);
+        Assert.True(boolR.Mobile);
+        Assert.False(boolR.Desktop);
+
+        var thickR = new Thickness(4).At(Breakpoint.Mobile).And(Breakpoint.Wide, new Thickness(16));
+        Assert.Equal(new Thickness(4), thickR.Mobile);
+        Assert.Equal(new Thickness(16), thickR.Wide);
+    }
+
+    private static void AssertBreakpoint<T>(Responsive<T> responsive, Breakpoint bp, T expected)
+    {
+        Assert.Equal(expected, GetBreakpointValue(responsive, bp));
+
+        // All other breakpoints should be default
+        foreach (var other in new[] { Breakpoint.Mobile, Breakpoint.Tablet, Breakpoint.Desktop, Breakpoint.Wide })
+        {
+            if (other != bp)
+                Assert.Equal(default, GetBreakpointValue(responsive, other));
+        }
+    }
+
+    private static T? GetBreakpointValue<T>(Responsive<T> responsive, Breakpoint bp) => bp switch
+    {
+        Breakpoint.Mobile => responsive.Mobile,
+        Breakpoint.Tablet => responsive.Tablet,
+        Breakpoint.Desktop => responsive.Desktop,
+        Breakpoint.Wide => responsive.Wide,
+        _ => throw new ArgumentOutOfRangeException(nameof(bp))
+    };
 }

--- a/src/Ivy/Shared/Responsive.cs
+++ b/src/Ivy/Shared/Responsive.cs
@@ -38,17 +38,17 @@ public static class ResponsiveExtensions
         _ => throw new ArgumentOutOfRangeException(nameof(bp))
     };
 
-    // int overloads (for gap, columns, etc.)
-    public static Responsive<int?> At(this int value, Breakpoint bp) => bp switch
+    // Private generic helpers for value types — the switch logic lives here once.
+    private static Responsive<T?> AtCore<T>(T value, Breakpoint bp) where T : struct => bp switch
     {
-        Breakpoint.Mobile => new Responsive<int?> { Mobile = value },
-        Breakpoint.Tablet => new Responsive<int?> { Tablet = value },
-        Breakpoint.Desktop => new Responsive<int?> { Desktop = value },
-        Breakpoint.Wide => new Responsive<int?> { Wide = value },
+        Breakpoint.Mobile => new Responsive<T?> { Mobile = value },
+        Breakpoint.Tablet => new Responsive<T?> { Tablet = value },
+        Breakpoint.Desktop => new Responsive<T?> { Desktop = value },
+        Breakpoint.Wide => new Responsive<T?> { Wide = value },
         _ => throw new ArgumentOutOfRangeException(nameof(bp))
     };
 
-    public static Responsive<int?> And(this Responsive<int?> r, Breakpoint bp, int value) => bp switch
+    private static Responsive<T?> AndCore<T>(Responsive<T?> r, Breakpoint bp, T value) where T : struct => bp switch
     {
         Breakpoint.Mobile => r with { Mobile = value },
         Breakpoint.Tablet => r with { Tablet = value },
@@ -56,82 +56,28 @@ public static class ResponsiveExtensions
         Breakpoint.Wide => r with { Wide = value },
         _ => throw new ArgumentOutOfRangeException(nameof(bp))
     };
+
+    // To add a new value type, add an At and And overload that delegates to AtCore/AndCore.
+
+    // int overloads (for gap, columns, etc.)
+    public static Responsive<int?> At(this int value, Breakpoint bp) => AtCore(value, bp);
+    public static Responsive<int?> And(this Responsive<int?> r, Breakpoint bp, int value) => AndCore(r, bp, value);
 
     // Orientation overloads
-    public static Responsive<Orientation?> At(this Orientation value, Breakpoint bp) => bp switch
-    {
-        Breakpoint.Mobile => new Responsive<Orientation?> { Mobile = value },
-        Breakpoint.Tablet => new Responsive<Orientation?> { Tablet = value },
-        Breakpoint.Desktop => new Responsive<Orientation?> { Desktop = value },
-        Breakpoint.Wide => new Responsive<Orientation?> { Wide = value },
-        _ => throw new ArgumentOutOfRangeException(nameof(bp))
-    };
-
-    public static Responsive<Orientation?> And(this Responsive<Orientation?> r, Breakpoint bp, Orientation value) => bp switch
-    {
-        Breakpoint.Mobile => r with { Mobile = value },
-        Breakpoint.Tablet => r with { Tablet = value },
-        Breakpoint.Desktop => r with { Desktop = value },
-        Breakpoint.Wide => r with { Wide = value },
-        _ => throw new ArgumentOutOfRangeException(nameof(bp))
-    };
+    public static Responsive<Orientation?> At(this Orientation value, Breakpoint bp) => AtCore(value, bp);
+    public static Responsive<Orientation?> And(this Responsive<Orientation?> r, Breakpoint bp, Orientation value) => AndCore(r, bp, value);
 
     // Density overloads
-    public static Responsive<Density?> At(this Density value, Breakpoint bp) => bp switch
-    {
-        Breakpoint.Mobile => new Responsive<Density?> { Mobile = value },
-        Breakpoint.Tablet => new Responsive<Density?> { Tablet = value },
-        Breakpoint.Desktop => new Responsive<Density?> { Desktop = value },
-        Breakpoint.Wide => new Responsive<Density?> { Wide = value },
-        _ => throw new ArgumentOutOfRangeException(nameof(bp))
-    };
-
-    public static Responsive<Density?> And(this Responsive<Density?> r, Breakpoint bp, Density value) => bp switch
-    {
-        Breakpoint.Mobile => r with { Mobile = value },
-        Breakpoint.Tablet => r with { Tablet = value },
-        Breakpoint.Desktop => r with { Desktop = value },
-        Breakpoint.Wide => r with { Wide = value },
-        _ => throw new ArgumentOutOfRangeException(nameof(bp))
-    };
+    public static Responsive<Density?> At(this Density value, Breakpoint bp) => AtCore(value, bp);
+    public static Responsive<Density?> And(this Responsive<Density?> r, Breakpoint bp, Density value) => AndCore(r, bp, value);
 
     // bool overloads (for visibility)
-    public static Responsive<bool?> At(this bool value, Breakpoint bp) => bp switch
-    {
-        Breakpoint.Mobile => new Responsive<bool?> { Mobile = value },
-        Breakpoint.Tablet => new Responsive<bool?> { Tablet = value },
-        Breakpoint.Desktop => new Responsive<bool?> { Desktop = value },
-        Breakpoint.Wide => new Responsive<bool?> { Wide = value },
-        _ => throw new ArgumentOutOfRangeException(nameof(bp))
-    };
-
-    public static Responsive<bool?> And(this Responsive<bool?> r, Breakpoint bp, bool value) => bp switch
-    {
-        Breakpoint.Mobile => r with { Mobile = value },
-        Breakpoint.Tablet => r with { Tablet = value },
-        Breakpoint.Desktop => r with { Desktop = value },
-        Breakpoint.Wide => r with { Wide = value },
-        _ => throw new ArgumentOutOfRangeException(nameof(bp))
-    };
+    public static Responsive<bool?> At(this bool value, Breakpoint bp) => AtCore(value, bp);
+    public static Responsive<bool?> And(this Responsive<bool?> r, Breakpoint bp, bool value) => AndCore(r, bp, value);
 
     // Thickness overloads (for padding)
-    public static Responsive<Thickness?> At(this Thickness value, Breakpoint bp) => bp switch
-    {
-        Breakpoint.Mobile => new Responsive<Thickness?> { Mobile = value },
-        Breakpoint.Tablet => new Responsive<Thickness?> { Tablet = value },
-        Breakpoint.Desktop => new Responsive<Thickness?> { Desktop = value },
-        Breakpoint.Wide => new Responsive<Thickness?> { Wide = value },
-        _ => throw new ArgumentOutOfRangeException(nameof(bp))
-    };
-
-    public static Responsive<Thickness?> And(this Responsive<Thickness?> r, Breakpoint bp, Thickness value) => bp switch
-    {
-        Breakpoint.Mobile => r with { Mobile = value },
-        Breakpoint.Tablet => r with { Tablet = value },
-        Breakpoint.Desktop => r with { Desktop = value },
-        Breakpoint.Wide => r with { Wide = value },
-        _ => throw new ArgumentOutOfRangeException(nameof(bp))
-    };
+    public static Responsive<Thickness?> At(this Thickness value, Breakpoint bp) => AtCore(value, bp);
+    public static Responsive<Thickness?> And(this Responsive<Thickness?> r, Breakpoint bp, Thickness value) => AndCore(r, bp, value);
 }
 
 public class ResponsiveJsonConverterFactory : JsonConverterFactory


### PR DESCRIPTION
# Summary

## Changes

Replaced 5 duplicated value-type overload pairs in `ResponsiveExtensions` with two private generic helper methods (`AtCore<T>` and `AndCore<T>`) that centralize the breakpoint switch logic. Each typed overload (int, Orientation, Density, bool, Thickness) now delegates to these helpers in a single line. Added 23 parameterized tests covering all value types across all breakpoints.

## API Changes

None. The public API surface is unchanged — all existing `At()` and `And()` extension methods retain their signatures. The change is purely internal (private helper methods).

## Files Modified

- **Core implementation:**
  - `src/Ivy/Shared/Responsive.cs` — Added `AtCore<T>` and `AndCore<T>` private helpers; replaced 5 value-type overload pair bodies with one-liner delegations

- **Tests:**
  - `src/Ivy.Tests/Shared/ResponsiveTests.cs` — Added parameterized `[Theory]` tests for all value types (int, Orientation, Density, bool, Thickness) and a combined chaining test

## Commits

- 750577fc5