### PR TITLE
[03260] Add filtering to Review view

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Plans/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Plans/ContentView.cs
@@ -1,0 +1,557 @@
+using System.Text.RegularExpressions;
+using Ivy.Core;
+using Ivy.Tendril.Apps.Plans.Dialogs;
+using Ivy.Tendril.Services;
+using Ivy.Tendril.Views;
+
+namespace Ivy.Tendril.Apps.Plans;
+
+public class ContentView(
+    PlanFile? selectedPlan,
+    List<PlanFile> allPlans,
+    IState<PlanFile?> selectedPlanState,
+    IPlanReaderService planService,
+    IJobService jobService,
+    Action refreshPlans,
+    IConfigService config,
+    IGitService gitService) : ViewBase
+{
+    private readonly List<PlanFile> _allPlans = allPlans;
+    private readonly IConfigService _config = config;
+    private readonly IGitService _gitService = gitService;
+    private readonly IJobService _jobService = jobService;
+    private readonly IPlanReaderService _planService = planService;
+    private readonly Action _refreshPlans = refreshPlans;
+    private readonly PlanFile? _selectedPlan = selectedPlan;
+    private readonly IState<PlanFile?> _selectedPlanState = selectedPlanState;
+
+    public override object Build()
+    {
+        var downloadUrl = PlanDownloadHelper.UsePlanDownload(Context, _planService, _selectedPlan);
+        var client = UseService<IClientProvider>();
+        var copyToClipboard = UseClipboard();
+        var updateDialogOpen = UseState(false);
+        var deleteDialogOpen = UseState(false);
+        var createIssueDialogOpen = UseState(false);
+        var openFile = UseState<string?>(null);
+        var selectedRepoState = UseState<string?>(null);
+        var issueAssigneeState = UseState<string?>(null);
+        var issueLabelsState = UseState<string[]>([]);
+        var issueCommentState = UseState("");
+
+        var updateText = UseState("");
+        var isEditing = UseState(false);
+        var editContent = UseState("");
+        var originalContent = UseState("");
+        var isEditingPrev = UseState(false);
+        var lastPlanId = UseState(_selectedPlan?.Id ?? -1);
+
+        var selectedTab = UseState(0);
+        var openVerification = UseState<string?>(null);
+        var openCommit = UseState<string?>(null);
+
+        var selectedPlanRef = UseRef(_selectedPlan);
+
+        var verificationReportQuery = UseQuery<string, string>(
+            openVerification.Value ?? "",
+            async (name, ct) =>
+            {
+                if (string.IsNullOrEmpty(name) || _selectedPlan is null) return "";
+                var verificationDir = Path.GetFullPath(Path.Combine(_selectedPlan.FolderPath, "verification"));
+                var resolvedPath = Path.GetFullPath(Path.Combine(verificationDir, $"{name}.md"));
+                if (!resolvedPath.StartsWith(verificationDir, StringComparison.OrdinalIgnoreCase))
+                    return "Access denied: file is outside the verification folder.";
+                return await Task.Run(() =>
+                    File.Exists(resolvedPath) ? FileHelper.ReadAllText(resolvedPath) : $"No report found for {name}.", ct);
+            },
+            initialValue: ""
+        );
+
+        var commitQuery = UseQuery<PlanContentHelpers.CommitDetailData?, string>(
+            openCommit.Value ?? "",
+            async (hash, ct) =>
+            {
+                if (string.IsNullOrEmpty(hash)) return null;
+                var repoPaths2 = _selectedPlan!.GetEffectiveRepoPaths(_config);
+                return await Task.Run(() =>
+                {
+                    foreach (var repo in repoPaths2)
+                    {
+                        var title = _gitService.GetCommitTitle(repo, hash);
+                        if (title != null)
+                        {
+                            var diff = _gitService.GetCommitDiff(repo, hash);
+                            var files = _gitService.GetCommitFiles(repo, hash);
+                            return new PlanContentHelpers.CommitDetailData(title, diff, files);
+                        }
+                    }
+                    return null;
+                }, ct);
+            },
+            initialValue: null
+        );
+
+        var planContentQuery = UseQuery<PlanContentData, string>(
+            _selectedPlan?.FolderPath ?? "",
+            async (folderPath, ct) =>
+            {
+                return await Task.Run(() =>
+                {
+                    if (_selectedPlan is null)
+                        return new PlanContentData(null,
+                            new Dictionary<string, List<string>>(), new List<PlanContentHelpers.CommitRow>(),
+                            new Dictionary<string, bool>());
+
+                    // Summary
+                    var summPath = Path.Combine(folderPath, "artifacts", "summary.md");
+                    var summaryMd = File.Exists(summPath) ? FileHelper.ReadAllText(summPath) : null;
+
+                    // Artifacts
+                    var artifacts = PlanContentHelpers.GetArtifacts(folderPath);
+
+                    // Commit rows
+                    var commitRows = PlanContentHelpers.BuildCommitRows(_selectedPlan!, _config, _gitService);
+
+                    // Verification report existence
+                    var verReports = _selectedPlan.Verifications.ToDictionary(
+                        v => v.Name,
+                        v => File.Exists(Path.Combine(folderPath, "verification", $"{v.Name}.md")));
+
+                    return new PlanContentData(summaryMd, artifacts, commitRows, verReports);
+                }, ct);
+            },
+            initialValue: new PlanContentData(null,
+                new Dictionary<string, List<string>>(), new List<PlanContentHelpers.CommitRow>(), new Dictionary<string, bool>())
+        );
+
+        UseEffect(() =>
+        {
+            var plan = selectedPlanRef.Value;
+            if (isEditing.Value && !isEditingPrev.Value)
+            {
+                if (plan != null)
+                {
+                    var raw = _planService.ReadRawPlan(plan.FolderName);
+                    editContent.Set(raw);
+                    originalContent.Set(raw);
+                }
+                else
+                {
+                    isEditing.Set(false);
+                }
+            }
+            else if (!isEditing.Value && isEditingPrev.Value)
+            {
+                if (plan != null && editContent.Value != originalContent.Value)
+                {
+                    _planService.SaveRevision(plan.FolderName, editContent.Value);
+                    _refreshPlans();
+                }
+            }
+
+            isEditingPrev.Set(isEditing.Value);
+        }, isEditing);
+
+        UseEffect(() => { selectedTab.Set(0); }, _selectedPlanState);
+
+#pragma warning disable CS8601
+        selectedPlanRef.Value = _selectedPlan;
+#pragma warning restore CS8601
+
+        if (lastPlanId.Value != (_selectedPlan?.Id ?? -1))
+        {
+            lastPlanId.Set(_selectedPlan?.Id ?? -1);
+            isEditing.Set(false);
+        }
+
+        if (_selectedPlan is null)
+        {
+            if (_allPlans.Count == 0)
+                return Layout.Vertical().AlignContent(Align.Center).Height(Size.Full()).Gap(4).Padding(8)
+                       | new Icon(Icons.Feather).Large().Color(Colors.Gray)
+                       | Text.H3("No draft plans")
+                       | new NewPlanButton().Width(Size.Fit());
+
+            return Layout.Vertical().AlignContent(Align.Center).Height(Size.Full())
+                   | Text.Muted("Select a plan from the sidebar");
+        }
+
+        var currentIndex = _allPlans.FindIndex(p => p.FolderName == _selectedPlan.FolderName);
+
+        var header = Layout.Horizontal().Width(Size.Full()).Padding(1).Gap(2)
+                     | Text.Block($"#{_selectedPlan.Id} {_selectedPlan.Title}").Bold();
+        header |= Text.Muted($"rev:{_selectedPlan.RevisionCount}");
+
+        if (!string.IsNullOrEmpty(_selectedPlan.SourceUrl))
+            header |= new Button(_selectedPlan.SourceUrl.Contains("/pull/") ? "PR" : "Issue")
+                .Icon(Icons.ExternalLink).Ghost().OnClick(() => client.OpenUrl(_selectedPlan.SourceUrl));
+
+        if (_selectedPlan.DependsOn.Count > 0)
+        {
+            var depIds = string.Join(", ", _selectedPlan.DependsOn.Select(d =>
+            {
+                var name = Path.GetFileName(d);
+                var dashIdx = name.IndexOf('-');
+                return dashIdx > 0 ? name[..dashIdx] : name;
+            }));
+            header |= new Badge($"Depends on: {depIds}").Variant(BadgeVariant.Secondary);
+        }
+
+        header |= isEditing.ToSwitchInput(Icons.Code);
+        header |= new Spacer().Width(Size.Grow());
+        header |= Text.Rich()
+            .Bold($"{currentIndex + 1}/{_allPlans.Count}", word: true)
+            .Muted("plans", word: true);
+        header |= new Button("Execute").Icon(Icons.Rocket).Primary().ShortcutKey("e").OnClick(() =>
+        {
+            _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Building);
+            _jobService.StartJob("ExecutePlan", _selectedPlan.FolderPath);
+            _refreshPlans();
+        });
+
+        // Build tab contents
+        var content = Layout.Vertical();
+        var planData = planContentQuery.Value;
+
+        // Plan tab content
+        object planTabContent;
+        if (isEditing.Value)
+            planTabContent = editContent.ToCodeInput()
+                .Language(Languages.Markdown)
+                .Width(Size.Full());
+        else
+        {
+            var planLayout = Layout.Vertical();
+            if (_selectedPlan.Status == PlanStatus.Failed) planLayout |= BuildFailureCallout(_selectedPlan);
+            var annotatedContent = MarkdownHelper.AnnotateBrokenFileLinks(_selectedPlan.LatestRevisionContent);
+            annotatedContent = MarkdownHelper.AnnotateBrokenPlanLinks(annotatedContent, _planService.PlansDirectory);
+            planLayout |= new Markdown(annotatedContent)
+                .DangerouslyAllowLocalFiles()
+                .OnLinkClick(FileLinkHelper.CreateFileLinkClickHandler(openFile, planId =>
+                {
+                    var planFolder = Directory.GetDirectories(_planService.PlansDirectory, $"{planId:D5}-*")
+                        .FirstOrDefault();
+                    if (planFolder != null)
+                    {
+                        var plan = _planService.GetPlanByFolder(planFolder);
+                        if (plan != null)
+                            _selectedPlanState.Set(plan);
+                    }
+                }));
+            planTabContent = planLayout;
+        }
+
+        if (planContentQuery.Loading)
+        {
+            content |= Layout.Vertical().AlignContent(Align.Center).Height(Size.Full())
+                       | Text.Muted("Loading...");
+        }
+        else
+        {
+            // Summary tab content
+            object summaryTabContent;
+            if (planData.SummaryMarkdown is { } summaryMd)
+                summaryTabContent = new Markdown(summaryMd).DangerouslyAllowLocalFiles();
+            else
+                summaryTabContent = Text.Muted("No summary available.");
+
+            // Verifications tab content
+            var verificationsTable = new Table(
+                new TableRow(
+                        new TableCell("Status").IsHeader(),
+                        new TableCell("Name").IsHeader()
+                    )
+                { IsHeader = true }
+            );
+            foreach (var v in _selectedPlan.Verifications)
+            {
+                var hasReport = planData.VerificationReports.TryGetValue(v.Name, out var exists) && exists;
+                var nameCapture = v.Name;
+                var nameCell = hasReport
+                    ? new Button(v.Name).Inline().OnClick(() => openVerification.Set(nameCapture))
+                    : (object)Text.Block(v.Name);
+
+                verificationsTable |= new TableRow(
+                    new TableCell(new Badge(v.Status).Variant(
+                        StatusMappings.VerificationStatusBadgeVariants.TryGetValue(v.Status, out var variant)
+                            ? variant
+                            : BadgeVariant.Outline)),
+                    new TableCell(nameCell)
+                );
+            }
+
+            // Commits tab content
+            var commitsTable = new Table(
+                new TableRow(
+                        new TableCell("Commit").IsHeader(),
+                        new TableCell("Message").IsHeader(),
+                        new TableCell("Files").IsHeader()
+                    )
+                { IsHeader = true }
+            );
+            foreach (var row in planData.CommitRows)
+                commitsTable |= new TableRow(
+                    new TableCell(new Button(row.ShortHash).Inline().OnClick(() => openCommit.Set(row.Hash))),
+                    new TableCell(row.Title),
+                    new TableCell(row.FileCount?.ToString() ?? "–")
+                );
+
+            var commitWarning = PlanContentHelpers.BuildCommitWarningCallout(planData.CommitRows);
+            object commitsContent = commitWarning != null
+                ? Layout.Vertical().Gap(2) | commitWarning | commitsTable
+                : commitsTable;
+
+            // PRs tab content
+            object prsContent;
+            if (_selectedPlan.Prs.Count > 0)
+            {
+                var prsTable = new Table(
+                    new TableRow(
+                            new TableCell("Repository").IsHeader(),
+                            new TableCell("PR").IsHeader()
+                        )
+                    { IsHeader = true }
+                );
+                foreach (var pr in _selectedPlan.Prs.Where(PullRequestApp.IsValidUrl))
+                {
+                    var prCapture = pr;
+                    prsTable |= new TableRow(
+                        new TableCell(PullRequestApp.ExtractRepo(pr)),
+                        new TableCell(new Button(pr).Link().OnClick(() => client.OpenUrl(prCapture)))
+                    );
+                }
+
+                prsContent = prsTable;
+            }
+            else
+            {
+                prsContent = new Empty();
+            }
+
+            // Artifacts tab content
+            var artifactsLayout = Layout.Vertical().Gap(2);
+            artifactsLayout |= PlanContentHelpers.RenderArtifactScreenshots(planData.Artifacts);
+
+            var totalArtifacts = (planData.Artifacts.GetValueOrDefault("screenshots")?.Count ?? 0)
+                                 + (planData.Artifacts.ContainsKey("sample") ? 1 : 0);
+
+            // Build tabs
+            var tabs = Layout.Tabs(
+                new Tab("Plan", Cap(planTabContent)),
+                new Tab("Summary", Cap(summaryTabContent)),
+                new Tab("Verifications", Cap(verificationsTable)).Badge(_selectedPlan.Verifications.Count.ToString()),
+                new Tab("Commits", Cap(commitsContent)).Badge(_selectedPlan.Commits.Count.ToString()),
+                new Tab("PRs", Cap(prsContent)).Badge(_selectedPlan.Prs.Count.ToString()),
+                new Tab("Artifacts", Cap(artifactsLayout)).Badge(totalArtifacts.ToString())
+            ).OnSelect(v => selectedTab.Set(v)).SelectedIndex(selectedTab.Value).Variant(TabsVariant.Content);
+
+            content |= tabs;
+        }
+
+        // Sheet modals
+        if (openVerification.Value is { } verName)
+            content |= new Sheet(
+                () => openVerification.Set(null),
+                verificationReportQuery.Loading
+                    ? Text.Muted("Loading...")
+                    : new Markdown(verificationReportQuery.Value).DangerouslyAllowLocalFiles(),
+                verName
+            ).Width(Size.Half()).Resizable();
+
+        if (openCommit.Value is { } commitHash && _selectedPlan is not null)
+        {
+            content |= PlanContentHelpers.RenderCommitDetailSheet(
+                commitQuery.Value,
+                commitQuery.Loading || commitQuery.Value is null && !string.IsNullOrEmpty(openCommit.Value),
+                commitHash,
+                () => openCommit.Set(null));
+        }
+
+        var actionBar = Layout.Horizontal().AlignContent(Align.Center).Gap(2).Padding(1)
+                        | new Button("Update").Icon(Icons.Pencil).Outline().ShortcutKey("u")
+                            .OnClick(() => updateDialogOpen.Set(true))
+                        | new Button("Split").Icon(Icons.Scissors).Outline().ShortcutKey("s").OnClick(() =>
+                        {
+                            _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Updating);
+                            _jobService.StartJob("SplitPlan", _selectedPlan.FolderPath);
+                            _refreshPlans();
+                        })
+                        | new Button("Expand").Icon(Icons.UnfoldVertical).Outline().ShortcutKey("x").OnClick(() =>
+                        {
+                            _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Building);
+                            var planPath = _selectedPlan.FolderPath;
+                            _jobService.StartJob("ExpandPlan", planPath);
+                            _refreshPlans();
+                        })
+                        | new Button("Delete").Icon(Icons.Trash).Outline().ShortcutKey("Backspace")
+                            .OnClick(() => deleteDialogOpen.Set(true))
+                        | new Button("Previous").Icon(Icons.ChevronLeft).Outline().OnClick(() => GoToPrevious())
+                            .ShortcutKey("p")
+                        | new Button("Next").Icon(Icons.ChevronRight, Align.Right).Outline().OnClick(() => GoToNext())
+                            .ShortcutKey("n")
+                        | new Button().Icon(Icons.EllipsisVertical).Ghost().WithDropDown(
+                            new MenuItem("Create Issue", Icon: Icons.Github, Tag: "CreateIssue").OnSelect(() =>
+                                createIssueDialogOpen.Set(true)),
+                            new MenuItem("Download", Icon: Icons.Download, Tag: "Download").OnSelect(() =>
+                            {
+                                var url = downloadUrl.Value;
+                                if (!string.IsNullOrEmpty(url)) client.OpenUrl(url);
+                            }),
+                            new MenuItem("Open in File Manager", Icon: Icons.FolderOpen, Tag: "OpenInExplorer")
+                                .OnSelect(() => { PlatformHelper.OpenInFileManager(_selectedPlan.FolderPath); }),
+                            new MenuItem("Open in Terminal", Icon: Icons.Terminal, Tag: "OpenInTerminal").OnSelect(() =>
+                            {
+                                PlatformHelper.OpenInTerminal(_selectedPlan.FolderPath);
+                            }),
+                            new MenuItem($"Open in {_config.Editor.Label}", Icon: Icons.Code, Tag: "OpenInEditor")
+                                .OnSelect(() => { _config.OpenInEditor(_selectedPlan.FolderPath); }),
+                            new MenuItem("Copy Path to Clipboard", Icon: Icons.ClipboardCopy, Tag: "CopyPath")
+                                .OnSelect(() =>
+                                {
+                                    copyToClipboard(_selectedPlan.FolderPath);
+                                    client.Toast("Copied path to clipboard", "Path Copied");
+                                }),
+                            new MenuItem("Copy Plan to Clipboard", Icon: Icons.Share, Tag: "CopyPlan")
+                                .OnSelect(() =>
+                                {
+                                    var exported = PlanExportHelper.ExportToClipboard(_selectedPlan);
+                                    copyToClipboard(exported);
+                                    client.Toast("Plan copied to clipboard", "Plan Exported");
+                                }),
+                            new MenuItem("Mark as Completed", Icon: Icons.CircleCheck, Tag: "MarkCompleted")
+                                .OnSelect(() =>
+                                {
+                                    _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Completed);
+                                    _refreshPlans();
+                                }),
+                            new MenuItem("Open plan.yaml", Icon: Icons.FileText, Tag: "OpenPlanYaml").OnSelect(() =>
+                            {
+                                var yamlPath = Path.Combine(_selectedPlan.FolderPath, "plan.yaml");
+                                _config.OpenInEditor(yamlPath);
+                            })
+                        );
+
+        var mainLayout = new HeaderLayout(
+            header,
+            new FooterLayout(
+                actionBar,
+                content
+            ).Size(Size.Full())
+        ).Scroll(Scroll.None).Size(Size.Full()).Key(_selectedPlan.Id);
+
+        var elements = new List<object>
+        {
+            mainLayout,
+            new UpdatePlanDialog(updateDialogOpen, updateText, _selectedPlan, _jobService, _planService, _refreshPlans),
+            new DeletePlanDialog(deleteDialogOpen, _selectedPlan, _planService, _refreshPlans),
+            new CreateIssueDialog(createIssueDialogOpen, selectedRepoState, issueAssigneeState, issueLabelsState,
+                issueCommentState, _selectedPlan, _jobService)
+        };
+
+        var repoPaths = _selectedPlan.GetEffectiveRepoPaths(_config);
+        var fileLinkSheet = FileLinkHelper.BuildFileLinkSheet(
+            openFile.Value, () => openFile.Set(null), repoPaths, _config);
+        if (fileLinkSheet is not null)
+            elements.Add(fileLinkSheet);
+
+        return new Fragment(elements.ToArray());
+
+        object Cap(object inner) => Layout.Vertical().Width(Size.Auto().Max(Size.Units(200))) | inner;
+    }
+
+    internal static object BuildFailureCallout(PlanFile plan)
+    {
+        var verificationDir = Path.Combine(plan.FolderPath, "verification");
+        var failedVerifications = plan.Verifications
+            .Where(v => v.Status is "Fail" or "Pending")
+            .ToList();
+
+        if (failedVerifications.Count > 0 && Directory.Exists(verificationDir))
+        {
+            var parts = new List<string>();
+            foreach (var v in failedVerifications)
+            {
+                var reportPath = Path.Combine(verificationDir, $"{v.Name}.md");
+                if (!File.Exists(reportPath))
+                {
+                    parts.Add($"**{v.Name}** — {v.Status}, no report generated");
+                    continue;
+                }
+
+                var report = FileHelper.ReadAllText(reportPath);
+
+                // Extract the Output section content
+                var outputMatch = Regex.Match(
+                    report, @"## Output\s*\n([\s\S]*?)(?=\n## |\z)");
+                var output = outputMatch.Success
+                    ? outputMatch.Groups[1].Value.Trim()
+                    : null;
+
+                // Extract Issues Found section
+                var issuesMatch = Regex.Match(
+                    report, @"## Issues Found\s*\n([\s\S]*?)(?=\n## |\z)");
+                var issues = issuesMatch.Success
+                    ? issuesMatch.Groups[1].Value.Trim()
+                    : null;
+
+                var detail = output ?? issues ?? "See verification report for details";
+                parts.Add($"**{v.Name}** — {detail}");
+            }
+
+            return Callout.Destructive(string.Join("\n\n", parts), "Execution Failed");
+        }
+
+        // Fall back to last execution log
+        var logsDir = Path.Combine(plan.FolderPath, "logs");
+        if (Directory.Exists(logsDir))
+        {
+            var lastLog = Directory.GetFiles(logsDir, "*.md")
+                .OrderByDescending(f => f)
+                .FirstOrDefault();
+            if (lastLog != null)
+            {
+                var logContent = FileHelper.ReadAllText(lastLog);
+                var summaryMatch = Regex.Match(
+                    logContent, @"## Summary\s*\n([\s\S]*?)(?=\n## |\z)");
+                if (summaryMatch.Success)
+                    return Callout.Destructive(summaryMatch.Groups[1].Value.Trim(), "Execution Failed");
+
+                var statusMatch = Regex.Match(
+                    logContent, @"\*\*Status:\*\*\s*(.+)");
+                if (statusMatch.Success)
+                {
+                    var status = statusMatch.Groups[1].Value.Trim();
+                    if (status == "Completed")
+                        return Callout.Warning(
+                            "Execution reported as completed but plan is in Failed state. The process may have crashed during state transition.",
+                            "State Mismatch");
+                    return Callout.Destructive($"Last execution status: {status}", "Execution Failed");
+                }
+            }
+        }
+
+        return Callout.Destructive("No details available. Check the logs folder.", "Execution Failed");
+    }
+
+    private void GoToNext()
+    {
+        if (_allPlans.Count == 0) return;
+        var currentIndex = _allPlans.FindIndex(p => p.FolderName == _selectedPlan?.FolderName);
+        var nextIndex = (currentIndex + 1) % _allPlans.Count;
+        _selectedPlanState.Set(_allPlans[nextIndex]);
+    }
+
+    private void GoToPrevious()
+    {
+        if (_allPlans.Count == 0) return;
+        var currentIndex = _allPlans.FindIndex(p => p.FolderName == _selectedPlan?.FolderName);
+        var prevIndex = (currentIndex - 1 + _allPlans.Count) % _allPlans.Count;
+        _selectedPlanState.Set(_allPlans[prevIndex]);
+    }
+
+    private record PlanContentData(
+        string? SummaryMarkdown,
+        Dictionary<string, List<string>> Artifacts,
+        List<PlanContentHelpers.CommitRow> CommitRows,
+        Dictionary<string, bool> VerificationReports);
+}

