### PR TITLE
[03208] Fix race condition in Create New Plan dialog

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Plans/Dialogs/CreatePlanDialog.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Plans/Dialogs/CreatePlanDialog.cs
@@ -25,6 +25,7 @@ public class CreatePlanDialog(
         var createPlanText = UseState("");
         var selectedProjects = UseState(_defaultProjects);
         var selectedPriority = UseState("Normal");
+        var isCreating = UseState(false);
 
         var exclusiveProjects = new ConvertedState<string[], string[]>(
             selectedProjects,
@@ -55,10 +56,11 @@ public class CreatePlanDialog(
             ),
             new DialogFooter(
                 new Button("Cancel").Outline().OnClick(onClose),
-                new Button("Create").Primary().ShortcutKey("Ctrl+Enter").OnClick(() =>
+                new Button("Create").Primary().ShortcutKey("Ctrl+Enter").Disabled(isCreating.Value).OnClick(() =>
                 {
-                    if (!string.IsNullOrWhiteSpace(createPlanText.Value))
+                    if (!string.IsNullOrWhiteSpace(createPlanText.Value) && !isCreating.Value)
                     {
+                        isCreating.Set(true);
                         var projects = selectedProjects.Value.Any() ? selectedProjects.Value : ["Auto"];
                         onCreatePlan(createPlanText.Value, projects, ParsePriority(selectedPriority.Value));
                         onClose();


### PR DESCRIPTION
# Summary

## Changes

Added a loading state (`isCreating`) to the Create New Plan dialog that disables the "Create" button after the first click. This prevents duplicate plan creation from rapid clicks or repeated Ctrl+Enter key presses during the window between `onCreatePlan()` and `onClose()`.

## API Changes

None.

## Files Modified

- **CreatePlanDialog.cs** — Added `isCreating` state variable, `.Disabled(isCreating.Value)` on the Create button, guard check in OnClick handler, and `isCreating.Set(true)` at the start of the handler.

## Commits

- cbb6af945 [03208] Fix race condition in Create New Plan dialog