### PR TITLE
[00159] Fix PrStatusSyncService invalid repo name from malformed PR URL

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/PrStatusSyncServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/PrStatusSyncServiceTests.cs
@@ -1,3 +1,4 @@
+using Ivy.Tendril.Apps;
 using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Services;
 using Microsoft.Data.Sqlite;
@@ -65,6 +66,40 @@ public class PrStatusSyncServiceTests : IDisposable
         Assert.Contains("https://github.com/owner/repo/pull/1", nonMerged);
         Assert.Contains("https://github.com/owner/repo/pull/3", nonMerged);
         Assert.DoesNotContain("https://github.com/owner/repo/pull/2", nonMerged);
+    }
+
+    [Fact]
+    public void GroupByOwnerRepo_OnlyReceivesValidPrUrls_WhenFilteredByIsValidUrl()
+    {
+        var rawUrls = new List<string>
+        {
+            "https://github.com/owner/repo/pull/1",
+            "https://github.com/Ivy-Interactive/Ivy.Releases (new repo — no PR needed)",
+            "https://github.com/owner/repo",  // repo URL, not a PR
+        };
+
+        // Simulate the CollectPrUrlsFromPlans filter
+        var filtered = rawUrls.Where(PullRequestApp.IsValidUrl).ToList();
+        var grouped = PrStatusSyncService.GroupByOwnerRepo(filtered);
+        Assert.Single(grouped);
+        Assert.Single(grouped["owner/repo"]);
+    }
+
+    [Fact]
+    public void IsValidUrl_AcceptsValidPrUrls()
+    {
+        Assert.True(PullRequestApp.IsValidUrl("https://github.com/owner/repo/pull/1"));
+        Assert.True(PullRequestApp.IsValidUrl("https://github.com/owner/repo/pull/123"));
+        Assert.True(PullRequestApp.IsValidUrl("http://github.com/owner/repo/pull/1"));
+    }
+
+    [Fact]
+    public void IsValidUrl_RejectsInvalidUrls()
+    {
+        Assert.False(PullRequestApp.IsValidUrl("https://github.com/owner/repo"));
+        Assert.False(PullRequestApp.IsValidUrl("https://github.com/Ivy-Interactive/Ivy.Releases (new repo — no PR needed)"));
+        Assert.False(PullRequestApp.IsValidUrl("not a url"));
+        Assert.False(PullRequestApp.IsValidUrl("https://example.com/page"));
     }
 
     [Fact]

--- a/src/tendril/Ivy.Tendril/Apps/PullRequestApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/PullRequestApp.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Apps.PullRequest;
 using Ivy.Tendril.Services;
@@ -162,9 +163,11 @@ public class PullRequestApp : ViewBase
     ///     Extracts "owner/repo" from a GitHub PR URL.
     ///     E.g. "https://github.com/owner/repo/pull/123" -> "owner/repo"
     /// </summary>
+    private static readonly Regex GitHubPrPattern = new(
+        @"^https?://github\.com/[^/]+/[^/]+/pull/\d+", RegexOptions.Compiled);
+
     internal static bool IsValidUrl(string value) =>
-        Uri.TryCreate(value, UriKind.Absolute, out var uri) &&
-        (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps);
+        GitHubPrPattern.IsMatch(value);
 
     internal static string ExtractRepo(string prUrl)
     {

--- a/src/tendril/Ivy.Tendril/Services/PrStatusSyncService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PrStatusSyncService.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using Ivy.Tendril.Apps;
 using Microsoft.Extensions.Logging;
 
 namespace Ivy.Tendril.Services;
@@ -111,8 +112,7 @@ public class PrStatusSyncService : IStartable, IDisposable
         return plans
             .Where(p => p.Prs.Count > 0)
             .SelectMany(p => p.Prs)
-            .Where(url => Uri.TryCreate(url, UriKind.Absolute, out var uri) &&
-                          (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps))
+            .Where(PullRequestApp.IsValidUrl)
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToList();
     }


### PR DESCRIPTION
## Changes

Tightened PR URL validation to require the GitHub `/pull/{number}` path pattern instead of just a valid HTTP URI. This prevents malformed PR URLs (like repo URLs with appended notes) from reaching the GitHub GraphQL API and causing lookup failures. Also cleaned up the bad data in plan 00066.

## API Changes

- `PullRequestApp.IsValidUrl(string)` — now uses regex matching for `github.com/{owner}/{repo}/pull/{number}` instead of `Uri.TryCreate` + scheme check
- `PullRequestApp.GitHubPrPattern` — new private static `Regex` field (compiled, not public API)
- `PrStatusSyncService.CollectPrUrlsFromPlans()` — now delegates to `PullRequestApp.IsValidUrl` instead of inline `Uri.TryCreate`

## Files Modified

- **src/tendril/Ivy.Tendril/Apps/PullRequestApp.cs** — Added Regex-based `IsValidUrl` replacing URI-only check
- **src/tendril/Ivy.Tendril/Services/PrStatusSyncService.cs** — Replaced inline URL filter with `PullRequestApp.IsValidUrl`
- **src/tendril/Ivy.Tendril.Test/PrStatusSyncServiceTests.cs** — Added 3 new tests for malformed URL filtering and IsValidUrl validation

## Commits

- 39714f267