### PR TITLE
[00189] Audit and fix cron schedule mismatches across Ivy repos

### DIFF
--- a/.github/workflows/merge-main-into-development.yml
+++ b/.github/workflows/merge-main-into-development.yml
@@ -1,5 +1,5 @@
 # Merges main into the development branch and pushes. Then triggers Sliplane staging deploys via API.
-# Runs every 6 hours on a schedule (UTC) or manually. On failure, a short summary is added to the workflow run.
+# Runs every 2 hours on a schedule (UTC) or manually. On failure, a short summary is added to the workflow run.
 
 name: Merge main into development
 


### PR DESCRIPTION
# Summary

## Changes

Updated the `merge-main-into-development.yml` workflow across 5 Ivy repos to use a consistent 2-hour cron schedule (`0 */2 * * *`) with matching comments. Ivy-Framework only needed a comment fix (cron was already updated by plan 00181). Ivy-Services and Ivy had both comment and cron changes. Ivy-Mcp and Ivy-Examples had the workflow on `development` but not `main`, so the full workflow file was added to `main` with the corrected schedule.

## API Changes

None.

## Files Modified

- **Ivy-Framework**: `.github/workflows/merge-main-into-development.yml` (comment fix only)
- **Ivy-Services**: `.github/workflows/merge-main-into-development.yml` (comment + cron)
- **Ivy-Mcp**: `.github/workflows/merge-main-into-development.yml` (new file on main branch, copied from development with corrected schedule)
- **Ivy**: `.github/workflows/merge-main-into-development.yml` (comment + cron)
- **Ivy-Examples**: `.github/workflows/merge-main-into-development.yml` (new file on main branch, copied from development with corrected schedule)

## Commits

- ed94e1535