### PR TITLE
[03249] Add Integrations Section Tendril Docs

### DIFF
--- a/src/tendril/Ivy.Tendril.Docs/Docs/06_Integrations/01_Github.md
+++ b/src/tendril/Ivy.Tendril.Docs/Docs/06_Integrations/01_Github.md
@@ -1,0 +1,48 @@
+---
+icon: Github
+searchHints:
+  - github
+  - issues
+  - pull requests
+  - prs
+  - import
+---
+
+# GitHub
+
+<Ingress>
+Tendril integrates with GitHub for issue importing, automatic PR creation, and PR status tracking.
+</Ingress>
+
+## Authentication
+
+Tendril uses the GitHub CLI (`gh`) for authentication. Run `gh auth login` to authenticate before using GitHub features.
+
+<Callout type="info">
+Ensure `gh` is installed and available on your PATH. Tendril will prompt you during onboarding if it is missing.
+</Callout>
+
+## Importing Issues
+
+Use the **Import Issues** dialog to fetch GitHub issues and convert them into Tendril plans:
+
+1. Open the **Plans** app
+2. Select **Import Issues** from the menu
+3. Choose the target repository and filter by labels or milestones
+4. Selected issues are converted into plans via the MakePlan promptware
+
+Each imported issue retains a link back to the original GitHub issue for traceability.
+
+## Automatic PR Creation
+
+When a plan reaches the **Completed** state, the **MakePr** promptware automatically:
+
+1. Pushes the worktree branch to the remote
+2. Creates a pull request with a summary of changes
+3. Links the PR back to the plan
+
+PR settings like merge strategy are controlled by the `prRule` field in your project configuration.
+
+## PR Status Sync
+
+The **PrStatusSyncService** monitors open PRs and updates plan state when PRs are merged or closed. This keeps your plan board in sync with your repository without manual intervention.

--- a/src/tendril/Ivy.Tendril.Docs/Docs/06_Integrations/02_ClaudeCode.md
+++ b/src/tendril/Ivy.Tendril.Docs/Docs/06_Integrations/02_ClaudeCode.md
@@ -1,0 +1,42 @@
+---
+icon: Bot
+searchHints:
+  - claude
+  - claude code
+  - anthropic
+  - coding agent
+  - ai agent
+---
+
+# Claude Code
+
+<Ingress>
+Claude Code is the default coding agent in Tendril, powered by Anthropic's Claude models.
+</Ingress>
+
+## Configuration
+
+Set Claude Code as your coding agent in `config.yaml`:
+
+```yaml
+codingAgent: claude
+```
+
+Or select it in **Settings > General > Coding Agent**.
+
+## Requirements
+
+- The Claude CLI must be installed and available as `claude` on your PATH
+- Run `claude` once to complete authentication before using Tendril
+
+## Profiles
+
+Tendril maps effort levels to Claude models:
+
+| Profile | Model | Use Case |
+|---------|-------|----------|
+| `deep` | Opus | Complex multi-file changes, architecture work |
+| `balanced` | Sonnet | Standard plan execution, most tasks |
+| `quick` | Haiku | Simple fixes, formatting, small edits |
+
+The profile is selected automatically based on the plan's complexity level, or can be configured per promptware in `config.yaml`.

--- a/src/tendril/Ivy.Tendril.Docs/Docs/06_Integrations/03_Codex.md
+++ b/src/tendril/Ivy.Tendril.Docs/Docs/06_Integrations/03_Codex.md
@@ -1,0 +1,36 @@
+---
+icon: Bot
+searchHints:
+  - codex
+  - openai
+  - gpt
+  - coding agent
+---
+
+# Codex
+
+<Ingress>
+Codex is an alternative coding agent powered by OpenAI's GPT models.
+</Ingress>
+
+## Configuration
+
+Set Codex as your coding agent in `config.yaml`:
+
+```yaml
+codingAgent: codex
+```
+
+Or select it in **Settings > General > Coding Agent**.
+
+## Profiles
+
+Tendril maps effort levels to Codex models:
+
+| Profile | Model | Use Case |
+|---------|-------|----------|
+| `deep` | gpt-5.4 | Complex multi-file changes |
+| `balanced` | gpt-5.4-mini | Standard plan execution |
+| `quick` | gpt-5.3-codex | Simple fixes and small edits |
+
+The profile is selected automatically based on the plan's complexity level.

