### PR TITLE
[03252] Inline code markdown doesn't scale in markdown renderer

### DIFF
--- a/src/frontend/src/lib/styles.ts
+++ b/src/frontend/src/lib/styles.ts
@@ -765,7 +765,7 @@ export const typography: Record<string, string> = {
   blockquote: "border-l-2 pl-6 italic",
 
   // Code
-  code: "relative rounded bg-muted px-[0.25rem] py-[0.05rem] font-mono text-sm font-semibold h-fit",
+  code: "relative rounded bg-muted px-[0.25rem] py-[0.05rem] font-mono text-[0.875em] font-semibold h-fit",
 
   // Table
   table: "w-full border-collapse border border-border",


### PR DESCRIPTION
# Summary

## Changes

Replaced the fixed `text-sm` Tailwind class (absolute 14px) with `text-[0.875em]` (relative to parent font size) in the `typography.code` definition. This ensures inline code blocks scale proportionally when MarkdownWidget applies CSS transforms for Small (`scale(0.85)`) and Large (`scale(1.15)`) density modes.

## API Changes

None.

## Files Modified

- **src/frontend/src/lib/styles.ts** — Changed `typography.code` class from `text-sm` to `text-[0.875em]`

## Commits

- 5fa53b779 [03252] Use relative em unit for inline code font size