### PR TITLE
[03198] Fix Import Issues from GitHub feature

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/GithubServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/GithubServiceTests.cs
@@ -232,6 +232,65 @@ public class GithubServiceTests
         Assert.Equal(error1, error2);
     }
 
+    [Fact]
+    public void GetRepoConfigFromPath_Returns_Null_For_NonExistent_Path()
+    {
+        var result = GithubService.GetRepoConfigFromPath(@"C:\nonexistent\path\xyz-999");
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetRepoConfigFromPath_Returns_Config_For_Valid_Repo()
+    {
+        var tempDir = CreateTempGitRepo("https://github.com/Test-Owner/Test-Repo.git");
+        try
+        {
+            var result = GithubService.GetRepoConfigFromPath(tempDir);
+            Assert.NotNull(result);
+            Assert.Equal("Test-Owner", result.Owner);
+            Assert.Equal("Test-Repo", result.Name);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void GetRepoConfigFromPathCached_Returns_Same_Instance_On_Repeated_Calls()
+    {
+        var tempDir = CreateTempGitRepo("https://github.com/Cache-Owner/Cache-Repo.git");
+        try
+        {
+            var settings = new TendrilSettings
+            {
+                Projects = [new ProjectConfig { Name = "CacheTest", Repos = [new RepoRef { Path = tempDir }] }]
+            };
+            var configService = new ConfigService(settings);
+            var githubService = new GithubService(configService);
+
+            var result1 = githubService.GetRepoConfigFromPathCached(tempDir);
+            var result2 = githubService.GetRepoConfigFromPathCached(tempDir);
+
+            Assert.NotNull(result1);
+            Assert.Same(result1, result2);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void GetRepoConfigFromPathCached_Returns_Null_For_Invalid_Path()
+    {
+        var configService = new ConfigService(new TendrilSettings());
+        var githubService = new GithubService(configService);
+
+        var result = githubService.GetRepoConfigFromPathCached(@"C:\nonexistent\xyz-999");
+        Assert.Null(result);
+    }
+
     private static string CreateTempGitRepo(string remoteUrl)
     {
         var tempDir = Path.Combine(Path.GetTempPath(), $"ivy-github-test-{Guid.NewGuid()}");

--- a/src/tendril/Ivy.Tendril/AppShell/Dialogs/ImportIssuesDialog.cs
+++ b/src/tendril/Ivy.Tendril/AppShell/Dialogs/ImportIssuesDialog.cs
@@ -95,11 +95,20 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
 
             try
             {
-                reposState.Set(githubService.GetRepos());
+                var repos = githubService.GetRepos();
+                if (repos.Count == 0)
+                {
+                    reposError.Set("No GitHub repositories found. Check that your projects in config.yaml have valid git repositories with 'origin' remotes.");
+                }
+                else
+                {
+                    reposState.Set(repos);
+                }
             }
             catch (Exception ex)
             {
                 reposError.Set($"Failed to load repositories: {ex.Message}");
+                Console.Error.WriteLine($"[ImportIssuesDialog] Exception loading repos: {ex}");
             }
         }, _dialogOpen);
 
@@ -185,7 +194,7 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
                 var inboxPath = Path.Combine(_config.TendrilHome, "Inbox");
                 Directory.CreateDirectory(inboxPath);
 
-                var projectName = GetProjectForRepo(repo.Owner, repo.Name);
+                var projectName = GetProjectForRepo(githubService, repo.Owner, repo.Name);
                 var importedCount = 0;
 
                 foreach (var issue in issues)
@@ -298,12 +307,12 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
         ).Width(Size.Rem(36));
     }
 
-    private string GetProjectForRepo(string owner, string repo)
+    private string GetProjectForRepo(IGithubService githubService, string owner, string repo)
     {
         var repoPath = $"{owner}/{repo}";
         var matchingProjects = _config.Settings.Projects
             .Where(p => p.RepoPaths.Any(path =>
-                GithubService.GetRepoConfigFromPath(path)?.FullName
+                githubService.GetRepoConfigFromPathCached(path)?.FullName
                     .Equals(repoPath, StringComparison.OrdinalIgnoreCase) ?? false))
             .ToList();
 

--- a/src/tendril/Ivy.Tendril/Services/GithubService.cs
+++ b/src/tendril/Ivy.Tendril/Services/GithubService.cs
@@ -14,6 +14,7 @@ public class GithubService(IConfigService config) : IGithubService
     private readonly ConcurrentDictionary<string, List<string>> _assigneeCache = new();
     private readonly IConfigService _config = config;
     private readonly ConcurrentDictionary<string, List<string>> _labelCache = new();
+    private readonly ConcurrentDictionary<string, RepoConfig?> _repoPathCache = new();
     private List<RepoConfig>? _repoCache;
 
     public List<RepoConfig> GetRepos()
@@ -148,10 +149,21 @@ public class GithubService(IConfigService config) : IGithubService
         return issues;
     }
 
+    public RepoConfig? GetRepoConfigFromPathCached(string repoPath)
+    {
+        return _repoPathCache.GetOrAdd(repoPath, path => GetRepoConfigFromPath(path));
+    }
+
     internal static RepoConfig? GetRepoConfigFromPath(string repoPath)
     {
         try
         {
+            if (!Directory.Exists(repoPath))
+            {
+                Console.Error.WriteLine($"[GithubService] Repository path does not exist: {repoPath}");
+                return null;
+            }
+
             var psi = new ProcessStartInfo("git", "remote get-url origin")
             {
                 WorkingDirectory = repoPath,
@@ -164,16 +176,32 @@ public class GithubService(IConfigService config) : IGithubService
             };
 
             using var process = Process.Start(psi);
-            if (process is null) return null;
+            if (process is null)
+            {
+                Console.Error.WriteLine($"[GithubService] Failed to start git process for {repoPath}");
+                return null;
+            }
 
             var url = process.StandardOutput.ReadToEnd().Trim();
+            var stderr = process.StandardError.ReadToEnd();
             process.WaitForExitOrKill(10000);
-            if (process.ExitCode != 0) return null;
 
-            return ParseRepoConfigFromUrl(url);
+            if (process.ExitCode != 0)
+            {
+                Console.Error.WriteLine($"[GithubService] git remote get-url failed for {repoPath}: {stderr}");
+                return null;
+            }
+
+            var config = ParseRepoConfigFromUrl(url);
+            if (config is null)
+            {
+                Console.Error.WriteLine($"[GithubService] Failed to parse remote URL for {repoPath}: {url}");
+            }
+            return config;
         }
-        catch
+        catch (Exception ex)
         {
+            Console.Error.WriteLine($"[GithubService] Exception getting repo config for {repoPath}: {ex.Message}");
             return null;
         }
     }

--- a/src/tendril/Ivy.Tendril/Services/IGithubService.cs
+++ b/src/tendril/Ivy.Tendril/Services/IGithubService.cs
@@ -11,6 +11,7 @@ public record GitHubIssue(
 public interface IGithubService
 {
     List<RepoConfig> GetRepos();
+    RepoConfig? GetRepoConfigFromPathCached(string repoPath);
     Task<(List<string> assignees, string? error)> GetAssigneesAsync(string owner, string repo);
     Task<(List<string> labels, string? error)> GetLabelsAsync(string owner, string repo);
     Task<(Dictionary<string, string> statuses, string? error)> GetPrStatusesAsync(string owner, string repo);


### PR DESCRIPTION
# Summary

## Changes

Fixed the Import Issues from GitHub feature by adding diagnostic logging to `GetRepoConfigFromPath` (so failures are no longer silently swallowed), surfacing an error message when no repositories are found, and adding instance-level caching via `GetRepoConfigFromPathCached` to eliminate redundant git process spawns during issue import.

## API Changes

- `IGithubService.GetRepoConfigFromPathCached(string repoPath)` — new interface method for cached repo config lookup
- `GithubService.GetRepoConfigFromPathCached(string repoPath)` — new instance method backed by `ConcurrentDictionary<string, RepoConfig?>`

## Files Modified

- **Services/GithubService.cs** — Added `_repoPathCache` field, `GetRepoConfigFromPathCached()` method, and diagnostic logging to `GetRepoConfigFromPath()`
- **Services/IGithubService.cs** — Added `GetRepoConfigFromPathCached` to interface
- **AppShell/Dialogs/ImportIssuesDialog.cs** — Added empty repo error surfacing, exception logging, updated `GetProjectForRepo` to use cached method
- **Ivy.Tendril.Test/GithubServiceTests.cs** — Added 4 new tests for `GetRepoConfigFromPath` and `GetRepoConfigFromPathCached`

---

**Commits:**
- c05d334c4 [03198] Fix Import Issues from GitHub: add diagnostic logging, empty repo error surfacing, and path caching