### PR TITLE
[00183] Replace cargo run with ivy-docs-cli in Regenerate scripts

### DIFF
--- a/src/Ivy.Docs.Shared/Regenerate.ps1
+++ b/src/Ivy.Docs.Shared/Regenerate.ps1
@@ -1,4 +1,4 @@
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
-rm -r ${scriptDir}\Generated
+rm -r "${scriptDir}\Generated"
 dotnet tool restore
-dotnet ivy-docs-cli convert ${scriptDir}\Docs ${scriptDir}\Generated
+dotnet ivy-docs-cli convert "${scriptDir}\Docs\*.md" "${scriptDir}\Generated"

--- a/src/Ivy.Docs.Shared/Regenerate.sh
+++ b/src/Ivy.Docs.Shared/Regenerate.sh
@@ -6,6 +6,6 @@ scriptDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Remove the Generated directory
 rm -rf "${scriptDir}/Generated"
 
-# Run the ivy-docs-cli command to regenerate files
+# Regenerate docs using the ivy-docs-cli NuGet tool
 dotnet tool restore
-dotnet ivy-docs-cli convert "${scriptDir}/Docs" "${scriptDir}/Generated"
+dotnet ivy-docs-cli convert "${scriptDir}/Docs"/*.md "${scriptDir}/Generated"


### PR DESCRIPTION
# Summary

## Changes

Updated `Regenerate.ps1` and `Regenerate.sh` to use proper `*.md` glob patterns when invoking `ivy-docs-cli convert`, and added proper quoting around paths in the PowerShell script. Plan 00163 had already replaced `cargo run` with `dotnet ivy-docs-cli`, so this plan refines the argument patterns to match the original `cargo run` invocations that passed `*.md` explicitly.

## API Changes

None.

## Files Modified

- `src/Ivy.Docs.Shared/Regenerate.ps1` — added quoting and `*.md` glob to `ivy-docs-cli convert` arguments
- `src/Ivy.Docs.Shared/Regenerate.sh` — added `*.md` glob to `ivy-docs-cli convert` arguments, updated comment

## Commits

- 9b915e2a7