### PR TITLE
[03270] Extract shared WithSlot helper to reduce duplication

### DIFF
--- a/src/Ivy/Widgets/Card.cs
+++ b/src/Ivy/Widgets/Card.cs
@@ -53,13 +53,6 @@ public static class CardExtensions
 {
     internal static Slot? GetSlot(this Card card, string name) => card.Children.FirstOrDefault(e => e is Slot slot && slot.Name == name) as Slot;
 
-    private static object[] WithSlot(Card card, string slotName, object? value)
-    {
-        var others = card.Children.OfType<Slot>().Where(s => s.Name != slotName);
-        var result = value != null ? others.Append(new Slot(slotName, value)) : others;
-        return result.Cast<object>().ToArray();
-    }
-
     public static Card Header(this Card card, object? title = null, object? description = null, object? icon = null)
     {
         object? header = Layout.Vertical().Gap(0)
@@ -98,10 +91,10 @@ public static class CardExtensions
     }
 
     public static Card Content(this Card card, object? content) =>
-        card with { Children = WithSlot(card, "Content", content) };
+        card with { Children = card.WithSlot("Content", content) };
 
     public static Card Footer(this Card card, object? footer) =>
-        card with { Children = WithSlot(card, "Footer", footer) };
+        card with { Children = card.WithSlot("Footer", footer) };
 
     public static Card Hover(this Card card, HoverEffect variant) => card with { HoverVariant = variant };
 

--- a/src/Ivy/Widgets/Inputs/BoolInput.cs
+++ b/src/Ivy/Widgets/Inputs/BoolInput.cs
@@ -328,17 +328,10 @@ public static class BoolInputExtensions
         return widget with { OnFocus = new(_ => { onFocus(); return ValueTask.CompletedTask; }) };
     }
 
-    private static object[] WithSlot(BoolInputBase widget, string slotName, object? value)
-    {
-        var others = widget.Children.Where(c => c is not Slot s || s.Name != slotName);
-        var result = value != null ? others.Append(new Slot(slotName, value)) : others;
-        return result.ToArray();
-    }
-
     public static BoolInputBase Prefix(this BoolInputBase widget, object prefix)
-        => widget with { Children = WithSlot(widget, "Prefix", prefix) };
+        => widget with { Children = widget.WithSlot("Prefix", prefix) };
 
     public static BoolInputBase Suffix(this BoolInputBase widget, object suffix)
-        => widget with { Children = WithSlot(widget, "Suffix", suffix) };
+        => widget with { Children = widget.WithSlot("Suffix", suffix) };
 
 }

--- a/src/Ivy/Widgets/Inputs/ColorInput.cs
+++ b/src/Ivy/Widgets/Inputs/ColorInput.cs
@@ -237,16 +237,9 @@ public static class ColorInputExtensions
         return widget.OnFocus(_ => { onFocus(); return ValueTask.CompletedTask; });
     }
 
-    private static object[] WithSlot(ColorInputBase widget, string slotName, object? value)
-    {
-        var others = widget.Children.Where(c => c is not Slot s || s.Name != slotName);
-        var result = value != null ? others.Append(new Slot(slotName, value)) : others;
-        return result.ToArray();
-    }
-
     public static ColorInputBase Prefix(this ColorInputBase widget, object prefix)
-        => widget with { Children = WithSlot(widget, "Prefix", prefix) };
+        => widget with { Children = widget.WithSlot("Prefix", prefix) };
 
     public static ColorInputBase Suffix(this ColorInputBase widget, object suffix)
-        => widget with { Children = WithSlot(widget, "Suffix", suffix) };
+        => widget with { Children = widget.WithSlot("Suffix", suffix) };
 }

--- a/src/Ivy/Widgets/Inputs/DateRangeInput.cs
+++ b/src/Ivy/Widgets/Inputs/DateRangeInput.cs
@@ -184,17 +184,10 @@ public static class DateRangeInputExtensions
         return widget.OnFocus(_ => { onFocus(); return ValueTask.CompletedTask; });
     }
 
-    private static object[] WithSlot(DateRangeInputBase widget, string slotName, object? value)
-    {
-        var others = widget.Children.Where(c => c is not Slot s || s.Name != slotName);
-        var result = value != null ? others.Append(new Slot(slotName, value)) : others;
-        return result.ToArray();
-    }
-
     public static DateRangeInputBase Prefix(this DateRangeInputBase widget, object prefix)
