### PR TITLE
[01099] Merge Duplicate Loading Conditions in Review ContentView

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -263,7 +263,7 @@ public class ContentView(
                 }
             }));
 
-        if (planContentQuery.Loading)
+        if (planContentQuery.Loading || planData is null)
         {
             content |= Layout.Vertical().AlignContent(Align.Center).Height(Size.Full())
                        | Text.Muted("Loading...");


### PR DESCRIPTION
## Problem

In Review ContentView, there are two separate conditions that render identical loading screens, which is redundant code that reduces maintainability.

## Solution

Merge the two conditions using the OR operator (`||`) to eliminate code duplication.

## Commits

- e01690cf6 [01099] Merge duplicate loading conditions in Review ContentView