### PR TITLE
[01480] Add CSS transition to DevTools overlay states

### DIFF
--- a/src/frontend/src/components/devtools.css
+++ b/src/frontend/src/components/devtools.css
@@ -6,7 +6,9 @@
   pointer-events: none;
   z-index: 99999;
   box-sizing: border-box;
-  transition: background 0.15s ease, box-shadow 0.15s ease;
+  transition:
+    background 0.15s ease,
+    box-shadow 0.15s ease;
 }
 
 .ivy-devtools-overlay--selected {

--- a/src/frontend/src/components/devtools.css
+++ b/src/frontend/src/components/devtools.css
@@ -6,6 +6,7 @@
   pointer-events: none;
   z-index: 99999;
   box-sizing: border-box;
+  transition: background 0.15s ease, box-shadow 0.15s ease;
 }
 
 .ivy-devtools-overlay--selected {


### PR DESCRIPTION
## Summary

Added a CSS `transition` property to `.ivy-devtools-overlay` in `devtools.css` so that background and box-shadow changes between hover and selected states animate smoothly over 0.15s with ease timing, matching the existing transition on `.ivy-devtools-icon-btn`.

## Files Modified

- **src/frontend/src/components/devtools.css** — Added `transition: background 0.15s ease, box-shadow 0.15s ease;` to `.ivy-devtools-overlay`

## Commits

- `2fa6e61c4` — [01480] Add CSS transition to DevTools overlay states
- `07ce4a744` — [01480] Fix formatting in devtools.css