### PR TITLE
[00181] Fix cron schedule and comment mismatches in workflow files

### DIFF
--- a/.github/workflows/merge-main-into-development.yml
+++ b/.github/workflows/merge-main-into-development.yml
@@ -5,7 +5,7 @@ name: Merge main into development
 
 on:
   schedule:
-    - cron: "0 */6 * * *"
+    - cron: "0 */2 * * *"
   workflow_dispatch:
   push:
     branches:

--- a/.github/workflows/periodic-redeploy.yml
+++ b/.github/workflows/periodic-redeploy.yml
@@ -1,5 +1,5 @@
 # Refreshes staging (docs + samples) on Sliplane via the deploy API. Does not touch git.
-# Runs every 10 minutes on a schedule, or manually from the Actions tab (no push trigger).
+# Runs every 30 minutes on a schedule, or manually from the Actions tab (no push trigger).
 
 name: Staging periodic redeploy
 


### PR DESCRIPTION
## Problem

Two GitHub Actions workflow files in Ivy-Framework have mismatches between their header comments and actual cron expressions:

1. **merge-main-into-development.yml**: Comment says "every 2 hours" but cron is `0 */6 * * *` (every 6 hours)
2. **periodic-redeploy.yml**: Comment says "every 10 minutes" but cron is `*/30 * * * *` (every 30 minutes)

## Solution

1. Changed `merge-main-into-development.yml` cron from `0 */6 * * *` to `0 */2 * * *` to match the intended "every 2 hours" schedule
2. Updated `periodic-redeploy.yml` comment from "every 10 minutes" to "every 30 minutes" to match the actual cron expression

## Commits

- 048ec8d15