### PR TITLE
[03266] Refactor duplicate configuration pipeline in Server.AddConnectionsFromAssembly

### DIFF
--- a/src/Ivy/Core/Server/ServerUtils.cs
+++ b/src/Ivy/Core/Server/ServerUtils.cs
@@ -5,10 +5,18 @@ namespace Ivy.Core.Server;
 
 public static class ServerUtils
 {
-    public static IConfiguration GetConfiguration(Action<IConfigurationBuilder>? configure = null)
+    public static IConfiguration GetConfiguration(
+        IEnumerable<KeyValuePair<string, string?>>? initialSources = null,
+        Action<IConfigurationBuilder>? configure = null)
     {
-        var builder = new ConfigurationBuilder()
-            .AddEnvironmentVariables()
+        var builder = new ConfigurationBuilder();
+
+        if (initialSources != null)
+        {
+            builder.AddInMemoryCollection(initialSources);
+        }
+
+        builder.AddEnvironmentVariables()
             .SetBasePath(Directory.GetCurrentDirectory())
             .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true);
 

--- a/src/Ivy/Server.cs
+++ b/src/Ivy/Server.cs
@@ -199,18 +199,7 @@ public class Server
 
         if (presets.Count > 0)
         {
-            var builder = new ConfigurationBuilder()
-                .AddInMemoryCollection(presets)
-                .AddEnvironmentVariables()
-                .SetBasePath(Directory.GetCurrentDirectory())
-                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true);
-
-            if (Assembly.GetEntryAssembly() is { } entryAssembly)
-            {
-                builder.AddUserSecrets(entryAssembly);
-            }
-
-            Configuration = builder.Build();
+            Configuration = ServerUtils.GetConfiguration(presets);
         }
 
         foreach (var connection in connections)
@@ -258,7 +247,7 @@ public class Server
 
     public Server UseConfiguration(Action<IConfigurationBuilder> configure)
     {
-        Configuration = ServerUtils.GetConfiguration(configure);
+        Configuration = ServerUtils.GetConfiguration(configure: configure);
         return this;
     }
 


### PR DESCRIPTION
# Summary

## Changes

Added an `initialSources` parameter to `ServerUtils.GetConfiguration()` that prepends in-memory configuration sources before the standard pipeline (env vars, appsettings.json, user secrets). Replaced the duplicate `ConfigurationBuilder` pipeline in `Server.AddConnectionsFromAssembly()` with a single call to the shared method.

## API Changes

- `ServerUtils.GetConfiguration()` signature changed from `(Action<IConfigurationBuilder>? configure = null)` to `(IEnumerable<KeyValuePair<string, string?>>? initialSources = null, Action<IConfigurationBuilder>? configure = null)`
- Existing caller `UseConfiguration(Action<IConfigurationBuilder>)` updated to use named argument `configure:`

## Files Modified

- **src/Ivy/Core/Server/ServerUtils.cs** — Added `initialSources` parameter with `AddInMemoryCollection` support
- **src/Ivy/Server.cs** — Replaced 12-line duplicate pipeline with `ServerUtils.GetConfiguration(presets)`; updated `UseConfiguration` to use named argument

## Commits

- e01e25259 [03266] Refactor duplicate configuration pipeline in Server.AddConnectionsFromAssembly