### PR TITLE
(responsive): refactor doc page

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/02_Layouts/10_ResponsiveDesign.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/02_Layouts/10_ResponsiveDesign.md
@@ -40,40 +40,17 @@ Layout.Grid()
 
 In this example, `Tablet` inherits the `Mobile` value of 1 column, and `Wide` inherits the `Desktop` value of 3 columns.
 
-## The Responsive Type
+## The Responsive type
 
-At the core of the responsive system is `Responsive<T>` — a generic record that holds per-breakpoint values:
-
-```csharp
-public record Responsive<T>
-{
-    public T? Default { get; init; }
-    public T? Mobile { get; init; }
-    public T? Tablet { get; init; }
-    public T? Desktop { get; init; }
-    public T? Wide { get; init; }
-}
-```
-
-**Implicit conversion** ensures full backward compatibility. Any plain value is automatically wrapped as a `Responsive<T>` with `Default` set:
+A plain `T` converts implicitly to `Responsive<T>` with only `Default` set, so existing call sites stay valid. For per-breakpoint values, chain `.At(breakpoint)` on a supported type, then `.And(breakpoint, value)` for further overrides:
 
 ```csharp
-// Non-responsive (backward compatible) — implicit conversion from T to Responsive<T>
+// Plain value → implicit Responsive<T> (Default only)
 Layout.Grid().Columns(3)
 
-// Responsive — explicit breakpoint values using .At() and .And()
+// Breakpoint overrides — cascade from Mobile unless a larger breakpoint sets its own
 Layout.Grid().Columns(1.At(Breakpoint.Mobile).And(Breakpoint.Desktop, 3))
-```
 
-### The `.At()` and `.And()` Builder Pattern
-
-Use `.At(Breakpoint)` to start a responsive chain, and `.And(Breakpoint, value)` to add more breakpoints:
-
-```csharp
-// .At() starts the chain — sets the value for a specific breakpoint
-Size.Full().At(Breakpoint.Mobile)
-
-// .And() adds additional breakpoint values to the chain
 Size.Full().At(Breakpoint.Mobile)
     .And(Breakpoint.Tablet, Size.Units(80))
     .And(Breakpoint.Desktop, Size.Half())

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/02_Layouts/10_ResponsiveDesign.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/02_Layouts/10_ResponsiveDesign.md
@@ -40,7 +40,7 @@ Layout.Grid()
 
 In this example, `Tablet` inherits the `Mobile` value of 1 column, and `Wide` inherits the `Desktop` value of 3 columns.
 
-## The `Responsive<T>` Type
+## The Responsive Type
 
 At the core of the responsive system is `Responsive<T>` — a generic record that holds per-breakpoint values:
 
@@ -130,7 +130,7 @@ Layout.Vertical()
 
 Hide the sidebar on mobile and show it on larger screens. The main content grows to fill available space.
 
-```csharp demo
+```csharp demo-tabs
 Layout.Horizontal()
     | new Box(Text.P("Sidebar"))
         .Width(Size.Units(60))
@@ -145,7 +145,7 @@ Layout.Horizontal()
 
 A progressive grid that goes from 1 column on mobile up to 4 columns on wide screens:
 
-```csharp demo
+```csharp demo-tabs
 Layout.Grid()
     .Columns(1.At(Breakpoint.Mobile)
         .And(Breakpoint.Tablet, 2)
@@ -161,7 +161,7 @@ Layout.Grid()
 
 Combine responsive grid, visibility, and orientation to build a dashboard that adapts across device sizes:
 
-```csharp demo
+```csharp demo-tabs
 Layout.Vertical()
     | new Badge("Dashboard").HideOn(Breakpoint.Mobile)
     | (Layout.Grid()
@@ -181,7 +181,7 @@ Layout.Vertical()
 
 Constrain form width on larger screens and adjust spacing:
 
-```csharp demo
+```csharp demo-tabs
 Layout.Vertical()
     .Width(Size.Full().At(Breakpoint.Mobile)
         .And(Breakpoint.Desktop, Size.Fraction(0.5f)))

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/02_Layouts/10_ResponsiveDesign.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/02_Layouts/10_ResponsiveDesign.md
@@ -120,72 +120,92 @@ Layout.Vertical()
         | new Card("Three"))
 ```
 
-## Common Patterns
+## Examples
 
