### PR TITLE
[03269] Add category labels to cartesian chart tooltips

### DIFF
--- a/src/frontend/src/widgets/charts/AreaChartWidget.tsx
+++ b/src/frontend/src/widgets/charts/AreaChartWidget.tsx
@@ -196,15 +196,20 @@ const AreaChartWidget: React.FC<AreaChartWidgetProps> = ({
         }),
         formatter: (params: any) => {
           if (Array.isArray(params)) {
-            return params
+            // Multi-series: add category header from first param
+            const header = params[0]?.name ? `<strong>${params[0].name}</strong><br/>` : "";
+            const lines = params
               .map((p) => {
                 const value = formatTooltipValue(p.value[isVertical ? 0 : 1], tooltip);
                 return `${p.marker} ${p.seriesName}: <strong>${value}</strong>`;
               })
               .join("<br/>");
+            return header + lines;
           }
+          // Single series: add category header
+          const header = params.name ? `<strong>${params.name}</strong><br/>` : "";
           const value = formatTooltipValue(params.value[isVertical ? 0 : 1], tooltip);
-          return `${params.marker} ${params.seriesName}: <strong>${value}</strong>`;
+          return `${header}${params.marker} ${params.seriesName}: <strong>${value}</strong>`;
         },
       },
       legend: generateEChartLegend(legend, {

--- a/src/frontend/src/widgets/charts/BarChartWidget.tsx
+++ b/src/frontend/src/widgets/charts/BarChartWidget.tsx
@@ -250,15 +250,20 @@ const BarChartWidget: React.FC<BarChartWidgetProps> = ({
         }),
         formatter: (params: any) => {
           if (Array.isArray(params)) {
-            return params
+            // Multi-series: add category header from first param
+            const header = params[0]?.name ? `<strong>${params[0].name}</strong><br/>` : "";
+            const lines = params
               .map((p) => {
                 const value = formatTooltipValue(p.value[isVertical ? 0 : 1], tooltip);
                 return `${p.marker} ${p.seriesName}: <strong>${value}</strong>`;
               })
               .join("<br/>");
+            return header + lines;
           }
+          // Single series: add category header
+          const header = params.name ? `<strong>${params.name}</strong><br/>` : "";
           const value = formatTooltipValue(params.value[isVertical ? 0 : 1], tooltip);
-          return `${params.marker} ${params.seriesName}: <strong>${value}</strong>`;
+          return `${header}${params.marker} ${params.seriesName}: <strong>${value}</strong>`;
         },
       },
       toolbox: generateEChartToolbox(toolbox),

--- a/src/frontend/src/widgets/charts/LineChartWidget.tsx
+++ b/src/frontend/src/widgets/charts/LineChartWidget.tsx
@@ -110,15 +110,20 @@ const LineChartWidget: React.FC<LineChartWidgetProps> = ({
         }),
         formatter: (params: any) => {
           if (Array.isArray(params)) {
-            return params
+            // Multi-series: add category header from first param
+            const header = params[0]?.name ? `<strong>${params[0].name}</strong><br/>` : "";
+            const lines = params
               .map((p) => {
                 const value = formatTooltipValue(p.value[isVertical ? 0 : 1], tooltip);
                 return `${p.marker} ${p.seriesName}: <strong>${value}</strong>`;
               })
               .join("<br/>");
+            return header + lines;
           }
+          // Single series: add category header
+          const header = params.name ? `<strong>${params.name}</strong><br/>` : "";
           const value = formatTooltipValue(params.value[isVertical ? 0 : 1], tooltip);
-          return `${params.marker} ${params.seriesName}: <strong>${value}</strong>`;
+          return `${header}${params.marker} ${params.seriesName}: <strong>${value}</strong>`;
         },
       },
       toolbox: generateEChartToolbox(toolbox),


### PR DESCRIPTION
# Summary

## Changes

Added category axis labels to tooltip headers in Line, Bar, and Area chart widgets. The category value (e.g., month name "Jan") now appears as a bold header line above the series data, matching the behavior of non-cartesian charts like Pie and Funnel. This makes tooltips more informative when hovering over data points.

## API Changes

None.

## Files Modified

- `src/frontend/src/widgets/charts/BarChartWidget.tsx` — Updated `formatter` callback to include category header
- `src/frontend/src/widgets/charts/LineChartWidget.tsx` — Updated `formatter` callback to include category header
- `src/frontend/src/widgets/charts/AreaChartWidget.tsx` — Updated `formatter` callback to include category header

## Commits

- ebb84d66f [03269] Add category labels to cartesian chart tooltips