### PR TITLE
[MadeWithIvy]: fix background artifacts and make logo theme-aware

### DIFF
--- a/src/frontend/src/components/MadeWithIvy.tsx
+++ b/src/frontend/src/components/MadeWithIvy.tsx
@@ -46,7 +46,7 @@ export default function MadeWithIvy() {
 
   return (
     <div
-      className="bg-ivy-green fixed bottom-0 right-0 z-100 overflow-hidden rounded-tl-full "
+      className="fixed bottom-0 right-0 z-100 overflow-hidden rounded-tl-full "
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >
@@ -62,7 +62,7 @@ export default function MadeWithIvy() {
           origin-bottom-right
           cursor-pointer
           ${isHovered ? "w-48 h-48" : "w-16 h-16"}
-          ${isHovered ? "bg-primary-foreground" : "bg-ivy-green"}
+          bg-ivy-green
         `}
         onClick={handleClick}
         role="button"
@@ -70,7 +70,6 @@ export default function MadeWithIvy() {
         onKeyDown={handleKeyDown}
       >
         <div
-          style={{ color: "var(--ivy-green)" }}
           className={`
             flex
             flex-col
@@ -79,10 +78,11 @@ export default function MadeWithIvy() {
             transition-opacity
             duration-300
             m-4
+            text-background
             ${isHovered ? "opacity-100" : "opacity-0"}
           `}
         >
-          <span className="font-mono font-bold text-gray-400">MADE WITH</span>
+          <span className="font-mono font-bold opacity-70">MADE WITH</span>
           <IvyLogo className="w-24" />
         </div>
       </div>


### PR DESCRIPTION
## The Issue
When hovering over the "MADE WITH ivy" icon in the bottom right corner of the screen, the following visual artifacts were observed:
1. **Green Halo (Border) Around the Rounded Corner**: Due to browser anti-aliasing behavior, the green color of the bottom container bled through the border of the top container, creating a thin colored outline along the curve.
2. **Incorrect Background Color (wrong bg color)**: Upon expansion (hover state), the badge changed its background to white/off-white (`bg-primary-foreground`). This looked disjointed, resembling a clunky white square overlay on the page background. Additionally, the original green logo was hard to read due to this style clash.

<img width="326" height="344" alt="image" src="https://github.com/user-attachments/assets/bd239598-bc73-413b-aa6b-762991fbe8f7" />


## What Was Done
To achieve the desired visual effect (a logo "cut out" inside a solid green background), the following changes were made in `src/frontend/src/components/MadeWithIvy.tsx`:

1. **Fixed the Subpixel Anti-Aliasing Artifact (Halo):**
   - Removed the `bg-ivy-green` class from the outer parent `<div>`. Now, only the inner expanding container handles the background fill. This completely eliminates the double-layering effect over rounded corners and permanently fixes the "bleeding green line."

2. **Updated Background Fill Logic:**
   - Removed the conditional background change on hover (`${isHovered ? "bg-background" : "bg-ivy-green"}`) from the inner `<div>`. The background is now strictly hardcoded to `bg-ivy-green`. This guarantees a stable, solid green semicircular shape at all times.

3. **Implemented Theme-Dependent Logo Adaptation:**
   - Removed the hardcoded inline style `style={{ color: "var(--ivy-green)" }}` from the logo container as well as the original `text-gray-400` from the "MADE WITH" string.
   - Applied the `text-background` class to the entire inner logo container.
   - Added `opacity-70` to the "MADE WITH" text for a subdued look.
   - **Result**: In UI libraries, `background` represents the page's main layout color (white in a light theme and dark gray/black in a dark theme). Using it as the logo's `text-color` on a green background creates a seamless **Cutout Effect**. The logo and text now directly inherit the surrounding page's background color, ensuring perfect contrast and 100% theme responsiveness without custom conditionals.
<img width="290" height="290" alt="image" src="https://github.com/user-attachments/assets/05059113-b0e5-4f69-89d3-16ee7701c1cc" />
<img width="312" height="301" alt="image" src="https://github.com/user-attachments/assets/8bba86f8-8a7b-46d8-862b-9b9b5676df17" />