--- a/src/tendril/Ivy.Tendril/Apps/Plans/Dialogs/CreateIssueDialog.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Plans/Dialogs/CreateIssueDialog.cs
@@ -1,0 +1,141 @@
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Apps.Plans.Dialogs;
+
+public class CreateIssueDialog(
+    IState<bool> dialogOpen,
+    IState<string?> selectedRepoState,
+    IState<string?> issueAssigneeState,
+    IState<string[]> issueLabelsState,
+    IState<string> issueCommentState,
+    PlanFile selectedPlan,
+    IJobService jobService) : ViewBase
+{
+    public override object? Build()
+    {
+        var githubService = UseService<IGithubService>();
+        var assigneesError = UseState<string?>(null);
+        var labelsError = UseState<string?>(null);
+
+        var assigneesQuery = UseQuery<string[], string>(
+            selectedRepoState.Value ?? "",
+            async (repoName, _) =>
+            {
+                if (string.IsNullOrEmpty(repoName))
+                {
+                    assigneesError.Set(null);
+                    return [];
+                }
+                var repos = githubService.GetRepos();
+                var selectedRepo = repos.FirstOrDefault(r => r.DisplayName == repoName);
+                if (selectedRepo is null)
+                {
+                    assigneesError.Set(null);
+                    return [];
+                }
+                var (assignees, error) = await githubService.GetAssigneesAsync(selectedRepo.Owner, selectedRepo.Name);
+                assigneesError.Set(error);
+                return assignees.ToArray();
+            },
+            initialValue: []
+        );
+
+        var labelsQuery = UseQuery<string[], string>(
+            selectedRepoState.Value ?? "",
+            async (repoName, _) =>
+            {
+                if (string.IsNullOrEmpty(repoName))
+                {
+                    labelsError.Set(null);
+                    return [];
+                }
+                var repos = githubService.GetRepos();
+                var selectedRepo = repos.FirstOrDefault(r => r.DisplayName == repoName);
+                if (selectedRepo is null)
+                {
+                    labelsError.Set(null);
+                    return [];
+                }
+                var (labels, error) = await githubService.GetLabelsAsync(selectedRepo.Owner, selectedRepo.Name);
+                labelsError.Set(error);
+                return labels.ToArray();
+            },
+            initialValue: []
+        );
+
+        UseEffect(() =>
+        {
+            assigneesError.Set(null);
+            labelsError.Set(null);
+        }, selectedRepoState);
+
+        if (!dialogOpen.Value) return null;
+
+        var repos = githubService.GetRepos();
+        var repositoryOptions = repos.Select(r => r.DisplayName).ToArray();
+        var assignees = assigneesQuery.Value;
+        var labels = labelsQuery.Value;
+
+        return new Dialog(
+            _ =>
+            {
+                issueCommentState.Set("");
+                issueAssigneeState.Set(null);
+                issueLabelsState.Set(Array.Empty<string>());
+                assigneesError.Set(null);
+                labelsError.Set(null);
+                dialogOpen.Set(false);
+            },
+            new DialogHeader($"Create GitHub Issue #{selectedPlan.Id}"),
+            new DialogBody(
+                Layout.Vertical().Gap(3)
+                | selectedRepoState.ToSelectInput(repositoryOptions.ToOptions())
+                    .AutoFocus().WithField().Label("Repository").Required()
+                | issueAssigneeState.ToSelectInput(assignees.ToOptions())
+                    .Nullable().WithField().Label("Assignee")
+                | issueLabelsState.ToSelectInput(labels.ToOptions())
+                    .Placeholder("Select labels...").WithField().Label("Labels")
+                | (assigneesError.Value is { } assigneeErr
+                    ? Text.Danger(assigneeErr).Small()
+                    : null)
+                | (labelsError.Value is { } labelErr
+                    ? Text.Danger(labelErr).Small()
+                    : null)
+                | issueCommentState.ToTextInput().Multiline().WithField().Label("Comment")
+            ),
+            new DialogFooter(
+                new Button("Cancel").Outline().OnClick(() =>
+                {
+                    issueCommentState.Set("");
+                    issueAssigneeState.Set(null);
+                    issueLabelsState.Set(Array.Empty<string>());
+                    assigneesError.Set(null);
+                    labelsError.Set(null);
+                    dialogOpen.Set(false);
+                }),
+                new Button("Create Issue").Primary().OnClick(() =>
+                {
+                    if (selectedRepoState.Value is { } repo)
+                    {
+                        var selectedRepo = repos.FirstOrDefault(r => r.DisplayName == repo);
+                        if (selectedRepo != null)
+                        {
+                            var repoPath = selectedRepo.FullName;
+                            var assignee = issueAssigneeState.Value ?? "";
+                            var selectedLabels = string.Join(",", issueLabelsState.Value);
+                            jobService.StartJob("CreateIssue", selectedPlan.FolderPath, "-Repo", repoPath,
+                                "-Assignee", assignee, "-Comment", issueCommentState.Value, "-Labels", selectedLabels);
+                        }
+                    }
+
+                    issueCommentState.Set("");
+                    issueAssigneeState.Set(null);
+                    issueLabelsState.Set(Array.Empty<string>());
+                    assigneesError.Set(null);
+                    labelsError.Set(null);
+                    dialogOpen.Set(false);
+                })
+            )
+        ).Width(Size.Rem(30));
+    }
+}

