### PR TITLE
[03200] Add Log-WorktreeEvent.ps1 call to ExecutePlan Program.md Step 2

### DIFF
--- a/src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
+++ b/src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
@@ -270,6 +270,17 @@ cat "<PlanFolder>/worktrees/<repo-folder-name>/.git"
 
 This ensures ExecutePlan fails immediately if worktree creation is incomplete, rather than leaving orphaned directories that trigger warnings during cleanup.
 
+5. Log the worktree creation event:
+
+```bash
+REPO_PATH="<original-repo-path>"
+WORKTREE_PATH="<PlanFolder>/worktrees/<repo-folder-name>"
+
+pwsh -NoProfile -Command '& "$env:TENDRIL_HOME/Promptwares/ExecutePlan/Tools/Log-WorktreeEvent.ps1" -Event Creation -PlanId "'"$PLAN_ID"'" -WorktreePath "'"$WORKTREE_PATH"'" -Metadata @{repo="'"$REPO_PATH"'"; branch="'"$BRANCH_NAME"'"}'
+```
+
+This creates a structured log entry in `$TENDRIL_HOME/Logs/worktrees.log` recording the worktree creation with repo path and branch metadata. Logging only happens after successful `.git` file verification (Step 2.4), ensuring only successfully created worktrees are recorded.
+
 ### 2.5. Setup Frontend Dependencies (JavaScript/TypeScript Projects Only)
 
 **Note:** This section applies only to projects using npm/pnpm. Skip if not applicable.


### PR DESCRIPTION
# Summary

## Changes

Added step 5 to ExecutePlan Program.md Step 2, instructing agents to call `Log-WorktreeEvent.ps1` after worktree creation and `.git` file verification. This completes the creation-side logging gap — cleanup events were already logged by C# services, but creation events from the bash-based ExecutePlan flow were missing.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/Program.md` — Added worktree creation logging step after `.git` verification (Step 2.4)


## Commits

- 136600988