### PR TITLE
[01098] Fix NullReferenceException in Review ContentView

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -268,6 +268,11 @@ public class ContentView(
             content |= Layout.Vertical().AlignContent(Align.Center).Height(Size.Full())
                        | Text.Muted("Loading...");
         }
+        else if (planData is null)
+        {
+            content |= Layout.Vertical().AlignContent(Align.Center).Height(Size.Full())
+                       | Text.Muted("Loading...");
+        }
         else
         {
             // Summary tab content


### PR DESCRIPTION
# Summary

## Changes

Added a null check for `planData` in the Review `ContentView.Build()` method. When `planContentQuery.Loading` is false but `planContentQuery.Value` is still null (race condition during plan selection), the UI now shows a "Loading..." message instead of crashing with a `NullReferenceException`.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs` — Added `else if (planData is null)` guard before the main content rendering block

## Commits

- 86e2e0270 [01098] Fix NullReferenceException in Review ContentView