--- a/src/tendril/Ivy.Tendril/Apps/Plans/Dialogs/CreatePlanDialog.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Plans/Dialogs/CreatePlanDialog.cs
@@ -1,0 +1,70 @@
+using Ivy.Core.Hooks;
+
+namespace Ivy.Tendril.Apps.Plans.Dialogs;
+
+public class CreatePlanDialog(
+    List<string> projectNames,
+    Action<string, string[], int> onCreatePlan,
+    Action onClose,
+    string[]? defaultProjects = null) : ViewBase
+{
+    private readonly string[] _defaultProjects = defaultProjects ?? ["Auto"];
+
+    internal static readonly List<string> PriorityOptions = ["Normal", "High", "Urgent"];
+
+    internal static int ParsePriority(string option) => option.ToLowerInvariant() switch
+    {
+        "normal" => 0,
+        "high" => 1,
+        "urgent" => 2,
+        _ => 0
+    };
+
+    public override object Build()
+    {
+        var createPlanText = UseState("");
+        var selectedProjects = UseState(_defaultProjects);
+        var selectedPriority = UseState("Normal");
+
+        var exclusiveProjects = new ConvertedState<string[], string[]>(
+            selectedProjects,
+            forward: v => v,
+            backward: newValue =>
+            {
+                var current = selectedProjects.Value;
+                if (newValue.Contains("Auto") && !current.Contains("Auto"))
+                    return ["Auto"];
+                if (newValue.Contains("Auto") && newValue.Any(p => p != "Auto"))
+                    return newValue.Where(p => p != "Auto").ToArray();
+                return newValue;
+            }
+        );
+
+        var options = new List<string> { "Auto" };
+        options.AddRange(projectNames);
+
+        return new Dialog(
+            _ => onClose(),
+            new DialogHeader("Create New Plan"),
+            new DialogBody(
+                Layout.Vertical()
+                | exclusiveProjects.ToSelectInput(options).Variant(SelectInputVariant.Toggle).WithField().Label("Select project(s)")
+                | selectedPriority.ToSelectInput(PriorityOptions).Variant(SelectInputVariant.Toggle).WithField().Label("Priority")
+                | createPlanText.ToTextareaInput("Enter task description...").Rows(6).AutoFocus().WithField()
+                    .Label("Describe the task for the new plan")
+            ),
+            new DialogFooter(
+                new Button("Cancel").Outline().OnClick(onClose),
+                new Button("Create").Primary().ShortcutKey("Ctrl+Enter").OnClick(() =>
+                {
+                    if (!string.IsNullOrWhiteSpace(createPlanText.Value))
+                    {
+                        var projects = selectedProjects.Value.Any() ? selectedProjects.Value : ["Auto"];
+                        onCreatePlan(createPlanText.Value, projects, ParsePriority(selectedPriority.Value));
+                        onClose();
+                    }
+                })
+            )
+        ).Width(Size.Rem(30));
+    }
+}

