### PR TITLE
[03250] Add View on Github button to Tendril.Docs sidebar

### DIFF
--- a/src/tendril/Ivy.Tendril.Docs/TendrilDocsServer.cs
+++ b/src/tendril/Ivy.Tendril.Docs/TendrilDocsServer.cs
@@ -42,7 +42,15 @@ public static class TendrilDocsServer
                 ).Gap(2).Padding(2).AlignContent(Align.BottomLeft)
             )
             .DefaultApp<IntroductionApp>()
-            .UsePages();
+            .UsePages()
+            .UseFooterMenuItemsTransformer((items, navigator) =>
+            {
+                var githubItem = MenuItem.Default("View on Github")
+                    .Tag("$github")
+                    .Icon(Icons.Github)
+                    .OnSelect(() => navigator.Navigate("https://github.com/Ivy-Interactive/Ivy-Framework/tree/development/src/tendril"));
+                return new[] { githubItem }.Concat(items);
+            });
         server.UseAppShell(() => new DefaultSidebarAppShell(appShellSettings));
 
         await server.RunAsync();


### PR DESCRIPTION
# Summary

## Changes

Added a "View on Github" button to the Tendril.Docs sidebar footer menu. The button uses the GitHub icon and opens the Tendril source code directory on GitHub in a new browser tab when clicked.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril.Docs/TendrilDocsServer.cs` — Added `.UseFooterMenuItemsTransformer()` call to prepend a GitHub menu item to the sidebar footer


## Commits

- 67ea50009