### PR TITLE
[01463] Add visual distinction for selected vs hover overlay in DevTools

### DIFF
--- a/src/frontend/src/components/DevTools.tsx
+++ b/src/frontend/src/components/DevTools.tsx
@@ -283,8 +283,9 @@ export function DevTools() {
     const { bounds, type } = activeWidget;
     if (bounds.width === 0 && bounds.height === 0) return;
 
+    const isSelected = !!dialogWidget;
     const overlay = document.createElement("div");
-    overlay.className = "ivy-devtools ivy-devtools-overlay";
+    overlay.className = `ivy-devtools ivy-devtools-overlay${isSelected ? " ivy-devtools-overlay--selected" : ""}`;
     Object.assign(overlay.style, {
       top: `${bounds.top}px`,
       left: `${bounds.left}px`,

--- a/src/frontend/src/components/devtools.css
+++ b/src/frontend/src/components/devtools.css
@@ -8,6 +8,14 @@
   box-sizing: border-box;
 }
 
+.ivy-devtools-overlay--selected {
+  border-style: solid;
+  border-width: 2px;
+  background: color-mix(in srgb, var(--primary) 15%, transparent);
+  border-color: var(--primary);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--primary) 40%, transparent);
+}
+
 .ivy-devtools-label {
   position: absolute;
   top: 0;


### PR DESCRIPTION
## Problem

After Plan 01462 added overlay persistence for the selected widget, both hover and selected states use the identical visual style: a `2px solid var(--primary)` border with `25% primary` background fill. Users cannot visually distinguish between "I'm hovering over this widget" and "I have this widget selected with the dialog open."

## Solution

Add a CSS modifier class `ivy-devtools-overlay--selected` when the overlay represents the selected widget (`dialogWidget` is set). The selected state uses:
- A slightly **lower** background opacity (15% vs 25%) — making the content more visible while selected
- An additional subtle outer `box-shadow` glow to create a "locked-in" feel
- The hover state retains its current stronger fill (25%) for immediate feedback

## Commits

- 9d1f43d61