--- a/src/tendril/Ivy.Tendril/Apps/Plans/Dialogs/DeletePlanDialog.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Plans/Dialogs/DeletePlanDialog.cs
@@ -1,0 +1,52 @@
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Apps.Plans.Dialogs;
+
+public class DeletePlanDialog(
+    IState<bool> dialogOpen,
+    PlanFile selectedPlan,
+    IPlanReaderService planService,
+    Action refreshPlans) : ViewBase
+{
+    private readonly IState<bool> _dialogOpen = dialogOpen;
+    private readonly IPlanReaderService _planService = planService;
+    private readonly Action _refreshPlans = refreshPlans;
+    private readonly PlanFile _selectedPlan = selectedPlan;
+
+    public override object? Build()
+    {
+        if (!_dialogOpen.Value) return null;
+
+        return new Dialog(
+            _ => _dialogOpen.Set(false),
+            new DialogHeader("Delete Plan"),
+            new DialogBody(
+                Text.P($"What would you like to do with plan #{_selectedPlan.Id}?")
+            ),
+            new DialogFooter(
+                Layout.Vertical().Gap(2)
+                | (Layout.Horizontal().Gap(2).Right()
+                   | new Button("Cancel").Outline().ShortcutKey("Escape").OnClick(() => _dialogOpen.Set(false))
+                   | new Button("Move to Skipped").Outline().ShortcutKey("s").OnClick(() =>
+                   {
+                       _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Skipped);
+                       _refreshPlans();
+                       _dialogOpen.Set(false);
+                   })
+                   | new Button("Move to Icebox").Outline().ShortcutKey("b").OnClick(() =>
+                   {
+                       _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Icebox);
+                       _refreshPlans();
+                       _dialogOpen.Set(false);
+                   }))
+                | (Layout.Horizontal().Right()
+                   | new Button("Delete").Destructive().ShortcutKey("Enter").AutoFocus().OnClick(() =>
+                   {
+                       _planService.DeletePlan(_selectedPlan.FolderName);
+                       _refreshPlans();
+                       _dialogOpen.Set(false);
+                   }))
+            )
+        ).Width(Size.Rem(40));
+    }
+}

