### PR TITLE
[00177] Add Prefix/Suffix slot support to BoolInput

### DIFF
--- a/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/BoolInputApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/BoolInputApp.cs
@@ -12,6 +12,7 @@ public class BoolInputApp : SampleBase
                    new Tab("Variants", new BoolInputVariantsTab()),
                    new Tab("Sizes", new BoolInputSizes()),
                    new Tab("Icons", new BoolInputIcons()),
+                   new Tab("Affixes", new BoolInputAffixesExample()),
                    new Tab("Data Binding", new BoolInputDataBinding()),
                    new Tab("Events", new BoolInputEventsTab())
                ).Variant(TabsVariant.Content);
@@ -430,5 +431,34 @@ public class BoolInputIcons : ViewBase
                | trueState
                    .ToToggleInput(Icons.Star)
                    .Label("Label");
+    }
+}
+
+public class BoolInputAffixesExample : ViewBase
+{
+    public override object Build()
+    {
+        var state = UseState(false);
+
+        return Layout.Grid().Columns(4)
+               | null!
+               | Text.Monospaced("Prefix only")
+               | Text.Monospaced("Suffix only")
+               | Text.Monospaced("Both")
+
+               | Text.Monospaced("Text prefix/suffix")
+               | state.ToBoolInput().Label("Accept").Prefix("Terms")
+               | state.ToBoolInput().Label("Accept").Suffix("Required")
+               | state.ToBoolInput().Label("Accept").Prefix("Terms").Suffix("Required")
+
+               | Text.Monospaced("Icon prefix/suffix")
+               | state.ToBoolInput().Label("Notifications").Prefix(Icons.Bell)
+               | state.ToBoolInput().Label("Notifications").Suffix(Icons.Bell)
+               | state.ToBoolInput().Label("Notifications").Prefix(Icons.Bell).Suffix(Icons.Bell)
+
+               | Text.Monospaced("Button prefix/suffix")
+               | state.ToBoolInput().Label("Feature").Prefix(new Button("Info", () => { }, icon: Icons.Info).Ghost().Small())
+               | state.ToBoolInput().Label("Feature").Suffix(new Button("Help").Ghost().Small())
+               | state.ToBoolInput().Label("Feature").Prefix(new Button("Info", () => { }, icon: Icons.Info).Ghost().Small()).Suffix(new Button("Help").Ghost().Small());
     }
 }

--- a/src/Ivy.Test/InputWidgetTests.cs
+++ b/src/Ivy.Test/InputWidgetTests.cs
@@ -384,4 +384,44 @@ public class InputPrefixSuffixSlotTests
         Assert.NotNull(slot);
         Assert.Same(button, slot!.Children[0]);
     }
+
+    [Fact]
+    public void BoolInput_Prefix_AddsPrefixSlot()
+    {
+        var state = new MockState<bool>(false);
+        var input = state.ToBoolInput().Prefix("On");
+        var slot = FindSlot(input, "Prefix");
+        Assert.NotNull(slot);
+        Assert.Equal("On", slot!.Children[0]);
+    }
+
+    [Fact]
+    public void BoolInput_Suffix_AddsSuffixSlot()
+    {
+        var state = new MockState<bool>(false);
+        var input = state.ToBoolInput().Suffix("Off");
+        var slot = FindSlot(input, "Suffix");
+        Assert.NotNull(slot);
+        Assert.Equal("Off", slot!.Children[0]);
+    }
+
+    [Fact]
+    public void BoolInput_PrefixAndSuffix_Coexist()
+    {
+        var state = new MockState<bool>(false);
+        var input = state.ToBoolInput().Prefix("On").Suffix("Off");
+        Assert.NotNull(FindSlot(input, "Prefix"));
+        Assert.NotNull(FindSlot(input, "Suffix"));
+    }
+
+    [Fact]
+    public void BoolInput_Prefix_AcceptsWidgetContent()
+    {
+        var state = new MockState<bool>(false);
+        var button = new Button("Click");
+        var input = state.ToBoolInput().Prefix(button);
+        var slot = FindSlot(input, "Prefix");
+        Assert.NotNull(slot);
+        Assert.Same(button, slot!.Children[0]);
+    }
 }

--- a/src/Ivy/Widgets/Inputs/BoolInput.cs
+++ b/src/Ivy/Widgets/Inputs/BoolInput.cs
@@ -328,5 +328,17 @@ public static class BoolInputExtensions
         return widget with { OnFocus = new(_ => { onFocus(); return ValueTask.CompletedTask; }) };
     }
 
+    private static object[] WithSlot(BoolInputBase widget, string slotName, object? value)
+    {
+        var others = widget.Children.Where(c => c is not Slot s || s.Name != slotName);
+        var result = value != null ? others.Append(new Slot(slotName, value)) : others;
+        return result.ToArray();
+    }
+
+    public static BoolInputBase Prefix(this BoolInputBase widget, object prefix)
+        => widget with { Children = WithSlot(widget, "Prefix", prefix) };
+
+    public static BoolInputBase Suffix(this BoolInputBase widget, object suffix)
+        => widget with { Children = WithSlot(widget, "Suffix", suffix) };
 
 }

