### PR TITLE
[03244] Fix NullReferenceException in Review ContentView when planData is null

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -268,6 +268,14 @@ public class ContentView(
             content |= Layout.Vertical().AlignContent(Align.Center).Height(Size.Full())
                        | Text.Muted("Loading...");
         }
+        else if (planData is null)
+        {
+            var errorMsg = planContentQuery.Error is { } err
+                ? $"Failed to load plan data: {err.Message}"
+                : "Failed to load plan data. Please try refreshing.";
+            content |= Layout.Vertical().AlignContent(Align.Center).Height(Size.Full())
+                       | Text.Muted(errorMsg);
+        }
         else
         {
             // Summary tab content


### PR DESCRIPTION
# Summary

## Changes

Added a null guard for `planData` in the Review app's `ContentView.Build()` method. When `planContentQuery.Value` is null after loading completes (e.g. due to a query failure), the UI now displays an error message instead of crashing with a `NullReferenceException`. The error message includes the actual exception message when available.

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs** — Added `else if (planData is null)` branch between the loading check and the main content rendering block

## Commits

- e34c472d8 [03244] Add null guard for planData in Review ContentView