### PR TITLE
[03264] Consolidate GridLayout props to use Responsive<T> types

### DIFF
--- a/src/Ivy.Tests/Widgets/ResponsiveWidgetTests.cs
+++ b/src/Ivy.Tests/Widgets/ResponsiveWidgetTests.cs
@@ -74,9 +74,62 @@ public class ResponsiveWidgetTests
 
         var result = WidgetSerializer.Serialize(widget);
         var props = result["props"]!.AsObject();
-        var rc = props["responsiveColumns"]!.AsObject();
+        var rc = props["columns"]!.AsObject();
 
         Assert.Equal(1, rc["mobile"]!.GetValue<int>());
         Assert.Equal(3, rc["desktop"]!.GetValue<int>());
+    }
+
+    [Fact]
+    public void GridLayout_SimpleColumns_SerializedAsPlainValue()
+    {
+        var grid = Layout.Grid()
+            .Columns(3);
+        var widget = (GridLayout)grid.Build()!;
+        widget.Id = Guid.NewGuid().ToString();
+
+        var result = WidgetSerializer.Serialize(widget);
+        var props = result["props"]!.AsObject();
+
+        Assert.Equal(3, props["columns"]!.GetValue<int>());
+    }
+
+    [Fact]
+    public void GridLayout_ResponsiveGap_SerializedCorrectly()
+    {
+        var grid = Layout.Grid();
+        var def = new GridDefinition
+        {
+            RowGap = 2.At(Breakpoint.Mobile).And(Breakpoint.Desktop, 8),
+            ColumnGap = 4.At(Breakpoint.Mobile).And(Breakpoint.Desktop, 12)
+        };
+        var widget = new GridLayout(def);
+        widget.Id = Guid.NewGuid().ToString();
+
+        var result = WidgetSerializer.Serialize(widget);
+        var props = result["props"]!.AsObject();
+
+        var rg = props["rowGap"]!.AsObject();
+        Assert.Equal(2, rg["mobile"]!.GetValue<int>());
+        Assert.Equal(8, rg["desktop"]!.GetValue<int>());
+
+        var cg = props["columnGap"]!.AsObject();
+        Assert.Equal(4, cg["mobile"]!.GetValue<int>());
+        Assert.Equal(12, cg["desktop"]!.GetValue<int>());
+    }
+
+    [Fact]
+    public void GridLayout_SimpleGap_SerializedAsPlainValue()
+    {
+        var grid = Layout.Grid()
+            .Gap(8);
+        var widget = (GridLayout)grid.Build()!;
+        widget.Id = Guid.NewGuid().ToString();
+
+        var result = WidgetSerializer.Serialize(widget);
+        var props = result["props"]!.AsObject();
+
+        Assert.Equal(8, props["rowGap"]!.GetValue<int>());
+        Assert.Equal(8, props["columnGap"]!.GetValue<int>());
     }
 }

--- a/src/Ivy/Views/GridView.cs
+++ b/src/Ivy/Views/GridView.cs
@@ -22,7 +22,7 @@ public class GridView : ViewBase, IStateless
 
     public GridView Columns(Responsive<int?> columns)
     {
-        _definition.ResponsiveColumns = columns;
+        _definition.Columns = columns;
         return this;
     }
 
