### PR TITLE
[00176] Replace http:// with https:// in docs and READMEs

### DIFF
--- a/src/.releases/Refactors/1.2.15/OAuth-Callback-URL.md
+++ b/src/.releases/Refactors/1.2.15/OAuth-Callback-URL.md
@@ -9,13 +9,13 @@ The OAuth callback URL has changed from `/ivy/webhook` to `/ivy/auth/callback`. 
 ### Before (v1.2.14 and earlier)
 
 ```
-http://localhost:5010/ivy/webhook
+https://localhost:5010/ivy/webhook
 ```
 
 ### After (v1.2.15+)
 
 ```
-http://localhost:5010/ivy/auth/callback
+https://localhost:5010/ivy/auth/callback
 ```
 
 ## How to Find Affected Code
@@ -44,7 +44,7 @@ You can also search your codebase for hardcoded webhook URLs:
 
 | Old URL | New URL |
 |---------|---------|
-| `http://localhost:5010/ivy/webhook` | `http://localhost:5010/ivy/auth/callback` |
+| `https://localhost:5010/ivy/webhook` | `https://localhost:5010/ivy/auth/callback` |
 | `https://myapp.com/ivy/webhook` | `https://myapp.com/ivy/auth/callback` |
 | `https://myapp.com/ivy/webhook/*` | `https://myapp.com/ivy/auth/callback/*` |
 

--- a/src/.releases/Refactors/1.2.27/Shorten-AppShell-Parameter.md
+++ b/src/.releases/Refactors/1.2.27/Shorten-AppShell-Parameter.md
@@ -18,14 +18,14 @@ The query parameter for controlling AppShell visibility has been shortened from 
 
 ```typescript
 const isAppShell = getAppShellParam();
-// URL: http://localhost:5000?appshell=false
+// URL: https://localhost:5000?appshell=false
 ```
 
 ## After
 
 ```typescript
 const isShell = getShellParam();
-// URL: http://localhost:5000?shell=false
+// URL: https://localhost:5000?shell=false
 ```
 
 ## Migration Path

--- a/src/.releases/weekly-notes-archive/weekly-notes-2025-09-06.md
+++ b/src/.releases/weekly-notes-archive/weekly-notes-2025-09-06.md
@@ -394,7 +394,7 @@ ivy app -p "Create a user management system" \
   --ignore-git
 
 # Run fix command without Git operations
-ivy fix --debug-agent-server http://localhost:5000 \
+ivy fix --debug-agent-server https://localhost:5000 \
   --ignore-git
 ```
 

--- a/src/.releases/weekly-notes-archive/weekly-notes-2025-11-21.md
+++ b/src/.releases/weekly-notes-archive/weekly-notes-2025-11-21.md
@@ -338,8 +338,8 @@ All Ivy framework endpoints have been reorganized under a single `/ivy` prefix:
 1. **Authentication Callback URLs** - Update redirect URIs in OAuth provider dashboards:
 
    ```
-   Before: http://localhost:5010/webhook
-   After:  http://localhost:5010/ivy/webhook
+   Before: https://localhost:5010/webhook
+   After:  https://localhost:5010/ivy/webhook
    ```
 
 2. **Image Paths** - Update asset references:
@@ -355,8 +355,8 @@ All Ivy framework endpoints have been reorganized under a single `/ivy` prefix:
 3. **Health Check Monitoring** - Update URLs in monitoring tools:
 
    ```
-   Before: http://localhost:5010/health
-   After:  http://localhost:5010/ivy/health
+   Before: https://localhost:5010/health
+   After:  https://localhost:5010/ivy/health
    ```
 
 ### Chart Toolboxes Now Opt-In

--- a/src/.releases/weekly-notes-archive/weekly-notes-2026-01-08.md
+++ b/src/.releases/weekly-notes-archive/weekly-notes-2026-01-08.md
@@ -165,7 +165,7 @@ Configure your GitHub OAuth App credentials using .NET user secrets (development
 ```terminal
 dotnet user-secrets set "GitHub:ClientId" "your_client_id"
 dotnet user-secrets set "GitHub:ClientSecret" "your_client_secret"
