### PR TITLE
[03205] Add Changes Tab to Review/Plans

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/PlanContentHelpersTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/PlanContentHelpersTests.cs
@@ -161,13 +161,102 @@ public class PlanContentHelpersTests
         Assert.Null(result);
     }
 
-    private class StubGitService(string? commitTitle = null,
-        List<(string Status, string FilePath)>? commitFiles = null) : IGitService
+    [Fact]
+    public void GetAllChangesData_WithMultipleCommits_ReturnsCombinedData()
+    {
+        var gitService = new StubGitService(
+            "Test commit",
+            [("A", "new.cs"), ("M", "existing.cs")],
+            combinedDiff: "diff --git a/new.cs b/new.cs\n+new content",
+            combinedFiles: [("A", "new.cs"), ("M", "existing.cs")]
+        );
+        var config = new StubConfigService();
+
+        var metadata = new PlanMetadata(
+            1, "Test", "Bug", "Test Plan", PlanStatus.Draft,
+            ["/fake/repo"], ["commit1", "commit2"], [], [], [], [], DateTime.UtcNow, DateTime.UtcNow, null, null);
+        var plan = new PlanFile(metadata, "", Path.GetTempPath(), "");
+
+        var result = PlanContentHelpers.GetAllChangesData(plan, config, gitService);
+
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Files.Count);
+        Assert.Equal(1, result.AddedCount);
+        Assert.Equal(1, result.ModifiedCount);
+        Assert.Equal(0, result.DeletedCount);
+        Assert.Contains("new content", result.Diff!);
+    }
+
+    [Fact]
+    public void GetAllChangesData_WithSingleCommit_UsesCommitDiff()
+    {
+        var gitService = new StubGitService(
+            "Single commit",
+            [("A", "file.cs")],
+            commitDiff: "diff --git a/file.cs b/file.cs\n+added"
+        );
+        var config = new StubConfigService();
+
+        var metadata = new PlanMetadata(
+            1, "Test", "Bug", "Test Plan", PlanStatus.Draft,
+            ["/fake/repo"], ["abc123"], [], [], [], [], DateTime.UtcNow, DateTime.UtcNow, null, null);
+        var plan = new PlanFile(metadata, "", Path.GetTempPath(), "");
+
+        var result = PlanContentHelpers.GetAllChangesData(plan, config, gitService);
+
+        Assert.NotNull(result);
+        Assert.Single(result.Files);
+        Assert.Equal(1, result.AddedCount);
+        Assert.Contains("added", result.Diff!);
+    }
+
+    [Fact]
+    public void GetAllChangesData_WithEmptyCommits_ReturnsNull()
+    {
+        var gitService = new StubGitService("Test", []);
+        var config = new StubConfigService();
+
+        var metadata = new PlanMetadata(
+            1, "Test", "Bug", "Test Plan", PlanStatus.Draft,
+            ["/fake/repo"], [], [], [], [], [], DateTime.UtcNow, DateTime.UtcNow, null, null);
+        var plan = new PlanFile(metadata, "", Path.GetTempPath(), "");
+
+        var result = PlanContentHelpers.GetAllChangesData(plan, config, gitService);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetAllChangesData_WithCommitsNotInRepo_ReturnsNull()
+    {
+        var gitService = new StubGitService(null, null);
+        var config = new StubConfigService();
+
+        var metadata = new PlanMetadata(
+            1, "Test", "Bug", "Test Plan", PlanStatus.Draft,
+            ["/fake/repo"], ["unknown1", "unknown2"], [], [], [], [], DateTime.UtcNow, DateTime.UtcNow, null, null);
+        var plan = new PlanFile(metadata, "", Path.GetTempPath(), "");
+
+        var result = PlanContentHelpers.GetAllChangesData(plan, config, gitService);
+
+        Assert.Null(result);
+    }
+
+    private class StubGitService(
+        string? commitTitle = null,
+        List<(string Status, string FilePath)>? commitFiles = null,
+        string? commitDiff = null,
+        string? combinedDiff = null,
+        List<(string Status, string FilePath)>? combinedFiles = null) : IGitService
     {
         public string? GetCommitTitle(string repoPath, string commitHash) => commitTitle;
-        public string? GetCommitDiff(string repoPath, string commitHash) => null;
+        public string? GetCommitDiff(string repoPath, string commitHash) => commitDiff;
         public List<(string Status, string FilePath)>? GetCommitFiles(string repoPath, string commitHash) => commitFiles;
         public int? GetCommitFileCount(string repoPath, string commitHash) => commitFiles?.Count;
+        public string? GetCombinedDiff(string repoPath, string firstCommit, string lastCommit) => combinedDiff;
+
+        public List<(string Status, string FilePath)>? GetCombinedChangedFiles(string repoPath, string firstCommit,
+            string lastCommit) => combinedFiles;
     }
 
 }

