### PR TITLE
fix: correct NuGet login user to match Trusted Publisher policy

### DIFF
--- a/.github/workflows/publish-tendril.yml
+++ b/.github/workflows/publish-tendril.yml
@@ -73,7 +73,7 @@ jobs:
         uses: NuGet/login@v1
         id: login
         with:
-          user: rorychatt-ivy
+          user: Ivy-Interactive
 
       - name: Clean NuGet output before signing
         run: |

--- a/.github/workflows/publish-tendril.yml
+++ b/.github/workflows/publish-tendril.yml
@@ -73,7 +73,7 @@ jobs:
         uses: NuGet/login@v1
         id: login
         with:
-          user: Ivy-Interactive
+          user: rorychatt-ivy
 
       - name: Clean NuGet output before signing
         run: |

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -431,3 +431,6 @@ worktrees/
 # Nested Plans artifacts (belt-and-suspenders)
 **/worktrees/**/Plans/
 
+# Stale Rust build artifacts (RustServer removed in plan 00130)
+RustServer/
+

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/02_Layouts/10_ResponsiveDesign.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/02_Layouts/10_ResponsiveDesign.md
@@ -290,7 +290,7 @@ Combine responsive grid, visibility, and orientation to build a dashboard that a
 
 ```csharp demo
 Layout.Vertical().Gap(4)
-    | Text.H3("Dashboard").HideOn(Breakpoint.Mobile)
+    | new Badge("Dashboard").HideOn(Breakpoint.Mobile)
     | (Layout.Grid()
         .Columns(1.At(Breakpoint.Mobile)
             .And(Breakpoint.Desktop, 3))

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/02_Layouts/10_ResponsiveDesign.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/02_Layouts/10_ResponsiveDesign.md
@@ -14,25 +14,84 @@ searchHints:
 # Responsive Design
 
 <Ingress>
-Build adaptive layouts that respond to viewport size using the built-in breakpoint system. Vary width, height, visibility, columns, orientation, gap, and density at different screen sizes.
+Build adaptive layouts that respond to viewport size using the built-in breakpoint system. Vary width, height, visibility, columns, orientation, gap, padding, and density at different screen sizes.
 </Ingress>
 
 Ivy's responsive design system lets you vary widget properties by viewport size using `Responsive<T>` values with mobile-first cascading.
 
 ## Breakpoints
 
-| Breakpoint | Max Width | Usage |
+| Breakpoint | Max Width | Typical Device |
 |---|---|---|
 | `Mobile` | 640px | Phones |
 | `Tablet` | 768px | Tablets |
 | `Desktop` | 1024px | Laptops |
 | `Wide` | 1280px | Large screens |
 
-Values cascade upward: a `Mobile` value applies to all sizes unless overridden by a larger breakpoint.
+Values **cascade upward**: when you set a value at a smaller breakpoint, it applies to all larger breakpoints unless overridden. This is called **mobile-first** design — you start with the smallest screen and layer on changes for bigger viewports.
+
+```csharp
+// Setting columns at Mobile means it applies to Mobile, Tablet, Desktop, and Wide
+// unless a larger breakpoint overrides it
+Layout.Grid()
+    .Columns(1.At(Breakpoint.Mobile)        // 1 col on Mobile AND Tablet (cascades up)
+        .And(Breakpoint.Desktop, 3))         // 3 cols on Desktop AND Wide
+```
+
+In this example, `Tablet` inherits the `Mobile` value of 1 column, and `Wide` inherits the `Desktop` value of 3 columns.
+
+## The `Responsive<T>` Type
+
+At the core of the responsive system is `Responsive<T>` — a generic record that holds per-breakpoint values:
+
+```csharp
+public record Responsive<T>
+{
+    public T? Default { get; init; }
+    public T? Mobile { get; init; }
+    public T? Tablet { get; init; }
+    public T? Desktop { get; init; }
+    public T? Wide { get; init; }
+}
+```
+
+**Implicit conversion** ensures full backward compatibility. Any plain value is automatically wrapped as a `Responsive<T>` with `Default` set:
+
+```csharp
+// Non-responsive (backward compatible) — implicit conversion from T to Responsive<T>
+Layout.Grid().Columns(3)
+
+// Responsive — explicit breakpoint values using .At() and .And()
+Layout.Grid().Columns(1.At(Breakpoint.Mobile).And(Breakpoint.Desktop, 3))
+```
+
+### The `.At()` and `.And()` Builder Pattern
+
+Use `.At(Breakpoint)` to start a responsive chain, and `.And(Breakpoint, value)` to add more breakpoints:
+
+```csharp
+// .At() starts the chain — sets the value for a specific breakpoint
+Size.Full().At(Breakpoint.Mobile)
+
+// .And() adds additional breakpoint values to the chain
+Size.Full().At(Breakpoint.Mobile)
+    .And(Breakpoint.Tablet, Size.Units(80))
+    .And(Breakpoint.Desktop, Size.Half())
+```
+
+The `.At()` extension method is available for the following types:
+
+| Type | Example | Used For |
+|---|---|---|
+| `Size` (class) | `Size.Full().At(Breakpoint.Mobile)` | Width, Height |
+| `int` | `1.At(Breakpoint.Mobile)` | Gap, Columns |
+| `Orientation` | `Orientation.Vertical.At(Breakpoint.Mobile)` | Layout orientation |
+| `Density` | `Density.Large.At(Breakpoint.Mobile)` | Touch target size |
+| `bool` | `true.At(Breakpoint.Mobile)` | Visibility |
 
 ## Responsive Width
 
-Use `.At()` and `.And()` to create responsive values:
+Use `.At()` and `.And()` to create responsive width values. This works on any widget via the `WidgetBase` extension methods.
 
 ```csharp
 new Box(Text.P("Responsive box"))
