### PR TITLE
[01481] Use --input token for devtools label background

### DIFF
--- a/src/frontend/src/components/devtools.css
+++ b/src/frontend/src/components/devtools.css
@@ -20,8 +20,8 @@
   position: absolute;
   top: 0;
   right: 0;
-  background-color: var(--popover);
-  color: var(--popover-foreground);
+  background-color: var(--input);
+  color: var(--foreground);
   padding: 4px 8px;
   font-size: 11px;
   font-family: var(--font-sans);


### PR DESCRIPTION
## Changes

Changed the `.ivy-devtools-label` CSS class to use `var(--input)` for background and `var(--foreground)` for text color, replacing `var(--popover)` and `var(--popover-foreground)`. This aligns the devtools label tooltip with the devtools dialog styling established in Plan 01461.

## Files Modified

- **src/frontend/src/components/devtools.css** — Updated `.ivy-devtools-label` background-color and color tokens

## Commits

- e72d4762c [01481] Use --input token for devtools label background