### PR TITLE
[03253] Show icon for sorting only if applied

### DIFF
--- a/src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx
+++ b/src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx
@@ -56,6 +56,7 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
     config,
     columnOrder,
     density,
+    activeSort,
     getRowData,
     arrowTableRef,
     loadMoreData,
@@ -212,6 +213,7 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
     columnWidths,
     showGroups: showGroups ?? false,
     showColumnTypeIcons: showColumnTypeIcons ?? true,
+    activeSort,
   });
 
   const orderedDataColumns = useMemo(

--- a/src/frontend/src/widgets/dataTables/dataTableEditor/hooks/useGridColumns.ts
+++ b/src/frontend/src/widgets/dataTables/dataTableEditor/hooks/useGridColumns.ts
@@ -3,6 +3,7 @@ import { getDefaultTheme } from "@glideapps/glide-data-grid";
 import { convertToGridColumns } from "../../utils/columnHelpers";
 import { useColumnGroups } from "../../hooks/useColumnGroups";
 import { DataColumn } from "../../types/types";
+import type { SortOrder } from "@/services/grpcTableService";
 
 interface UseGridColumnsProps {
   columns: DataColumn[];
@@ -10,6 +11,7 @@ interface UseGridColumnsProps {
   columnWidths: Record<string, number>;
   showGroups?: boolean;
   showColumnTypeIcons?: boolean;
+  activeSort?: SortOrder[] | null;
 }
 
 /**
@@ -21,6 +23,7 @@ export const useGridColumns = ({
   columnWidths,
   showGroups = false,
   showColumnTypeIcons = true,
+  activeSort,
 }: UseGridColumnsProps) => {
   const headerFont = useMemo(() => {
     const t = getDefaultTheme();
@@ -38,8 +41,9 @@ export const useGridColumns = ({
         showGroups,
         showColumnTypeIcons,
         headerFont,
+        activeSort,
       ),
-    [columns, columnOrder, columnWidths, showGroups, showColumnTypeIcons, headerFont],
+    [columns, columnOrder, columnWidths, showGroups, showColumnTypeIcons, headerFont, activeSort],
   );
 
   // Use column groups hook when showGroups is enabled

--- a/src/frontend/src/widgets/dataTables/utils/columnHelpers.ts
+++ b/src/frontend/src/widgets/dataTables/utils/columnHelpers.ts
@@ -1,5 +1,6 @@
 import { GridColumn, GridColumnIcon } from "@glideapps/glide-data-grid";
 import type { DataColumn } from "../types/types";
+import type { SortOrder } from "@/services/grpcTableService";
 import {
   estimateHeaderWidth,
   parseSizeGrow,
@@ -117,6 +118,7 @@ export function convertToGridColumns(
   showGroups: boolean,
   showColumnTypeIcons: boolean = true,
   headerFont?: string,
+  activeSort?: SortOrder[] | null,
 ): GridColumn[] {
   const orderedColumns = getOrderedVisibleDataColumns(columns, columnOrder);
 
@@ -141,12 +143,21 @@ export function convertToGridColumns(
     // Determine effective grow: explicit Size-based grow, or default last column to 1
     const effectiveGrow = grow !== undefined ? grow : isLastColumn ? 1 : undefined;
 
+    let columnIcon = showColumnTypeIcons ? mapColumnIcon(col) : undefined;
+
+    if (activeSort && activeSort.length > 0) {
+      const sortForColumn = activeSort.find((sort) => sort.column === col.name);
+      if (sortForColumn) {
+        columnIcon = sortForColumn.direction === "ASC" ? "ArrowUp" : "ArrowDown";
+      }
+    }
+
     return {
       title: col.header || col.name,
       width: numericBaseWidth,
       ...(effectiveGrow !== undefined && { grow: effectiveGrow }),
       group: showGroups ? col.group : undefined,
-      icon: showColumnTypeIcons ? mapColumnIcon(col) : undefined,
+      icon: columnIcon,
     };
   });
 }

--- a/src/frontend/src/widgets/dataTables/utils/headerIcons.ts
+++ b/src/frontend/src/widgets/dataTables/utils/headerIcons.ts
@@ -39,6 +39,10 @@ const ICON_PATHS: Record<string, string> = {
     "M12 5a1 1 0 1 0 0-2 1 1 0 0 0 0 2z M12 13a1 1 0 1 0 0-2 1 1 0 0 0 0 2z M12 21a1 1 0 1 0 0-2 1 1 0 0 0 0 2z",
   // HelpCircle
   HelpCircle: "M12 22a10 10 0 1 0 0-20 10 10 0 0 0 0 20z M9 9a3 3 0 0 1 6 0c0 2-3 3-3 3 M12 17h.01",
+  // ArrowUp icon (Lucide)
+  ArrowUp: "M12 19V5 M5 12l7-7 7 7",
+  // ArrowDown icon (Lucide)
+  ArrowDown: "M12 5v14 M19 12l-7 7-7-7",
 };
 
 /**
@@ -95,6 +99,8 @@ export function generateHeaderIcons(columns: Array<{ icon?: string | null }>): S
  */
 export function addStandardIcons(baseIcons: SpriteMap): SpriteMap {
   const standardIcons = [
+    "ArrowUp",
+    "ArrowDown",
     "ChevronUp",
     "ChevronDown",
     "Filter",


### PR DESCRIPTION
**Note:** Plan [03043](plan://03043) previously attempted this feature but was skipped. The commits never merged to main and GitHub issue #1163 remains open. This plan provides a fresh implementation approach.

## Problem

The DataTable currently shows column type icons (Number, Text, Date, etc.) in column headers, but does not visually indicate which column is actively sorted or in which direction. Users cannot tell at a glance if data is sorted without triggering the sort action.

**Current behavior:**
- Column headers display type icons (Hash for numbers, Calendar for dates, etc.)
- Sorting is functional via `useSorting` hook and `activeSort` state tracks which column is sorted
- No visual indication in the header when a column is sorted

**Desired behavior:**
- When a column is sorted ascending (ASC), show ArrowUp icon in the header
- When a column is sorted descending (DESC), show ArrowDown icon in the header
- When a column is not sorted, show the original column type icon
- Icon should only appear when sorting is actively applied

**Reference:**
- Issue: https://github.com/Ivy-Interactive/Ivy-Framework/issues/1163
- Screenshot shows desired state with sort indicator in header

## Solution

Modify the column icon logic to dynamically display sort direction icons when a column is actively sorted.

### Key Changes

1. **Add ArrowUp and ArrowDown icons** to `src/frontend/src/widgets/dataTables/utils/headerIcons.ts`:
   - Add "ArrowUp" and "ArrowDown" path definitions to the `ICON_PATHS` object
   - Add these icons to the `standardIcons` array in `addStandardIcons` function

2. **Update `convertToGridColumns` function** in `src/frontend/src/widgets/dataTables/utils/columnHelpers.ts`:
   - Add `activeSort` parameter to accept current sort state
   - For each column, check if it's in the `activeSort` array
   - If sorted ASC, override icon with "ArrowUp"
   - If sorted DESC, override icon with "ArrowDown"
   - If not sorted, keep original type icon from `mapColumnIcon`

3. **Update `useGridColumns` hook** in `src/frontend/src/widgets/dataTables/dataTableEditor/hooks/useGridColumns.ts`:
   - Accept `activeSort` parameter from props
   - Pass `activeSort` to `convertToGridColumns` call

4. **Update `DataTableEditor` component** in `src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx`:
   - Pass `activeSort` from table context to `useGridColumns` hook

## Commits

- 743d4561f [03253] Show sort direction icons in DataTable column headers