-        => widget with { Children = WithSlot(widget, "Prefix", prefix) };
+        => widget with { Children = widget.WithSlot("Prefix", prefix) };
 
     public static DateRangeInputBase Suffix(this DateRangeInputBase widget, object suffix)
-        => widget with { Children = WithSlot(widget, "Suffix", suffix) };
+        => widget with { Children = widget.WithSlot("Suffix", suffix) };
 
 }

--- a/src/Ivy/Widgets/Inputs/DateTimeInput.cs
+++ b/src/Ivy/Widgets/Inputs/DateTimeInput.cs
@@ -309,16 +309,9 @@ public static class DateTimeInputExtensions
         return widget.OnFocus(_ => { onFocus(); return ValueTask.CompletedTask; });
     }
 
-    private static object[] WithSlot(DateTimeInputBase widget, string slotName, object? value)
-    {
-        var others = widget.Children.Where(c => c is not Slot s || s.Name != slotName);
-        var result = value != null ? others.Append(new Slot(slotName, value)) : others;
-        return result.ToArray();
-    }
-
     public static DateTimeInputBase Prefix(this DateTimeInputBase widget, object prefix)
-        => widget with { Children = WithSlot(widget, "Prefix", prefix) };
+        => widget with { Children = widget.WithSlot("Prefix", prefix) };
 
     public static DateTimeInputBase Suffix(this DateTimeInputBase widget, object suffix)
-        => widget with { Children = WithSlot(widget, "Suffix", suffix) };
+        => widget with { Children = widget.WithSlot("Suffix", suffix) };
 }

--- a/src/Ivy/Widgets/Inputs/NumberInput.cs
+++ b/src/Ivy/Widgets/Inputs/NumberInput.cs
@@ -242,18 +242,11 @@ public static class NumberInputExtensions
         return widget with { Invalid = invalid };
     }
 
-    private static object[] WithSlot(NumberInputBase widget, string slotName, object? value)
-    {
-        var others = widget.Children.Where(c => c is not Slot s || s.Name != slotName);
-        var result = value != null ? others.Append(new Slot(slotName, value)) : others;
-        return result.ToArray();
-    }
-
     public static NumberInputBase Prefix(this NumberInputBase widget, object prefix)
-        => widget with { Children = WithSlot(widget, "Prefix", prefix) };
+        => widget with { Children = widget.WithSlot("Prefix", prefix) };
 
     public static NumberInputBase Suffix(this NumberInputBase widget, object suffix)
-        => widget with { Children = WithSlot(widget, "Suffix", suffix) };
+        => widget with { Children = widget.WithSlot("Suffix", suffix) };
 
     [OverloadResolutionPriority(1)]
     public static NumberInputBase OnBlur(this NumberInputBase widget, Func<Event<IAnyInput>, ValueTask> onBlur)

--- a/src/Ivy/Widgets/Inputs/NumberRangeInput.cs
+++ b/src/Ivy/Widgets/Inputs/NumberRangeInput.cs
@@ -224,18 +224,11 @@ public static class NumberRangeInputExtensions
         return widget with { Invalid = invalid };
     }
 
-    private static object[] WithSlot(NumberRangeInputBase widget, string slotName, object? value)
-    {
-        var others = widget.Children.Where(c => c is not Slot s || s.Name != slotName);
-        var result = value != null ? others.Append(new Slot(slotName, value)) : others;
-        return result.ToArray();
-    }
-
     public static NumberRangeInputBase Prefix(this NumberRangeInputBase widget, object prefix)
-        => widget with { Children = WithSlot(widget, "Prefix", prefix) };
+        => widget with { Children = widget.WithSlot("Prefix", prefix) };
 
     public static NumberRangeInputBase Suffix(this NumberRangeInputBase widget, object suffix)
-        => widget with { Children = WithSlot(widget, "Suffix", suffix) };
+        => widget with { Children = widget.WithSlot("Suffix", suffix) };
 
     [OverloadResolutionPriority(1)]
     public static NumberRangeInputBase OnBlur(this NumberRangeInputBase widget, Func<Event<IAnyInput>, ValueTask> onBlur)

