### PR TITLE
[03265] Fix table cell typography scaling in markdown renderer

### DIFF
--- a/src/frontend/src/lib/styles.ts
+++ b/src/frontend/src/lib/styles.ts
@@ -771,8 +771,8 @@ export const typography: Record<string, string> = {
   table: "w-full border-collapse border border-border",
   thead: "bg-muted",
   tr: "border border-border",
-  th: "border border-border px-4 py-2 text-left font-bold text-sm",
-  td: "border border-border px-4 py-2 text-sm",
+  th: "border border-border px-4 py-2 text-left font-bold text-[0.875em]",
+  td: "border border-border px-4 py-2 text-[0.875em]",
 
   // Media
   img: "max-w-full h-auto cursor-zoom-in border border-border rounded-md",


### PR DESCRIPTION
# Summary

## Changes

Replaced fixed `text-sm` (absolute 14px) with relative `text-[0.875em]` in markdown table header (`th`) and cell (`td`) typography styles. This ensures table text scales proportionally with MarkdownWidget's density-based CSS transform, consistent with the inline code fix in Plan 03252.

## API Changes

None.

## Files Modified

- **src/frontend/src/lib/styles.ts** — Updated `typography.th` and `typography.td` class strings from `text-sm` to `text-[0.875em]`


## Commits

- 1223b908b