@@ -48,9 +107,27 @@ Layout.Vertical()
         .Background(Colors.Primary)
 ```
 
+## Responsive Height
+
+Height also supports responsive values on all widgets:
+
+```csharp
+new Box(Text.P("Tall on mobile, shorter on desktop"))
+    .Height(Size.Units(80).At(Breakpoint.Mobile)
+        .And(Breakpoint.Desktop, Size.Units(40)))
+```
+
+```csharp demo
+Layout.Vertical()
+    | new Box(Text.P("Tall on mobile, shorter on desktop"))
+        .Height(Size.Units(80).At(Breakpoint.Mobile)
+            .And(Breakpoint.Desktop, Size.Units(40)))
+        .Background(Colors.Primary)
+```
+
 ## Conditional Visibility
 
-Hide or show widgets at specific breakpoints:
+Hide or show widgets at specific breakpoints using `.HideOn()` and `.ShowOn()`:
 
 ```csharp
 // Hidden on mobile and tablet
@@ -59,6 +136,8 @@ new Badge("Desktop only").HideOn(Breakpoint.Mobile, Breakpoint.Tablet)
 // Only visible on mobile
 new Badge("Mobile only").ShowOn(Breakpoint.Mobile)
 ```
+
+Under the hood, these methods build a `Responsive<bool?>` value. `.HideOn()` starts with `Default = true` (visible) and sets specified breakpoints to `false`. `.ShowOn()` starts with `Default = false` (hidden) and sets specified breakpoints to `true`.
 
 ```csharp demo
 Layout.Vertical()
@@ -95,7 +174,7 @@ Layout.Grid()
 
 ## Responsive Orientation
 
-Switch between horizontal and vertical layouts:
+Switch between horizontal and vertical layouts based on screen size:
 
 ```csharp
 Layout.Horizontal()
@@ -114,7 +193,7 @@ Layout.Horizontal()
 
 ## Responsive Gap
 
-Vary spacing between items:
+Vary spacing between items by viewport size:
 
 ```csharp
 Layout.Vertical()
@@ -129,9 +208,35 @@ Layout.Vertical()
     | Text.P("Item 3")
 ```
 
+## Responsive Padding
+
+Adjust layout padding by breakpoint. Since there is no `.At()` extension for `Thickness`, construct the `Responsive<Thickness?>` directly using object initialization:
+
+```csharp
+Layout.Vertical()
+    .Padding(new Responsive<Thickness?>
+    {
+        Mobile = new Thickness(8),
+        Desktop = new Thickness(24)
+    })
+```
+
+```csharp demo
+Layout.Vertical()
+    .Padding(new Responsive<Thickness?>
+    {
+        Mobile = new Thickness(8),
+        Desktop = new Thickness(24)
+    })
+    | new Box(Text.P("Compact padding on mobile, spacious on desktop"))
+        .Background(Colors.Primary)
+    | new Box(Text.P("Notice the padding change"))
+        .Background(Colors.Secondary)
+```
+
 ## Responsive Density
 
-Adjust touch target size by device:
+Adjust touch target size by device — useful for making buttons and inputs larger on touch devices:
 
 ```csharp
 new Button("Adaptive Button")
@@ -149,31 +254,83 @@ new Button("Adaptive Button")
 
 ### Collapsing Sidebar
 
-```csharp
+Hide the sidebar on mobile and show it on larger screens. The main content grows to fill available space.
+
+```csharp demo
 Layout.Horizontal()
     | new Box(Text.P("Sidebar"))
         .Width(Size.Units(60))
         .HideOn(Breakpoint.Mobile)
+        .Background(Colors.Muted)
     | new Box(Text.P("Main Content"))
         .Width(Size.Grow())