--- a/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -2,6 +2,7 @@ using Ivy.Core;
 using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Apps.Review.Dialogs;
 using Ivy.Tendril.Services;
+using Ivy.Widgets.DiffView;
 using Microsoft.Extensions.Logging;
 
 namespace Ivy.Tendril.Apps.Review;
@@ -123,6 +124,19 @@ public class ContentView(
                         }
                     }
                     return null;
+                }, ct);
+            },
+            initialValue: null
+        );
+
+        var allChangesQuery = UseQuery<PlanContentHelpers.AllChangesData?, string>(
+            _selectedPlan?.FolderPath ?? "",
+            async (folderPath, ct) =>
+            {
+                return await Task.Run(() =>
+                {
+                    if (_selectedPlan is null) return null;
+                    return PlanContentHelpers.GetAllChangesData(_selectedPlan, _config, _gitService);
                 }, ct);
             },
             initialValue: null
@@ -345,6 +359,54 @@ public class ContentView(
 
             commitsLayout |= commitsTable;
 
+            // Changes tab content
+            object changesTabContent;
+            var changesData = allChangesQuery.Value;
+            var changesFileCount = 0;
+            if (allChangesQuery.Loading)
+            {
+                changesTabContent = Text.Muted("Loading...");
+            }
+            else if (changesData is null)
+            {
+                changesTabContent = Text.Muted("No commits yet.");
+            }
+            else
+            {
+                changesFileCount = changesData.Files.Count;
+                var changesLayout = Layout.Vertical().Gap(4).Padding(2);
+
+                var statsText =
+                    $"{changesData.Files.Count} files changed ({changesData.AddedCount} added, {changesData.ModifiedCount} modified, {changesData.DeletedCount} deleted)";
+                changesLayout |= Text.Block(statsText).Bold();
+
+                if (changesData.Files.Count > 0)
+                {
+                    var filesLayout = Layout.Vertical().Gap(1);
+                    foreach (var (status, filePath) in changesData.Files)
+                    {
+                        var (label, variant) = status switch
+                        {
+                            "A" => ("Added", BadgeVariant.Success),
+                            "D" => ("Deleted", BadgeVariant.Destructive),
+                            _ => ("Modified", BadgeVariant.Outline)
+                        };
+                        filesLayout |= Layout.Horizontal().Gap(2)
+                            | new Badge(label).Variant(variant).Small()
+                            | Text.Block(filePath);
+                    }
+
+                    changesLayout |= filesLayout;
+                }
+
+                if (!string.IsNullOrWhiteSpace(changesData.Diff))
+                {
+                    changesLayout |= new DiffView().Diff(changesData.Diff).Split();
+                }
+
+                changesTabContent = changesLayout;
+            }
+
             // PRs tab content
             object prsContent;
             if (_selectedPlan.Prs.Count > 0)
@@ -433,6 +495,7 @@ public class ContentView(
                 new Tab("Summary", Cap(summaryTabContent)),
                 new Tab("Verifications", Cap(verificationsTable)).Badge(_selectedPlan.Verifications.Count.ToString()),
                 new Tab("Commits", Cap(commitsLayout)).Badge(_selectedPlan.Commits.Count.ToString()),
+                new Tab("Changes", Cap(changesTabContent)).Badge(changesFileCount > 0 ? changesFileCount.ToString() : ""),
                 new Tab("PRs", Cap(prsContent)).Badge(_selectedPlan.Prs.Count.ToString()),
                 new Tab("Artifacts", Cap(artifactsLayout)).Badge(totalArtifacts.ToString()),
                 new Tab("Recommendations", Cap(recommendationsLayout)).Badge(planData.Recommendations.Count.ToString()),

--- a/src/tendril/Ivy.Tendril/Services/GitService.cs
+++ b/src/tendril/Ivy.Tendril/Services/GitService.cs
@@ -109,4 +109,60 @@ public class GitService : IGitService
             return null; /* git may not be installed, or repo path invalid */
         }
     }
+
+    public string? GetCombinedDiff(string repoPath, string firstCommit, string lastCommit)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo("git", $"diff {firstCommit}^..{lastCommit}")
+            {
+                WorkingDirectory = repoPath,
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                StandardOutputEncoding = Encoding.UTF8
+            };
+            using var process = Process.Start(psi);
+            var output = process?.StandardOutput.ReadToEnd();
+            process.WaitForExitOrKill(10000);
+            return process?.ExitCode == 0 ? output : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public List<(string Status, string FilePath)>? GetCombinedChangedFiles(string repoPath, string firstCommit, string lastCommit)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo("git", $"diff --name-status {firstCommit}^..{lastCommit}")
+            {
+                WorkingDirectory = repoPath,
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                StandardOutputEncoding = Encoding.UTF8
+            };
+            using var process = Process.Start(psi);
+            var output = process?.StandardOutput.ReadToEnd();
+            process.WaitForExitOrKill(10000);
+            if (process?.ExitCode != 0 || output == null) return null;
+
+            var files = new List<(string Status, string FilePath)>();
+            foreach (var line in output.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+            {
+                var parts = line.Split('\t', 2);
+                if (parts.Length == 2)
+                    files.Add((parts[0].Trim(), parts[1].Trim()));
+            }
+
+            return files;
+        }
+        catch
+        {
+            return null;
+        }
+    }
 }

