### PR TITLE
[03274] Replace JsonStream with UseStream in JobsApp for real-time job output

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/JobsApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/JobsApp.cs
@@ -22,6 +22,34 @@ public class JobsApp : ViewBase
         var showOutput = UseState<string?>(null);
         var showPrompt = UseState<string?>(null);
         var openFile = UseState<string?>(null);
+        var outputStream = UseStream<string>();
+        var lastProcessedIndex = UseState(0);
+        var streamingJobId = UseState<string?>(null);
+
+        UseInterval(() =>
+        {
+            if (showOutput.Value is not { } activeJobId) return;
+
+            var activeJob = jobService.GetJob(activeJobId);
+            if (activeJob is not { Status: JobStatus.Running }) return;
+
+            var startIdx = lastProcessedIndex.Value;
+
+            if (streamingJobId.Value != activeJobId)
+            {
+                streamingJobId.Set(activeJobId);
+                startIdx = 0;
+            }
+
+            var currentLines = activeJob.OutputLines.ToArray();
+
+            for (var i = startIdx; i < currentLines.Length; i++)
+            {
+                outputStream.Write(currentLines[i]);
+            }
+
+            lastProcessedIndex.Set(currentLines.Length);
+        }, TimeSpan.FromMilliseconds(300));
         var config = UseService<IConfigService>();
         UseEffect(() =>
         {
@@ -337,14 +365,23 @@ public class JobsApp : ViewBase
             var job = jobService.GetJob(jobId);
             object outputContent;
 
-            if (job is not null && job.OutputLines.Count > 0)
+            if (job is { Status: JobStatus.Running })
+            {
+                outputContent = new ClaudeJsonRenderer()
+                    .Stream(outputStream)
+                    .ShowThinking(true)
+                    .ShowSystemEvents(true)
+                    .AutoScroll(true)
+                    .Height(Size.Full());
+            }
+            else if (job is not null && job.OutputLines.Count > 0)
             {
                 var jsonStream = string.Join("\n", job.OutputLines);
                 outputContent = new ClaudeJsonRenderer()
                     .JsonStream(jsonStream)
                     .ShowThinking(true)
                     .ShowSystemEvents(true)
-                    .AutoScroll(job.Status == JobStatus.Running)
+                    .AutoScroll(false)
                     .Height(Size.Full());
             }
             else


### PR DESCRIPTION
# Summary

## Changes

Replaced the static `JsonStream` prop on `ClaudeJsonRenderer` with the real-time `Stream` prop for running jobs in `JobsApp`. A `UseStream<string>()` hook pumps new output lines every 300ms via `UseInterval`, so running job output updates automatically without page refresh. Completed jobs still use the static `JsonStream` approach with no polling overhead.

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/Apps/JobsApp.cs** — Added `UseStream<string>`, `UseState<int>` (line tracking), `UseState<string?>` (job tracking), and `UseInterval` hooks at top level; switched running-job rendering from `.JsonStream()` to `.Stream()`

## Commits

- 2a76fec73