### PR TITLE
[03213] Fix markdown links rendering as literal text instead of clickable links

### DIFF
--- a/src/frontend/src/components/MarkdownRenderer.tsx
+++ b/src/frontend/src/components/MarkdownRenderer.tsx
@@ -159,7 +159,11 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
 
       // Validate URL to prevent open redirect vulnerabilities
       // validateLinkUrl always returns a string ('#' for invalid URLs)
-      const validatedHref = validateLinkUrl(href);
+      // When onLinkClick is registered, allow custom protocols (e.g. plan://)
+      // since the handler intercepts navigation rather than the browser
+      const validatedHref = validateLinkUrl(href, {
+        allowCustomProtocols: !!onLinkClick,
+      });
       if (validatedHref === "#") {
         event.preventDefault();
         return;
@@ -438,7 +442,9 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
           // When local files are enabled, allow file:// URLs to render as clickable links
           const isLocalFileUrl = dangerouslyAllowLocalFiles && href?.startsWith("file:///");
 
-          const safeHref = isLocalFileUrl ? href! : validateLinkUrl(href);
+          const safeHref = isLocalFileUrl
+            ? href!
+            : validateLinkUrl(href, { allowCustomProtocols: !!onLinkClick });
           if (safeHref === "#") {
             return <span {...props}>{children}</span>;
           }

--- a/src/frontend/src/lib/url.ts
+++ b/src/frontend/src/lib/url.ts
@@ -180,14 +180,22 @@ export function validateRedirectUrl(
   }
 }
 
+const DANGEROUS_PROTOCOLS = new Set(["javascript:", "data:", "vbscript:", "blob:"]);
+
 /**
  * Validates and sanitizes a URL for use in anchor tags or window.open.
  * Allows relative paths, external http/https URLs, and app:// URLs, but prevents dangerous protocols.
  *
  * @param url - The URL to validate
+ * @param options.allowCustomProtocols - When true, allows any URL scheme that isn't dangerous
+ *   (javascript:, data:, vbscript:, blob:). Useful when an onLinkClick handler intercepts all
+ *   navigation, so custom schemes like plan:// are passed to application code rather than the browser.
  * @returns The sanitized URL if valid, '#' otherwise
  */
-export function validateLinkUrl(url: string | null | undefined): string {
+export function validateLinkUrl(
+  url: string | null | undefined,
+  options?: { allowCustomProtocols?: boolean },
+): string {
   if (!url || typeof url !== "string") {
     return "#";
   }
@@ -266,9 +274,14 @@ export function validateLinkUrl(url: string | null | undefined): string {
   try {
     const urlObj = new URL(url);
 
-    // Only allow http and https protocols (prevent javascript:, data:, etc.)
-    if (urlObj.protocol !== "http:" && urlObj.protocol !== "https:") {
-      return "#";
+    if (options?.allowCustomProtocols) {
+      if (DANGEROUS_PROTOCOLS.has(urlObj.protocol)) {
+        return "#";
+      }
+    } else {
+      if (urlObj.protocol !== "http:" && urlObj.protocol !== "https:") {
+        return "#";
+      }
     }
 
     return urlObj.toString();

--- a/src/frontend/src/lib/utils.test.ts
+++ b/src/frontend/src/lib/utils.test.ts
@@ -302,6 +302,45 @@ describe("validateLinkUrl", () => {
       );
     });
   });
+
+  describe("allowCustomProtocols option", () => {
+    it("should allow custom protocol URLs when enabled", () => {
+      expect(validateLinkUrl("plan://03156", { allowCustomProtocols: true })).toBe("plan://03156");
+      expect(validateLinkUrl("tel:+1234567890", { allowCustomProtocols: true })).toBe(
+        "tel:+1234567890",
+      );
+      expect(validateLinkUrl("custom://some-resource", { allowCustomProtocols: true })).toBe(
+        "custom://some-resource",
+      );
+    });
+
+    it("should still block dangerous protocols when custom protocols are allowed", () => {
+      expect(validateLinkUrl('javascript:alert("xss")', { allowCustomProtocols: true })).toBe("#");
+      expect(
+        validateLinkUrl('data:text/html,<script>alert("xss")</script>', {
+          allowCustomProtocols: true,
+        }),
+      ).toBe("#");
+      expect(
+        validateLinkUrl('vbscript:msgbox("xss")', { allowCustomProtocols: true }),
+      ).toBe("#");
+    });
+
+    it("should reject custom protocols by default", () => {
+      expect(validateLinkUrl("plan://03156")).toBe("#");
+      expect(validateLinkUrl("custom://resource")).toBe("#");
+    });
+
+    it("should still allow standard URLs when custom protocols are enabled", () => {
+      expect(validateLinkUrl("https://example.com", { allowCustomProtocols: true })).toBe(
+        "https://example.com/",
+      );
+      expect(validateLinkUrl("app://dashboard", { allowCustomProtocols: true })).toBe(
+        "app://dashboard",
+      );
+      expect(validateLinkUrl("/relative", { allowCustomProtocols: true })).toBe("/relative");
+    });
+  });
 });
 
 describe("getIvyHost", () => {


### PR DESCRIPTION
# Summary

## Changes

Added an `allowCustomProtocols` option to `validateLinkUrl()` that switches from a strict protocol allowlist (http/https only) to a blocklist of dangerous protocols (javascript:, data:, vbscript:, blob:). `MarkdownRenderer` now passes this option when an `onLinkClick` handler is registered, allowing custom URL schemes like `plan://` to render as clickable links instead of plain `<span>` text.

## API Changes

- `validateLinkUrl(url, options?)` — new optional second parameter `{ allowCustomProtocols?: boolean }`. Default behavior is unchanged.

## Files Modified

- `src/frontend/src/lib/url.ts` — Added `DANGEROUS_PROTOCOLS` set and `allowCustomProtocols` option to `validateLinkUrl`
- `src/frontend/src/components/MarkdownRenderer.tsx` — Pass `allowCustomProtocols: !!onLinkClick` in both the link component and `handleLinkClick` callback
- `src/frontend/src/lib/utils.test.ts` — Added test suite for `allowCustomProtocols` behavior

## Commits

- dd3653e74 [03213] Allow custom URL protocols in MarkdownRenderer when onLinkClick is registered