--- a/src/tendril/Ivy.Tendril/Apps/Plans/Dialogs/UpdatePlanDialog.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Plans/Dialogs/UpdatePlanDialog.cs
@@ -1,0 +1,63 @@
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Apps.Plans.Dialogs;
+
+public class UpdatePlanDialog(
+    IState<bool> dialogOpen,
+    IState<string> updateText,
+    PlanFile selectedPlan,
+    IJobService jobService,
+    IPlanReaderService planService,
+    Action refreshPlans) : ViewBase
+{
+    private readonly IState<bool> _dialogOpen = dialogOpen;
+    private readonly IJobService _jobService = jobService;
+    private readonly IPlanReaderService _planService = planService;
+    private readonly Action _refreshPlans = refreshPlans;
+    private readonly PlanFile _selectedPlan = selectedPlan;
+    private readonly IState<string> _updateText = updateText;
+
+    public override object? Build()
+    {
+        if (!_dialogOpen.Value) return null;
+
+        return new Dialog(
+            _ =>
+            {
+                _updateText.Set("");
+                _dialogOpen.Set(false);
+            },
+            new DialogHeader($"Update Plan #{_selectedPlan.Id}"),
+            new DialogBody(
+                Layout.Vertical()
+                | Text.P("Provide instructions for revising this draft plan.")
+                | _updateText.ToTextareaInput("Enter update instructions...").Rows(6).AutoFocus()
+            ),
+            new DialogFooter(
+                new Button("Cancel").Outline().OnClick(() =>
+                {
+                    _updateText.Set("");
+                    _dialogOpen.Set(false);
+                }),
+                new Button("Submit Update").Primary().ShortcutKey("Ctrl+Enter").OnClick(() =>
+                {
+                    if (!string.IsNullOrWhiteSpace(_updateText.Value))
+                    {
+                        // Append >> comments to the latest revision so UpdatePlan can process them
+                        var currentContent = _planService.ReadLatestRevision(_selectedPlan.FolderName);
+                        var comments = string.Join("\n", _updateText.Value
+                            .Split('\n')
+                            .Select(line => $">> {line}"));
+                        _planService.SavePlan(_selectedPlan.FolderName, currentContent + "\n\n" + comments + "\n");
+                    }
+
+                    _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Updating);
+                    _jobService.StartJob("UpdatePlan", _selectedPlan.FolderPath);
+                    _refreshPlans();
+                    _updateText.Set("");
+                    _dialogOpen.Set(false);
+                })
+            )
+        ).Width(Size.Rem(30));
+    }
+}

