### PR TITLE
[03267] Verify CLI commands load connection presets before testing

### DIFF
--- a/src/Ivy.Tests/ServerConfigurationTests.cs
+++ b/src/Ivy.Tests/ServerConfigurationTests.cs
@@ -72,4 +72,40 @@ public class ServerConfigurationTests
 
         Assert.Same(originalConfig, server.Configuration);
     }
+
+    [Fact]
+    public void AddConnectionsFromAssembly_CalledMultipleTimes_DoesNotCorruptConfiguration()
+    {
+        var server = new Server(new ServerArgs());
+
+        server.AddConnectionsFromAssembly(typeof(ServerConfigurationTests).Assembly);
+        server.AddConnectionsFromAssembly(typeof(ServerConfigurationTests).Assembly);
+
+        Assert.Equal("preset-api-key-123", server.Configuration["Test:ApiKey"]);
+        Assert.Equal("https://preset.example.com/", server.Configuration["Test:Endpoint"]);
+    }
+
+    [Fact]
+    public void TestConnectionValidation_PresetSecrets_AvailableInConfigurationAfterLoading()
+    {
+        var server = new Server(new ServerArgs());
+        var connection = new TestConnectionWithPresets();
+        var hasSecrets = (IHaveSecrets)connection;
+
+        Assert.Null(server.Configuration["Test:ApiKey"]);
+
+        server.AddConnectionsFromAssembly(typeof(ServerConfigurationTests).Assembly);
+
+        var missing = hasSecrets.GetSecrets()
+            .Where(s => !s.Optional && s.Preset == null && string.IsNullOrEmpty(server.Configuration[s.Key]))
+            .Select(s => s.Key)
+            .ToList();
+        Assert.Empty(missing);
+
+        foreach (var secret in hasSecrets.GetSecrets().Where(s => s.Preset != null))
+        {
+            Assert.False(string.IsNullOrEmpty(server.Configuration[secret.Key]),
+                $"Preset secret '{secret.Key}' should have a value in Configuration");
+        }
+    }
 }

--- a/src/Ivy/Server.cs
+++ b/src/Ivy/Server.cs
@@ -97,6 +97,7 @@ public class Server
     private Action<HtmlPipeline>? _pipelineConfigurator;
     private ManifestOptions? _manifestOptions;
     private ServerArgs _args;
+    private bool _presetsLoaded;
 
     public Server(ServerArgs? args = null)
     {
@@ -175,6 +176,7 @@ public class Server
 
     public void AddConnectionsFromAssembly(Assembly? assembly = null)
     {
+        _presetsLoaded = true;
         assembly ??= Assembly.GetEntryAssembly();
 
         var connections = assembly!.GetLoadableTypes()
@@ -217,6 +219,12 @@ public class Server
         {
             connection.RegisterServices(this);
         }
+    }
+
+    private void EnsurePresetsLoaded()
+    {
+        if (_presetsLoaded) return;
+        AddConnectionsFromAssembly();
     }
 
     public AppDescriptor GetApp(string id)
@@ -936,6 +944,11 @@ public class Server
             var description = ServerDescription.Gather(this, app.Services);
             Console.WriteLine(description.ToYaml());
             return;
+        }
+
+        if (_args.DescribeConnection != null || _args.TestConnection != null)
+        {
+            EnsurePresetsLoaded();
         }
 
         if (_args.DescribeConnection != null)


### PR DESCRIPTION
# Summary

## Changes

Added automatic connection preset loading for `--describe-connection` and `--test-connection` CLI commands. When a user runs these commands without having explicitly called `AddConnectionsFromAssembly()`, the framework now auto-loads presets into Configuration, preventing silent failures where preset secret values were missing.

## API Changes

- `Server._presetsLoaded` (private field) — tracks whether `AddConnectionsFromAssembly()` has been called
- `Server.EnsurePresetsLoaded()` (private method) — auto-calls `AddConnectionsFromAssembly()` if not already done

No public API changes.

## Files Modified

- **src/Ivy/Server.cs** — Added `_presetsLoaded` flag, `EnsurePresetsLoaded()` method, and call before CLI connection commands in `RunAsync()`
- **src/Ivy.Tests/ServerConfigurationTests.cs** — Added 2 tests: idempotency of multiple `AddConnectionsFromAssembly()` calls, and preset secret availability in Configuration

## Commits

- 272d7e573 [03267] Ensure CLI commands load connection presets before testing