-### Collapsing Sidebar
-
-Hide the sidebar on mobile and show it on larger screens. The main content grows to fill available space.
-
-```csharp demo-tabs
-Layout.Horizontal()
-    | new Box(Text.P("Sidebar"))
-        .Width(Size.Units(60))
-        .HideOn(Breakpoint.Mobile)
-        .Background(Colors.Muted)
-    | new Box(Text.P("Main Content"))
-        .Width(Size.Grow())
-        .Background(Colors.Primary)
-```
-
-### Mobile-First Card Grid
-
-A progressive grid that goes from 1 column on mobile up to 4 columns on wide screens:
+<Details>
+<Summary>
+Collapsing Sidebar
+</Summary>
+<Body>
+Hide the sidebar on mobile and let the main content grow to fill the row on larger screens.
 
 ```csharp demo-tabs
-Layout.Grid()
-    .Columns(1.At(Breakpoint.Mobile)
-        .And(Breakpoint.Tablet, 2)
-        .And(Breakpoint.Desktop, 3)
-        .And(Breakpoint.Wide, 4))
-    | new Card("Card 1")
-    | new Card("Card 2")
-    | new Card("Card 3")
-    | new Card("Card 4")
+public class CollapsingSidebarExample : ViewBase
+{
+    public override object? Build()
+    {
+        return Layout.Horizontal()
+            | new Box(Text.P("Sidebar"))
+                .Width(Size.Units(60))
+                .HideOn(Breakpoint.Mobile)
+                .Background(Colors.Muted)
+            | new Box(Text.P("Main Content"))
+                .Width(Size.Grow())
+                .Background(Colors.Primary);
+    }
+}
 ```
 
-### Responsive Dashboard
+</Body>
+</Details>
 
-Combine responsive grid, visibility, and orientation to build a dashboard that adapts across device sizes:
+<Details>
+<Summary>
+Responsive Dashboard
+</Summary>
+<Body>
+Combine a responsive grid, conditional visibility, and stack orientation for a layout that works across device sizes.
 
 ```csharp demo-tabs
-Layout.Vertical()
-    | new Badge("Dashboard").HideOn(Breakpoint.Mobile)
-    | (Layout.Grid()
-        .Columns(1.At(Breakpoint.Mobile)
-            .And(Breakpoint.Desktop, 3))
-        | new Card("Revenue")
-        | new Card("Users")
-        | new Card("Orders"))
-    | (Layout.Horizontal()
-        .Orientation(Orientation.Vertical.At(Breakpoint.Mobile)
-            .And(Breakpoint.Desktop, Orientation.Horizontal))
-        | new Box(Text.P("Chart Area")).Width(Size.Grow()).Background(Colors.Muted)
-        | new Box(Text.P("Activity Feed")).Width(Size.Units(60).At(Breakpoint.Desktop)).HideOn(Breakpoint.Mobile).Background(Colors.Muted))
+public class ResponsiveDashboardExample : ViewBase
+{
+    public override object? Build()
+    {
+        return Layout.Vertical()
+            | new Badge("Dashboard").HideOn(Breakpoint.Mobile)
+            | (Layout.Grid()
+                .Columns(1.At(Breakpoint.Mobile)
+                    .And(Breakpoint.Desktop, 3))
+                | new Card("Revenue")
+                | new Card("Users")
+                | new Card("Orders"))
+            | (Layout.Horizontal()
+                .Orientation(Orientation.Vertical.At(Breakpoint.Mobile)
+                    .And(Breakpoint.Desktop, Orientation.Horizontal))
+                | new Box(Text.P("Chart Area")).Width(Size.Grow()).Background(Colors.Muted)
+                | new Box(Text.P("Activity Feed")).Width(Size.Units(60).At(Breakpoint.Desktop)).HideOn(Breakpoint.Mobile).Background(Colors.Muted));
+    }
+}
 ```
 
-### Mobile-First Form
+</Body>
+</Details>
 
