### PR TITLE
[03246] Jobs Status Not Updated When Plan Stopped

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/JobsApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/JobsApp.cs
@@ -54,7 +54,9 @@ public class JobsApp : ViewBase
                 {
                     var currentJobs = jobService.GetJobs();
                     return currentJobs
-                        .Where(j => j.Status == JobStatus.Running)
+                        .Where(j => j.Status == JobStatus.Running ||
+                                    (j.CompletedAt.HasValue &&
+                                     DateTime.UtcNow - j.CompletedAt.Value < TimeSpan.FromSeconds(3)))
                         .SelectMany(j => new[]
                         {
                             new DataTableCellUpdate(j.Id, "Timer", FormatTimer(j)),
@@ -471,6 +473,7 @@ public class JobsApp : ViewBase
             JobStatus.Failed => "Job encountered an error during execution",
             JobStatus.Timeout => "Job exceeded the configured timeout",
             JobStatus.Queued => "Waiting for a job slot to become available",
+            JobStatus.Stopped => "Job was manually stopped",
             _ => ""
         };
     }


### PR DESCRIPTION
# Summary

## Changes

Modified the Jobs table update stream in `JobsApp.cs` to include recently-completed jobs (within 3 seconds of completion) so their terminal status is pushed to the UI in real-time. Added a default status message for manually stopped jobs.

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/Apps/JobsApp.cs** — Extended update stream filter to include jobs that completed within the last 3 seconds; added `JobStatus.Stopped` case to `GetStatusMessage()`.

---

## Commits

- 6620689d4a3916d42219b3fbbce519e009f8f010 [03246] Fix job status not updating in UI when plan stopped