### PR TITLE
[03248] Consolidate WidgetBase props to use Responsive<T> types

### DIFF
--- a/src/Ivy.Tests/Widgets/ResponsiveWidgetTests.cs
+++ b/src/Ivy.Tests/Widgets/ResponsiveWidgetTests.cs
@@ -13,10 +13,37 @@ public class ResponsiveWidgetTests
 
         var result = WidgetSerializer.Serialize(badge);
         var props = result["props"]!.AsObject();
-        var rw = props["responsiveWidth"]!.AsObject();
+        var rw = props["width"]!.AsObject();
 
         Assert.Equal("Full", rw["mobile"]!.GetValue<string>());
         Assert.Equal("Fraction:0.5", rw["desktop"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void WidgetBase_SimpleWidth_SerializedAsPlainValue()
+    {
+        var badge = new Badge("test")
+            .Width(Size.Px(100));
+        badge.Id = Guid.NewGuid().ToString();
+
+        var result = WidgetSerializer.Serialize(badge);
+        var props = result["props"]!.AsObject();
+
+        Assert.Equal("Px:100", props["width"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void WidgetBase_ResponsiveHeight_SerializedCorrectly()
+    {
+        var badge = new Badge("test")
+            .Height(Size.Full().At(Breakpoint.Mobile));
+        badge.Id = Guid.NewGuid().ToString();
+
+        var result = WidgetSerializer.Serialize(badge);
+        var props = result["props"]!.AsObject();
+        var rh = props["height"]!.AsObject();
+
+        Assert.Equal("Full", rh["mobile"]!.GetValue<string>());
     }
 
     [Fact]

--- a/src/Ivy/Shared/Responsive.cs
+++ b/src/Ivy/Shared/Responsive.cs
@@ -19,6 +19,12 @@ public record Responsive<T>
 
 public static class ResponsiveExtensions
 {
+    public static Responsive<T>? ToResponsive<T>(this T? value) where T : class
+        => value is not null ? new Responsive<T> { Default = value } : null;
+
+    public static Responsive<Density?>? ToResponsiveDensity(this Density? value)
+        => value.HasValue ? new Responsive<Density?> { Default = value } : null;
+
     // Reference type overloads (Size, etc.)
     public static Responsive<T> At<T>(this T value, Breakpoint bp) where T : class => bp switch
     {

--- a/src/Ivy/Views/Charts/AreaChartView.cs
+++ b/src/Ivy/Views/Charts/AreaChartView.cs
@@ -150,9 +150,9 @@ public class AreaChartBuilder<TSource>(
         var result = polish?.Invoke(configuredChart) ?? configuredChart;
 
         if (_height is not null)
-            result = result with { Height = _height };
+            result = result.Height(_height);
         if (_width is not null)
-            result = result with { Width = _width };
+            result = result.Width(_width);
 
         return result;
     }

--- a/src/Ivy/Views/Charts/BarChartView.cs
+++ b/src/Ivy/Views/Charts/BarChartView.cs
@@ -160,9 +160,9 @@ public class BarChartBuilder<TSource>(
         var result = polish?.Invoke(configuredChart) ?? configuredChart;
 
         if (_height is not null)
-            result = result with { Height = _height };
+            result = result.Height(_height);
         if (_width is not null)
-            result = result with { Width = _width };
+            result = result.Width(_width);
 
         return result;
     }

--- a/src/Ivy/Views/Charts/ChordChartView.cs
+++ b/src/Ivy/Views/Charts/ChordChartView.cs
@@ -164,9 +164,9 @@ public class ChordChartBuilder<TSource>(
         var result = polish?.Invoke(configuredChart) ?? configuredChart;
 
         if (_height is not null)
-            result = result with { Height = _height };
+            result = result.Height(_height);
         if (_width is not null)
-            result = result with { Width = _width };
+            result = result.Width(_width);
 
         return result;
     }

--- a/src/Ivy/Views/Charts/FunnelChartView.cs
+++ b/src/Ivy/Views/Charts/FunnelChartView.cs
@@ -148,9 +148,9 @@ public class FunnelChartBuilder<TSource>(
         var result = polish?.Invoke(configuredChart) ?? configuredChart;
 
         if (_height is not null)
-            result = result with { Height = _height };
+            result = result.Height(_height);
         if (_width is not null)
-            result = result with { Width = _width };
+            result = result.Width(_width);
 
         return result;
     }

--- a/src/Ivy/Views/Charts/LineChartView.cs
+++ b/src/Ivy/Views/Charts/LineChartView.cs
@@ -182,9 +182,9 @@ public class LineChartBuilder<TSource>(
         var result = polish?.Invoke(configuredChart) ?? configuredChart;
 
         if (_height is not null)
-            result = result with { Height = _height };
+            result = result.Height(_height);
         if (_width is not null)
-            result = result with { Width = _width };
+            result = result.Width(_width);
 
         return result;
     }

--- a/src/Ivy/Views/Charts/PieChartView.cs
+++ b/src/Ivy/Views/Charts/PieChartView.cs
@@ -160,9 +160,9 @@ public class PieChartBuilder<TSource>(
         var result = polish?.Invoke(configuredChart) ?? configuredChart;
 
         if (_height is not null)
-            result = result with { Height = _height };
+            result = result.Height(_height);
         if (_width is not null)
-            result = result with { Width = _width };
+            result = result.Width(_width);
 
         return result;
     }

--- a/src/Ivy/Views/Charts/RadarChartView.cs
+++ b/src/Ivy/Views/Charts/RadarChartView.cs
@@ -193,9 +193,9 @@ public class RadarChartBuilder<TSource>(
         var result = polish?.Invoke(configuredChart) ?? configuredChart;
 
         if (_height is not null)
-            result = result with { Height = _height };
+            result = result.Height(_height);
         if (_width is not null)
-            result = result with { Width = _width };
+            result = result.Width(_width);
 
         return result;
     }

--- a/src/Ivy/Views/Charts/SankeyChartView.cs
+++ b/src/Ivy/Views/Charts/SankeyChartView.cs
@@ -157,9 +157,9 @@ public class SankeyChartBuilder<TSource>(
         var result = polish?.Invoke(configuredChart) ?? configuredChart;
 
         if (_height is not null)
-            result = result with { Height = _height };
+            result = result.Height(_height);
         if (_width is not null)
-            result = result with { Width = _width };
+            result = result.Width(_width);
 
         return result;
     }

--- a/src/Ivy/Views/Charts/ScatterChartView.cs
+++ b/src/Ivy/Views/Charts/ScatterChartView.cs
@@ -211,9 +211,9 @@ public class ScatterChartBuilder<TSource>(
         var result = polish?.Invoke(configuredChart) ?? configuredChart;
 
         if (_height is not null)
-            result = result with { Height = _height };
+            result = result.Height(_height);
         if (_width is not null)
-            result = result with { Width = _width };
+            result = result.Width(_width);
 
         return result;
     }

--- a/src/Ivy/Views/LayoutView.cs
+++ b/src/Ivy/Views/LayoutView.cs
@@ -22,8 +22,8 @@ public class LayoutView : ViewBase, IStateless
     private int _columnGap = 4;
     private Thickness? _padding = null;
     private Thickness? _margin = null;
-    private Size? _width = null;
-    private Size? _height = null;
+    private Responsive<Size>? _width = null;
+    private Responsive<Size>? _height = null;
     private Colors? _background = null;
     private Align? _alignment = null;
     private Scroll _scroll = Ivy.Scroll.None;
@@ -34,8 +34,6 @@ public class LayoutView : ViewBase, IStateless
     private Thickness _borderThickness = new(0);
     private string? _testId = null;
     private GridView? _activeGrid = null;
-    private Responsive<Size>? _responsiveWidth = null;
-    private Responsive<Size>? _responsiveHeight = null;
     private Responsive<OrientationEnum?>? _responsiveOrientation = null;
     private Responsive<int?>? _responsiveRowGap = null;
     private Responsive<int?>? _responsiveColumnGap = null;
@@ -64,13 +62,13 @@ public class LayoutView : ViewBase, IStateless
 
     public LayoutView Width(Responsive<Size> width)
     {
-        _responsiveWidth = width;
+        _width = width;
         return this;
     }
 
     public LayoutView Height(Responsive<Size> height)
     {
-        _responsiveHeight = height;
+        _height = height;
         return this;
     }
 
@@ -461,11 +459,9 @@ public class LayoutView : ViewBase, IStateless
             ResponsiveRowGap = _responsiveRowGap,
             ResponsiveColumnGap = _responsiveColumnGap,
             ResponsivePadding = _responsivePadding,
-            ResponsiveWidth = _responsiveWidth,
-            ResponsiveHeight = _responsiveHeight
-        }
-            .Width(_width)
-            .Height(_height);
+            Width = _width,
+            Height = _height
+        };
 
         if (_testId != null) layout.TestId = _testId;
 

--- a/src/Ivy/Views/Text.cs
+++ b/src/Ivy/Views/Text.cs
@@ -217,23 +217,23 @@ public class TextBuilder(string content, TextVariant variant, Languages codeLang
         switch (variant)
         {
             case TextVariant.Code:
-                return new CodeBlock(content, codeLanguage) { Width = _width, Height = _height, Density = _density, TestId = _testId };
+                return new CodeBlock(content, codeLanguage) { Width = _width.ToResponsive(), Height = _height.ToResponsive(), Density = _density.ToResponsiveDensity(), TestId = _testId };
             case TextVariant.Markdown:
-                return new Markdown(content) { Width = _width, Height = _height, Density = _density, TestId = _testId };
+                return new Markdown(content) { Width = _width.ToResponsive(), Height = _height.ToResponsive(), Density = _density.ToResponsiveDensity(), TestId = _testId };
             case TextVariant.Json:
-                return new Json(content) { Width = _width, Height = _height, Density = _density, TestId = _testId };
+                return new Json(content) { Width = _width.ToResponsive(), Height = _height.ToResponsive(), Density = _density.ToResponsiveDensity(), TestId = _testId };
             case TextVariant.Xml:
-                return new Xml(content) { Width = _width, Height = _height, Density = _density, TestId = _testId };
+                return new Xml(content) { Width = _width.ToResponsive(), Height = _height.ToResponsive(), Density = _density.ToResponsiveDensity(), TestId = _testId };
             case TextVariant.Html:
-                return new Html(content) { Width = _width, Height = _height, Density = _density, TestId = _testId };
+                return new Html(content) { Width = _width.ToResponsive(), Height = _height.ToResponsive(), Density = _density.ToResponsiveDensity(), TestId = _testId };
             case TextVariant.Latex:
-                return new Markdown("$$" + Environment.NewLine + content + Environment.NewLine + "$$") { Width = _width, Density = _density, TestId = _testId };
+                return new Markdown("$$" + Environment.NewLine + content + Environment.NewLine + "$$") { Width = _width.ToResponsive(), Density = _density.ToResponsiveDensity(), TestId = _testId };
             default:
                 {
                     var text = new TextBlock(
                         content, variant, _width, _strikeThrough, _color, _noWrap, _overflow, _bold, _italic, _muted, _textAlignment)
                     {
-                        Density = _density,
+                        Density = _density.ToResponsiveDensity(),
                         TestId = _testId,
                         Anchor = _anchor
                     };

--- a/src/Ivy/Widgets/Layouts/GridLayout.cs
+++ b/src/Ivy/Widgets/Layouts/GridLayout.cs
@@ -70,8 +70,8 @@ internal record GridLayout : WidgetBase<GridLayout>
         Padding = def.Padding;
         AutoFlow = def.AutoFlow;
         AlignContent = def.AlignContent;
-        Width = def.Width;
-        Height = def.Height;
+        Width = def.Width.ToResponsive();
+        Height = def.Height.ToResponsive();
         ColumnWidths = def.ColumnWidths;
         RowHeights = def.RowHeights;
         ResponsiveColumns = def.ResponsiveColumns;

--- a/src/Ivy/Widgets/Layouts/HeaderLayout.cs
+++ b/src/Ivy/Widgets/Layouts/HeaderLayout.cs
@@ -33,7 +33,7 @@ public static class HeaderLayoutExtensions
         // When scroll is disabled, automatically set height to Full if no height is explicitly set
         if (scroll == Ivy.Scroll.None && result.Height == null)
         {
-            return result with { Height = Size.Full() };
+            return result.Height(Size.Full());
         }
 
         return result;

--- a/src/Ivy/Widgets/Layouts/SidebarLayout.cs
+++ b/src/Ivy/Widgets/Layouts/SidebarLayout.cs
@@ -14,7 +14,7 @@ public record SidebarLayout : WidgetBase<SidebarLayout>
     public SidebarLayout(object mainContent, object sidebarContent, object? sidebarHeader = null, object? sidebarFooter = null, Size? width = null)
     : base(BuildSlots(mainContent, sidebarContent, sidebarHeader, sidebarFooter))
     {
-        Width = width ?? DefaultWidth;
+        Width = (width ?? DefaultWidth).ToResponsive();
     }
 
     private static Slot[] BuildSlots(object mainContent, object sidebarContent, object? sidebarHeader, object? sidebarFooter) =>
@@ -71,7 +71,7 @@ public static class SidebarLayoutExtensions
         }
 
         // Apply default min/max constraints if not already set on the Width
-        var width = sidebar.Width ?? SidebarLayout.DefaultWidth;
+        var width = sidebar.Width?.Default ?? SidebarLayout.DefaultWidth;
         if (width.Min == null)
         {
             width = width.Min(Size.Px(200));
@@ -81,11 +81,7 @@ public static class SidebarLayoutExtensions
             width = width.Max(Size.Px(600));
         }
 
-        return sidebar with
-        {
-            Resizable = true,
-            Width = width
-        };
+        return (sidebar with { Resizable = true }).Width(width);
     }
 }
 

--- a/src/Ivy/Widgets/Primitives/Icon.cs
+++ b/src/Ivy/Widgets/Primitives/Icon.cs
@@ -33,16 +33,16 @@ public static class IconExtensions
 
     public static Icon Small(this Icon icon)
     {
-        return icon with { Width = Size.Units(4), Height = Size.Units(4) };
+        return icon.Width(Size.Units(4)).Height(Size.Units(4));
     }
 
     public static Icon Medium(this Icon icon)
     {
-        return icon with { Width = Size.Units(6), Height = Size.Units(6) };
+        return icon.Width(Size.Units(6)).Height(Size.Units(6));
     }
 
     public static Icon Large(this Icon icon)
     {
-        return icon with { Width = Size.Units(12), Height = Size.Units(12) };
+        return icon.Width(Size.Units(12)).Height(Size.Units(12));
     }
 }

--- a/src/Ivy/Widgets/Primitives/TextBlock.cs
+++ b/src/Ivy/Widgets/Primitives/TextBlock.cs
@@ -44,7 +44,7 @@ public record TextBlock : WidgetBase<TextBlock>
         Content = content;
         Variant = variant;
         StrikeThrough = strikeThrough;
-        Width = width;
+        Width = width.ToResponsive();
         Color = color;
         NoWrap = noWrap;
         Overflow = overflow;

--- a/src/Ivy/Widgets/Sheet.cs
+++ b/src/Ivy/Widgets/Sheet.cs
@@ -90,7 +90,7 @@ public static class SheetExtensions
 
         if (isHorizontal)
         {
-            var width = sheet.Width ?? Sheet.DefaultWidth;
+            var width = sheet.Width?.Default ?? Sheet.DefaultWidth;
             if (width.Min == null)
             {
                 width = width.Min(Size.Px(200));
@@ -99,11 +99,11 @@ public static class SheetExtensions
             {
                 width = width.Max(Size.Px(1200));
             }
-            return sheet with { Resizable = true, Width = width };
+            return (sheet with { Resizable = true }).Width(width);
         }
         else
         {
-            var height = sheet.Height ?? Sheet.DefaultHeight;
+            var height = sheet.Height?.Default ?? Sheet.DefaultHeight;
             if (height.Min == null)
             {
                 height = height.Min(Size.Px(100));
@@ -112,7 +112,7 @@ public static class SheetExtensions
             {
                 height = height.Max(Size.Px(900));
             }
-            return sheet with { Resizable = true, Height = height };
+            return (sheet with { Resizable = true }).Height(height);
         }
     }
 

--- a/src/Ivy/Widgets/WidgetBase.cs
+++ b/src/Ivy/Widgets/WidgetBase.cs
@@ -11,23 +11,17 @@ public abstract record WidgetBase : AbstractWidget
     {
     }
 
-    [Prop] public Size? Width { get; set; }
+    [Prop] public Responsive<Size>? Width { get; internal set; }
 
-    [Prop] public Size? Height { get; set; }
+    [Prop] public Responsive<Size>? Height { get; internal set; }
 
     [Prop] public float? AspectRatio { get; set; }
 
-    [Prop] public Density? Density { get; set; }
+    [Prop] public Responsive<Density?>? Density { get; internal set; }
 
     [Prop, ScaffoldColumn(false)] public string? TestId { get; set; }
 
-    [Prop] public Responsive<Size>? ResponsiveWidth { get; set; }
-
-    [Prop] public Responsive<Size>? ResponsiveHeight { get; set; }
-
     [Prop] public Responsive<bool?>? ResponsiveVisible { get; set; }
-
-    [Prop] public Responsive<Density?>? ResponsiveDensity { get; set; }
 }
 
 public abstract record WidgetBase<T> : WidgetBase where T : WidgetBase<T>
@@ -39,9 +33,17 @@ public abstract record WidgetBase<T> : WidgetBase where T : WidgetBase<T>
 
 public static class WidgetBaseExtensions
 {
-    public static T Width<T>(this T widget, Size? width) where T : WidgetBase => widget with { Width = width };
+    public static T Width<T>(this T widget, Size? width) where T : WidgetBase
+        => widget with { Width = width is not null ? (Responsive<Size>)width : null };
 
-    public static T Height<T>(this T widget, Size? height) where T : WidgetBase => widget with { Height = height };
+    public static T Width<T>(this T widget, Responsive<Size> width) where T : WidgetBase
+        => widget with { Width = width };
+
+    public static T Height<T>(this T widget, Size? height) where T : WidgetBase
+        => widget with { Height = height is not null ? (Responsive<Size>)height : null };
+
+    public static T Height<T>(this T widget, Responsive<Size> height) where T : WidgetBase
+        => widget with { Height = height };
 
     public static T Size<T>(this T widget, Size? size) where T : WidgetBase => widget.Width(size).Height(size);
 
@@ -49,21 +51,16 @@ public static class WidgetBaseExtensions
 
     public static T Grow<T>(this T widget) where T : WidgetBase => widget.Width(Ivy.Size.Grow());
 
-    public static T Density<T>(this T widget, Density density) where T : WidgetBase => widget with { Density = density };
+    public static T Density<T>(this T widget, Density density) where T : WidgetBase
+        => widget with { Density = (Responsive<Density?>)(Density?)density };
 
-    public static T Small<T>(this T widget) where T : WidgetBase => widget with { Density = Ivy.Density.Small };
+    public static T Small<T>(this T widget) where T : WidgetBase => widget.Density(Ivy.Density.Small);
 
-    public static T Medium<T>(this T widget) where T : WidgetBase => widget with { Density = Ivy.Density.Medium };
+    public static T Medium<T>(this T widget) where T : WidgetBase => widget.Density(Ivy.Density.Medium);
 
-    public static T Large<T>(this T widget) where T : WidgetBase => widget with { Density = Ivy.Density.Large };
+    public static T Large<T>(this T widget) where T : WidgetBase => widget.Density(Ivy.Density.Large);
 
     public static T TestId<T>(this T widget, string testId) where T : WidgetBase => widget with { TestId = testId };
-
-    public static T Width<T>(this T widget, Responsive<Size> width) where T : WidgetBase
-        => widget with { ResponsiveWidth = width };
-
-    public static T Height<T>(this T widget, Responsive<Size> height) where T : WidgetBase
-        => widget with { ResponsiveHeight = height };
 
     public static T HideOn<T>(this T widget, params Breakpoint[] breakpoints) where T : WidgetBase
     {
@@ -82,7 +79,7 @@ public static class WidgetBaseExtensions
     }
 
     public static T Density<T>(this T widget, Responsive<Density?> density) where T : WidgetBase
-        => widget with { ResponsiveDensity = density };
+        => widget with { Density = density };
 
     internal static void SetDensityViaReflection(object input, Density? density)
     {
@@ -94,8 +91,15 @@ public static class WidgetBaseExtensions
 
         if (prop is null) return;
         if (!prop.CanWrite) return;
-        if (!prop.PropertyType.IsAssignableFrom(typeof(Density))) return;
 
-        prop.SetValue(input, density);
+        if (prop.PropertyType == typeof(Responsive<Density?>))
+        {
+            Responsive<Density?>? value = density.HasValue ? (Responsive<Density?>)(Density?)density.Value : null;
+            prop.SetValue(input, value);
+        }
+        else if (prop.PropertyType.IsAssignableFrom(typeof(Density)))
+        {
+            prop.SetValue(input, density);
+        }
     }
 }

--- a/src/frontend/src/widgets/__tests__/widgetRenderer-responsive.test.tsx
+++ b/src/frontend/src/widgets/__tests__/widgetRenderer-responsive.test.tsx
@@ -90,39 +90,37 @@ describe("MemoizedWidget responsive props", () => {
     expect(container.querySelector('[data-testid="test-widget"]')).not.toBeNull();
   });
 
-  it("overrides width from responsiveWidth", () => {
+  it("resolves responsive width for current breakpoint", () => {
     mockBreakpoint.mockReturnValue("mobile");
     const node = makeNode({
-      width: "50%",
-      responsiveWidth: { default: "50%", mobile: "100%" },
+      width: { default: "50%", mobile: "100%" },
     });
     mount(<MemoizedWidget node={node} />);
     const el = container.querySelector('[data-testid="test-widget"]');
     expect(el?.getAttribute("data-width")).toBe("100%");
   });
 
-  it("overrides height from responsiveHeight", () => {
+  it("resolves responsive height for current breakpoint", () => {
     mockBreakpoint.mockReturnValue("tablet");
     const node = makeNode({
-      height: "200px",
-      responsiveHeight: { default: "200px", tablet: "100px" },
+      height: { default: "200px", tablet: "100px" },
     });
     mount(<MemoizedWidget node={node} />);
     const el = container.querySelector('[data-testid="test-widget"]');
     expect(el?.getAttribute("data-height")).toBe("100px");
   });
 
-  it("overrides density from responsiveDensity", () => {
+  it("resolves responsive density for current breakpoint", () => {
     mockBreakpoint.mockReturnValue("mobile");
     const node = makeNode({
-      responsiveDensity: { default: "Normal", mobile: "Compact" },
+      density: { default: "Normal", mobile: "Compact" },
     });
     mount(<MemoizedWidget node={node} />);
     const el = container.querySelector('[data-testid="test-widget"]');
     expect(el?.getAttribute("data-density")).toBe("Compact");
   });
 
-  it("passes through props unchanged when no responsive props present", () => {
+  it("passes through plain string props unchanged", () => {
     const node = makeNode({
       width: "50%",
       height: "200px",

--- a/src/frontend/src/widgets/widgetRenderer.tsx
+++ b/src/frontend/src/widgets/widgetRenderer.tsx
@@ -75,36 +75,36 @@ export const MemoizedWidget = React.memo(
 
     const props = processWidgetProps(node, inheritedScale);
 
-    // Override width/height with resolved responsive values
-    const responsiveWidth = node.props.responsiveWidth;
-    if (responsiveWidth) {
+    // Resolve responsive width/height/density — these props may be plain values
+    // or responsive objects with breakpoint keys (default, mobile, tablet, desktop, wide)
+    if (props.width) {
       const resolved = resolveResponsive(
-        responsiveWidth as string,
+        props.width as string,
         breakpoint,
         undefined as unknown as string,
       );
       if (resolved !== undefined) props.width = resolved;
+      else delete props.width;
     }
 
-    const responsiveHeight = node.props.responsiveHeight;
-    if (responsiveHeight) {
+    if (props.height) {
       const resolved = resolveResponsive(
-        responsiveHeight as string,
+        props.height as string,
         breakpoint,
         undefined as unknown as string,
       );
       if (resolved !== undefined) props.height = resolved;
+      else delete props.height;
     }
 
-    // Override density with resolved responsive value
-    const responsiveDensity = node.props.responsiveDensity;
-    if (responsiveDensity) {
+    if (props.density && typeof props.density === "object") {
       const resolved = resolveResponsive(
-        responsiveDensity as string,
+        props.density as unknown as string,
         breakpoint,
         undefined as unknown as string,
       );
       if (resolved !== undefined) props.density = resolved;
+      else delete props.density;
     }
 
     const children = flattenChildren(node.children || []);


### PR DESCRIPTION
# Summary

## Changes

Consolidated duplicate WidgetBase properties (`Width`/`ResponsiveWidth`, `Height`/`ResponsiveHeight`, `Density`/`ResponsiveDensity`) into single `Responsive<T>` typed properties with internal setters. Updated all call sites to use extension methods instead of `with` syntax for Width, Height, and Density. Updated the frontend `widgetRenderer.tsx` to resolve responsive objects directly from the unified `width`/`height`/`density` props instead of reading separate `responsiveWidth`/`responsiveHeight`/`responsiveDensity` props.

## API Changes

- `WidgetBase.Width`: changed from `Size?` to `Responsive<Size>?` (internal set)
- `WidgetBase.Height`: changed from `Size?` to `Responsive<Size>?` (internal set)
- `WidgetBase.Density`: changed from `Density?` to `Responsive<Density?>?` (internal set)
- Removed `WidgetBase.ResponsiveWidth` property
- Removed `WidgetBase.ResponsiveHeight` property
- Removed `WidgetBase.ResponsiveDensity` property
- Added `ResponsiveExtensions.ToResponsive<T>()` helper for null-safe `T?` to `Responsive<T>?` conversion
- Added `ResponsiveExtensions.ToResponsiveDensity()` helper for `Density?` to `Responsive<Density?>?` conversion
- Serialized JSON key changes: `responsiveWidth` -> `width` (responsive object), `responsiveHeight` -> `height`, `responsiveDensity` -> `density`

## Files Modified

- **Core:** `WidgetBase.cs`, `Responsive.cs`
- **Widgets:** `Icon.cs`, `HeaderLayout.cs`, `Sheet.cs`, `SidebarLayout.cs`, `GridLayout.cs`, `TextBlock.cs`
- **Views:** `LayoutView.cs`, `Text.cs`, 9 chart views (BarChartView, LineChartView, etc.)
- **Frontend:** `widgetRenderer.tsx`, `widgetRenderer-responsive.test.tsx`
- **Tests:** `ResponsiveWidgetTests.cs`

## Commits

- b0a8a8ae5 [03248] Consolidate WidgetBase props to use Responsive<T> types