### PR TITLE
[01479] Remove duplicate stopPropagation in DevTools handleWheel

### DIFF
--- a/src/frontend/src/components/DevTools.tsx
+++ b/src/frontend/src/components/DevTools.tsx
@@ -190,7 +190,6 @@ export function DevTools() {
       if (target.closest(".ivy-devtools")) return;
 
       e.stopPropagation();
-      e.stopPropagation();
 
       const currentIndex = widgetStack.findIndex((el) => el === highlightedWidget?.element);
       if (currentIndex === -1) return;


### PR DESCRIPTION
## Summary

Removed the duplicate `e.stopPropagation()` call in the `handleWheel` callback in DevTools.tsx. The second call was a copy-paste artifact with no behavioral effect.

## Files Modified

- **src/frontend/src/components/DevTools.tsx** — Removed redundant `e.stopPropagation()` call (1 line deleted)

## Commits

- `7e07a69ac` — [01479] Remove duplicate stopPropagation in DevTools handleWheel