-Constrain form width on larger screens and adjust spacing:
+<Details>
+<Summary>
+Mobile-First Form
+</Summary>
+<Body>
+Keep the form full width on phones and cap width plus gap on larger breakpoints.
 
 ```csharp demo-tabs
-Layout.Vertical()
-    .Width(Size.Full().At(Breakpoint.Mobile)
-        .And(Breakpoint.Desktop, Size.Fraction(0.5f)))
-    .Gap(4.At(Breakpoint.Mobile).And(Breakpoint.Desktop, 6))
-    | new Box(Text.P("Form field 1")).Background(Colors.Muted)
-    | new Box(Text.P("Form field 2")).Background(Colors.Muted)
-    | new Button("Submit")
+public class MobileFirstFormExample : ViewBase
+{
+    public override object? Build()
+    {
+        return Layout.Vertical()
+            .Width(Size.Full().At(Breakpoint.Mobile)
+                .And(Breakpoint.Desktop, Size.Fraction(0.5f)))
+            .Gap(4.At(Breakpoint.Mobile).And(Breakpoint.Desktop, 6))
+            | new Box(Text.P("Form field 1")).Background(Colors.Muted)
+            | new Box(Text.P("Form field 2")).Background(Colors.Muted)
+            | new Button("Submit");
+    }
+}
 ```
+
+</Body>
+</Details>
 
 ## API Reference
 

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/02_Layouts/10_ResponsiveDesign.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/02_Layouts/10_ResponsiveDesign.md
@@ -89,165 +89,39 @@ The `.At()` extension method is available for the following types:
 | `Density` | `Density.Large.At(Breakpoint.Mobile)` | Touch target size |
 | `bool` | `true.At(Breakpoint.Mobile)` | Visibility |
 
-## Responsive Width
+## Responsive properties
 
-Use `.At()` and `.And()` to create responsive width values. This works on any widget via the `WidgetBase` extension methods.
+Most layout and widget APIs accept `Responsive<T>` values built with `.At()` and `.And()`. Use `.HideOn()` and `.ShowOn()` for visibility, and construct `Responsive<Thickness?>` with object initializers when setting padding (there is no `.At()` for `Thickness`). The demo below shows width, height, grid columns, stack orientation, gap, padding, density, and badges in a single view.
 
-```csharp
-new Box(Text.P("Responsive box"))
-    .Width(Size.Full().At(Breakpoint.Mobile)
-        .And(Breakpoint.Desktop, Size.Half()))
-```
-
-```csharp demo
-Layout.Vertical()
-    | new Box(Text.P("Full on mobile, half on desktop"))
-        .Width(Size.Full().At(Breakpoint.Mobile)
-            .And(Breakpoint.Desktop, Size.Half()))
-        .Background(Colors.Primary)
-```
-
-## Responsive Height
-
-Height also supports responsive values on all widgets:
-
-```csharp
-new Box(Text.P("Tall on mobile, shorter on desktop"))
-    .Height(Size.Units(80).At(Breakpoint.Mobile)
-        .And(Breakpoint.Desktop, Size.Units(40)))
-```
-
-```csharp demo
-Layout.Vertical()
-    | new Box(Text.P("Tall on mobile, shorter on desktop"))
-        .Height(Size.Units(80).At(Breakpoint.Mobile)
-            .And(Breakpoint.Desktop, Size.Units(40)))
-        .Background(Colors.Primary)
-```
-
-## Conditional Visibility
-
-Hide or show widgets at specific breakpoints using `.HideOn()` and `.ShowOn()`:
-
-```csharp
-// Hidden on mobile and tablet
-new Badge("Desktop only").HideOn(Breakpoint.Mobile, Breakpoint.Tablet)
-
-// Only visible on mobile
-new Badge("Mobile only").ShowOn(Breakpoint.Mobile)
-```
-
-Under the hood, these methods build a `Responsive<bool?>` value. `.HideOn()` starts with `Default = true` (visible) and sets specified breakpoints to `false`. `.ShowOn()` starts with `Default = false` (hidden) and sets specified breakpoints to `true`.
-
-```csharp demo
-Layout.Vertical()
-    | new Badge("Desktop only").HideOn(Breakpoint.Mobile, Breakpoint.Tablet)
-    | new Badge("Mobile only").ShowOn(Breakpoint.Mobile)
-    | new Badge("Always visible")
-```
-
-## Responsive Grid Columns
-
-Adjust grid column count by viewport:
-
-```csharp
-Layout.Grid()
-    .Columns(1.At(Breakpoint.Mobile)
-        .And(Breakpoint.Tablet, 2)
-        .And(Breakpoint.Desktop, 3))
-    .Gap(4)
-```
-
-```csharp demo
-Layout.Grid()
-    .Columns(1.At(Breakpoint.Mobile)
-        .And(Breakpoint.Tablet, 2)
-        .And(Breakpoint.Desktop, 3))
-    .Gap(4)
-    | new Card("Card 1")
-    | new Card("Card 2")
-    | new Card("Card 3")
-    | new Card("Card 4")
-    | new Card("Card 5")
-    | new Card("Card 6")
-```
-
-## Responsive Orientation
-
-Switch between horizontal and vertical layouts based on screen size:
-
-```csharp
-Layout.Horizontal()
-    .Orientation(Orientation.Vertical.At(Breakpoint.Mobile)
-        .And(Breakpoint.Desktop, Orientation.Horizontal))
-```
-
-```csharp demo
-Layout.Horizontal()
-    .Orientation(Orientation.Vertical.At(Breakpoint.Mobile)
-        .And(Breakpoint.Desktop, Orientation.Horizontal))
-    | new Button("Action 1")
-    | new Button("Action 2")
-    | new Button("Action 3")
-```
-
-## Responsive Gap
-
-Vary spacing between items by viewport size:
-
-```csharp
+```csharp demo-below
 Layout.Vertical()
     .Gap(2.At(Breakpoint.Mobile).And(Breakpoint.Desktop, 6))