+        .Background(Colors.Primary)
 ```
 
 ### Mobile-First Card Grid
 
-```csharp
+A progressive grid that goes from 1 column on mobile up to 4 columns on wide screens:
+
+```csharp demo
 Layout.Grid()
     .Columns(1.At(Breakpoint.Mobile)
         .And(Breakpoint.Tablet, 2)
         .And(Breakpoint.Desktop, 3)
         .And(Breakpoint.Wide, 4))
     .Gap(4)
+    | new Card("Card 1")
+    | new Card("Card 2")
+    | new Card("Card 3")
+    | new Card("Card 4")
+```
+
+### Responsive Dashboard
+
+Combine responsive grid, visibility, and orientation to build a dashboard that adapts across device sizes:
+
+```csharp demo
+Layout.Vertical().Gap(4)
+    | Text.H3("Dashboard").HideOn(Breakpoint.Mobile)
+    | (Layout.Grid()
+        .Columns(1.At(Breakpoint.Mobile)
+            .And(Breakpoint.Desktop, 3))
+        .Gap(4)
+        | new Card("Revenue")
+        | new Card("Users")
+        | new Card("Orders"))
+    | (Layout.Horizontal()
+        .Orientation(Orientation.Vertical.At(Breakpoint.Mobile)
+            .And(Breakpoint.Desktop, Orientation.Horizontal))
+        .Gap(4)
+        | new Box(Text.P("Chart Area")).Width(Size.Grow()).Background(Colors.Muted)
+        | new Box(Text.P("Activity Feed")).Width(Size.Units(60).At(Breakpoint.Desktop)).HideOn(Breakpoint.Mobile).Background(Colors.Muted))
 ```
 
 ### Mobile-First Form
 
-```csharp
+Constrain form width on larger screens and adjust spacing:
+
+```csharp demo
 Layout.Vertical()
     .Width(Size.Full().At(Breakpoint.Mobile)
         .And(Breakpoint.Desktop, Size.Fraction(0.5f)))
     .Gap(4.At(Breakpoint.Mobile).And(Breakpoint.Desktop, 6))
