### PR TITLE
[03207] Order Pull Requests by Latest First

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/PullRequestApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/PullRequestApp.cs
@@ -29,7 +29,7 @@ public class PullRequestApp : ViewBase
             var cost = costValue > 0 ? $"${costValue:F2}" : "";
             var tokenValue = planService.GetPlanTotalTokens(plan.FolderPath);
             var tokens = tokenValue > 0 ? FormatHelper.FormatTokens(tokenValue) : "";
-            return plan.Prs.Where(IsValidUrl).Select((pr, i) => new PrRow
+            return plan.Prs.Where(IsValidUrl).Reverse().Select((pr, i) => new PrRow
             {
                 Id = $"{plan.Id}-{i}",
                 PlanId = $"{plan.Id:D5}",


### PR DESCRIPTION
# Summary

## Changes

Added `.Reverse()` to the PR enumeration chain in `PullRequestApp.cs` so that the most recent PR (last entry in `plan.yaml`) appears first in the Pull Requests app table, reversing the previous oldest-first ordering.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Apps/PullRequestApp.cs` — Added `.Reverse()` before `.Select()` in the PR row mapping (line 32)


## Commits

- c0473dd2d