### PR TITLE
[01461] Devtools bg color should be --input

### DIFF
--- a/src/frontend/src/components/devtools.css
+++ b/src/frontend/src/components/devtools.css
@@ -31,7 +31,7 @@
 .ivy-devtools-dialog {
   position: fixed;
   z-index: 100001;
-  background: var(--popover);
+  background: var(--input);
   border: 2px solid var(--primary);
   border-radius: var(--radius-boxes);
   box-shadow:


### PR DESCRIPTION
## Changes

Changed the `.ivy-devtools-dialog` background color from `var(--popover)` to `var(--input)` in `devtools.css` to match the input-style appearance of the command palette.

## API Changes

None.

## Files Modified

- `src/frontend/src/components/devtools.css` — Updated background variable on `.ivy-devtools-dialog` class (line 34)

## Commits

- 3dfc00274