+    | new Box(Text.P("Form field 1")).Background(Colors.Muted)
+    | new Box(Text.P("Form field 2")).Background(Colors.Muted)
+    | new Button("Submit")
 ```
+
+## API Reference
+
+Summary of all responsive-capable properties:
+
+| Property | Widget/Layout | Type | Fluent Method |
+|---|---|---|---|
+| Width | All widgets | `Responsive<Size>` | `.Width()` |
+| Height | All widgets | `Responsive<Size>` | `.Height()` |
+| Visible | All widgets | `Responsive<bool?>` | `.HideOn()` / `.ShowOn()` |
+| Density | All widgets | `Responsive<Density?>` | `.Density()` |
+| Columns | GridLayout | `Responsive<int?>` | `.Columns()` |
+| Orientation | StackLayout | `Responsive<Orientation?>` | `.Orientation()` |
+| Gap | StackLayout, GridLayout | `Responsive<int?>` | `.Gap()` |
+| Padding | StackLayout | `Responsive<Thickness?>` | `.Padding()` |

--- a/src/Ivy.Tests/Shared/ResponsiveTests.cs
+++ b/src/Ivy.Tests/Shared/ResponsiveTests.cs
@@ -82,4 +82,41 @@ public class ResponsiveTests
         Assert.True(visible.Mobile);
         Assert.Null(visible.Desktop);
     }
+
+    [Fact]
+    public void Thickness_At_CreatesBreakpointValue()
+    {
+        var responsive = new Thickness(8).At(Breakpoint.Mobile);
+        Assert.Equal(new Thickness(8), responsive.Mobile);
+        Assert.Null(responsive.Default);
+        Assert.Null(responsive.Desktop);
+        Assert.Null(responsive.Tablet);
+        Assert.Null(responsive.Wide);
+    }
+
+    [Fact]
+    public void Thickness_And_ChainsBreakpoints()
+    {
+        var responsive = new Thickness(8).At(Breakpoint.Mobile)
+            .And(Breakpoint.Desktop, new Thickness(16));
+        Assert.Equal(new Thickness(8), responsive.Mobile);
+        Assert.Equal(new Thickness(16), responsive.Desktop);
+        Assert.Null(responsive.Default);
+        Assert.Null(responsive.Tablet);
+    }
+
+    [Fact]
+    public void Thickness_JsonSerialization_MultiBreakpoint_WritesObject()
+    {
+        var responsive = new Thickness(8).At(Breakpoint.Mobile)
+            .And(Breakpoint.Desktop, new Thickness(16));
+        var json = JsonSerializer.Serialize(responsive, SerializerOptions);
+        var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.Equal(JsonValueKind.Object, root.ValueKind);
+        Assert.Equal("8,8,8,8", root.GetProperty("mobile").GetString());
+        Assert.Equal("16,16,16,16", root.GetProperty("desktop").GetString());
+        Assert.False(root.TryGetProperty("default", out _));
+    }
 }

--- a/src/Ivy.Tests/Shared/ResponsiveTests.cs
+++ b/src/Ivy.Tests/Shared/ResponsiveTests.cs
@@ -119,4 +119,115 @@ public class ResponsiveTests
         Assert.Equal("16,16,16,16", root.GetProperty("desktop").GetString());
         Assert.False(root.TryGetProperty("default", out _));
     }
+
+    [Theory]
+    [InlineData(Breakpoint.Mobile)]
+    [InlineData(Breakpoint.Tablet)]
+    [InlineData(Breakpoint.Desktop)]
+    [InlineData(Breakpoint.Wide)]
+    public void Int_At_SetsCorrectBreakpoint(Breakpoint bp)
+    {
+        var responsive = 42.At(bp);
+        AssertBreakpoint(responsive, bp, 42);
+    }
+
+    [Theory]
+    [InlineData(Breakpoint.Mobile)]
+    [InlineData(Breakpoint.Tablet)]
+    [InlineData(Breakpoint.Desktop)]
+    [InlineData(Breakpoint.Wide)]
+    public void Int_And_SetsCorrectBreakpoint(Breakpoint bp)
+    {
+        var responsive = 1.At(Breakpoint.Mobile).And(bp, 99);
+        Assert.Equal(99, GetBreakpointValue(responsive, bp));
+    }
+
+    [Theory]
+    [InlineData(Breakpoint.Mobile)]
+    [InlineData(Breakpoint.Tablet)]
+    [InlineData(Breakpoint.Desktop)]
+    [InlineData(Breakpoint.Wide)]
+    public void Orientation_At_SetsCorrectBreakpoint(Breakpoint bp)
+    {
+        var responsive = Orientation.Horizontal.At(bp);
+        AssertBreakpoint(responsive, bp, Orientation.Horizontal);
+    }
+
+    [Theory]
+    [InlineData(Breakpoint.Mobile)]
+    [InlineData(Breakpoint.Tablet)]
+    [InlineData(Breakpoint.Desktop)]
+    [InlineData(Breakpoint.Wide)]
+    public void Density_At_SetsCorrectBreakpoint(Breakpoint bp)
+    {
+        var responsive = Density.Small.At(bp);
+        AssertBreakpoint(responsive, bp, Density.Small);
+    }
+
+    [Theory]
+    [InlineData(Breakpoint.Mobile)]
+    [InlineData(Breakpoint.Tablet)]
+    [InlineData(Breakpoint.Desktop)]
+    [InlineData(Breakpoint.Wide)]
+    public void Bool_At_SetsCorrectBreakpoint(Breakpoint bp)
+    {
+        var responsive = true.At(bp);
+        AssertBreakpoint(responsive, bp, true);
+    }
+
+    [Theory]
+    [InlineData(Breakpoint.Mobile)]
+    [InlineData(Breakpoint.Tablet)]
+    [InlineData(Breakpoint.Desktop)]
+    [InlineData(Breakpoint.Wide)]
+    public void Thickness_At_SetsCorrectBreakpoint(Breakpoint bp)
+    {
+        var responsive = new Thickness(8).At(bp);
+        AssertBreakpoint(responsive, bp, new Thickness(8));
+    }
+
+    [Fact]
+    public void AllValueTypes_At_And_Chain()
+    {
+        var intR = 1.At(Breakpoint.Mobile).And(Breakpoint.Desktop, 2);
+        Assert.Equal(1, intR.Mobile);
+        Assert.Equal(2, intR.Desktop);
+
+        var orientR = Orientation.Horizontal.At(Breakpoint.Tablet).And(Breakpoint.Wide, Orientation.Vertical);
+        Assert.Equal(Orientation.Horizontal, orientR.Tablet);
+        Assert.Equal(Orientation.Vertical, orientR.Wide);
+
+        var densityR = Density.Small.At(Breakpoint.Mobile).And(Breakpoint.Desktop, Density.Large);
+        Assert.Equal(Density.Small, densityR.Mobile);
+        Assert.Equal(Density.Large, densityR.Desktop);
+
+        var boolR = true.At(Breakpoint.Mobile).And(Breakpoint.Desktop, false);
+        Assert.True(boolR.Mobile);
+        Assert.False(boolR.Desktop);
+
+        var thickR = new Thickness(4).At(Breakpoint.Mobile).And(Breakpoint.Wide, new Thickness(16));
+        Assert.Equal(new Thickness(4), thickR.Mobile);
+        Assert.Equal(new Thickness(16), thickR.Wide);
+    }
+
+    private static void AssertBreakpoint<T>(Responsive<T> responsive, Breakpoint bp, T expected)
+    {
+        Assert.Equal(expected, GetBreakpointValue(responsive, bp));
+
+        // All other breakpoints should be default
+        foreach (var other in new[] { Breakpoint.Mobile, Breakpoint.Tablet, Breakpoint.Desktop, Breakpoint.Wide })
+        {
+            if (other != bp)
+                Assert.Equal(default, GetBreakpointValue(responsive, other));
+        }
+    }
+
+    private static T? GetBreakpointValue<T>(Responsive<T> responsive, Breakpoint bp) => bp switch
+    {
+        Breakpoint.Mobile => responsive.Mobile,
+        Breakpoint.Tablet => responsive.Tablet,
+        Breakpoint.Desktop => responsive.Desktop,
+        Breakpoint.Wide => responsive.Wide,
+        _ => throw new ArgumentOutOfRangeException(nameof(bp))
+    };
 }

--- a/src/Ivy.Tests/Shared/ResponsiveTests.cs
+++ b/src/Ivy.Tests/Shared/ResponsiveTests.cs
@@ -83,43 +83,6 @@ public class ResponsiveTests
         Assert.Null(visible.Desktop);
     }
 
-    [Fact]
-    public void Thickness_At_CreatesBreakpointValue()
-    {
-        var responsive = new Thickness(8).At(Breakpoint.Mobile);
-        Assert.Equal(new Thickness(8), responsive.Mobile);
-        Assert.Null(responsive.Default);
-        Assert.Null(responsive.Desktop);
-        Assert.Null(responsive.Tablet);
-        Assert.Null(responsive.Wide);
-    }
-
-    [Fact]
-    public void Thickness_And_ChainsBreakpoints()
-    {
-        var responsive = new Thickness(8).At(Breakpoint.Mobile)
-            .And(Breakpoint.Desktop, new Thickness(16));
-        Assert.Equal(new Thickness(8), responsive.Mobile);
-        Assert.Equal(new Thickness(16), responsive.Desktop);
-        Assert.Null(responsive.Default);
-        Assert.Null(responsive.Tablet);
-    }
-
-    [Fact]
-    public void Thickness_JsonSerialization_MultiBreakpoint_WritesObject()
-    {
-        var responsive = new Thickness(8).At(Breakpoint.Mobile)
-            .And(Breakpoint.Desktop, new Thickness(16));
-        var json = JsonSerializer.Serialize(responsive, SerializerOptions);
-        var doc = JsonDocument.Parse(json);
-        var root = doc.RootElement;
-
-        Assert.Equal(JsonValueKind.Object, root.ValueKind);
-        Assert.Equal("8,8,8,8", root.GetProperty("mobile").GetString());
-        Assert.Equal("16,16,16,16", root.GetProperty("desktop").GetString());
-        Assert.False(root.TryGetProperty("default", out _));
-    }
-
     [Theory]
     [InlineData(Breakpoint.Mobile)]
     [InlineData(Breakpoint.Tablet)]
@@ -175,17 +138,6 @@ public class ResponsiveTests
         AssertBreakpoint(responsive, bp, true);
     }
 
-    [Theory]
-    [InlineData(Breakpoint.Mobile)]
-    [InlineData(Breakpoint.Tablet)]
-    [InlineData(Breakpoint.Desktop)]
-    [InlineData(Breakpoint.Wide)]
-    public void Thickness_At_SetsCorrectBreakpoint(Breakpoint bp)
-    {
-        var responsive = new Thickness(8).At(bp);
-        AssertBreakpoint(responsive, bp, new Thickness(8));
-    }
-
     [Fact]
     public void AllValueTypes_At_And_Chain()
     {
@@ -204,10 +156,6 @@ public class ResponsiveTests
         var boolR = true.At(Breakpoint.Mobile).And(Breakpoint.Desktop, false);
         Assert.True(boolR.Mobile);
         Assert.False(boolR.Desktop);
-
-        var thickR = new Thickness(4).At(Breakpoint.Mobile).And(Breakpoint.Wide, new Thickness(16));
-        Assert.Equal(new Thickness(4), thickR.Mobile);
-        Assert.Equal(new Thickness(16), thickR.Wide);
     }
 
     private static void AssertBreakpoint<T>(Responsive<T> responsive, Breakpoint bp, T expected)

--- a/src/Ivy/Shared/Responsive.cs
+++ b/src/Ivy/Shared/Responsive.cs
@@ -74,10 +74,6 @@ public static class ResponsiveExtensions
     // bool overloads (for visibility)
     public static Responsive<bool?> At(this bool value, Breakpoint bp) => AtCore(value, bp);
     public static Responsive<bool?> And(this Responsive<bool?> r, Breakpoint bp, bool value) => AndCore(r, bp, value);
-
-    // Thickness overloads (for padding)
-    public static Responsive<Thickness?> At(this Thickness value, Breakpoint bp) => AtCore(value, bp);
-    public static Responsive<Thickness?> And(this Responsive<Thickness?> r, Breakpoint bp, Thickness value) => AndCore(r, bp, value);
 }
 
 public class ResponsiveJsonConverterFactory : JsonConverterFactory

--- a/src/Ivy/Shared/Responsive.cs
+++ b/src/Ivy/Shared/Responsive.cs
@@ -113,6 +113,25 @@ public static class ResponsiveExtensions
         Breakpoint.Wide => r with { Wide = value },
         _ => throw new ArgumentOutOfRangeException(nameof(bp))
     };
+
+    // Thickness overloads (for padding)
+    public static Responsive<Thickness?> At(this Thickness value, Breakpoint bp) => bp switch
+    {
+        Breakpoint.Mobile => new Responsive<Thickness?> { Mobile = value },
+        Breakpoint.Tablet => new Responsive<Thickness?> { Tablet = value },
+        Breakpoint.Desktop => new Responsive<Thickness?> { Desktop = value },
+        Breakpoint.Wide => new Responsive<Thickness?> { Wide = value },
+        _ => throw new ArgumentOutOfRangeException(nameof(bp))
+    };
+
+    public static Responsive<Thickness?> And(this Responsive<Thickness?> r, Breakpoint bp, Thickness value) => bp switch
+    {
+        Breakpoint.Mobile => r with { Mobile = value },
+        Breakpoint.Tablet => r with { Tablet = value },
+        Breakpoint.Desktop => r with { Desktop = value },
+        Breakpoint.Wide => r with { Wide = value },
+        _ => throw new ArgumentOutOfRangeException(nameof(bp))
+    };
 }
 
 public class ResponsiveJsonConverterFactory : JsonConverterFactory

--- a/src/Ivy/Shared/Responsive.cs
+++ b/src/Ivy/Shared/Responsive.cs
@@ -38,17 +38,17 @@ public static class ResponsiveExtensions
         _ => throw new ArgumentOutOfRangeException(nameof(bp))
     };
 
-    // int overloads (for gap, columns, etc.)
-    public static Responsive<int?> At(this int value, Breakpoint bp) => bp switch
+    // Private generic helpers for value types — the switch logic lives here once.
+    private static Responsive<T?> AtCore<T>(T value, Breakpoint bp) where T : struct => bp switch
     {
-        Breakpoint.Mobile => new Responsive<int?> { Mobile = value },
-        Breakpoint.Tablet => new Responsive<int?> { Tablet = value },
-        Breakpoint.Desktop => new Responsive<int?> { Desktop = value },
-        Breakpoint.Wide => new Responsive<int?> { Wide = value },
+        Breakpoint.Mobile => new Responsive<T?> { Mobile = value },
+        Breakpoint.Tablet => new Responsive<T?> { Tablet = value },
+        Breakpoint.Desktop => new Responsive<T?> { Desktop = value },
+        Breakpoint.Wide => new Responsive<T?> { Wide = value },
         _ => throw new ArgumentOutOfRangeException(nameof(bp))
     };
 
-    public static Responsive<int?> And(this Responsive<int?> r, Breakpoint bp, int value) => bp switch
+    private static Responsive<T?> AndCore<T>(Responsive<T?> r, Breakpoint bp, T value) where T : struct => bp switch
     {
         Breakpoint.Mobile => r with { Mobile = value },
         Breakpoint.Tablet => r with { Tablet = value },
@@ -56,82 +56,28 @@ public static class ResponsiveExtensions
         Breakpoint.Wide => r with { Wide = value },
         _ => throw new ArgumentOutOfRangeException(nameof(bp))
     };
+
+    // To add a new value type, add an At and And overload that delegates to AtCore/AndCore.
+
+    // int overloads (for gap, columns, etc.)
+    public static Responsive<int?> At(this int value, Breakpoint bp) => AtCore(value, bp);
+    public static Responsive<int?> And(this Responsive<int?> r, Breakpoint bp, int value) => AndCore(r, bp, value);
 
     // Orientation overloads
-    public static Responsive<Orientation?> At(this Orientation value, Breakpoint bp) => bp switch
-    {
-        Breakpoint.Mobile => new Responsive<Orientation?> { Mobile = value },
-        Breakpoint.Tablet => new Responsive<Orientation?> { Tablet = value },
-        Breakpoint.Desktop => new Responsive<Orientation?> { Desktop = value },
-        Breakpoint.Wide => new Responsive<Orientation?> { Wide = value },
-        _ => throw new ArgumentOutOfRangeException(nameof(bp))
-    };
-
-    public static Responsive<Orientation?> And(this Responsive<Orientation?> r, Breakpoint bp, Orientation value) => bp switch
-    {
-        Breakpoint.Mobile => r with { Mobile = value },
-        Breakpoint.Tablet => r with { Tablet = value },
-        Breakpoint.Desktop => r with { Desktop = value },
-        Breakpoint.Wide => r with { Wide = value },
-        _ => throw new ArgumentOutOfRangeException(nameof(bp))
-    };
+    public static Responsive<Orientation?> At(this Orientation value, Breakpoint bp) => AtCore(value, bp);
+    public static Responsive<Orientation?> And(this Responsive<Orientation?> r, Breakpoint bp, Orientation value) => AndCore(r, bp, value);
 
     // Density overloads
-    public static Responsive<Density?> At(this Density value, Breakpoint bp) => bp switch
-    {
-        Breakpoint.Mobile => new Responsive<Density?> { Mobile = value },
-        Breakpoint.Tablet => new Responsive<Density?> { Tablet = value },
-        Breakpoint.Desktop => new Responsive<Density?> { Desktop = value },
-        Breakpoint.Wide => new Responsive<Density?> { Wide = value },
-        _ => throw new ArgumentOutOfRangeException(nameof(bp))
-    };
-
-    public static Responsive<Density?> And(this Responsive<Density?> r, Breakpoint bp, Density value) => bp switch
-    {
-        Breakpoint.Mobile => r with { Mobile = value },
-        Breakpoint.Tablet => r with { Tablet = value },
-        Breakpoint.Desktop => r with { Desktop = value },
-        Breakpoint.Wide => r with { Wide = value },
-        _ => throw new ArgumentOutOfRangeException(nameof(bp))
-    };
+    public static Responsive<Density?> At(this Density value, Breakpoint bp) => AtCore(value, bp);
+    public static Responsive<Density?> And(this Responsive<Density?> r, Breakpoint bp, Density value) => AndCore(r, bp, value);
 
     // bool overloads (for visibility)
-    public static Responsive<bool?> At(this bool value, Breakpoint bp) => bp switch
-    {
-        Breakpoint.Mobile => new Responsive<bool?> { Mobile = value },
-        Breakpoint.Tablet => new Responsive<bool?> { Tablet = value },
-        Breakpoint.Desktop => new Responsive<bool?> { Desktop = value },
-        Breakpoint.Wide => new Responsive<bool?> { Wide = value },
-        _ => throw new ArgumentOutOfRangeException(nameof(bp))
-    };
-
-    public static Responsive<bool?> And(this Responsive<bool?> r, Breakpoint bp, bool value) => bp switch
-    {
-        Breakpoint.Mobile => r with { Mobile = value },
-        Breakpoint.Tablet => r with { Tablet = value },
-        Breakpoint.Desktop => r with { Desktop = value },
-        Breakpoint.Wide => r with { Wide = value },
-        _ => throw new ArgumentOutOfRangeException(nameof(bp))
-    };
+    public static Responsive<bool?> At(this bool value, Breakpoint bp) => AtCore(value, bp);
+    public static Responsive<bool?> And(this Responsive<bool?> r, Breakpoint bp, bool value) => AndCore(r, bp, value);
 
     // Thickness overloads (for padding)
-    public static Responsive<Thickness?> At(this Thickness value, Breakpoint bp) => bp switch
-    {
-        Breakpoint.Mobile => new Responsive<Thickness?> { Mobile = value },
-        Breakpoint.Tablet => new Responsive<Thickness?> { Tablet = value },
-        Breakpoint.Desktop => new Responsive<Thickness?> { Desktop = value },
-        Breakpoint.Wide => new Responsive<Thickness?> { Wide = value },
-        _ => throw new ArgumentOutOfRangeException(nameof(bp))
-    };
-
-    public static Responsive<Thickness?> And(this Responsive<Thickness?> r, Breakpoint bp, Thickness value) => bp switch
-    {
-        Breakpoint.Mobile => r with { Mobile = value },
-        Breakpoint.Tablet => r with { Tablet = value },
-        Breakpoint.Desktop => r with { Desktop = value },
-        Breakpoint.Wide => r with { Wide = value },
-        _ => throw new ArgumentOutOfRangeException(nameof(bp))
-    };
+    public static Responsive<Thickness?> At(this Thickness value, Breakpoint bp) => AtCore(value, bp);
+    public static Responsive<Thickness?> And(this Responsive<Thickness?> r, Breakpoint bp, Thickness value) => AndCore(r, bp, value);
 }
 
 public class ResponsiveJsonConverterFactory : JsonConverterFactory

--- a/src/tendril/Ivy.Tendril.TeamIvyConfig/Foo/issue-201.md
+++ b/src/tendril/Ivy.Tendril.TeamIvyConfig/Foo/issue-201.md
@@ -1,0 +1,1 @@
+https://github.com/Ivy-Interactive/Ivy-Agent/issues/201

--- a/src/tendril/Ivy.Tendril.TeamIvyConfig/Foo/issue-202.md
+++ b/src/tendril/Ivy.Tendril.TeamIvyConfig/Foo/issue-202.md
@@ -1,0 +1,1 @@
+https://github.com/Ivy-Interactive/Ivy-Agent/issues/202

--- a/src/tendril/Ivy.Tendril.TeamIvyConfig/Foo/issue-203.md
+++ b/src/tendril/Ivy.Tendril.TeamIvyConfig/Foo/issue-203.md
@@ -1,0 +1,1 @@
+https://github.com/Ivy-Interactive/Ivy-Agent/issues/203

--- a/src/tendril/Ivy.Tendril.TeamIvyConfig/Foo/issue-204.md
+++ b/src/tendril/Ivy.Tendril.TeamIvyConfig/Foo/issue-204.md
@@ -1,0 +1,1 @@
+https://github.com/Ivy-Interactive/Ivy-Agent/issues/204

--- a/src/tendril/Ivy.Tendril.TeamIvyConfig/Foo/issue-205.md
+++ b/src/tendril/Ivy.Tendril.TeamIvyConfig/Foo/issue-205.md
@@ -1,0 +1,1 @@
+https://github.com/Ivy-Interactive/Ivy-Agent/issues/205

--- a/src/tendril/Ivy.Tendril.TeamIvyConfig/Foo/issue-206.md
+++ b/src/tendril/Ivy.Tendril.TeamIvyConfig/Foo/issue-206.md
@@ -1,0 +1,1 @@
+https://github.com/Ivy-Interactive/Ivy-Agent/issues/206

--- a/src/tendril/Ivy.Tendril.TeamIvyConfig/Foo/issue-207.md
+++ b/src/tendril/Ivy.Tendril.TeamIvyConfig/Foo/issue-207.md
@@ -1,0 +1,1 @@
+https://github.com/Ivy-Interactive/Ivy-Agent/issues/207

--- a/src/tendril/Ivy.Tendril.TeamIvyConfig/Foo/issue-208.md
+++ b/src/tendril/Ivy.Tendril.TeamIvyConfig/Foo/issue-208.md
@@ -1,0 +1,1 @@
+https://github.com/Ivy-Interactive/Ivy-Agent/issues/208

--- a/src/tendril/Ivy.Tendril.Test/PrStatusSyncServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/PrStatusSyncServiceTests.cs
@@ -1,3 +1,4 @@
+using Ivy.Tendril.Apps;
 using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Services;
 using Microsoft.Data.Sqlite;
@@ -65,6 +66,40 @@ public class PrStatusSyncServiceTests : IDisposable
         Assert.Contains("https://github.com/owner/repo/pull/1", nonMerged);
         Assert.Contains("https://github.com/owner/repo/pull/3", nonMerged);
         Assert.DoesNotContain("https://github.com/owner/repo/pull/2", nonMerged);
+    }
+
+    [Fact]
+    public void GroupByOwnerRepo_OnlyReceivesValidPrUrls_WhenFilteredByIsValidUrl()
+    {
+        var rawUrls = new List<string>
+        {
+            "https://github.com/owner/repo/pull/1",
+            "https://github.com/Ivy-Interactive/Ivy.Releases (new repo — no PR needed)",
+            "https://github.com/owner/repo",  // repo URL, not a PR
+        };
+
+        // Simulate the CollectPrUrlsFromPlans filter
+        var filtered = rawUrls.Where(PullRequestApp.IsValidUrl).ToList();
+        var grouped = PrStatusSyncService.GroupByOwnerRepo(filtered);
+        Assert.Single(grouped);
+        Assert.Single(grouped["owner/repo"]);
+    }
+
+    [Fact]
+    public void IsValidUrl_AcceptsValidPrUrls()
+    {
+        Assert.True(PullRequestApp.IsValidUrl("https://github.com/owner/repo/pull/1"));
+        Assert.True(PullRequestApp.IsValidUrl("https://github.com/owner/repo/pull/123"));
+        Assert.True(PullRequestApp.IsValidUrl("http://github.com/owner/repo/pull/1"));
+    }
+
+    [Fact]
+    public void IsValidUrl_RejectsInvalidUrls()
+    {
+        Assert.False(PullRequestApp.IsValidUrl("https://github.com/owner/repo"));
+        Assert.False(PullRequestApp.IsValidUrl("https://github.com/Ivy-Interactive/Ivy.Releases (new repo — no PR needed)"));
+        Assert.False(PullRequestApp.IsValidUrl("not a url"));
+        Assert.False(PullRequestApp.IsValidUrl("https://example.com/page"));
     }
 
     [Fact]

--- a/src/tendril/Ivy.Tendril/Apps/PullRequestApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/PullRequestApp.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Apps.PullRequest;
 using Ivy.Tendril.Services;
@@ -162,9 +163,11 @@ public class PullRequestApp : ViewBase
     ///     Extracts "owner/repo" from a GitHub PR URL.
     ///     E.g. "https://github.com/owner/repo/pull/123" -> "owner/repo"
     /// </summary>
+    private static readonly Regex GitHubPrPattern = new(
+        @"^https?://github\.com/[^/]+/[^/]+/pull/\d+", RegexOptions.Compiled);
+
     internal static bool IsValidUrl(string value) =>
-        Uri.TryCreate(value, UriKind.Absolute, out var uri) &&
-        (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps);
+        GitHubPrPattern.IsMatch(value);
 
     internal static string ExtractRepo(string prUrl)
     {

--- a/src/tendril/Ivy.Tendril/Services/PlanDatabaseService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanDatabaseService.cs
@@ -1468,6 +1468,7 @@ public class PlanDatabaseService : IPlanDatabaseService
 
         foreach (var value in values)
         {
+            if (value == null) continue;
             insertCmd.Parameters["@planId"].Value = planId;
             insertCmd.Parameters["@value"].Value = value;
             insertCmd.ExecuteNonQuery();

--- a/src/tendril/Ivy.Tendril/Services/PrStatusSyncService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PrStatusSyncService.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using Ivy.Tendril.Apps;
 using Microsoft.Extensions.Logging;
 
 namespace Ivy.Tendril.Services;
@@ -111,8 +112,7 @@ public class PrStatusSyncService : IStartable, IDisposable
         return plans
             .Where(p => p.Prs.Count > 0)
             .SelectMany(p => p.Prs)
-            .Where(url => Uri.TryCreate(url, UriKind.Absolute, out var uri) &&
-                          (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps))
+            .Where(PullRequestApp.IsValidUrl)
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToList();
     }


### PR DESCRIPTION
Reverts the NuGet login user from Ivy-Interactive to rorychatt-ivy to match the account that holds the Trusted Publisher policy on NuGet.org. This resolves the 401 Unauthorized error in the publish-tendril workflow.