### PR TITLE
[WithLabel]: unify visual behavior with WithField

### DIFF
--- a/src/Ivy/Views/ViewHelpers.cs
+++ b/src/Ivy/Views/ViewHelpers.cs
@@ -5,12 +5,7 @@ namespace Ivy;
 
 public static class ViewHelpers
 {
-    public static ViewBase WithLabel(this IWidget widget, string label)
-    {
-        return Layout.Vertical()
-            | Text.Label(label)
-            | widget;
-    }
+
 
     [Obsolete("Not needed anymore.")]
     public static Action HandleError(this Action action, IView view)

--- a/src/Ivy/Widgets/Inputs/Field.cs
+++ b/src/Ivy/Widgets/Inputs/Field.cs
@@ -65,4 +65,6 @@ public static class FieldExtensions
     public static Field LabelPosition(this Field field, LabelPosition position) => field with { LabelPosition = position };
 
     public static Field WithField(this IAnyInput input) => new Field(input);
+
+    public static Field WithLabel(this IAnyInput input, string label) => new Field(input).Label(label);
 }


### PR DESCRIPTION
## The Problem (Issue)
Historically, there were two similar but conceptually different ways to attach a label to a UI element in the framework:

1. **`WithLabel`** (in `ViewHelpers.cs`): Accepted any widget (`IWidget`) and wrapped it in a basic `Layout.Vertical()` + `Text.Label(...)`.
   - The result was functional, but appeared as bare text above the element, without proper spacing, modern styling, or support for additional features.
2. **`WithField`** (in `Field.cs`): Accepted only inputs (`IAnyInput`) and wrapped them in a full-fledged `Field` component.
   - The result had proper padding, clean styling, and supported modifiers like `required`, `description`, `help`, horizontal label placement, and validation hints.

**The Issue:** In the UI (for example, the `CreatePlanDialog` in Tendril), this caused visual desynchronization. Inputs wrapped via `.WithLabel("...")` inherently looked different from inputs wrapped via `.WithField().Label("...")`, even though they were part of the very same form workflow for the user.

## What Was Done
1. **Removed the old `WithLabel`:** The `WithLabel(this IWidget...)` extension was completely removed from `ViewHelpers.cs`. It was essentially unused in the codebase, but its presence confused both the compiler and developers.
2. **Added a `WithLabel` alias for `IAnyInput`:** A new extension method was added to `FieldExtensions.cs`:
   ```csharp
   public static Field WithLabel(this IAnyInput input, string label) => new Field(input).Label(label);
   ```
3. **Created a Demonstration App:** Added a `WithLabelVsWithFieldApp` inside `Ivy.Samples.Shared` which visually demonstrates the "Before" and "After" comparison side-by-side.

## Why This Approach (Architectural Decision)
* **Synonymity:** Framework users naturally expect `.WithLabel("...")` on an input to simply provide a visually consistent and standard label. Forcing them to write `.WithField().Label("...")` is less ergonomic. The new alias keeps the code clean and familiar.
* **Consistency:** Under the hood, all inputs now use the fully styled `Field` component when a label is requested. Visual mismatches in basic input scenarios are no longer possible.
* **Why fully remove instead of tagging `[Obsolete]`:** When trying to retain the old `WithLabel(IWidget)` alongside the new `WithLabel(IAnyInput)`, the C# compiler threw a `CS0121` error (ambiguous invocation). Because `TextInput` and other input classes implicitly cast to both interfaces, the compiler couldn't pick a "best" match. Fully removing the old method was safely the cleanest solution.
<img width="2229" height="797" alt="image" src="https://github.com/user-attachments/assets/82620f84-2306-405e-a511-a75e4bb435bf" />
