### PR TITLE
[03077] Add configurable base branch and sync settings per repo

### DIFF
--- a/src/tendril/Ivy.Tendril.TeamIvyConfig/Promptwares/IvyFrameworkVerification/IvyFrameworkVerification.ps1
+++ b/src/tendril/Ivy.Tendril.TeamIvyConfig/Promptwares/IvyFrameworkVerification/IvyFrameworkVerification.ps1
@@ -60,7 +60,14 @@ $frontendDir = Join-Path $frameworkPath "src/frontend"
 # Check if worktree has frontend (.ts/.tsx) changes requiring a rebuild
 $needsFrontendRebuild = $false
 if (Test-Path $worktreePath) {
-    $tsChanges = git -C $worktreePath diff --name-only origin/main...HEAD -- "*.ts" "*.tsx" 2>$null
+    $repoConfig = GetRepoConfig -RepoPath $mainRepoPath
+    $baseBranch = if ($repoConfig.BaseBranch) {
+        $repoConfig.BaseBranch
+    } else {
+        $detected = git -C $mainRepoPath symbolic-ref refs/remotes/origin/HEAD 2>$null | ForEach-Object { $_ -replace 'refs/remotes/origin/', '' }
+        if ($detected) { $detected } else { "main" }
+    }
+    $tsChanges = git -C $worktreePath diff --name-only "origin/${baseBranch}...HEAD" -- "*.ts" "*.tsx" 2>$null
     $needsFrontendRebuild = ($tsChanges.Count -gt 0)
 }
 

--- a/src/tendril/Ivy.Tendril.TeamIvyConfig/config.yaml
+++ b/src/tendril/Ivy.Tendril.TeamIvyConfig/config.yaml
@@ -11,6 +11,7 @@ projects:
   - &o5
     path: D:\Repos\_Ivy\Ivy-Framework
     prRule: yolo
+    baseBranch: development
   verifications:
   - &o0
     name: DotnetBuild
@@ -57,9 +58,11 @@ projects:
   repos:
   - path: D:\Repos\_Ivy\Ivy-Agent
     prRule: yolo
+    baseBranch: development
   - &o4
     path: D:\Repos\_Ivy\Ivy
     prRule: yolo
+    baseBranch: development
   verifications:
   - *o0
   - *o1
@@ -85,8 +88,10 @@ projects:
   repos:
   - path: D:\Repos\_Ivy\Ivy-Agent\Ivy.Agent.Test.Studio
     prRule: yolo
+    baseBranch: development
   - path: D:\Repos\_Ivy\Ivy-Agent\Ivy.Agent.Test.Manager
     prRule: yolo
+    baseBranch: development
   verifications:
   - *o0
   - *o1
@@ -164,6 +169,7 @@ projects:
   repos:
   - path: D:\Repos\_Ivy\Ivy-Mcp
     prRule: yolo
+    baseBranch: development
   verifications:
   - *o0
   - *o1
@@ -188,6 +194,7 @@ projects:
   repos:
   - path: D:\Repos\_Ivy\Ivy-Services
     prRule: yolo
+    baseBranch: development
   verifications:
   - *o0
   - *o1

--- a/src/tendril/Ivy.Tendril.Test/ConfigServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/ConfigServiceTests.cs
@@ -1036,6 +1036,144 @@ jobTimeout: 30
     }
 
     [Fact]