-```
-
-```csharp demo
-Layout.Vertical()
-    .Gap(2.At(Breakpoint.Mobile).And(Breakpoint.Desktop, 6))
-    | Text.P("Item 1")
-    | Text.P("Item 2")
-    | Text.P("Item 3")
-```
-
-## Responsive Padding
-
-Adjust layout padding by breakpoint. Since there is no `.At()` extension for `Thickness`, construct the `Responsive<Thickness?>` directly using object initialization:
-
-```csharp
-Layout.Vertical()
     .Padding(new Responsive<Thickness?>
     {
         Mobile = new Thickness(8),
         Desktop = new Thickness(24)
     })
-```
-
-```csharp demo
-Layout.Vertical()
-    .Padding(new Responsive<Thickness?>
-    {
-        Mobile = new Thickness(8),
-        Desktop = new Thickness(24)
-    })
-    | new Box(Text.P("Compact padding on mobile, spacious on desktop"))
-        .Background(Colors.Primary)
-    | new Box(Text.P("Notice the padding change"))
-        .Background(Colors.Secondary)
-```
-
-## Responsive Density
-
-Adjust touch target size by device — useful for making buttons and inputs larger on touch devices:
-
-```csharp
-new Button("Adaptive Button")
-    .Density(Density.Large.At(Breakpoint.Mobile)
-        .And(Breakpoint.Desktop, Density.Medium))
-```
-
-```csharp demo
-new Button("Adaptive Button")
-    .Density(Density.Large.At(Breakpoint.Mobile)
-        .And(Breakpoint.Desktop, Density.Medium))
+    | new Badge("Large screens").HideOn(Breakpoint.Mobile, Breakpoint.Tablet)
+    | new Badge("Phones").ShowOn(Breakpoint.Mobile)
+    | (Layout.Horizontal()
+        .Orientation(Orientation.Vertical.At(Breakpoint.Mobile)
+            .And(Breakpoint.Desktop, Orientation.Horizontal))
+        | new Button("Density")
+            .Density(Density.Large.At(Breakpoint.Mobile)
+                .And(Breakpoint.Desktop, Density.Medium))
+        | new Box(Text.P("Sized box"))
+            .Width(Size.Full().At(Breakpoint.Mobile)
+                .And(Breakpoint.Desktop, Size.Half()))
+            .Height(Size.Units(56).At(Breakpoint.Mobile)
+                .And(Breakpoint.Desktop, Size.Units(40)))
+            .Background(Colors.Primary))
+    | (Layout.Grid()
+        .Columns(1.At(Breakpoint.Mobile)
+            .And(Breakpoint.Tablet, 2)
+            .And(Breakpoint.Desktop, 3))
+        | new Card("One")
+        | new Card("Two")
+        | new Card("Three"))
 ```
 
 ## Common Patterns
@@ -277,7 +151,6 @@ Layout.Grid()
         .And(Breakpoint.Tablet, 2)
         .And(Breakpoint.Desktop, 3)
         .And(Breakpoint.Wide, 4))
-    .Gap(4)
     | new Card("Card 1")
     | new Card("Card 2")
     | new Card("Card 3")
@@ -289,19 +162,17 @@ Layout.Grid()
 Combine responsive grid, visibility, and orientation to build a dashboard that adapts across device sizes:
 
 ```csharp demo
