### PR TITLE
[03234] Link issue in Slack notification

### DIFF
--- a/src/tendril/Ivy.Tendril.TeamIvyConfig/Hooks/NotifySlack.ps1
+++ b/src/tendril/Ivy.Tendril.TeamIvyConfig/Hooks/NotifySlack.ps1
@@ -31,6 +31,7 @@ $plan = ConvertFrom-Yaml $planContent
 $title = if ($plan.title) { $plan.title } else { "" }
 $project = if ($plan.project) { $plan.project } else { "" }
 $prs = if ($plan.prs) { @($plan.prs) } else { @() }
+$sourceUrl = if ($plan.sourceUrl) { $plan.sourceUrl } else { "" }
 
 if ($prs.Count -eq 0) {
     Write-Output "No PRs found in plan.yaml, skipping Slack notification"
@@ -70,6 +71,18 @@ foreach ($pr in $prs) {
 }
 $prLinksText = $prLinks -join ", "
 
+# Build issue link for Slack
+$issueLink = ""
+if ($sourceUrl) {
+    if ($sourceUrl -match "github\.com/([^/]+/[^/]+)/(issues|pull)/(\d+)") {
+        $repoSlug = $Matches[1]
+        $issueNumber = $Matches[3]
+        $issueLink = "<$sourceUrl|$repoSlug#$issueNumber>"
+    } else {
+        $issueLink = $sourceUrl
+    }
+}
+
 # Build project display with emoji
 $projectDisplay = if ($slackEmoji) { "$slackEmoji $project" } else { $project }
 
@@ -91,6 +104,9 @@ if (Test-Path $screenshotsDir) {
 
 # Build message text
 $messageText = "*Title:* $title`n*Project:* $projectDisplay`n*PR:* $prLinksText"
+if ($issueLink) {
+    $messageText += "`n*Issue:* $issueLink"
+}
 
 if ($screenshotUrl) {
     # Block Kit JSON with image accessory


### PR DESCRIPTION
# Summary

## Changes

Enhanced `NotifySlack.ps1` to read the `sourceUrl` field from plan.yaml and include it as a formatted issue link in Slack notifications. GitHub issue/PR URLs are formatted as `owner/repo#number` links, matching the existing PR link style.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril.TeamIvyConfig/Hooks/NotifySlack.ps1` — Added sourceUrl reading, issue link formatting, and message text inclusion

## Commits

- 0e08c92ea [03234] Link issue in Slack notification