### PR TITLE
[03199] Add --fix flag to doctor plans command

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/DoctorCommandPlansTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/DoctorCommandPlansTests.cs
@@ -122,6 +122,92 @@ public class DoctorCommandPlansTests : IDisposable
     }
 
     [Fact]
+    public void HasNestedWorktrees_WithNestedGit_ReturnsTrue()
+    {
+        var planDir = CreatePlan("00020-WithNested", ValidYaml);
+        var wtRepoDir = Path.Combine(planDir, "worktrees", "SomeRepo");
+        Directory.CreateDirectory(wtRepoDir);
+        File.WriteAllText(Path.Combine(wtRepoDir, ".git"), "gitdir: /some/path");
+
+        var result = DoctorCommand.HasNestedWorktrees(planDir);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void HasNestedWorktrees_NoWorktrees_ReturnsFalse()
+    {
+        var planDir = CreatePlan("00021-NoWt", ValidYaml);
+
+        var result = DoctorCommand.HasNestedWorktrees(planDir);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void HasStaleWorktrees_WithStaleDir_ReturnsTrue()
+    {
+        var planDir = CreatePlan("00022-Stale", ValidYaml);
+        var wtDir = Path.Combine(planDir, "worktrees", "StaleRepo");
+        Directory.CreateDirectory(wtDir);
+
+        var result = DoctorCommand.HasStaleWorktrees(planDir);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void HasStaleWorktrees_WithValidGit_ReturnsFalse()
+    {
+        var planDir = CreatePlan("00023-Valid", ValidYaml);
+        var wtDir = Path.Combine(planDir, "worktrees", "ValidRepo");
+        Directory.CreateDirectory(wtDir);
+        File.WriteAllText(Path.Combine(wtDir, ".git"), "gitdir: /some/path");
+
+        var result = DoctorCommand.HasStaleWorktrees(planDir);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void RepairPlan_StaleWorktree_RemovesDirectory()
+    {
+        var planDir = CreatePlan("00024-RepairStale", ValidYaml);
+        var wtDir = Path.Combine(planDir, "worktrees", "StaleRepo");
+        Directory.CreateDirectory(wtDir);
+        File.WriteAllText(Path.Combine(wtDir, "dummy.txt"), "test");
+
+        var healthResult = new DoctorCommand.PlanHealthResult(
+            "00024", "RepairStale", "Draft", 1, "StaleWorktree", false);
+
+        var result = DoctorCommand.RepairPlan(planDir, healthResult);
+
+        Assert.True(result.Success);
+        Assert.Contains("removed stale worktrees", result.Message);
+        Assert.False(Directory.Exists(wtDir));
+    }
+
+    [Fact]
+    public void RepairPlan_NestedWorktree_RemovesNested()
+    {
+        var planDir = CreatePlan("00025-RepairNested", ValidYaml);
+        var wtDir = Path.Combine(planDir, "worktrees", "SomeRepo");
+        Directory.CreateDirectory(wtDir);
+        var nestedPlansDir = Path.Combine(wtDir, "Plans");
+        Directory.CreateDirectory(nestedPlansDir);
+        File.WriteAllText(Path.Combine(nestedPlansDir, "dummy.txt"), "test");
+
+        var healthResult = new DoctorCommand.PlanHealthResult(
+            "00025", "RepairNested", "Draft", 1, "NestedWorktree", false);
+
+        var result = DoctorCommand.RepairPlan(planDir, healthResult);
+
+        Assert.True(result.Success);
+        Assert.Contains("cleaned nested worktrees", result.Message);
+        Assert.False(Directory.Exists(nestedPlansDir));
+    }
+
+    [Fact]
     public void CheckYamlHealth_EmptyFile_ReportsEmpty()
     {
         var path = Path.Combine(_plansDir, "empty.yaml");

--- a/src/tendril/Ivy.Tendril.Test/DoctorCommandPlansTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/DoctorCommandPlansTests.cs
@@ -32,7 +32,8 @@ public class DoctorCommandPlansTests : IDisposable
         state: Completed
         project: TestProject
         title: Test Plan
-        repos: []
+        repos:
+        - /dummy/repo
         commits: []
         """;
 
@@ -74,7 +75,7 @@ public class DoctorCommandPlansTests : IDisposable
 
         Assert.Single(results);
         Assert.False(results[0].IsHealthy);
-        Assert.Contains("YAML:Invalid structure", results[0].Health);
+        Assert.Contains("YAML:No repos", results[0].Health);
     }
 
     [Fact]
@@ -89,7 +90,8 @@ public class DoctorCommandPlansTests : IDisposable
 
         Assert.Single(results);
         Assert.Equal(2, results[0].Worktrees);
-        Assert.True(results[0].IsHealthy);
+        Assert.False(results[0].IsHealthy);
+        Assert.Contains("StaleWorktree", results[0].Health);
     }
 
     [Fact]

--- a/src/tendril/Ivy.Tendril/Commands/DoctorCommand.cs
+++ b/src/tendril/Ivy.Tendril/Commands/DoctorCommand.cs
@@ -472,6 +472,7 @@ public static class DoctorCommand
     internal static int DoctorPlans(string[] args)
     {
         var showAll = args.Contains("--all");
+        var fix = args.Contains("--fix");
         var stateFilter = GetArgValue(args, "--state");
         var worktreesOnly = args.Contains("--worktrees");
 
@@ -493,6 +494,46 @@ public static class DoctorCommand
         Console.WriteLine();
 
         var allResults = ScanPlans(plansDir);
+
+        if (fix)
+        {
+            Console.WriteLine();
+            Console.ForegroundColor = ConsoleColor.Yellow;
+            Console.WriteLine("Repairing unhealthy plans...");
+            Console.ResetColor();
+            Console.WriteLine();
+
+            var repairedCount = 0;
+            var failedCount = 0;
+
+            foreach (var result in allResults.Where(r => !r.IsHealthy))
+            {
+                var matchingDir = Directory.GetDirectories(plansDir, $"{result.Id}-*").FirstOrDefault();
+                if (matchingDir == null) continue;
+
+                var repairResult = RepairPlan(matchingDir, result);
+                if (repairResult.Success)
+                {
+                    Console.ForegroundColor = ConsoleColor.Green;
+                    Console.WriteLine($"  ✓ {result.Id}: {repairResult.Message}");
+                    Console.ResetColor();
+                    repairedCount++;
+                }
+                else if (repairResult.Message != null)
+                {
+                    Console.ForegroundColor = ConsoleColor.Red;
+                    Console.WriteLine($"  ✗ {result.Id}: {repairResult.Message}");
+                    Console.ResetColor();
+                    failedCount++;
+                }
+            }
+
+            Console.WriteLine();
+            Console.WriteLine($"Repair summary: {repairedCount} repaired, {failedCount} failed");
+            Console.WriteLine();
+
+            allResults = ScanPlans(plansDir);
+        }
 
         IEnumerable<PlanHealthResult> results;
         if (showAll)
@@ -529,6 +570,8 @@ public static class DoctorCommand
             var yamlPath = Path.Combine(dir, "plan.yaml");
             var (yamlHealthy, yamlError, state) = CheckYamlHealth(yamlPath);
             var worktreeCount = CountWorktrees(dir);
+            var hasNestedWorktrees = HasNestedWorktrees(dir);
+            var hasStaleWorktrees = HasStaleWorktrees(dir);
 
             var recsError = CheckRecommendationsHealth(dir);
 
@@ -537,6 +580,10 @@ public static class DoctorCommand
                 healthIssues.Add($"YAML:{yamlError}");
             if (recsError != null)
                 healthIssues.Add($"Recs:{recsError}");
+            if (hasNestedWorktrees)
+                healthIssues.Add("NestedWorktree");
+            if (hasStaleWorktrees)
+                healthIssues.Add("StaleWorktree");
 
             var health = healthIssues.Count == 0 ? "OK" : string.Join(",", healthIssues);
 
@@ -614,6 +661,46 @@ public static class DoctorCommand
         return Directory.GetDirectories(worktreesPath).Length;
     }
 
+    internal static bool HasNestedWorktrees(string planPath)
+    {
+        var worktreesPath = Path.Combine(planPath, "worktrees");
+        if (!Directory.Exists(worktreesPath))
+            return false;
+
+        try
+        {
+            var nestedGit = Directory.EnumerateFileSystemEntries(worktreesPath, ".git", SearchOption.AllDirectories);
+            return nestedGit.Any();
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    internal static bool HasStaleWorktrees(string planPath)
+    {
+        var worktreesPath = Path.Combine(planPath, "worktrees");
+        if (!Directory.Exists(worktreesPath))
+            return false;
+
+        try
+        {
+            foreach (var wtDir in Directory.GetDirectories(worktreesPath))
+            {
+                var gitFile = Path.Combine(wtDir, ".git");
+                if (!File.Exists(gitFile))
+                    return true;
+            }
+        }
+        catch
+        {
+            // Ignore access errors
+        }
+
+        return false;
+    }
+
     internal static string? CheckRecommendationsHealth(string planPath)
     {
         var recsPath = Path.Combine(planPath, "artifacts", "recommendations.yaml");
@@ -681,5 +768,69 @@ public static class DoctorCommand
         Console.WriteLine($"  Healthy: {allResults.Count(r => r.IsHealthy)}");
         Console.WriteLine($"  Unhealthy: {allResults.Count(r => !r.IsHealthy)}");
         Console.WriteLine($"  With worktrees: {allResults.Count(r => r.Worktrees > 0)}");
+    }
+
+    internal record RepairResult(bool Success, string? Message);
+
+    internal static RepairResult RepairPlan(string planPath, PlanHealthResult healthResult)
+    {
+        var repairs = new List<string>();
+
+        try
+        {
+            if (healthResult.Health.Contains("StaleWorktree"))
+            {
+                PlanReaderService.RemoveWorktrees(planPath);
+                repairs.Add("removed stale worktrees");
+            }
+
+            if (healthResult.Health.Contains("NestedWorktree"))
+            {
+                CleanupNestedWorktrees(planPath);
+                repairs.Add("cleaned nested worktrees");
+            }
+
+            if (repairs.Count == 0)
+                return new RepairResult(false, null);
+
+            return new RepairResult(true, string.Join(", ", repairs));
+        }
+        catch (Exception ex)
+        {
+            return new RepairResult(false, $"repair failed: {ex.Message}");
+        }
+    }
+
+    internal static void CleanupNestedWorktrees(string planPath)
+    {
+        var worktreesPath = Path.Combine(planPath, "worktrees");
+        if (!Directory.Exists(worktreesPath))
+            return;
+
+        var nestedPlans = Directory.GetDirectories(worktreesPath, "Plans", SearchOption.AllDirectories);
+        foreach (var nestedPlanDir in nestedPlans)
+        {
+            WorktreeCleanupService.ForceDeleteDirectory(nestedPlanDir);
+        }
+
+        foreach (var wtDir in Directory.GetDirectories(worktreesPath))
+        {
+            try
+            {
+                var nestedGit = Directory.EnumerateFileSystemEntries(wtDir, ".git", SearchOption.AllDirectories).ToList();
+
+                if (nestedGit.Count == 1 && nestedGit[0] == Path.Combine(wtDir, ".git"))
+                    continue;
+
+                if (nestedGit.Count > 1 || (nestedGit.Count == 1 && nestedGit[0] != Path.Combine(wtDir, ".git")))
+                {
+                    WorktreeCleanupService.ForceDeleteDirectory(wtDir);
+                }
+            }
+            catch
+            {
+                // Ignore errors on individual worktrees
+            }
+        }
     }
 }


### PR DESCRIPTION
# Summary

## Changes

Added `--fix` flag to `tendril doctor plans` that auto-repairs stale and nested worktree issues. Also implemented the missing nested worktree and stale worktree detection in `ScanPlans()`, which was expected by existing tests but not yet implemented. Fixed pre-existing test data issues where `ValidYaml` used `repos: []` that failed the repos validation check.

## API Changes

- `DoctorCommand.HasNestedWorktrees(string planPath)` — new internal static method detecting `.git` entries under worktrees/
- `DoctorCommand.HasStaleWorktrees(string planPath)` — new internal static method detecting worktree dirs without `.git` file
- `DoctorCommand.RepairPlan(string planPath, PlanHealthResult healthResult)` — new internal static method that repairs stale/nested worktree issues
- `DoctorCommand.CleanupNestedWorktrees(string planPath)` — new internal static method removing nested Plans dirs and invalid nested worktrees
- `DoctorCommand.RepairResult` — new internal record for repair operation results
- `DoctorPlans()` now accepts `--fix` flag in args

## Files Modified

- **src/tendril/Ivy.Tendril/Commands/DoctorCommand.cs** — Added detection methods, --fix flag parsing, repair logic
- **src/tendril/Ivy.Tendril.Test/DoctorCommandPlansTests.cs** — Added 6 new tests, fixed pre-existing test data issues

## Commits

- 53b01e367, f30cb43c3