+    public void RepoRef_BaseBranch_DefaultsToNull()
+    {
+        var repo = new RepoRef();
+        Assert.Null(repo.BaseBranch);
+    }
+
+    [Fact]
+    public void RepoRef_SyncStrategy_DefaultsToFetch()
+    {
+        var repo = new RepoRef();
+        Assert.Equal("fetch", repo.SyncStrategy);
+    }
+
+    [Fact]
+    public void Should_Deserialize_RepoRef_With_BaseBranch_And_SyncStrategy()
+    {
+        var yaml = @"
+projects:
+  - name: TestProject
+    repos:
+      - path: D:\Repos\Test
+        prRule: yolo
+        baseBranch: develop
+        syncStrategy: rebase
+";
+
+        var tempDir = CreateTempConfigFile(yaml);
+        var service = new ConfigService(new TendrilSettings());
+
+        try
+        {
+            service.SetTendrilHome(tempDir);
+
+            var repo = service.Settings.Projects[0].Repos[0];
+            Assert.Equal(@"D:\Repos\Test", repo.Path);
+            Assert.Equal("yolo", repo.PrRule);
+            Assert.Equal("develop", repo.BaseBranch);
+            Assert.Equal("rebase", repo.SyncStrategy);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void Should_Deserialize_RepoRef_Without_New_Fields_BackwardCompatible()
+    {
+        var yaml = @"
+projects:
+  - name: TestProject
+    repos:
+      - path: D:\Repos\Test
+        prRule: default
+";
+
+        var tempDir = CreateTempConfigFile(yaml);
+        var service = new ConfigService(new TendrilSettings());
+
+        try
+        {
+            service.SetTendrilHome(tempDir);
+
+            var repo = service.Settings.Projects[0].Repos[0];
+            Assert.Equal(@"D:\Repos\Test", repo.Path);
+            Assert.Equal("default", repo.PrRule);
+            Assert.Null(repo.BaseBranch);
+            Assert.Equal("fetch", repo.SyncStrategy);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void Should_Deserialize_RepoRef_With_Only_BaseBranch()
+    {
+        var yaml = @"
+projects:
+  - name: TestProject
+    repos:
+      - path: D:\Repos\Test
+        baseBranch: release/2.0
+";
+
+        var tempDir = CreateTempConfigFile(yaml);
+        var service = new ConfigService(new TendrilSettings());
+
+        try
+        {
+            service.SetTendrilHome(tempDir);
+
+            var repo = service.Settings.Projects[0].Repos[0];
+            Assert.Equal("release/2.0", repo.BaseBranch);
+            Assert.Equal("fetch", repo.SyncStrategy);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void Should_Roundtrip_RepoRef_With_New_Fields()
+    {
+        var yaml = @"
+projects:
+  - name: TestProject
+    repos:
+      - path: D:\Repos\Test
+        prRule: yolo
+        baseBranch: develop
+        syncStrategy: merge
+";
+
+        var tempDir = CreateTempConfigFile(yaml);
+        var service = new ConfigService(new TendrilSettings());
+
+        try
+        {
+            service.SetTendrilHome(tempDir);
+            service.SaveSettings();
+
+            var reloaded = new ConfigService(new TendrilSettings());
+            reloaded.SetTendrilHome(tempDir);
+
+            var repo = reloaded.Settings.Projects[0].Repos[0];
+            Assert.Equal("develop", repo.BaseBranch);
+            Assert.Equal("merge", repo.SyncStrategy);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
     public void ResetToDefaults_Clears_Error_And_Sets_Onboarding()
     {
         var tempDir = CreateTempConfigFile("broken: [yaml");

--- a/src/tendril/Ivy.Tendril/Promptwares/.shared/Utils.ps1
+++ b/src/tendril/Ivy.Tendril/Promptwares/.shared/Utils.ps1
@@ -367,6 +367,51 @@ function GetProjectWorkDir {
     return (Get-Location).Path
 }
 
+function GetRepoConfig {
+    param(
+        [string]$RepoPath,
+        [string]$Project = ""
+    )
+
+    $config = Get-ConfigYaml
+    if (-not $config -or -not $config.projects) {
+        return @{ BaseBranch = $null; SyncStrategy = "fetch" }
+    }
+
+    $resolvedRepoPath = try { (Resolve-Path $RepoPath -ErrorAction Stop).Path } catch { $RepoPath }
+
+    $projectEntries = if ($Project) {
+        @($config.projects | Where-Object { $_.name -eq $Project })
+    } else {
+        @($config.projects)
+    }
+
+    foreach ($projectEntry in $projectEntries) {
+        if (-not $projectEntry.repos) { continue }
+        foreach ($repo in $projectEntry.repos) {
+            $repoPathValue = if ($repo -is [hashtable] -or $repo -is [System.Collections.IDictionary]) {
+                [Environment]::ExpandEnvironmentVariables($repo.path)
+            } else {
+                [Environment]::ExpandEnvironmentVariables("$repo")
+            }
+
+            if (-not $repoPathValue) { continue }
+            $resolvedConfigPath = try { (Resolve-Path $repoPathValue -ErrorAction Stop).Path } catch { $repoPathValue }
+
+            if ($resolvedConfigPath -eq $resolvedRepoPath) {
+                if ($repo -is [hashtable] -or $repo -is [System.Collections.IDictionary]) {
+                    return @{
+                        BaseBranch   = $repo.baseBranch
+                        SyncStrategy = if ($repo.syncStrategy) { $repo.syncStrategy } else { "fetch" }
+                    }
+                }
+            }
+        }
+    }
+
+    return @{ BaseBranch = $null; SyncStrategy = "fetch" }
+}
+
 function Get-ConfigYaml {
     if (-not (Test-Path $script:ConfigPath)) {
         return $null

--- a/src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/ExecutePlan.ps1
+++ b/src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/ExecutePlan.ps1
@@ -37,6 +37,20 @@ if ($Note) {
     $firmwareValues["Note"] = $Note
 }
 
+$repoConfigsYaml = ""
+foreach ($repoPath in $planInfo.Yaml.repos) {
+    $cfg = GetRepoConfig -RepoPath $repoPath -Project $planInfo.Project
+    $repoName = Split-Path $repoPath -Leaf
+    $repoConfigsYaml += "${repoName}:`n"
+    if ($cfg.BaseBranch) {
+        $repoConfigsYaml += "  baseBranch: $($cfg.BaseBranch)`n"
+    }
+    $repoConfigsYaml += "  syncStrategy: $($cfg.SyncStrategy)`n"
+}
+if ($repoConfigsYaml) {
+    $firmwareValues["RepoConfigs"] = $repoConfigsYaml
+}
+
 $promptFile = PrepareFirmware $PSScriptRoot $logFile $programFolder $firmwareValues
 
 $agent = GetAgentCommand -Promptware "ExecutePlan"

--- a/src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
+++ b/src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
@@ -219,7 +219,10 @@ fi
 For each repo listed in `plan.yaml` `repos` (or the project's repos from `config.yaml` if empty):
 
 1. Fetch latest from remote: `git fetch origin`
-2. Detect the default branch: `git symbolic-ref refs/remotes/origin/HEAD | sed 's|refs/remotes/origin/||'` (usually `master` or `main`)
+2. Determine the base branch:
+   - Check the `RepoConfigs` firmware header for this repo's `baseBranch` value
+   - If configured, use that value as the base branch
+   - Otherwise, auto-detect via: `git symbolic-ref refs/remotes/origin/HEAD | sed 's|refs/remotes/origin/||'`
 3. If the worktree or branch already exists from a prior execution, remove it first. A prior run may have left a **stale directory** (the filesystem tree still exists but git no longer tracks it as a worktree — there's no `.git` file at the worktree root). In that case `git worktree remove` will fail with "is not a working tree"; you must also `rm -rf` the directory. **Do all three unconditionally** so the next `git worktree add` starts from a clean slate:
 
 ```bash
@@ -244,7 +247,7 @@ PLAN_FOLDER_NAME=$(basename "<PlanFolder>")
 PLAN_ID=$(echo "$PLAN_FOLDER_NAME" | grep -oP '^\d+')
 SAFE_TITLE=$(echo "$PLAN_FOLDER_NAME" | sed 's/^[0-9]\+-//')
 BRANCH_NAME="tendril/$PLAN_ID-$SAFE_TITLE"
-git worktree add "<PlanFolder>/worktrees/<repo-folder-name>" -b "$BRANCH_NAME" "origin/<default-branch>"
+git worktree add "<PlanFolder>/worktrees/<repo-folder-name>" -b "$BRANCH_NAME" "origin/<resolved-base-branch>"
 ```
 
 Example:
@@ -252,10 +255,19 @@ Example:
 ```bash
 cd <RepoPath>
 git fetch origin
-git worktree add "<PlanFolder>/worktrees/<RepoName>" -b "tendril/<PlanId>-<SafeTitle>" origin/master
+git worktree add "<PlanFolder>/worktrees/<RepoName>" -b "tendril/<PlanId>-<SafeTitle>" origin/<resolved-base-branch>
 ```
 
-**Important:** Always branch from `origin/<default-branch>`, not local HEAD. This ensures the PR only contains the plan's commits, not any unpushed local work.
+**Important:** Always branch from `origin/<resolved-base-branch>`, not local HEAD. This ensures the PR only contains the plan's commits, not any unpushed local work. The `<resolved-base-branch>` comes from either the `RepoConfigs` firmware header (if `baseBranch` is configured) or auto-detection.
+
+**Note on `RepoConfigs`:** The firmware header may include a `RepoConfigs` value injected by ExecutePlan.ps1. It contains per-repo configuration from `config.yaml`:
+```yaml
+RepoConfigs: |
+  Ivy-Framework:
+    baseBranch: develop
+    syncStrategy: rebase
+```
+If `baseBranch` is present for a repo, use it instead of auto-detecting. If absent, fall back to `git symbolic-ref refs/remotes/origin/HEAD`.
 
 4. After creating the worktree, **verify the `.git` file exists** and fail fast if it's missing:
 
@@ -280,6 +292,12 @@ pwsh -NoProfile -Command '& "$env:TENDRIL_HOME/Promptwares/ExecutePlan/Tools/Log
 ```
 
 This creates a structured log entry in `$TENDRIL_HOME/Logs/worktrees.log` recording the worktree creation with repo path and branch metadata. Logging only happens after successful `.git` file verification (Step 2.4), ensuring only successfully created worktrees are recorded.
+
+6. Apply sync strategy (if configured in `RepoConfigs`):
+   - If `syncStrategy` is `"fetch"` (or not specified), no additional action needed (already fetched in step 1)
+   - If `syncStrategy` is `"rebase"`, after worktree creation run: `cd <worktree-path> && git fetch origin && git rebase origin/<resolved-base-branch>`
+   - If `syncStrategy` is `"merge"`, after worktree creation run: `cd <worktree-path> && git fetch origin && git merge origin/<resolved-base-branch>`
+   - Note: These sync operations should also be run before each commit created during plan execution to keep the branch up-to-date
 
 ### 2.5. Setup Frontend Dependencies (JavaScript/TypeScript Projects Only)
 

--- a/src/tendril/Ivy.Tendril/Promptwares/MakePr/MakePr.ps1
+++ b/src/tendril/Ivy.Tendril/Promptwares/MakePr/MakePr.ps1
@@ -13,9 +13,24 @@ $logFile = GetNextLogFile $programFolder
 $PlanPath | Set-Content $logFile
 Write-Host "Log file: $logFile"
 
-$promptFile = PrepareFirmware $PSScriptRoot $logFile $programFolder @{
+$repoConfigsYaml = ""
+foreach ($repoPath in $planInfo.Yaml.repos) {
+    $cfg = GetRepoConfig -RepoPath $repoPath -Project $planInfo.Project
+    $repoName = Split-Path $repoPath -Leaf
+    $repoConfigsYaml += "${repoName}:`n"
+    if ($cfg.BaseBranch) {
+        $repoConfigsYaml += "  baseBranch: $($cfg.BaseBranch)`n"
+    }
+    $repoConfigsYaml += "  syncStrategy: $($cfg.SyncStrategy)`n"
+}
+
+$fwValues = @{
     Args = $PlanPath; PlanFolder = $PlanPath; Project = $planInfo.Project
 }
+if ($repoConfigsYaml) {
+    $fwValues["RepoConfigs"] = $repoConfigsYaml
+}
+$promptFile = PrepareFirmware $PSScriptRoot $logFile $programFolder $fwValues
 
 $agent = GetAgentCommand -Promptware "MakePr"
 $sessionId = $env:TENDRIL_SESSION_ID

--- a/src/tendril/Ivy.Tendril/Promptwares/MakePr/Program.md
+++ b/src/tendril/Ivy.Tendril/Promptwares/MakePr/Program.md
@@ -85,7 +85,11 @@ EOF
 )"
 ```
 
-- **Base branch:** `gh repo view <owner/repo> --json defaultBranchRef -q .defaultBranchRef.name`
+- **Base branch:**
+  1. Read plan.yaml and get the project name
+  2. For each repo, call `GetRepoConfig` (from Utils.ps1) to check if `baseBranch` is configured
+  3. If configured, use that value
+  4. Otherwise, auto-detect via: `gh repo view <owner/repo> --json defaultBranchRef -q .defaultBranchRef.name`
 - **Title:** `[<planId>] <plan title>`
 - **Body:** If `<PlanFolder>/artifacts/summary.md` exists, use its content as the PR body (followed by list of commits). Otherwise, fall back to summary from Problem + Solution sections. If `$artifactMarkdown` from step 2.5 is non-empty, append it under an `## Artifacts` heading after the commits list.
 - **Assignee (custom options):** If custom options exist and `assignee` is non-empty, add `--assignee <assignee>` to the `gh pr create` command.

--- a/src/tendril/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/tendril/Ivy.Tendril/Services/ConfigService.cs
@@ -17,6 +17,8 @@ public record RepoRef
 {
     public string Path { get; set; } = "";
     public string PrRule { get; set; } = "default";
+    public string? BaseBranch { get; set; }
+    public string SyncStrategy { get; set; } = "fetch";
 }
 
 public record ProjectConfig

--- a/src/tendril/Ivy.Tendril/example.config.yaml
+++ b/src/tendril/Ivy.Tendril/example.config.yaml
@@ -90,7 +90,11 @@ promptwares:
 #     repos:
 #       - path: /absolute/path/to/repo
 #         prRule: default    # PR merge strategy: default or yolo (auto-merge)
+#         # baseBranch: develop       # Override default branch (auto-detected if omitted)
+#         # syncStrategy: fetch       # fetch (default) | rebase | merge
 #       - path: "%REPOS_HOME%/my-repo"
+#         baseBranch: main
+#         syncStrategy: rebase
 #     verifications:
 #       - name: Build
 #         required: true


### PR DESCRIPTION
# Summary

## Changes

Added configurable `baseBranch` and `syncStrategy` per-repo settings to Tendril's config model. Promptwares (ExecutePlan, MakePr) now read these settings and inject them into firmware headers, allowing worktrees to be created from the configured branch instead of relying solely on auto-detection. Fixed a hardcoded `origin/main` reference in IvyFrameworkVerification and configured all Team Ivy repos to use `baseBranch: development`.

## API Changes

- `RepoRef` record: Added `string? BaseBranch` (default: null) and `string SyncStrategy` (default: "fetch")
- `GetRepoConfig` PowerShell function added to Utils.ps1 — returns `@{ BaseBranch; SyncStrategy }` for a given repo path
- `RepoConfigs` firmware header value: new YAML-formatted per-repo config injected into ExecutePlan and MakePr firmware
- config.yaml repos: `baseBranch` and `syncStrategy` fields now recognized per repo entry

## Files Modified

**Core model:**
- `src/tendril/Ivy.Tendril/Services/ConfigService.cs` — Extended RepoRef record

**Shared utilities:**
- `src/tendril/Ivy.Tendril/Promptwares/.shared/Utils.ps1` — Added GetRepoConfig function

**Promptwares:**
- `src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/ExecutePlan.ps1` — Inject RepoConfigs into firmware
- `src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/Program.md` — Use configured base branch, add sync strategy docs
- `src/tendril/Ivy.Tendril/Promptwares/MakePr/MakePr.ps1` — Inject RepoConfigs into firmware
- `src/tendril/Ivy.Tendril/Promptwares/MakePr/Program.md` — Use configured base branch for PR creation

**Configuration:**
- `src/tendril/Ivy.Tendril/example.config.yaml` — Added commented examples for new fields
- `src/tendril/Ivy.Tendril.TeamIvyConfig/config.yaml` — Set baseBranch: development for all repos
- `src/tendril/Ivy.Tendril.TeamIvyConfig/Promptwares/IvyFrameworkVerification/IvyFrameworkVerification.ps1` — Replace hardcoded origin/main

**Tests:**
- `src/tendril/Ivy.Tendril.Test/ConfigServiceTests.cs` — 6 new tests for RepoRef deserialization

## Commits

- 743c0fbc3 [03077] Add BaseBranch and SyncStrategy to RepoRef model and GetRepoConfig utility
- dc6d962e1 [03077] Thread RepoConfigs through ExecutePlan and MakePr promptwares
- 3a3bd5fbd [03077] Update configs and fix hardcoded origin/main in IvyFrameworkVerification
- 43359ef90 [03077] Add unit tests for RepoRef BaseBranch and SyncStrategy deserialization