### PR TITLE
[03247] Add review actions to Tendril project config

### DIFF
--- a/src/tendril/Ivy.Tendril.TeamIvyConfig/config.yaml
+++ b/src/tendril/Ivy.Tendril.TeamIvyConfig/config.yaml
@@ -141,7 +141,13 @@ projects:
   - *o3
   context: >
     Plan management TUI. Key folders: - Services\ — ConfigService, PlanReaderService, JobService - Apps\ — PlansApp, JobsApp UI - Promptwares\ — MakePlan, UpdatePlan, SplitPlan, ExpandPlan This project uses the Ivy Framework - there's CLI helper methods you can use:  ivy docs AGENTS.md  ivy question "How do I make a button in Ivy?"
-  reviewActions: []
+  reviewActions:
+  - name: Tendril
+    condition: Test-Path "worktrees\Ivy-Framework\src\tendril\Ivy.Tendril"
+    action: dotnet run --project worktrees\Ivy-Framework\src\tendril\Ivy.Tendril
+  - name: Docs
+    condition: Test-Path "worktrees\Ivy-Framework\src\tendril\Ivy.Tendril.Docs"
+    action: dotnet run --project worktrees\Ivy-Framework\src\tendril\Ivy.Tendril.Docs --browse --find-available-port
   hooks:
   - name: SlackNotify
     when: after


### PR DESCRIPTION
# Summary

## Changes

Added two reviewActions to the Tendril project in `config.yaml`: a "Tendril" action that launches the Tendril TUI app from the plan's worktree, and a "Docs" action that launches Tendril.Docs with browser auto-open. These follow the same pattern as the Framework project's existing reviewActions.

## API Changes

New config keys under `projects[Tendril].reviewActions`:
- `Tendril` — condition: `Test-Path "worktrees\Ivy-Framework\src\tendril\Ivy.Tendril"`, runs `dotnet run --project worktrees\Ivy-Framework\src\tendril\Ivy.Tendril`
- `Docs` — condition: `Test-Path "worktrees\Ivy-Framework\src\tendril\Ivy.Tendril.Docs"`, runs `dotnet run --project worktrees\Ivy-Framework\src\tendril\Ivy.Tendril.Docs --browse --find-available-port`

## Files Modified

- `src/tendril/Ivy.Tendril.TeamIvyConfig/config.yaml` — replaced empty `reviewActions: []` with two action entries


## Commits

- fe8ed1ca0