--- a/src/tendril/Ivy.Tendril/Apps/Plans/Models.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Plans/Models.cs
@@ -1,0 +1,98 @@
+using Ivy.Tendril.Helpers;
+
+namespace Ivy.Tendril.Apps.Plans;
+
+public enum PlanStatus
+{
+    Draft,
+    Building,
+    Updating,
+    Executing,
+    Completed,
+    Failed,
+    ReadyForReview,
+    Skipped,
+    Icebox,
+    Blocked
+}
+
+public record PlanMetadata(
+    int Id,
+    string Project,
+    string Level,
+    string Title,
+    PlanStatus State,
+    List<string> Repos,
+    List<string> Commits,
+    List<string> Prs,
+    List<PlanVerificationEntry> Verifications,
+    List<string> RelatedPlans,
+    List<string> DependsOn,
+    DateTime Created,
+    DateTime Updated,
+    string? InitialPrompt,
+    string? SourceUrl);
+
+public record PlanFile(
+    PlanMetadata Metadata,
+    string LatestRevisionContent,
+    string FolderPath,
+    string PlanYamlRaw,
+    int RevisionCount = 1
+)
+{
+    public int Id => Metadata.Id;
+    public string Title => Metadata.Title;
+    public string Project => Metadata.Project;
+    public string Level => Metadata.Level;
+    public PlanStatus Status => Metadata.State;
+    public List<string> Repos => Metadata.Repos;
+    public List<string> Commits => Metadata.Commits;
+    public List<string> Prs => Metadata.Prs;
+    public List<PlanVerificationEntry> Verifications => Metadata.Verifications;
+    public List<string> RelatedPlans => Metadata.RelatedPlans;
+    public List<string> DependsOn => Metadata.DependsOn;
+    public DateTime Created => Metadata.Created;
+    public DateTime Updated => Metadata.Updated;
+    public string? InitialPrompt => Metadata.InitialPrompt;
+    public string? SourceUrl => Metadata.SourceUrl;
+    public string FolderName => Path.GetFileName(FolderPath);
+}
+
+public class RecommendationYaml
+{
+    public string Title { get; set; } = "";
+    public string Description { get; set; } = "";
+    public string State { get; set; } = "Pending";
+    public string? DeclineReason { get; set; }
+}
+
+public static class PlanFilters
+{
+    public static IEnumerable<PlanFile> ApplyFilters(
+        IEnumerable<PlanFile> plans,
+        string? projectFilter,
+        string? levelFilter,
+        string? textFilter)
+    {
+        var filtered = plans;
+
+        if (levelFilter is { } level)
+            filtered = filtered.Where(p => p.Level == level);
+
+        if (projectFilter is { } project)
+            filtered = filtered.Where(p => ProjectHelper.ContainsProject(p.Project, project));
+
+        if (!string.IsNullOrWhiteSpace(textFilter))
+        {
+            var search = textFilter.ToLowerInvariant();
+            filtered = filtered.Where(p =>
+                p.Title.ToLowerInvariant().Contains(search) ||
+                p.Id.ToString().Contains(search) ||
+                p.Project.ToLowerInvariant().Contains(search) ||
+                p.LatestRevisionContent.ToLowerInvariant().Contains(search));
+        }
+
+        return filtered;
+    }
+}