@@ -138,7 +138,7 @@ public class GridView : ViewBase, IStateless
     public override object? Build()
     {
         var cells = _cells.ToArray();
-        var columnsCount = _definition.Columns ?? 1;
+        var columnsCount = _definition.Columns?.Default ?? 1;
 
         // Apply builders to transform cells before creating GridLayout
         if (_definition.HeaderBuilder != null || _definition.FooterBuilder != null || _definition.CellBuilder != null)

--- a/src/Ivy/Widgets/Layouts/GridLayout.cs
+++ b/src/Ivy/Widgets/Layouts/GridLayout.cs
@@ -11,23 +11,13 @@ public enum AutoFlow
 
 public class GridDefinition
 {
-    public int? Columns { get; set; }
+    public Responsive<int?>? Columns { get; set; }
 
     public int? Rows { get; set; }
 
-    public int RowGap { get; set; } = 4;
+    public Responsive<int?>? RowGap { get; set; }
 
-    public int ColumnGap { get; set; } = 4;
-
-    /// <summary>
-    /// Sets both RowGap and ColumnGap to the same value. For backward compatibility.
-    /// </summary>
-    [Obsolete("Use RowGap and ColumnGap instead")]
-    public int Gap
-    {
-        get => RowGap;
-        set { RowGap = value; ColumnGap = value; }
-    }
+    public Responsive<int?>? ColumnGap { get; set; }
 
     public Thickness Padding { get; set; } = new(0);
 
@@ -42,12 +32,6 @@ public class GridDefinition
     public Size?[]? RowHeights { get; set; } = null;
 
     public Align? AlignContent { get; set; } = null;
-
-    public Responsive<int?>? ResponsiveColumns { get; set; } = null;
-
-    public Responsive<int?>? ResponsiveRowGap { get; set; } = null;
-
-    public Responsive<int?>? ResponsiveColumnGap { get; set; } = null;
 
     public Func<int, object, object>? HeaderBuilder { get; set; } = null;
 
@@ -74,22 +58,21 @@ internal record GridLayout : WidgetBase<GridLayout>
         Height = def.Height.ToResponsive();
         ColumnWidths = def.ColumnWidths;
         RowHeights = def.RowHeights;
-        ResponsiveColumns = def.ResponsiveColumns;
-        ResponsiveRowGap = def.ResponsiveRowGap;
-        ResponsiveColumnGap = def.ResponsiveColumnGap;
     }
 
     internal GridLayout()
     {
+        RowGap = 4;
+        ColumnGap = 4;
     }
 
-    [Prop] public int? Columns { get; set; }
+    [Prop] public Responsive<int?>? Columns { get; set; }
 
     [Prop] public int? Rows { get; set; }
 
-    [Prop] public int RowGap { get; set; } = 4;
+    [Prop] public Responsive<int?>? RowGap { get; set; }
 
-    [Prop] public int ColumnGap { get; set; } = 4;
+    [Prop] public Responsive<int?>? ColumnGap { get; set; }
 
     [Prop] public Thickness Padding { get; set; } = new(0);
 
@@ -100,12 +83,6 @@ internal record GridLayout : WidgetBase<GridLayout>
     [Prop] public Size?[]? ColumnWidths { get; set; }
 
     [Prop] public Size?[]? RowHeights { get; set; }
-
-    [Prop] public Responsive<int?>? ResponsiveColumns { get; set; }
-
-    [Prop] public Responsive<int?>? ResponsiveRowGap { get; set; }
-
-    [Prop] public Responsive<int?>? ResponsiveColumnGap { get; set; }
 
     [Prop(attached: nameof(GridExtensions.GridColumn))] public int?[] ChildColumn { get; set; } = null!;
 

--- a/src/frontend/src/widgets/layouts/GridLayoutWidget.tsx
+++ b/src/frontend/src/widgets/layouts/GridLayoutWidget.tsx
@@ -18,10 +18,10 @@ import { useCurrentBreakpoint } from "@/hooks/use-breakpoint-context";
 const EMPTY_ARRAY: never[] = [];
 
 interface GridLayoutWidgetProps {
-  columns?: number;
+  columns?: number | Responsive<number>;
   rows?: number;
-  rowGap?: number;
-  columnGap?: number;
+  rowGap?: number | Responsive<number>;
+  columnGap?: number | Responsive<number>;
   padding: string;
   alignContent?: Align;
   autoFlow?: "Row" | "Column" | "RowDense" | "ColumnDense";
@@ -36,9 +36,6 @@ interface GridLayoutWidgetProps {
   childRowSpan?: (number | undefined)[];
   childAlignSelf?: (Align | undefined)[];
   className?: string;
-  responsiveColumns?: Responsive<number>;
-  responsiveRowGap?: Responsive<number>;
-  responsiveColumnGap?: Responsive<number>;
 }
 
 interface GridLayoutCellProps {
@@ -80,14 +77,14 @@ const GridLayoutCell: React.FC<GridLayoutCellProps> = ({
 
 export const GridLayoutWidget: React.FC<GridLayoutWidgetProps> = ({
   children,
-  columns = 1,
+  columns,
   rows = 1,
   alignContent,
   autoFlow,
   width,
   height,
-  rowGap = 4,
-  columnGap = 4,
+  rowGap,
+  columnGap,
   padding = "0,0,0,0",
   columnWidths,
   rowHeights,
@@ -97,22 +94,12 @@ export const GridLayoutWidget: React.FC<GridLayoutWidgetProps> = ({
   childRowSpan = EMPTY_ARRAY,
   childAlignSelf = EMPTY_ARRAY,
   className = "",
-  responsiveColumns,
-  responsiveRowGap,
-  responsiveColumnGap,
 }) => {
   const bp = useCurrentBreakpoint();
 
-  // Resolve responsive values
-  const resolvedColumns = responsiveColumns
-    ? resolveResponsive(responsiveColumns, bp, columns)
-    : columns;
-  const resolvedRowGap = responsiveRowGap
-    ? resolveResponsive(responsiveRowGap, bp, rowGap)
-    : rowGap;
-  const resolvedColumnGap = responsiveColumnGap
-    ? resolveResponsive(responsiveColumnGap, bp, columnGap)
-    : columnGap;
+  const resolvedColumns = resolveResponsive(columns, bp, 1);
+  const resolvedRowGap = resolveResponsive(rowGap, bp, 4);
+  const resolvedColumnGap = resolveResponsive(columnGap, bp, 4);
 
   const styles: React.CSSProperties = {
     display: "grid",


### PR DESCRIPTION
# Summary

## Changes

Consolidated duplicate grid layout properties (`Columns`/`ResponsiveColumns`, `RowGap`/`ResponsiveRowGap`, `ColumnGap`/`ResponsiveColumnGap`) into single `Responsive<int?>?` properties in both `GridDefinition` and `GridLayout`. Updated the frontend `GridLayoutWidget` to accept unified props that handle both plain numbers and responsive objects via `resolveResponsive`. The obsolete `Gap` property on `GridDefinition` was removed as part of the consolidation.

## API Changes

- `GridDefinition.Columns`: changed from `int?` to `Responsive<int?>?`
- `GridDefinition.RowGap`: changed from `int` (default 4) to `Responsive<int?>?`
- `GridDefinition.ColumnGap`: changed from `int` (default 4) to `Responsive<int?>?`
- `GridDefinition.ResponsiveColumns`: removed
- `GridDefinition.ResponsiveRowGap`: removed
- `GridDefinition.ResponsiveColumnGap`: removed
- `GridDefinition.Gap` (obsolete): removed
- `GridLayout.Columns`: changed from `int?` to `Responsive<int?>?`
- `GridLayout.RowGap`: changed from `int` (default 4) to `Responsive<int?>?`
- `GridLayout.ColumnGap`: changed from `int` (default 4) to `Responsive<int?>?`
- `GridLayout.ResponsiveColumns`: removed
- `GridLayout.ResponsiveRowGap`: removed
- `GridLayout.ResponsiveColumnGap`: removed
- `GridView.Columns(Responsive<int?>)`: now sets `Columns` directly instead of `ResponsiveColumns`
- Frontend `GridLayoutWidgetProps.columns`: changed from `number` to `number | Responsive<number>`
- Frontend `GridLayoutWidgetProps.rowGap`: changed from `number` to `number | Responsive<number>`
- Frontend `GridLayoutWidgetProps.columnGap`: changed from `number` to `number | Responsive<number>`
- Frontend `responsiveColumns`, `responsiveRowGap`, `responsiveColumnGap` props: removed

## Files Modified

- **Backend:**
  - `src/Ivy/Widgets/Layouts/GridLayout.cs` - Consolidated properties in GridDefinition and GridLayout
  - `src/Ivy/Views/GridView.cs` - Updated fluent API to use unified Columns property
- **Frontend:**
  - `src/frontend/src/widgets/layouts/GridLayoutWidget.tsx` - Unified responsive/plain prop handling
- **Tests:**
  - `src/Ivy.Tests/Widgets/ResponsiveWidgetTests.cs` - Updated and added tests for consolidated props

## Commits

- d27816f1d [03264] Consolidate GridLayout props to use Responsive<T> types
- 7da295f6d [03264] Add tests for consolidated grid responsive props