### PR TITLE
[00158] Revert Thickness responsive extensions (.At/.And)

### DIFF
--- a/src/Ivy.Tests/Shared/ResponsiveTests.cs
+++ b/src/Ivy.Tests/Shared/ResponsiveTests.cs
@@ -83,43 +83,6 @@ public class ResponsiveTests
         Assert.Null(visible.Desktop);
     }
 
-    [Fact]
-    public void Thickness_At_CreatesBreakpointValue()
-    {
-        var responsive = new Thickness(8).At(Breakpoint.Mobile);
-        Assert.Equal(new Thickness(8), responsive.Mobile);
-        Assert.Null(responsive.Default);
-        Assert.Null(responsive.Desktop);
-        Assert.Null(responsive.Tablet);
-        Assert.Null(responsive.Wide);
-    }
-
-    [Fact]
-    public void Thickness_And_ChainsBreakpoints()
-    {
-        var responsive = new Thickness(8).At(Breakpoint.Mobile)
-            .And(Breakpoint.Desktop, new Thickness(16));
-        Assert.Equal(new Thickness(8), responsive.Mobile);
-        Assert.Equal(new Thickness(16), responsive.Desktop);
-        Assert.Null(responsive.Default);
-        Assert.Null(responsive.Tablet);
-    }
-
-    [Fact]
-    public void Thickness_JsonSerialization_MultiBreakpoint_WritesObject()
-    {
-        var responsive = new Thickness(8).At(Breakpoint.Mobile)
-            .And(Breakpoint.Desktop, new Thickness(16));
-        var json = JsonSerializer.Serialize(responsive, SerializerOptions);
-        var doc = JsonDocument.Parse(json);
-        var root = doc.RootElement;
-
-        Assert.Equal(JsonValueKind.Object, root.ValueKind);
-        Assert.Equal("8,8,8,8", root.GetProperty("mobile").GetString());
-        Assert.Equal("16,16,16,16", root.GetProperty("desktop").GetString());
-        Assert.False(root.TryGetProperty("default", out _));
-    }
-
     [Theory]
     [InlineData(Breakpoint.Mobile)]
     [InlineData(Breakpoint.Tablet)]
@@ -175,17 +138,6 @@ public class ResponsiveTests
         AssertBreakpoint(responsive, bp, true);
     }
 
-    [Theory]
-    [InlineData(Breakpoint.Mobile)]
-    [InlineData(Breakpoint.Tablet)]
-    [InlineData(Breakpoint.Desktop)]
-    [InlineData(Breakpoint.Wide)]
-    public void Thickness_At_SetsCorrectBreakpoint(Breakpoint bp)
-    {
-        var responsive = new Thickness(8).At(bp);
-        AssertBreakpoint(responsive, bp, new Thickness(8));
-    }
-
     [Fact]
     public void AllValueTypes_At_And_Chain()
     {
@@ -204,10 +156,6 @@ public class ResponsiveTests
         var boolR = true.At(Breakpoint.Mobile).And(Breakpoint.Desktop, false);
         Assert.True(boolR.Mobile);
         Assert.False(boolR.Desktop);
-
-        var thickR = new Thickness(4).At(Breakpoint.Mobile).And(Breakpoint.Wide, new Thickness(16));
-        Assert.Equal(new Thickness(4), thickR.Mobile);
-        Assert.Equal(new Thickness(16), thickR.Wide);
     }
 
     private static void AssertBreakpoint<T>(Responsive<T> responsive, Breakpoint bp, T expected)

--- a/src/Ivy/Shared/Responsive.cs
+++ b/src/Ivy/Shared/Responsive.cs
@@ -74,10 +74,6 @@ public static class ResponsiveExtensions
     // bool overloads (for visibility)
     public static Responsive<bool?> At(this bool value, Breakpoint bp) => AtCore(value, bp);
     public static Responsive<bool?> And(this Responsive<bool?> r, Breakpoint bp, bool value) => AndCore(r, bp, value);
-
-    // Thickness overloads (for padding)
-    public static Responsive<Thickness?> At(this Thickness value, Breakpoint bp) => AtCore(value, bp);
-    public static Responsive<Thickness?> And(this Responsive<Thickness?> r, Breakpoint bp, Thickness value) => AndCore(r, bp, value);
 }
 
 public class ResponsiveJsonConverterFactory : JsonConverterFactory


### PR DESCRIPTION
# Summary

## Changes

Removed the `Thickness` responsive extension methods (`.At()` and `.And()`) from `ResponsiveExtensions` and all associated tests. The `AtCore`/`AndCore` generic helpers (added by plan 00150) remain intact since they serve int, Orientation, Density, and bool overloads. The existing `Responsive<Thickness?>` type usage in `LayoutView.Padding()` and `StackLayout.ResponsivePadding` is unaffected — those use the type directly, not the fluent extension methods.

## API Changes

- **Removed:** `ResponsiveExtensions.At(this Thickness value, Breakpoint bp)` -> `Responsive<Thickness?>`
- **Removed:** `ResponsiveExtensions.And(this Responsive<Thickness?> r, Breakpoint bp, Thickness value)` -> `Responsive<Thickness?>`

## Files Modified

- `src/Ivy/Shared/Responsive.cs` — Removed Thickness overloads (lines 78-80)
- `src/Ivy.Tests/Shared/ResponsiveTests.cs` — Removed 3 Thickness Fact tests, 1 Thickness Theory test, and Thickness assertions from AllValueTypes_At_And_Chain

## Commits

- 9f4fd23b9