### PR TITLE
[03188] Add focus ring styling to SearchVariant outer container

### DIFF
--- a/src/frontend/src/widgets/inputs/TextInputWidget/variants/SearchVariant.tsx
+++ b/src/frontend/src/widgets/inputs/TextInputWidget/variants/SearchVariant.tsx
@@ -110,7 +110,8 @@ export const SearchVariant: React.FC<SearchVariantProps> = ({
     <div className="relative w-full select-none" style={styles}>
       <div
         className={cn(
-          "relative flex items-stretch rounded-field border border-input bg-transparent shadow-sm dark:bg-white/5 dark:border-white/10",
+          "relative flex items-stretch rounded-field border border-input bg-transparent shadow-sm transition-colors dark:bg-white/5 dark:border-white/10",
+          isFocused && "outline-none ring-1 ring-ring",
           props.invalid && "border-destructive",
           props.disabled && "cursor-not-allowed opacity-50",
           props.ghost &&


### PR DESCRIPTION
# Summary

## Changes

Added focus ring styling (`outline-none ring-1 ring-ring`) to SearchVariant's outer container div, matching the existing pattern in DefaultVariant. Also added `transition-colors` for smooth focus transitions.

## API Changes

None.

## Files Modified

- `src/frontend/src/widgets/inputs/TextInputWidget/variants/SearchVariant.tsx` — Added `isFocused` conditional focus ring and `transition-colors` to outer container className

## Commits

- fd54a8370281b0a68b1ec4a59ad0f3a6f03e74ae: [03188] Add focus ring styling to SearchVariant outer container