### PR TITLE
[01462] Keep selected element highlighted when devtools dialog shows

### DIFF
--- a/src/frontend/src/components/DevTools.tsx
+++ b/src/frontend/src/components/DevTools.tsx
@@ -275,9 +275,12 @@ export function DevTools() {
   }, [enabled, dialogWidget, handleMouseOver, handleClick, handleKeyDown, handleWheel]);
 
   useEffect(() => {
-    if (!enabled || !highlightedWidget || dialogWidget) return;
+    if (!enabled) return;
 
-    const { bounds, type } = highlightedWidget;
+    const activeWidget = dialogWidget ?? highlightedWidget;
+    if (!activeWidget) return;
+
+    const { bounds, type } = activeWidget;
     if (bounds.width === 0 && bounds.height === 0) return;
 
     const overlay = document.createElement("div");


### PR DESCRIPTION
## Changes

Modified the overlay `useEffect` in `DevTools.tsx` to keep the selected element's highlight overlay visible when the devtools dialog opens. The early-return condition that bailed out when `dialogWidget` was set was replaced with a fallback pattern: `dialogWidget ?? highlightedWidget` is used as the active widget source, so the overlay persists for the selected widget while the dialog is open and reverts to normal hover behavior when no dialog is shown.

## API Changes

None.

## Files Modified

- **src/frontend/src/components/DevTools.tsx** — Updated overlay useEffect to use `dialogWidget ?? highlightedWidget` instead of bailing out when `dialogWidget` is set

## Commits

- 3e1d5f146