--- a/src/frontend/src/widgets/inputs/BoolInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/BoolInputWidget.tsx
@@ -34,6 +34,7 @@ interface BoolInputWidgetProps {
   density?: Densities;
   autoFocus?: boolean;
   events?: string[];
+  slots?: { Prefix?: React.ReactNode[]; Suffix?: React.ReactNode[] };
   "data-testid"?: string;
 }
 
@@ -292,6 +293,7 @@ export const BoolInputWidget: React.FC<BoolInputWidgetProps> = ({
   density = Densities.Medium,
   autoFocus,
   events = EMPTY_ARRAY,
+  slots,
   "data-testid": dataTestId,
 }) => {
   const eventHandler = useEventHandler();
@@ -312,6 +314,31 @@ export const BoolInputWidget: React.FC<BoolInputWidgetProps> = ({
 
   const VariantComponent = useMemo(() => VariantComponents[variant], [variant]);
 
+  const prefixContent = slots?.Prefix;
+  const suffixContent = slots?.Suffix;
+  const hasPrefix = (prefixContent?.length ?? 0) > 0;
+  const hasSuffix = (suffixContent?.length ?? 0) > 0;
+  const hasAffixes = hasPrefix || hasSuffix;
+
+  const variantContent = (
+    <VariantComponent
+      id={id}
+      label={label}
+      description={description}
+      value={localValue}
+      disabled={disabled}
+      loading={loading}
+      nullable={nullable}
+      icon={icon}
+      invalid={invalid}
+      density={density}
+      autoFocus={autoFocus}
+      onCheckedChange={handleChange}
+      onPressedChange={handleChange}
+      data-testid={dataTestId}
+    />
+  );
+
   return (
     <div
       onBlur={(e) => {
@@ -325,22 +352,29 @@ export const BoolInputWidget: React.FC<BoolInputWidgetProps> = ({
         }
       }}
     >
-      <VariantComponent
-        id={id}
-        label={label}
-        description={description}
-        value={localValue}
-        disabled={disabled}
-        loading={loading}
-        nullable={nullable}
-        icon={icon}
-        invalid={invalid}
-        density={density}
-        autoFocus={autoFocus}
-        onCheckedChange={handleChange}
-        onPressedChange={handleChange}
-        data-testid={dataTestId}
-      />
+      {hasAffixes ? (
+        <div
+          className={cn(
+            "relative flex items-stretch rounded-field border border-input bg-transparent shadow-sm transition-colors dark:bg-white/5 dark:border-white/10",
+            invalid && "border-destructive",
+            disabled && "cursor-not-allowed opacity-50",
+          )}
+        >
+          {hasPrefix && (
+            <div className="flex items-center px-3 bg-muted text-muted-foreground border-r border-input rounded-tl-[var(--radius-fields)] rounded-bl-[var(--radius-fields)]">
+              {prefixContent}
+            </div>
+          )}
+          <div className="flex-1 px-3 py-2">{variantContent}</div>
+          {hasSuffix && (
+            <div className="flex items-center px-3 bg-muted text-muted-foreground border-l border-input rounded-tr-[var(--radius-fields)] rounded-br-[var(--radius-fields)]">
+              {suffixContent}
+            </div>
+          )}
+        </div>
+      ) : (
+        variantContent
+      )}
     </div>
   );
 };


### PR DESCRIPTION
# Summary

Added Prefix/Suffix slot support to BoolInput, following the identical `WithSlot` + extension method pattern established by TextInput and SelectInput. Backend extension methods allow chaining `.Prefix()` and `.Suffix()` on any `BoolInputBase`. Frontend conditionally wraps the bool input variant in an affix container with `bg-muted` styled prefix/suffix slots.

## API Changes

- `BoolInputExtensions.Prefix(this BoolInputBase widget, object prefix)` — new extension method
- `BoolInputExtensions.Suffix(this BoolInputBase widget, object suffix)` — new extension method
- `BoolInputWidgetProps.slots` — new optional prop `{ Prefix?: ReactNode[]; Suffix?: ReactNode[] }`

## Files Modified

- **Backend:** `src/Ivy/Widgets/Inputs/BoolInput.cs` — added `WithSlot`, `Prefix`, `Suffix` methods to `BoolInputExtensions`
- **Frontend:** `src/frontend/src/widgets/inputs/BoolInputWidget.tsx` — added `slots` prop and affix container rendering
- **Tests:** `src/Ivy.Test/InputWidgetTests.cs` — added 4 BoolInput prefix/suffix tests
- **Samples:** `src/Ivy.Samples.Shared/Apps/Widgets/Inputs/BoolInputApp.cs` — added `BoolInputAffixesExample` tab

## Commits

- 834b1e2f7