### PR TITLE
[03263] Consolidate StackLayout props to use Responsive<T> types

### DIFF
--- a/src/Ivy.Tests/Widgets/ResponsiveWidgetTests.cs
+++ b/src/Ivy.Tests/Widgets/ResponsiveWidgetTests.cs
@@ -30,10 +30,50 @@ public class ResponsiveWidgetTests
 
         var result = WidgetSerializer.Serialize((StackLayout)widget);
         var props = result["props"]!.AsObject();
-        var ro = props["responsiveOrientation"]!.AsObject();
+        var ro = props["orientation"]!.AsObject();
 
         Assert.Equal("Vertical", ro["mobile"]!.GetValue<string>());
         Assert.Equal("Horizontal", ro["desktop"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void StackLayout_Orientation_ImplicitConversion_SerializesAsSimpleValue()
+    {
+        var layout = Layout.Horizontal();
+        var widget = (StackLayout)layout.Build()!;
+        widget.Id = Guid.NewGuid().ToString();
+
+        var result = WidgetSerializer.Serialize(widget);
+        var props = result["props"]!.AsObject();
+
+        Assert.Equal("Horizontal", props["orientation"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void StackLayout_RowGap_ImplicitConversion_SerializesAsSimpleValue()
+    {
+        var layout = Layout.Horizontal().Gap(8);
+        var widget = (StackLayout)layout.Build()!;
+        widget.Id = Guid.NewGuid().ToString();
+
+        var result = WidgetSerializer.Serialize(widget);
+        var props = result["props"]!.AsObject();
+
+        Assert.Equal(8, props["rowGap"]!.GetValue<int>());
+        Assert.Equal(8, props["columnGap"]!.GetValue<int>());
+    }
+
+    [Fact]
+    public void StackLayout_Padding_ImplicitConversion_SerializesAsSimpleValue()
+    {
+        var layout = Layout.Horizontal().Padding(4);
+        var widget = (StackLayout)layout.Build()!;
+        widget.Id = Guid.NewGuid().ToString();
+
+        var result = WidgetSerializer.Serialize(widget);
+        var props = result["props"]!.AsObject();
+
+        Assert.NotNull(props["padding"]);
     }
 
     [Fact]

--- a/src/Ivy/Views/LayoutView.cs
+++ b/src/Ivy/Views/LayoutView.cs
@@ -6,7 +6,7 @@ namespace Ivy;
 public class LayoutView : ViewBase, IStateless
 {
     private readonly List<LayoutElement> _elements = new();
-    private OrientationEnum _orientation = OrientationEnum.Vertical;
+    private Responsive<OrientationEnum?>? _orientation = (OrientationEnum?)OrientationEnum.Vertical;
     private bool _wrap = false;
 
     private class LayoutElement(object content)
@@ -18,9 +18,9 @@ public class LayoutView : ViewBase, IStateless
     {
     }
 
-    private int _rowGap = 4;
-    private int _columnGap = 4;
-    private Thickness? _padding = null;
+    private Responsive<int?>? _rowGap = (int?)4;
+    private Responsive<int?>? _columnGap = (int?)4;
+    private Responsive<Thickness?>? _padding = null;
     private Thickness? _margin = null;
     private Size? _width = null;
     private Size? _height = null;
@@ -36,29 +36,25 @@ public class LayoutView : ViewBase, IStateless
     private GridView? _activeGrid = null;
     private Responsive<Size>? _responsiveWidth = null;
     private Responsive<Size>? _responsiveHeight = null;
-    private Responsive<OrientationEnum?>? _responsiveOrientation = null;
-    private Responsive<int?>? _responsiveRowGap = null;
-    private Responsive<int?>? _responsiveColumnGap = null;
-    private Responsive<Thickness?>? _responsivePadding = null;
 
     public LayoutView Gap(bool gap)
     {
-        _rowGap = gap ? 4 : 0;
-        _columnGap = gap ? 4 : 0;
+        _rowGap = (int?)(gap ? 4 : 0);
+        _columnGap = (int?)(gap ? 4 : 0);
         return this;
     }
 
     public LayoutView Gap(int gap)
     {
-        _rowGap = gap;
-        _columnGap = gap;
+        _rowGap = (int?)gap;
+        _columnGap = (int?)gap;
         return this;
     }
 
     public LayoutView Gap(int rowGap, int columnGap)
     {
-        _rowGap = rowGap;
-        _columnGap = columnGap;
+        _rowGap = (int?)rowGap;
+        _columnGap = (int?)columnGap;
         return this;
     }
 
@@ -76,20 +72,20 @@ public class LayoutView : ViewBase, IStateless
 
     public LayoutView Orientation(Responsive<OrientationEnum?> orientation)
     {
-        _responsiveOrientation = orientation;
+        _orientation = orientation;
         return this;
     }
 
     public LayoutView Gap(Responsive<int?> gap)
     {
-        _responsiveRowGap = gap;
-        _responsiveColumnGap = gap;
+        _rowGap = gap;
+        _columnGap = gap;
         return this;
     }
 
     public LayoutView Padding(Responsive<Thickness?> padding)
     {
-        _responsivePadding = padding;
+        _padding = padding;
         return this;
     }
 
@@ -101,7 +97,7 @@ public class LayoutView : ViewBase, IStateless
 
     public LayoutView Grow()
     {
-        if (_orientation == OrientationEnum.Vertical)
+        if (_orientation?.Default == OrientationEnum.Vertical)
         {
             _height = Ivy.Size.Grow();
         }
@@ -114,7 +110,7 @@ public class LayoutView : ViewBase, IStateless
 
     public LayoutView Shrink()
     {
-        if (_orientation == OrientationEnum.Vertical)
+        if (_orientation?.Default == OrientationEnum.Vertical)
         {
             _height = Ivy.Size.Shrink();
         }
@@ -204,37 +200,37 @@ public class LayoutView : ViewBase, IStateless
 
     public LayoutView Padding(int padding)
     {
-        _padding = new Thickness(padding);
+        _padding = (Thickness?)new Thickness(padding);
         return this;
     }
 
     public LayoutView Padding(int horizontal, int vertical)
     {
-        _padding = new Thickness(horizontal, vertical);
+        _padding = (Thickness?)new Thickness(horizontal, vertical);
         return this;
     }
 
     public LayoutView Padding(int left, int top, int right, int bottom)
     {
-        _padding = new Thickness(left, top, right, bottom);
+        _padding = (Thickness?)new Thickness(left, top, right, bottom);
         return this;
     }
 
     public LayoutView P(int padding)
     {
-        _padding = new Thickness(padding);
+        _padding = (Thickness?)new Thickness(padding);
         return this;
     }
 
     public LayoutView P(int horizontal, int vertical)
     {
-        _padding = new Thickness(horizontal, vertical);
+        _padding = (Thickness?)new Thickness(horizontal, vertical);
         return this;
     }
 
     public LayoutView P(int left, int top, int right, int bottom)
     {
-        _padding = new Thickness(left, top, right, bottom);
+        _padding = (Thickness?)new Thickness(left, top, right, bottom);
         return this;
     }
 
@@ -379,7 +375,7 @@ public class LayoutView : ViewBase, IStateless
     public LayoutView Vertical(params object[] elements)
     {
         _wrap = false;
-        _orientation = OrientationEnum.Vertical;
+        _orientation = (OrientationEnum?)OrientationEnum.Vertical;
         Add(elements);
         return this;
     }
@@ -392,7 +388,7 @@ public class LayoutView : ViewBase, IStateless
     public LayoutView Horizontal(params object[] elements)
     {
         _wrap = false;
-        _orientation = OrientationEnum.Horizontal;
+        _orientation = (OrientationEnum?)OrientationEnum.Horizontal;
         Add(elements);
         return this;
     }
@@ -405,7 +401,7 @@ public class LayoutView : ViewBase, IStateless
     public LayoutView Wrap(params object[] elements)
     {
         _wrap = true;
-        _orientation = OrientationEnum.Horizontal;
+        _orientation = (OrientationEnum?)OrientationEnum.Horizontal;
         Add(elements);
         return this;
     }
@@ -418,7 +414,7 @@ public class LayoutView : ViewBase, IStateless
     public LayoutView Wrap(OrientationEnum orientation, params object[] elements)
     {
         _wrap = true;
-        _orientation = orientation;
+        _orientation = (OrientationEnum?)orientation;
         Add(elements);
         return this;
     }
@@ -457,10 +453,6 @@ public class LayoutView : ViewBase, IStateless
             BorderRadius = _borderRadius,
             BorderStyle = _borderStyle,
             BorderThickness = _borderThickness,
-            ResponsiveOrientation = _responsiveOrientation,
-            ResponsiveRowGap = _responsiveRowGap,
-            ResponsiveColumnGap = _responsiveColumnGap,
-            ResponsivePadding = _responsivePadding,
             ResponsiveWidth = _responsiveWidth,
             ResponsiveHeight = _responsiveHeight
         }

--- a/src/Ivy/Widgets/Layouts/StackLayout.cs
+++ b/src/Ivy/Widgets/Layouts/StackLayout.cs
@@ -6,11 +6,11 @@ namespace Ivy;
 /// </summary>
 internal record StackLayout : WidgetBase<StackLayout>
 {
-    public StackLayout(object[] children, Orientation orientation = Orientation.Vertical, int gap = 4, Thickness? padding = null, Thickness? margin = null, Colors? background = null, Align? alignContent = null, bool removeParentPadding = false, bool wrap = false) : base(children)
+    public StackLayout(object[] children, Responsive<Orientation?>? orientation = null, Responsive<int?>? gap = null, Responsive<Thickness?>? padding = null, Thickness? margin = null, Colors? background = null, Align? alignContent = null, bool removeParentPadding = false, bool wrap = false) : base(children)
     {
-        Orientation = orientation;
-        RowGap = gap;
-        ColumnGap = gap;
+        Orientation = orientation ?? (Orientation?)Ivy.Orientation.Vertical;
+        RowGap = gap ?? (int?)4;
+        ColumnGap = gap ?? (int?)4;
         Padding = padding;
         Margin = margin;
         Background = background;
@@ -21,13 +21,13 @@ internal record StackLayout : WidgetBase<StackLayout>
 
     internal StackLayout() { }
 
-    [Prop] public Orientation Orientation { get; set; } = Orientation.Vertical;
+    [Prop] public Responsive<Orientation?>? Orientation { get; internal set; } = (Orientation?)Ivy.Orientation.Vertical;
 
-    [Prop] public int RowGap { get; set; } = 4;
+    [Prop] public Responsive<int?>? RowGap { get; internal set; } = (int?)4;
 
-    [Prop] public int ColumnGap { get; set; } = 4;
+    [Prop] public Responsive<int?>? ColumnGap { get; internal set; } = (int?)4;
 
-    [Prop] public Thickness? Padding { get; set; }
+    [Prop] public Responsive<Thickness?>? Padding { get; internal set; }
 
     [Prop] public Thickness? Margin { get; set; }
 
@@ -45,14 +45,6 @@ internal record StackLayout : WidgetBase<StackLayout>
     [Prop] public Thickness BorderThickness { get; set; } = new(0);
 
     [Prop] public Scroll Scroll { get; set; } = Scroll.None;
-
-    [Prop] public Responsive<Orientation?>? ResponsiveOrientation { get; set; }
-
-    [Prop] public Responsive<int?>? ResponsiveRowGap { get; set; }
-
-    [Prop] public Responsive<int?>? ResponsiveColumnGap { get; set; }
-
-    [Prop] public Responsive<Thickness?>? ResponsivePadding { get; set; }
 
     [Prop(attached: nameof(StackLayoutExtensions.AlignSelf))] public Align?[] ChildAlignSelf { get; set; } = null!;
 }


### PR DESCRIPTION
# Summary

## Changes

Consolidated duplicate StackLayout properties into single `Responsive<T>` properties, following the same pattern applied to WidgetBase in plan 03248. Removed `ResponsiveOrientation`, `ResponsiveRowGap`, `ResponsiveColumnGap`, and `ResponsivePadding` properties, replacing them with responsive-typed `Orientation`, `RowGap`, `ColumnGap`, and `Padding` properties with internal setters.

## API Changes

- `StackLayout.Orientation`: changed from `Orientation` to `Responsive<Orientation?>?` with `internal set`
- `StackLayout.RowGap`: changed from `int` to `Responsive<int?>?` with `internal set`
- `StackLayout.ColumnGap`: changed from `int` to `Responsive<int?>?` with `internal set`
- `StackLayout.Padding`: changed from `Thickness?` to `Responsive<Thickness?>?` with `internal set`
- Removed: `StackLayout.ResponsiveOrientation`, `StackLayout.ResponsiveRowGap`, `StackLayout.ResponsiveColumnGap`, `StackLayout.ResponsivePadding`
- `StackLayout` constructor: parameter types updated to `Responsive<Orientation?>?`, `Responsive<int?>?`, `Responsive<Thickness?>?`
- Serialized JSON property names: `responsiveOrientation` merged into `orientation`, `responsiveRowGap` merged into `rowGap`, `responsiveColumnGap` merged into `columnGap`, `responsivePadding` merged into `padding`

## Files Modified

- **Core widget:** `src/Ivy/Widgets/Layouts/StackLayout.cs` — consolidated properties, removed duplicates
- **View builder:** `src/Ivy/Views/LayoutView.cs` — consolidated fields, updated all methods to use responsive types
- **Tests:** `src/Ivy.Tests/Widgets/ResponsiveWidgetTests.cs` — updated assertion, added 3 new serialization tests

## Commits

- eea2005c6 [03263] Consolidate StackLayout props to use Responsive<T> types