### PR TITLE
[00175] Remove push trigger from merge-main-into-development workflow

### DIFF
--- a/.github/workflows/merge-main-into-development.yml
+++ b/.github/workflows/merge-main-into-development.yml
@@ -1,5 +1,5 @@
 # Merges main into the development branch and pushes. Then triggers Sliplane staging deploys via API.
-# Runs every 2 hours on a schedule (UTC), on push to `development`, or manually. On failure, a short summary is added to the workflow run.
+# Runs every 6 hours on a schedule (UTC) or manually. On failure, a short summary is added to the workflow run.
 
 name: Merge main into development
 
@@ -7,9 +7,6 @@ on:
   schedule:
     - cron: "0 */6 * * *"
   workflow_dispatch:
-  push:
-    branches:
-      - development
 
 concurrency:
   group: merge-main-into-development


### PR DESCRIPTION
## Problem

The GitHub Actions workflow `merge-main-into-development.yml` currently triggers on push to `development`, which can create a recursive trigger loop when the workflow itself merges `main` into `development` and pushes. Routine commits to `development` should not trigger a merge from `main`.

## Solution

Remove the `push` trigger from the workflow's `on:` block, keeping only `schedule` and `workflow_dispatch`.

## Commits

- 99141906e