--- a/src/tendril/Ivy.Tendril/Apps/Plans/PlanFileExtensions.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Plans/PlanFileExtensions.cs
@@ -1,0 +1,18 @@
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Apps.Plans;
+
+public static class PlanFileExtensions
+{
+    /// <summary>
+    ///     Gets the effective repository paths for this plan.
+    ///     Returns the plan's explicit repos if set, otherwise falls back to the project's default repos from config.
+    /// </summary>
+    public static List<string> GetEffectiveRepoPaths(this PlanFile plan, IConfigService config)
+    {
+        if ((plan.Repos?.Count ?? 0) > 0)
+            return plan.Repos;
+
+        return config.GetProject(plan.Project)?.RepoPaths ?? [];
+    }
+}

--- a/src/tendril/Ivy.Tendril/Apps/Plans/PlanYaml.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Plans/PlanYaml.cs
@@ -1,0 +1,29 @@
+using YamlDotNet.Serialization;
+
+namespace Ivy.Tendril.Apps.Plans;
+
+public class PlanVerificationEntry
+{
+    public string Name { get; set; } = "";
+    public string Status { get; set; } = "Pending";
+}
+
+public class PlanYaml
+{
+    public string State { get; set; } = "Draft";
+    public string Project { get; set; } = "Auto";
+    public string Level { get; set; } = "NiceToHave";
+    public string Title { get; set; } = "";
+    public List<string> Repos { get; set; } = new();
+    public DateTime Created { get; set; } = DateTime.UtcNow;
+    public DateTime Updated { get; set; } = DateTime.UtcNow;
+    public List<string> Prs { get; set; } = new();
+    public List<string> Commits { get; set; } = new();
+    public List<PlanVerificationEntry> Verifications { get; set; } = new();
+    public List<string> RelatedPlans { get; set; } = new();
+    public List<string> DependsOn { get; set; } = new();
+    [YamlMember(DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
+    public int Priority { get; set; }
+    public string? InitialPrompt { get; set; }
+    public string? SourceUrl { get; set; }
+}

--- a/src/tendril/Ivy.Tendril/Apps/Plans/SidebarView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Plans/SidebarView.cs
@@ -1,0 +1,79 @@
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Apps.Plans;
+
+public class SidebarView(
+    List<PlanFile> plans,
+    IState<PlanFile?> selectedPlanState,
+    IState<string?> projectFilter,
+    IState<string?> levelFilter,
+    IState<string?> textFilter,
+    IConfigService config) : ViewBase
+{
+    public override object Build()
+    {
+        var filtersOpen = UseState(false);
+
+        var filteredPlans =
+            PlanFilters.ApplyFilters(plans, projectFilter.Value, levelFilter.Value, textFilter.Value);
+
+        var levelOptions = config.LevelNames;
+
+        var levelFilteredPlans = plans.AsEnumerable();
+        if (levelFilter.Value is { } level)
+            levelFilteredPlans = levelFilteredPlans.Where(p => p.Level == level);
+
+        var projectCounts = levelFilteredPlans
+            .GroupBy(p => p.Project)
+            .OrderByDescending(g => g.Count())
+            .Select(g => new Option<string>($"{g.Key} ({g.Count()})", g.Key))
+            .ToArray<IAnyOption>();
+
+        var searchInput = textFilter.ToSearchInput()
+            .Placeholder("Search plans...")
+            .Suffix(
+                new Button()
+                    .Icon(filtersOpen.Value ? Icons.ChevronUp : Icons.ChevronDown)
+                    .Ghost()
+                    .Small()
+                    .OnClick(() => filtersOpen.Set(!filtersOpen.Value))
+            );
+
+        var header = Layout.Vertical() | searchInput;
+
+        if (filtersOpen.Value)
+        {
+            header |= Layout.Vertical()
+                      | projectFilter.ToSelectInput(projectCounts).Placeholder("All Projects").Nullable()
+                          .WithField().Label("Project")
+                      | levelFilter.ToSelectInput(levelOptions.ToOptions()).Placeholder("All Levels").Nullable()
+                          .WithField().Label("Level");
+        }
+
+        var content = new List(filteredPlans.Select(plan =>
+        {
+            var clickablePlan = plan;
+            var stateBadgeVariant = StatusMappings.PlanStatusBadgeVariants.TryGetValue(plan.Status, out var variant)
+                ? variant
+                : BadgeVariant.Outline;
+
+            var badges = Layout.Horizontal().Gap(1);
+            if (plan.Status != PlanStatus.Draft)
+                badges |= new Badge(plan.Status.ToString()).Variant(stateBadgeVariant).Small();
+            var projects = ProjectHelper.ParseProjects(plan.Project);
+            foreach (var proj in projects)
+            {
+                badges |= new Badge(proj).Variant(BadgeVariant.Outline).Small()
+                    .WithProjectColor(config, proj);
+            }
+            badges |= new Badge(plan.Level).Variant(config.GetBadgeVariant(plan.Level)).Small();
+
+            return new ListItem($"#{plan.Id} {plan.Title}")
+                .Content(badges)
+                .OnClick(() => selectedPlanState.Set(clickablePlan));
+        }));
+
+        return new HeaderLayout(header, content);
+    }
+}

--- a/src/tendril/Ivy.Tendril/Apps/Review/SidebarView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Review/SidebarView.cs
@@ -6,20 +6,56 @@ namespace Ivy.Tendril.Apps.Review;
 public class SidebarView(
     List<PlanFile> plans,
     IState<PlanFile?> selectedPlanState,
+    IState<string?> projectFilter,
+    IState<string?> levelFilter,
     IState<string?> textFilter,
     IConfigService config) : ViewBase
 {
     private readonly IConfigService _config = config;
     private readonly List<PlanFile> _plans = plans;
     private readonly IState<PlanFile?> _selectedPlanState = selectedPlanState;
+    private readonly IState<string?> _projectFilter = projectFilter;
+    private readonly IState<string?> _levelFilter = levelFilter;
     private readonly IState<string?> _textFilter = textFilter;
 
     public override object Build()
     {
-        var filteredPlans = PlanFilters.ApplyFilters(_plans, null, null, _textFilter.Value);
+        var filtersOpen = UseState(false);
 
-        var header = Layout.Vertical()
-                     | _textFilter.ToSearchInput().Placeholder("Search plans...");
+        var filteredPlans = PlanFilters.ApplyFilters(_plans, _projectFilter.Value, _levelFilter.Value, _textFilter.Value);
+
+        var levelOptions = _config.LevelNames;
+
+        var levelFilteredPlans = _plans.AsEnumerable();
+        if (_levelFilter.Value is { } level)
+            levelFilteredPlans = levelFilteredPlans.Where(p => p.Level == level);
+
+        var projectCounts = levelFilteredPlans
+            .GroupBy(p => p.Project)
+            .OrderByDescending(g => g.Count())
+            .Select(g => new Option<string>($"{g.Key} ({g.Count()})", g.Key))
+            .ToArray<IAnyOption>();
+
+        var searchInput = _textFilter.ToSearchInput()
+            .Placeholder("Search plans...")
+            .Suffix(
+                new Button()
+                    .Icon(filtersOpen.Value ? Icons.ChevronUp : Icons.ChevronDown)
+                    .Ghost()
+                    .Small()
+                    .OnClick(() => filtersOpen.Set(!filtersOpen.Value))
+            );
+
+        var header = Layout.Vertical() | searchInput;
+
+        if (filtersOpen.Value)
+        {
+            header |= Layout.Vertical()
+                      | _projectFilter.ToSelectInput(projectCounts).Placeholder("All Projects").Nullable()
+                          .WithField().Label("Project")
+                      | _levelFilter.ToSelectInput(levelOptions.ToOptions()).Placeholder("All Levels").Nullable()
+                          .WithField().Label("Level");
+        }
 
         var content = new List(filteredPlans.Select(plan =>
         {

--- a/src/tendril/Ivy.Tendril/Apps/ReviewApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/ReviewApp.cs
@@ -18,6 +18,8 @@ public class ReviewApp : ViewBase
         var gitService = UseService<IGitService>();
         var planWatcher = UseService<IPlanWatcherService>();
         var selectedPlanState = UseState<PlanFile?>(null);
+        var projectFilter = UseState<string?>(null);
+        var levelFilter = UseState<string?>(null);
         var textFilter = UseState<string?>("");
         var refreshToken = UseRefreshToken();
 
@@ -37,7 +39,7 @@ public class ReviewApp : ViewBase
         var plans = planService.GetPlans()
             .Where(p => p.Status is PlanStatus.ReadyForReview or PlanStatus.Failed)
             .ToList();
-        var filteredPlans = PlanFilters.ApplyFilters(plans, null, null, textFilter.Value).ToList();
+        var filteredPlans = PlanFilters.ApplyFilters(plans, projectFilter.Value, levelFilter.Value, textFilter.Value).ToList();
 
         if (selectedPlanState.Value == null && filteredPlans.Count > 0) selectedPlanState.Set(filteredPlans[0]);
 
@@ -57,7 +59,7 @@ public class ReviewApp : ViewBase
 
         previousPlans.Value = filteredPlans;
 
-        var sidebar = new SidebarView(plans, selectedPlanState, textFilter, configService);
+        var sidebar = new SidebarView(plans, selectedPlanState, projectFilter, levelFilter, textFilter, configService);
 
         return new SidebarLayout(
             new ContentView(selectedPlanState.Value, filteredPlans, selectedPlanState, planService, jobService,


### PR DESCRIPTION
# Summary

## Changes

Restored 9 missing Plans namespace files that were accidentally deleted during merge conflicts (from commit 09b524bec), then added project and level filtering to the Review view. The Review sidebar now has a collapsible filter UI with project dropdown (showing counts) and level dropdown, matching the existing Plans/Drafts SidebarView pattern.

## API Changes

- `Review.SidebarView` constructor: added `IState<string?> projectFilter` and `IState<string?> levelFilter` parameters (between `selectedPlanState` and `textFilter`)
- `ReviewApp.Build()`: added `projectFilter` and `levelFilter` state variables, passed to both `PlanFilters.ApplyFilters()` and `SidebarView` constructor

## Files Modified

- **Restored Plans namespace (9 files):**
  - `Apps/Plans/Models.cs` — PlanFilters, PlanStatus, PlanFile types
  - `Apps/Plans/SidebarView.cs` — Plans sidebar with filtering UI
  - `Apps/Plans/ContentView.cs` — Plan detail content view
  - `Apps/Plans/PlanFileExtensions.cs`, `PlanYaml.cs` — Helpers
  - `Apps/Plans/Dialogs/` — CreateIssueDialog, CreatePlanDialog, DeletePlanDialog, UpdatePlanDialog

- **Review filtering (2 files):**
  - `Apps/ReviewApp.cs` — Added projectFilter/levelFilter state and wiring
  - `Apps/Review/SidebarView.cs` — Added collapsible filter UI with project and level dropdowns


## Commits

- 615aa1d3c, 4155d4364