-Layout.Vertical().Gap(4)
+Layout.Vertical()
     | new Badge("Dashboard").HideOn(Breakpoint.Mobile)
     | (Layout.Grid()
         .Columns(1.At(Breakpoint.Mobile)
             .And(Breakpoint.Desktop, 3))
-        .Gap(4)
         | new Card("Revenue")
         | new Card("Users")
         | new Card("Orders"))
     | (Layout.Horizontal()
         .Orientation(Orientation.Vertical.At(Breakpoint.Mobile)
             .And(Breakpoint.Desktop, Orientation.Horizontal))
-        .Gap(4)
         | new Box(Text.P("Chart Area")).Width(Size.Grow()).Background(Colors.Muted)
         | new Box(Text.P("Activity Feed")).Width(Size.Units(60).At(Breakpoint.Desktop)).HideOn(Breakpoint.Mobile).Background(Colors.Muted))
 ```

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/02_Layouts/10_ResponsiveDesign.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/02_Layouts/10_ResponsiveDesign.md
@@ -142,7 +142,7 @@ Summary of all responsive-capable properties:
 Collapsing Sidebar
 </Summary>
 <Body>
-Hide the sidebar on mobile and let the main content grow to fill the row on larger screens.
+Hide the sidebar on phones only. Prefer `.ShowOn(Breakpoint.Tablet)` here: `.HideOn(Breakpoint.Mobile)` sets visibility false at `Mobile`, and that value **cascades** to tablet unless you override it—so the sidebar would stay hidden on tablet too.
 
 ```csharp demo-tabs
 public class CollapsingSidebarExample : ViewBase
