### PR TITLE
[03210] Use ClaudeJsonRenderer to visualize DataTable RowActions

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/JobsApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/JobsApp.cs
@@ -4,6 +4,7 @@ using Ivy.Tendril.Apps.Jobs;
 using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Services;
+using Ivy.Widgets.ClaudeJsonRenderer;
 
 namespace Ivy.Tendril.Apps;
 
@@ -182,6 +183,8 @@ public class JobsApp : ViewBase
             })
             .RowActions(
                 new MenuItem("View Plan", Icon: Icons.FileText, Tag: "view-plan").Tooltip("Open the associated plan"),
+                new MenuItem("View Output", Icon: Icons.Terminal, Tag: "view-output").Tooltip(
+                    "View job output with Claude JSON rendering"),
                 new MenuItem("Show Prompt", Icon: Icons.MessageSquare, Tag: "show-prompt").Tooltip(
                     "Show the full prompt text"),
                 new MenuItem("Stop", Icon: Icons.Square, Tag: "stop-job").Tooltip("Stop this running job"),
@@ -204,6 +207,10 @@ public class JobsApp : ViewBase
                             if (Directory.Exists(fullPath))
                                 showPlan.Set(fullPath);
                         }
+                    }
+                    else if (tag == "view-output")
+                    {
+                        showOutput.Set(job.Id);
                     }
                     else if (tag == "show-prompt")
                     {
@@ -310,13 +317,26 @@ public class JobsApp : ViewBase
         if (showOutput.Value is { } jobId)
         {
             var job = jobService.GetJob(jobId);
-            var outputText = job is not null && job.OutputLines.Count > 0
-                ? string.Join("\n", job.OutputLines)
-                : "No output available.";
+            object outputContent;
+
+            if (job is not null && job.OutputLines.Count > 0)
+            {
+                var jsonStream = string.Join("\n", job.OutputLines);
+                outputContent = new ClaudeJsonRenderer()
+                    .JsonStream(jsonStream)
+                    .ShowThinking(true)
+                    .ShowSystemEvents(true)
+                    .AutoScroll(job.Status == JobStatus.Running)
+                    .Height(Size.Full());
+            }
+            else
+            {
+                outputContent = Text.P("No output available.");
+            }
 
             var outputSheet = new Sheet(
                 () => showOutput.Set(null),
-                new Markdown($"```\n{outputText}\n```"),
+                outputContent,
                 job is not null ? $"{job.Type} — {ExtractPlanId(job.PlanFile)}" : "Job Output"
             ).Width(Size.Half()).Resizable();
 

--- a/src/tendril/Ivy.Tendril/Ivy.Tendril.csproj
+++ b/src/tendril/Ivy.Tendril/Ivy.Tendril.csproj
@@ -46,6 +46,7 @@
     <ProjectReference Include="../../Ivy.Hooks.Pty/Ivy.Hooks.Pty.csproj" />
     <ProjectReference Include="../../widgets/Ivy.Widgets.Xterm/Ivy.Widgets.Xterm.csproj" />
     <ProjectReference Include="../../widgets/Ivy.Widgets.DiffView/Ivy.Widgets.DiffView.csproj" />
+    <ProjectReference Include="../../widgets/Ivy.Widgets.ClaudeJsonRenderer/Ivy.Widgets.ClaudeJsonRenderer.csproj" />
     <ProjectReference Include="../../Ivy.Desktop/Ivy.Desktop.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(IvySource)' != 'true'">
@@ -53,6 +54,7 @@
     <PackageReference Include="Ivy.Hooks.Pty" Version="1.2.37-pre-20260410110521" />
     <PackageReference Include="Ivy.Widgets.Xterm" Version="1.2.37-pre-20260410110521" />
     <PackageReference Include="Ivy.Widgets.DiffView" Version="1.2.37-pre-20260410110521" />
+    <PackageReference Include="Ivy.Widgets.ClaudeJsonRenderer" Version="1.2.37-pre-20260410110521" />
     <PackageReference Include="Ivy.Desktop" Version="1.2.37-pre-20260410110521" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
# Summary

## Changes

Integrated ClaudeJsonRenderer into JobsApp's DataTable to provide rich visual rendering of job output. Added a "View Output" RowAction and replaced the previous raw Markdown output sheet with a ClaudeJsonRenderer widget that properly renders Claude Code JSON stream events, showing thinking blocks and system events.

## API Changes

None. This change only modifies internal UI rendering in JobsApp. No public APIs, methods, or endpoints were added or changed.

## Files Modified

- **src/tendril/Ivy.Tendril/Apps/JobsApp.cs** — Added "View Output" RowAction, replaced Markdown output sheet with ClaudeJsonRenderer, added `using Ivy.Widgets.ClaudeJsonRenderer`
- **src/tendril/Ivy.Tendril/Ivy.Tendril.csproj** — Added ProjectReference and PackageReference for Ivy.Widgets.ClaudeJsonRenderer

## Commits

- 6492c4970 [03210] Use ClaudeJsonRenderer to visualize DataTable RowActions output