--- a/src/tendril/Ivy.Tendril.Docs/Docs/06_Integrations/04_Gemini.md
+++ b/src/tendril/Ivy.Tendril.Docs/Docs/06_Integrations/04_Gemini.md
@@ -1,0 +1,35 @@
+---
+icon: Bot
+searchHints:
+  - gemini
+  - google
+  - coding agent
+---
+
+# Gemini
+
+<Ingress>
+Gemini is an alternative coding agent powered by Google's Gemini models.
+</Ingress>
+
+## Configuration
+
+Set Gemini as your coding agent in `config.yaml`:
+
+```yaml
+codingAgent: gemini
+```
+
+Or select it in **Settings > General > Coding Agent**.
+
+## Profiles
+
+Tendril maps effort levels to Gemini models:
+
+| Profile | Model | Use Case |
+|---------|-------|----------|
+| `deep` | gemini-3-flash-preview | Complex multi-file changes |
+| `balanced` | gemini-2.5-flash | Standard plan execution |
+| `quick` | gemini-2.5-flash-lite | Simple fixes and small edits |
+
+The profile is selected automatically based on the plan's complexity level.

--- a/src/tendril/Ivy.Tendril.Docs/Docs/06_Integrations/05_JamDev.md
+++ b/src/tendril/Ivy.Tendril.Docs/Docs/06_Integrations/05_JamDev.md
@@ -1,0 +1,78 @@
+---
+icon: Bug
+searchHints:
+  - jam
+  - jam.dev
+  - webhook
+  - inbox api
+  - bug reports
+---
+
+# jam.dev
+
+<Ingress>
+Integrate jam.dev with Tendril to automatically create plans from bug reports via the inbox API webhook.
+</Ingress>
+
+## Overview
+
+jam.dev can send bug reports to Tendril's inbox API endpoint, which automatically creates plans via the MakePlan promptware.
+
+## Webhook URL
+
+Configure jam.dev to POST to:
+
+```
+http://localhost:5000/api/inbox
+```
+
+Replace `localhost:5000` with your Tendril host and port if configured differently.
+
+## Request Format
+
+Send a POST request with a JSON body:
+
+```json
+{
+  "description": "Bug description from jam.dev",
+  "project": "ProjectName",
+  "sourcePath": "optional/path/to/related/code"
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `description` | Yes | The bug report or issue description |
+| `project` | No | Target project name (defaults to `Auto`) |
+| `sourcePath` | No | Path hint for related source code |
+
+## Authentication
+
+If you have an API key configured in `config.yaml` under `api.apiKey`, include it in the request header:
+
+```
+X-Api-Key: your-api-key
+```
+
+<Callout type="tip">
+Without an API key configured, the endpoint accepts unauthenticated requests. Set an API key in production environments.
+</Callout>
+
+## Response
+
+A successful request returns:
+
+```json
+{
+  "jobId": "abc123",
+  "status": "Started",
+  "message": "Plan creation started for project 'ProjectName'"
+}
+```
+
+## Setting Up in jam.dev
+
+1. Open your jam.dev workspace settings
+2. Navigate to integrations or webhooks
+3. Add a new webhook pointing to your Tendril inbox URL
+4. Configure the payload to match the request format above

--- a/src/tendril/Ivy.Tendril.Docs/Docs/06_Integrations/06_OpenClaw.md
+++ b/src/tendril/Ivy.Tendril.Docs/Docs/06_Integrations/06_OpenClaw.md
@@ -1,0 +1,70 @@
+---
+icon: FolderInput
+searchHints:
+  - openclaw
+  - inbox
+  - folder
+  - file watcher
+  - drop folder
+---
+
+# OpenClaw
+
+<Ingress>
+Integrate OpenClaw or any file-based tool with Tendril by dropping markdown files into the Inbox folder.
+</Ingress>
+
+## Overview
+
+Tendril watches an **Inbox folder** for new markdown files and automatically converts them into plans. This provides a simple, file-based integration point for any tool that can write files to disk.
+
+## Inbox Folder Location
+
+```
+$TENDRIL_HOME/Inbox/
+```
+
+The `InboxWatcherService` monitors this directory for new `.md` files.
+
+## File Format
+
+Drop a markdown file (`.md`) with optional YAML frontmatter:
+
+```markdown
+---
+project: ProjectName
+sourcePath: optional/path/to/code
+---
+
+Describe the plan here. This text becomes the plan description
+and is passed to the MakePlan promptware.
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `project` | No | Target project name (defaults to `Auto`) |
+| `sourcePath` | No | Path hint for related source code |
+
+The content after the frontmatter becomes the plan description.
+
+<Callout type="info">
+If you omit the frontmatter entirely, the entire file content is used as the plan description with default settings.
+</Callout>
+
+## File Lifecycle
+
+1. **Drop** a `.md` file into the Inbox folder
+2. **Processing** — The file is renamed to `.md.processing` while being handled
+3. **Completion** — The file is deleted once the plan is created successfully
+
+## Recovery
+
+If Tendril restarts during processing, any `.md.processing` files are automatically recovered back to `.md` and reprocessed on startup.
+
+## Setting Up with OpenClaw
+
+Configure OpenClaw to write its output as markdown files to the Tendril Inbox folder. Each file becomes a separate plan:
+
+1. Set the output directory to `$TENDRIL_HOME/Inbox/`
+2. Use markdown format with YAML frontmatter for project targeting
+3. Tendril picks up new files automatically — no polling or API calls needed