@@ -150,9 +150,10 @@ public class CollapsingSidebarExample : ViewBase
     public override object? Build()
     {
         return Layout.Horizontal()
+            .Height(Size.Units(36))
             | new Box(Text.P("Sidebar"))
                 .Width(Size.Units(60))
-                .HideOn(Breakpoint.Mobile)
+                .ShowOn(Breakpoint.Tablet)
                 .Background(Colors.Muted)
             | new Box(Text.P("Main Content"))
                 .Width(Size.Grow())
@@ -201,20 +202,23 @@ public class ResponsiveDashboardExample : ViewBase
 Mobile-First Form
 </Summary>
 <Body>
-Keep the form full width on phones and cap width plus gap on larger breakpoints.
+Keep the form full width on phones and cap width plus gap on larger breakpoints. Use [`.ToForm()`](../../01_Onboarding/02_Concepts/08_Forms.md) on state so fields and validation match a real model.
 
 ```csharp demo-tabs
 public class MobileFirstFormExample : ViewBase
 {
+    public record ContactModel(string Name, string Email);
+
     public override object? Build()
     {
+        var contact = UseState(() => new ContactModel("", ""));
+
         return Layout.Vertical()
             .Width(Size.Full().At(Breakpoint.Mobile)
                 .And(Breakpoint.Desktop, Size.Fraction(0.5f)))
             .Gap(4.At(Breakpoint.Mobile).And(Breakpoint.Desktop, 6))
-            | new Box(Text.P("Form field 1")).Background(Colors.Muted)
-            | new Box(Text.P("Form field 2")).Background(Colors.Muted)
-            | new Button("Submit");
+            | contact.ToForm()
+                .Required(m => m.Name, m => m.Email);
     }
 }
 ```

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/02_Layouts/10_ResponsiveDesign.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/02_Layouts/10_ResponsiveDesign.md
@@ -19,6 +19,27 @@ Build adaptive layouts that respond to viewport size using the built-in breakpoi
 
 Ivy's responsive design system lets you vary widget properties by viewport size using `Responsive<T>` values with mobile-first cascading.
 
+## Basic Usage
+
+A typical first step is a [grid](03_GridLayout.md) whose column count depends on the viewport: chain `.At()` and `.And()` on the value you pass to `.Columns()`:
+
+```csharp
+Layout.Grid()
+    .Columns(1.At(Breakpoint.Mobile).And(Breakpoint.Desktop, 3))
+    | new Card("A")
+    | new Card("B")
+    | new Card("C")
+```
+
+```csharp demo
+Layout.Grid()
+    .Columns(1.At(Breakpoint.Mobile).And(Breakpoint.Desktop, 3))
+    .Gap(4)
+    | new Card("A")
+    | new Card("B")
+    | new Card("C")
+```
+
 ## Breakpoints
 
 | Breakpoint | Max Width | Typical Device |
@@ -37,8 +58,6 @@ Layout.Grid()
     .Columns(1.At(Breakpoint.Mobile)        // 1 col on Mobile AND Tablet (cascades up)
         .And(Breakpoint.Desktop, 3))         // 3 cols on Desktop AND Wide
 ```
-
-In this example, `Tablet` inherits the `Mobile` value of 1 column, and `Wide` inherits the `Desktop` value of 3 columns.
 
 ## The Responsive type
 

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/02_Layouts/10_ResponsiveDesign.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/02_Layouts/10_ResponsiveDesign.md
@@ -120,6 +120,21 @@ Layout.Vertical()
         | new Card("Three"))
 ```
 
+## API Reference
+
+Summary of all responsive-capable properties:
+
+| Property | Widget/Layout | Type | Fluent Method |
+|---|---|---|---|
+| Width | All widgets | `Responsive<Size>` | `.Width()` |
+| Height | All widgets | `Responsive<Size>` | `.Height()` |
+| Visible | All widgets | `Responsive<bool?>` | `.HideOn()` / `.ShowOn()` |
+| Density | All widgets | `Responsive<Density?>` | `.Density()` |
+| Columns | GridLayout | `Responsive<int?>` | `.Columns()` |
+| Orientation | StackLayout | `Responsive<Orientation?>` | `.Orientation()` |
+| Gap | StackLayout, GridLayout | `Responsive<int?>` | `.Gap()` |
+| Padding | StackLayout | `Responsive<Thickness?>` | `.Padding()` |
+
 ## Examples
 
 <Details>
@@ -206,18 +221,3 @@ public class MobileFirstFormExample : ViewBase
 
 </Body>
 </Details>
-
-## API Reference
-
-Summary of all responsive-capable properties:
-
-| Property | Widget/Layout | Type | Fluent Method |
-|---|---|---|---|
-| Width | All widgets | `Responsive<Size>` | `.Width()` |
-| Height | All widgets | `Responsive<Size>` | `.Height()` |
-| Visible | All widgets | `Responsive<bool?>` | `.HideOn()` / `.ShowOn()` |
-| Density | All widgets | `Responsive<Density?>` | `.Density()` |
-| Columns | GridLayout | `Responsive<int?>` | `.Columns()` |
-| Orientation | StackLayout | `Responsive<Orientation?>` | `.Orientation()` |
-| Gap | StackLayout, GridLayout | `Responsive<int?>` | `.Gap()` |
-| Padding | StackLayout | `Responsive<Thickness?>` | `.Padding()` |


### PR DESCRIPTION
### less is more
- compressed responsive props explanation to single example
- used charp demo-tabs and csharp demo-below instead of simple csharp 
- cleaned up duplicated info
- implemented basic usage example since other docs in layout folder have it
- used examples section instead of common patterns

<img width="1429" height="754" alt="Screenshot 2026-04-14 at 02 34 50" src="https://github.com/user-attachments/assets/b8c54271-b72d-4ffb-be9b-18781aceabb1" />
<img width="1435" height="761" alt="Screenshot 2026-04-14 at 02 34 59" src="https://github.com/user-attachments/assets/c5658371-a9de-4bc7-84d6-a2ad01c024ee" />
<img width="1430" height="749" alt="Screenshot 2026-04-14 at 02 35 08" src="https://github.com/user-attachments/assets/22c272b0-1327-45e4-a28e-8ba047ca477a" />
<img width="1422" height="751" alt="Screenshot 2026-04-14 at 02 35 19" src="https://github.com/user-attachments/assets/d219af3a-345c-4850-a1e2-15ad5538ac77" />
<img width="1145" height="584" alt="Screenshot 2026-04-14 at 02 39 22" src="https://github.com/user-attachments/assets/3b7e0f26-3fbc-44d3-8e82-8aaf2218e642" />
<img width="1119" height="342" alt="Screenshot 2026-04-14 at 02 39 30" src="https://github.com/user-attachments/assets/2c79300b-2e9e-45f6-b8d4-8e8df245e1be" />
