### PR TITLE
[03201] Add AnnotateBrokenPlanLinks to TrashApp

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/TrashApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/TrashApp.cs
@@ -20,6 +20,7 @@ public class TrashApp : ViewBase
     {
         var configService = UseService<IConfigService>();
         var jobService = UseService<IJobService>();
+        var planService = UseService<IPlanReaderService>();
         var client = UseService<IClientProvider>();
         var refreshToken = UseRefreshToken();
         var selectedFile = UseState<string?>(null);
@@ -92,6 +93,7 @@ public class TrashApp : ViewBase
                             });
 
             var annotatedContent = MarkdownHelper.AnnotateBrokenFileLinks(selected.Content);
+            annotatedContent = MarkdownHelper.AnnotateBrokenPlanLinks(annotatedContent, planService.PlansDirectory);
             var scrollableContent = Layout.Vertical().Width(Size.Auto().Max(Size.Units(200)))
                                     | new Markdown(annotatedContent)
                                         .DangerouslyAllowLocalFiles()


### PR DESCRIPTION
# Summary

## Changes

Added `AnnotateBrokenPlanLinks` call to `TrashApp.cs` so that broken `plan://` links in trashed plans display warning indicators. This completes the annotation coverage started in plan 03183, matching the sequential pattern used by Plans and Review apps.

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/Apps/TrashApp.cs** — Added `IPlanReaderService` dependency and `AnnotateBrokenPlanLinks` call after existing `AnnotateBrokenFileLinks` call.


## Commits

- 885dc8206