### PR TITLE
[03233] Auto-close and tag GitHub issues when PRs are created

### DIFF
--- a/src/tendril/Ivy.Tendril/Promptwares/MakePr/Tools/Run-MakePr.ps1
+++ b/src/tendril/Ivy.Tendril/Promptwares/MakePr/Tools/Run-MakePr.ps1
@@ -16,6 +16,17 @@ Write-Host "Plan: $PlanFolder" -ForegroundColor Cyan
 $planYamlPath = Join-Path $PlanFolder "plan.yaml"
 $planYaml = Get-Content $planYamlPath -Raw | ConvertFrom-Yaml
 
+# Extract issue number if sourceUrl is a GitHub issue
+$issueNumber = $null
+$issueRepo = $null
+if ($planYaml.sourceUrl -match 'github\.com/([^/]+)/([^/]+)/issues/(\d+)') {
+    $issueOwner = $Matches[1]
+    $issueRepoName = $Matches[2]
+    $issueNumber = $Matches[3]
+    $issueRepo = "$issueOwner/$issueRepoName"
+    Write-Host "Linked to issue: $issueRepo#$issueNumber" -ForegroundColor Cyan
+}
+
 # Step 0: Check if already completed
 if ($planYaml.state -eq "Completed") {
     Write-Host "`nPlan is already completed. PRs:" -ForegroundColor Green
@@ -150,6 +161,11 @@ if (Test-Path $worktreesDir) {
             $commits = $planYaml.commits -join ", "
             $prBody += "`n`n## Commits`n`n- $commits"
 
+            # Add issue reference to PR body
+            if ($issueNumber -and $issueRepo) {
+                $prBody += "`n`nCloses $issueRepo#$issueNumber"
+            }
+
             # Add artifacts if any
             if ($artifactMarkdown) {
                 $prBody += "`n`n## Artifacts`n`n$artifactMarkdown"
@@ -165,6 +181,14 @@ if (Test-Path $worktreesDir) {
                 $prNumber = $Matches[1]
             } else {
                 Write-Error "Could not extract PR number from: $prUrl"
+            }
+
+            # Tag issue as in-progress for non-yolo
+            if ($issueNumber -and $issueRepo -and $prRule -ne "yolo") {
+                Write-Host "`n  [3.5] Tagging linked issue as in-progress..." -ForegroundColor Yellow
+                gh label create "tendril:in-progress" --repo $issueRepo --description "PR open, awaiting review" --color "FBCA04" --force 2>$null
+                gh issue edit $issueNumber --repo $issueRepo --add-label "tendril:in-progress"
+                Write-Host "  Issue $issueRepo#$issueNumber tagged as in-progress" -ForegroundColor Gray
             }
 
             # Step 4: Apply PR rule
@@ -199,6 +223,17 @@ if (Test-Path $worktreesDir) {
                         Write-Host "  Merge failed, retrying with squash..."
                         gh pr merge $prNumber --repo $ownerRepo --squash --delete-branch --admin
                         Write-Host "  PR squashed and merged successfully" -ForegroundColor Green
+                    }
+
+                    # Close linked issue if exists
+                    if ($issueNumber -and $issueRepo) {
+                        Write-Host "`n  [4.5] Closing linked issue..." -ForegroundColor Yellow
+                        gh label create "tendril:automated" --repo $issueRepo --description "Closed automatically by Tendril" --color "0E8A16" --force 2>$null
+                        gh issue edit $issueNumber --repo $issueRepo --add-label "tendril:automated"
+                        $comment = "Automatically closed by Tendril PR: $prUrl (Plan $planId)"
+                        gh issue comment $issueNumber --repo $issueRepo --body $comment
+                        gh issue close $issueNumber --repo $issueRepo --reason completed
+                        Write-Host "  Issue $issueRepo#$issueNumber closed" -ForegroundColor Green
                     }
 
                     # Pull default branch


### PR DESCRIPTION
# Summary

## Changes

Added automatic GitHub issue handling to the MakePr workflow. When a plan has a `sourceUrl` pointing to a GitHub issue, the PR body now includes a `Closes owner/repo#N` reference. For yolo PRs, the issue is automatically closed with a comment and `tendril:automated` label after merge. For default (non-yolo) PRs, the issue is tagged with `tendril:in-progress` when the PR is created.

## API Changes

None. This adds behavior to the existing `Run-MakePr.ps1` script based on the already-existing `sourceUrl` field in `plan.yaml`.

## Files Modified

- `src/tendril/Ivy.Tendril/Promptwares/MakePr/Tools/Run-MakePr.ps1` — Added issue extraction, PR body reference, in-progress tagging, and post-merge close logic

## Commits

- d4f3d7269 [03233] Add automatic GitHub issue tagging and closing in MakePr