### PR TITLE
[03262] Remove Plan status filtering in Recommendations

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Recommendations/SidebarView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Recommendations/SidebarView.cs
@@ -6,13 +6,11 @@ public class SidebarView(
     List<Recommendation> recommendations,
     IState<Recommendation?> selectedState,
     IState<string?> projectFilter,
-    IState<string?> planStatusFilter,
     int totalCount,
     bool hasActiveFilters,
     IState<string?> textFilter) : ViewBase
 {
     private readonly bool _hasActiveFilters = hasActiveFilters;
-    private readonly IState<string?> _planStatusFilter = planStatusFilter;
     private readonly IState<string?> _projectFilter = projectFilter;
     private readonly List<Recommendation> _recommendations = recommendations;
     private readonly IState<Recommendation?> _selectedState = selectedState;
@@ -25,13 +23,6 @@ public class SidebarView(
             .GroupBy(r => r.Project)
             .OrderByDescending(g => g.Count())
             .Select(g => new Option<string>($"{g.Key} ({g.Count()})", g.Key))
-            .ToArray<IAnyOption>();
-
-        var statusOptions = _recommendations
-            .Select(r => r.SourcePlanStatus)
-            .Distinct()
-            .OrderBy(s => s)
-            .Select(s => new Option<string>(s.ToString(), s.ToString()))
             .ToArray<IAnyOption>();
 
         var searchInput = _textFilter.ToSearchInput()
@@ -50,9 +41,7 @@ public class SidebarView(
         {
             header |= Layout.Vertical()
                       | _projectFilter.ToSelectInput(projectOptions).Placeholder("All Projects").Nullable()
-                          .WithField().Label("Project")
-                      | _planStatusFilter.ToSelectInput(statusOptions).Placeholder("All Statuses").Nullable()
-                          .WithField().Label("Plan Status");
+                          .WithField().Label("Project");
         }
 
         return header;
@@ -62,7 +51,6 @@ public class SidebarView(
     {
         var filtered = _recommendations
             .Where(r => _projectFilter.Value == null || r.Project == _projectFilter.Value)
-            .Where(r => _planStatusFilter.Value == null || r.SourcePlanStatus.ToString() == _planStatusFilter.Value)
             .Where(r =>
             {
                 if (string.IsNullOrWhiteSpace(_textFilter.Value)) return true;

--- a/src/tendril/Ivy.Tendril/Apps/RecommendationsApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/RecommendationsApp.cs
@@ -13,7 +13,6 @@ public class RecommendationsApp : ViewBase
         var refreshToken = UseRefreshToken();
         var selectedState = UseState<Recommendation?>(null);
         var projectFilter = UseState<string?>(null);
-        var planStatusFilter = UseState<string?>(null);
         var textFilter = UseState<string?>("");
 
         UseInterval(() => refreshToken.Refresh(), TimeSpan.FromMinutes(1));
@@ -24,7 +23,6 @@ public class RecommendationsApp : ViewBase
 
         var filtered = allPending
             .Where(r => projectFilter.Value == null || r.Project == projectFilter.Value)
-            .Where(r => planStatusFilter.Value == null || r.SourcePlanStatus.ToString() == planStatusFilter.Value)
             .Where(r =>
             {
                 if (string.IsNullOrWhiteSpace(textFilter.Value)) return true;
@@ -49,14 +47,12 @@ public class RecommendationsApp : ViewBase
         }
 
         var totalPendingCount = allPending.Count;
-        var hasActiveFilters = projectFilter.Value != null || planStatusFilter.Value != null ||
-                               !string.IsNullOrWhiteSpace(textFilter.Value);
+        var hasActiveFilters = projectFilter.Value != null || !string.IsNullOrWhiteSpace(textFilter.Value);
 
         var sidebar = new SidebarView(
             allPending,
             selectedState,
             projectFilter,
-            planStatusFilter,
             totalPendingCount,
             hasActiveFilters,
             textFilter


### PR DESCRIPTION
# Summary

## Changes

Removed the Plan Status filter from the Recommendations app. The `planStatusFilter` state, filtering logic, and UI dropdown were removed from both `RecommendationsApp.cs` and `SidebarView.cs`. The Project filter and text search remain functional.

## API Changes

- `SidebarView` constructor: removed `IState<string?> planStatusFilter` parameter
- `SidebarView`: removed `_planStatusFilter` field
- `RecommendationsApp`: removed `planStatusFilter` state and its usage in filtering and `hasActiveFilters` calculation

## Files Modified

- `src/tendril/Ivy.Tendril/Apps/RecommendationsApp.cs` — removed planStatusFilter state, filtering, and constructor arg
- `src/tendril/Ivy.Tendril/Apps/Recommendations/SidebarView.cs` — removed planStatusFilter parameter, field, status options extraction, Plan Status dropdown UI, and filtering logic


## Commits

- 2c5b786b2