--- a/src/tendril/Ivy.Tendril/Services/IGitService.cs
+++ b/src/tendril/Ivy.Tendril/Services/IGitService.cs
@@ -6,4 +6,6 @@ public interface IGitService
     string? GetCommitDiff(string repoPath, string commitHash);
     List<(string Status, string FilePath)>? GetCommitFiles(string repoPath, string commitHash);
     int? GetCommitFileCount(string repoPath, string commitHash);
+    string? GetCombinedDiff(string repoPath, string firstCommit, string lastCommit);
+    List<(string Status, string FilePath)>? GetCombinedChangedFiles(string repoPath, string firstCommit, string lastCommit);
 }

--- a/src/tendril/Ivy.Tendril/Services/PlanContentHelpers.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanContentHelpers.cs
@@ -125,6 +125,52 @@ public static class PlanContentHelpers
         ).Width(Size.Half()).Resizable();
     }
 
+    public record AllChangesData(
+        string? Diff,
+        List<(string Status, string FilePath)> Files,
+        int AddedCount,
+        int ModifiedCount,
+        int DeletedCount
+    );
+
+    public static AllChangesData? GetAllChangesData(PlanFile plan, IConfigService config, IGitService gitService)
+    {
+        if (plan.Commits.Count == 0) return null;
+
+        var repoPaths = plan.GetEffectiveRepoPaths(config);
+        var firstCommit = plan.Commits.First();
+        var lastCommit = plan.Commits.Last();
+
+        foreach (var repo in repoPaths)
+        {
+            var title = gitService.GetCommitTitle(repo, firstCommit);
+            if (title == null) continue;
+
+            string? diff;
+            List<(string Status, string FilePath)>? files;
+
+            if (plan.Commits.Count == 1)
+            {
+                diff = gitService.GetCommitDiff(repo, firstCommit);
+                files = gitService.GetCommitFiles(repo, firstCommit);
+            }
+            else
+            {
+                diff = gitService.GetCombinedDiff(repo, firstCommit, lastCommit);
+                files = gitService.GetCombinedChangedFiles(repo, firstCommit, lastCommit);
+            }
+
+            var fileList = files ?? [];
+            var added = fileList.Count(f => f.Status == "A");
+            var deleted = fileList.Count(f => f.Status == "D");
+            var modified = fileList.Count - added - deleted;
+
+            return new AllChangesData(diff, fileList, added, modified, deleted);
+        }
+
+        return null;
+    }
+
     public static object RenderArtifactScreenshots(Dictionary<string, List<string>> artifacts)
     {
         if (!artifacts.TryGetValue("screenshots", out var screenshotFiles))


### PR DESCRIPTION
# Summary

## Changes

Added a new "Changes" tab to the Review/Plans interface that displays a unified diff of all code changes across all commits in a plan. The tab shows file change statistics (added/modified/deleted counts), lists all changed files with status badges, and renders the combined diff using the DiffView component.

## API Changes

- `IGitService`: Added `GetCombinedDiff(string repoPath, string firstCommit, string lastCommit)` and `GetCombinedChangedFiles(string repoPath, string firstCommit, string lastCommit)` methods
- `GitService`: Implemented both new methods using `git diff <firstCommit>^..<lastCommit>` and `git diff --name-status <firstCommit>^..<lastCommit>`
- `PlanContentHelpers`: Added `AllChangesData` record and `GetAllChangesData(PlanFile, IConfigService, IGitService)` static method

## Files Modified

- `src/tendril/Ivy.Tendril/Services/IGitService.cs` — Added 2 new interface methods
- `src/tendril/Ivy.Tendril/Services/GitService.cs` — Implemented combined diff and changed files methods
- `src/tendril/Ivy.Tendril/Services/PlanContentHelpers.cs` — Added AllChangesData record and GetAllChangesData helper
- `src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs` — Added Changes tab with query, file list, and DiffView
- `src/tendril/Ivy.Tendril.Test/PlanContentHelpersTests.cs` — Added 4 tests for GetAllChangesData, updated StubGitService


## Commits

- 763505000000000000000000000000000000000000, 48ab0a8a3