### PR TITLE
[03202] Refactor MakePlan priority injection to use YAML serialization

### DIFF
--- a/src/tendril/Ivy.Tendril/Promptwares/MakePlan/MakePlan.ps1
+++ b/src/tendril/Ivy.Tendril/Promptwares/MakePlan/MakePlan.ps1
@@ -123,12 +123,10 @@ if ($planFolder) {
         $planYamlPath = Join-Path $planFolder.FullName "plan.yaml"
         if (Test-Path $planYamlPath) {
             $content = Get-Content $planYamlPath -Raw
-            if ($content -match '(?m)^priority:\s') {
-                $content = $content -replace '(?m)^priority:\s.*$', "priority: $Priority"
-            } else {
-                $content = $content -replace '(?m)^(level:\s)', "priority: $Priority`n`$1"
-            }
-            Set-Content $planYamlPath $content -NoNewline
+            $yaml = $content | ConvertFrom-Yaml -Ordered
+            $yaml["priority"] = $Priority
+            $content = ConvertTo-Yaml $yaml
+            Set-Content -Path $planYamlPath -Value $content -NoNewline -Encoding UTF8
             Write-Host "Set priority: $Priority" -ForegroundColor Cyan
         }
     }


### PR DESCRIPTION
# Summary

## Changes

Replaced the fragile regex-based priority injection in MakePlan.ps1 with proper YAML deserialization/serialization using `ConvertFrom-Yaml -Ordered` and `ConvertTo-Yaml`. This follows the same pattern already used by `UpdatePlanState` in Utils.ps1.

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/Promptwares/MakePlan/MakePlan.ps1** — Replaced lines 122-133 regex logic with YAML round-trip (4 insertions, 6 deletions)

## Commits

- 5741d55d8 [03202] Refactor MakePlan priority injection to use YAML serialization