--- a/src/tendril/Ivy.Tendril.Docs/Docs/06_Integrations/_Index.md
+++ b/src/tendril/Ivy.Tendril.Docs/Docs/06_Integrations/_Index.md
@@ -1,0 +1,14 @@
+---
+icon: Link
+searchHints:
+  - integrations
+  - external
+  - tools
+  - services
+---
+
+# Integrations
+
+<Ingress>
+Connect Tendril with external tools and services to streamline your development workflow.
+</Ingress>


### PR DESCRIPTION
# Summary

## Changes

Added a new **06_Integrations** documentation section to Tendril.Docs with seven files covering GitHub, Claude Code, Codex, Gemini, jam.dev, and OpenClaw integrations. Each page follows the existing docs pattern with YAML frontmatter, search hints, Ingress components, and structured content.

## API Changes

None.

## Files Modified

- **New section:**
  - `src/tendril/Ivy.Tendril.Docs/Docs/06_Integrations/_Index.md` — Section index
  - `src/tendril/Ivy.Tendril.Docs/Docs/06_Integrations/01_Github.md` — GitHub integration (issues, PRs, status sync)
  - `src/tendril/Ivy.Tendril.Docs/Docs/06_Integrations/02_ClaudeCode.md` — Claude Code agent configuration and profiles
  - `src/tendril/Ivy.Tendril.Docs/Docs/06_Integrations/03_Codex.md` — Codex agent configuration and profiles
  - `src/tendril/Ivy.Tendril.Docs/Docs/06_Integrations/04_Gemini.md` — Gemini agent configuration and profiles
  - `src/tendril/Ivy.Tendril.Docs/Docs/06_Integrations/05_JamDev.md` — jam.dev webhook integration via inbox API
  - `src/tendril/Ivy.Tendril.Docs/Docs/06_Integrations/06_OpenClaw.md` — OpenClaw file-based integration via Inbox folder


## Commits

- 2de5a6629