--- a/src/Ivy/Widgets/Inputs/SelectInput.cs
+++ b/src/Ivy/Widgets/Inputs/SelectInput.cs
@@ -263,17 +263,10 @@ public static class SelectInputExtensions
         return new SelectInput<string[]>(state, options.ToOptions(), placeholder ?? "Select options...", disabled, variant, true);
     }
 
-    private static object[] WithSlot(SelectInputBase widget, string slotName, object? value)
-    {
-        var others = widget.Children.Where(c => c is not Slot s || s.Name != slotName);
-        var result = value != null ? others.Append(new Slot(slotName, value)) : others;
-        return result.ToArray();
-    }
-
     public static SelectInputBase Prefix(this SelectInputBase widget, object prefix)
-        => widget with { Children = WithSlot(widget, "Prefix", prefix) };
+        => widget with { Children = widget.WithSlot("Prefix", prefix) };
 
     public static SelectInputBase Suffix(this SelectInputBase widget, object suffix)
-        => widget with { Children = WithSlot(widget, "Suffix", suffix) };
+        => widget with { Children = widget.WithSlot("Suffix", suffix) };
 
 }

--- a/src/Ivy/Widgets/Inputs/TextInput.cs
+++ b/src/Ivy/Widgets/Inputs/TextInput.cs
@@ -269,18 +269,11 @@ public static class TextInputExtensions
 
     public static TextInputBase Rows(this TextInputBase widget, int rows) => widget with { Rows = rows };
 
-    private static object[] WithSlot(TextInputBase widget, string slotName, object? value)
-    {
-        var others = widget.Children.Where(c => c is not Slot s || s.Name != slotName);
-        var result = value != null ? others.Append(new Slot(slotName, value)) : others;
-        return result.ToArray();
-    }
-
     public static TextInputBase Prefix(this TextInputBase widget, object prefix)
-        => widget with { Children = WithSlot(widget, "Prefix", prefix) };
+        => widget with { Children = widget.WithSlot("Prefix", prefix) };
 
     public static TextInputBase Suffix(this TextInputBase widget, object suffix)
-        => widget with { Children = WithSlot(widget, "Suffix", suffix) };
+        => widget with { Children = widget.WithSlot("Suffix", suffix) };
 
     [OverloadResolutionPriority(1)]
     public static TextInputBase OnBlur(this TextInputBase widget, Func<Event<IAnyInput>, ValueTask> onBlur)

--- a/src/Ivy/Widgets/WidgetBase.cs
+++ b/src/Ivy/Widgets/WidgetBase.cs
@@ -81,6 +81,13 @@ public static class WidgetBaseExtensions
     public static T Density<T>(this T widget, Responsive<Density?> density) where T : WidgetBase
         => widget with { Density = density };
 
+    internal static object[] WithSlot<T>(this T widget, string slotName, object? value) where T : WidgetBase
+    {
+        var others = widget.Children.Where(c => c is not Slot s || s.Name != slotName);
+        var result = value != null ? others.Append(new Slot(slotName, value)) : others;
+        return result.ToArray();
+    }
+
     internal static void SetDensityViaReflection(object input, Density? density)
     {
         var type = input.GetType();


### PR DESCRIPTION
# Summary

## Changes

Extracted the duplicated `WithSlot` helper method from 9 widget extension classes into a single generic `internal static object[] WithSlot<T>(this T widget, string slotName, object? value) where T : WidgetBase` method on `WidgetBaseExtensions`. Card's slightly different implementation (using `OfType<Slot>()`) was unified to use the same logic since Card only stores Slot children — the broader filter is strictly more correct.

## API Changes

- Added `WidgetBaseExtensions.WithSlot<T>(this T widget, string slotName, object? value)` — `internal` visibility, not a public API change.
- Removed 9 `private static WithSlot(...)` methods from individual extension classes.

## Files Modified

- **Shared helper:** `src/Ivy/Widgets/WidgetBase.cs` — added generic `WithSlot<T>` extension method
- **Input widgets (8 files):** TextInput.cs, NumberInput.cs, NumberRangeInput.cs, BoolInput.cs, SelectInput.cs, DateTimeInput.cs, DateRangeInput.cs, ColorInput.cs — removed private WithSlot, updated Prefix/Suffix to use shared helper
- **Card:** `src/Ivy/Widgets/Card.cs` — removed private WithSlot, updated Content/Footer to use shared helper


## Commits

- 3d7d69a8c