### PR TITLE
[01466] Devtools dialog should close when clicking outside

### DIFF
--- a/src/frontend/src/components/DevTools.tsx
+++ b/src/frontend/src/components/DevTools.tsx
@@ -286,7 +286,15 @@ export function DevTools() {
         document.removeEventListener("keydown", handleKeyDown);
       };
     }
-  }, [enabled, dialogWidget, handleMouseOver, handleClick, handleKeyDown, handleWheel, closeDialog]);
+  }, [
+    enabled,
+    dialogWidget,
+    handleMouseOver,
+    handleClick,
+    handleKeyDown,
+    handleWheel,
+    closeDialog,
+  ]);
 
   useEffect(() => {
     if (!enabled || !highlightedWidget || dialogWidget) return;
@@ -317,7 +325,11 @@ export function DevTools() {
   return (
     <div className="ivy-devtools-container">
       {dialogWidget && (
-        <div ref={dialogRef} className="ivy-devtools ivy-devtools-dialog" style={getDialogPosition(clickPosition)}>
+        <div
+          ref={dialogRef}
+          className="ivy-devtools ivy-devtools-dialog"
+          style={getDialogPosition(clickPosition)}
+        >
           <input
             ref={inputRef}
             type="text"

--- a/src/frontend/src/components/DevTools.tsx
+++ b/src/frontend/src/components/DevTools.tsx
@@ -96,6 +96,7 @@ export function DevTools() {
   const { highlightedWidget, widgetStack, dialogWidget, dialogText, clickPosition } = devState;
 
   const inputRef = useRef<HTMLInputElement>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
 
   const getWidgetInfo = useCallback((element: HTMLElement): WidgetInfo => {
     const widgetId = element.getAttribute("id")!;
@@ -261,18 +262,31 @@ export function DevTools() {
         capture: true,
       });
       document.body.style.cursor = "crosshair";
+
+      document.addEventListener("keydown", handleKeyDown);
+
+      return () => {
+        document.removeEventListener("mouseover", handleMouseOver, true);
+        document.removeEventListener("click", handleClick, true);
+        document.removeEventListener("keydown", handleKeyDown);
+        document.removeEventListener("wheel", handleWheel, true);
+        document.body.style.cursor = "";
+      };
+    } else {
+      const handleClickOutside = (e: MouseEvent) => {
+        if (dialogRef.current && !dialogRef.current.contains(e.target as Node)) {
+          closeDialog();
+        }
+      };
+      document.addEventListener("mousedown", handleClickOutside, true);
+      document.addEventListener("keydown", handleKeyDown);
+
+      return () => {
+        document.removeEventListener("mousedown", handleClickOutside, true);
+        document.removeEventListener("keydown", handleKeyDown);
+      };
     }
-
-    document.addEventListener("keydown", handleKeyDown);
-
-    return () => {
-      document.removeEventListener("mouseover", handleMouseOver, true);
-      document.removeEventListener("click", handleClick, true);
-      document.removeEventListener("keydown", handleKeyDown);
-      document.removeEventListener("wheel", handleWheel, true);
-      document.body.style.cursor = "";
-    };
-  }, [enabled, dialogWidget, handleMouseOver, handleClick, handleKeyDown, handleWheel]);
+  }, [enabled, dialogWidget, handleMouseOver, handleClick, handleKeyDown, handleWheel, closeDialog]);
 
   useEffect(() => {
     if (!enabled || !highlightedWidget || dialogWidget) return;
@@ -303,7 +317,7 @@ export function DevTools() {
   return (
     <div className="ivy-devtools-container">
       {dialogWidget && (
-        <div className="ivy-devtools ivy-devtools-dialog" style={getDialogPosition(clickPosition)}>
+        <div ref={dialogRef} className="ivy-devtools ivy-devtools-dialog" style={getDialogPosition(clickPosition)}>
           <input
             ref={inputRef}
             type="text"


### PR DESCRIPTION
## Summary

Added click-outside-to-close behavior to the DevTools dialog. When the dialog is open, a `mousedown` listener on `document` (capture phase) detects clicks outside the dialog element and closes it via `closeDialog()`. The useEffect cleanup was restructured so each branch (dialog open vs closed) returns its own cleanup function, preventing removal of listeners that were never added.

## Files Modified

- **src/frontend/src/components/DevTools.tsx** — Added `dialogRef` ref, mousedown click-outside handler in the `useEffect`, and attached `ref={dialogRef}` to the dialog div.

## Commits

- `0ceb57832` [01466] Add click-outside-to-close for DevTools dialog
- `355cfe340` [01466] Fix formatting in DevTools.tsx

Closes #4052