### PR TITLE
[03235] UseContext<BladeContext> fails in child views created by UseBlades

### DIFF
--- a/src/Ivy/Views/Blades/UseBlades.cs
+++ b/src/Ivy/Views/Blades/UseBlades.cs
@@ -20,7 +20,7 @@ public interface IBladeContext
     int GetIndex(IView bladeView);
 }
 
-public class BladeContext : IBladeContext
+internal class BladeContext : IBladeContext
 {
     public BladeContext()
     {


### PR DESCRIPTION
# Summary

## Changes

Changed `BladeContext` class visibility from `public` to `internal` in `UseBlades.cs`. This prevents agents from referencing the concrete type in `UseContext<BladeContext>()`, converting a confusing runtime `InvalidOperationException` into a clear compile-time error about inaccessibility.

## API Changes

- `BladeContext` class: `public` -> `internal` (no longer accessible outside the Ivy assembly)

## Files Modified

- **src/Ivy/Views/Blades/UseBlades.cs** — Changed class visibility modifier


## Commits

- 0f3a820fd