-dotnet user-secrets set "GitHub:RedirectUri" "http://localhost:5010/ivy/webhook"
+dotnet user-secrets set "GitHub:RedirectUri" "https://localhost:5010/ivy/webhook"
 ```
 
 ### Dynamic Page Titles

--- a/src/.releases/weekly-notes-archive/weekly-notes-2026-03-13.md
+++ b/src/.releases/weekly-notes-archive/weekly-notes-2026-03-13.md
@@ -70,7 +70,7 @@ new Button("Save").Icon(Icons.Save)
 
 The OAuth authentication callback URL has changed from `/ivy/webhook` to `/ivy/auth/callback`.
 
-- Local development: `http://localhost:5010/ivy/auth/callback`
+- Local development: `https://localhost:5010/ivy/auth/callback`
 - Production: `https://your-app.com/ivy/auth/callback`
 
 ### DesktopWindow API Improvements

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/08_Table.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/08_Table.md
@@ -35,9 +35,9 @@ public class BasicRowTable : ViewBase
     public override object? Build()
     {
         var products = new[] {
-            new {Sku = "1234", Name = "T-shirt", Price = 10, Url = "http://example.com/tshirt"},
-            new {Sku = "1235", Name = "Jeans", Price = 20, Url = "http://example.com/jeans"},
-            new {Sku = "1236", Name = "Sneakers", Price = 30, Url = "http://example.com/sneakers"},
+            new {Sku = "1234", Name = "T-shirt", Price = 10, Url = "https://example.com/tshirt"},
+            new {Sku = "1235", Name = "Jeans", Price = 20, Url = "https://example.com/jeans"},
+            new {Sku = "1236", Name = "Sneakers", Price = 30, Url = "https://example.com/sneakers"},
         };
 
         return products.ToTable()
@@ -74,8 +74,8 @@ public class TableConfigurationExample : ViewBase
     public override object? Build()
     {
         var products = new[] {
-            new {Sku = "1234", Name = "T-shirt", Price = 10, Url = "http://example.com/tshirt", _hiddenNotes = "archived"},
-            new {Sku = "1235", Name = "Jeans", Price = 20, Url = "http://example.com/jeans", _hiddenNotes = "best-seller"}
+            new {Sku = "1234", Name = "T-shirt", Price = 10, Url = "https://example.com/tshirt", _hiddenNotes = "archived"},
+            new {Sku = "1235", Name = "Jeans", Price = 20, Url = "https://example.com/jeans", _hiddenNotes = "best-seller"}
         };
 
         return products.ToTable()
@@ -339,8 +339,8 @@ public class CellBuildersExample : ViewBase
     public override object? Build()
     {
         var products = new[] {
-            new {Sku = "1234", Name = "T-shirt", Price = 10, Url = "http://example.com/tshirt", Description = "High quality cotton T-shirt with a comfortable fit and durable construction. Perfect for everyday wear and available in multiple colors."},
-            new {Sku = "1235", Name = "Jeans", Price = 20, Url = "http://example.com/jeans", Description = "Classic denim jeans with a modern cut and premium stitching. Features include reinforced pockets, comfortable waistband, and fade-resistant fabric."}
+            new {Sku = "1234", Name = "T-shirt", Price = 10, Url = "https://example.com/tshirt", Description = "High quality cotton T-shirt with a comfortable fit and durable construction. Perfect for everyday wear and available in multiple colors."},
+            new {Sku = "1235", Name = "Jeans", Price = 20, Url = "https://example.com/jeans", Description = "Classic denim jeans with a modern cut and premium stitching. Features include reinforced pockets, comfortable waistband, and fade-resistant fabric."}
         };
 
         return products.ToTable()

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/14_Terminal.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/14_Terminal.md
@@ -72,7 +72,7 @@ Layout.Vertical()
         .AddCommand("myapp init")
         .AddOutput("Configuration created at ./myapp.config.json")
         .AddCommand("myapp start")
-        .AddOutput("Server running at http://localhost:3000")
+        .AddOutput("Server running at https://localhost:3000")
 ```
 
 </Body>

--- a/src/Ivy.Samples.Shared/Apps/Widgets/TableApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/TableApp.cs
@@ -38,11 +38,11 @@ public class TableSizesExample : ViewBase
         //Anonymous type array
 
         var products = new[] {
-            new {Sku = "1234", Foo = true, Name = "T-shirt", Price = 10.0, Url = "http://example.com/tshirt"},
-            new {Sku = "1235", Foo = true, Name = "Jeans", Price = 20.0, Url = "http://example.com/jeans"},
-            new {Sku = "1236", Foo = true, Name = "Sneakers", Price = 30.0, Url = "http://example.com/sneakers"},
-            new {Sku = "1237", Foo = true, Name = "Hat", Price = 5.0, Url = "http://example.com/hat"},
-            new {Sku = "1238", Foo = true, Name = "Premium Luxury Extra-Soft Organic Cotton Socks with Reinforced Heel and Toe - Perfect for All-Day Comfort and Athletic Performance - Available in Multiple Colors", Price = 2.0, Url = "http://example.com/socks"}
+            new {Sku = "1234", Foo = true, Name = "T-shirt", Price = 10.0, Url = "https://example.com/tshirt"},
+            new {Sku = "1235", Foo = true, Name = "Jeans", Price = 20.0, Url = "https://example.com/jeans"},
+            new {Sku = "1236", Foo = true, Name = "Sneakers", Price = 30.0, Url = "https://example.com/sneakers"},
+            new {Sku = "1237", Foo = true, Name = "Hat", Price = 5.0, Url = "https://example.com/hat"},
+            new {Sku = "1238", Foo = true, Name = "Premium Luxury Extra-Soft Organic Cotton Socks with Reinforced Heel and Toe - Perfect for All-Day Comfort and Athletic Performance - Available in Multiple Colors", Price = 2.0, Url = "https://example.com/socks"}
         };
 
         // Table with long headers to test overflow and tooltips


### PR DESCRIPTION
# Summary

## Changes

Replaced all `http://` URLs with `https://` across documentation files, sample code, refactor guides, and weekly notes. This covers both `http://example.com` placeholder URLs in Table widget examples and `http://localhost` URLs in developer-facing docs (which were misleading since Ivy binds HTTPS-only locally).

## API Changes

None.

## Files Modified

- **Sample apps:**
  - `src/Ivy.Samples.Shared/Apps/Widgets/TableApp.cs` — 5 `http://example.com` replacements

- **Widget documentation:**
  - `src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/08_Table.md` — 7 `http://example.com` replacements
  - `src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/14_Terminal.md` — 1 `http://localhost` replacement

- **Refactor guides:**
  - `src/.releases/Refactors/1.2.15/OAuth-Callback-URL.md` — 4 `http://localhost:5010` replacements
  - `src/.releases/Refactors/1.2.27/Shorten-AppShell-Parameter.md` — 2 `http://localhost:5000` replacements

- **Weekly notes:**
  - `src/.releases/weekly-notes-archive/weekly-notes-2026-03-13.md` — 1 replacement
  - `src/.releases/weekly-notes-archive/weekly-notes-2026-01-08.md` — 1 replacement
  - `src/.releases/weekly-notes-archive/weekly-notes-2025-11-21.md` — 4 replacements
  - `src/.releases/weekly-notes-archive/weekly-notes-2025-09-06.md` — 1 replacement

## Commits

- 1a927dbe8