### PR TITLE
[00200] Add PerformanceAnalyzer project to tendril config

### DIFF
--- a/src/tendril/Ivy.Tendril.TeamIvyConfig/config.yaml
+++ b/src/tendril/Ivy.Tendril.TeamIvyConfig/config.yaml
@@ -224,6 +224,30 @@ projects:
     action: pwsh -NoProfile -File D:\Tendril\Hooks\NotifySlack.ps1
   repoPaths:
   - D:\Repos\_Ivy\Ivy-Services
+- name: PerformanceAnalyzer
+  color: Violet
+  meta:
+    slackEmoji: ':chart_with_upwards_trend:'
+  repos:
+  - path: D:\Repos\_Ivy\PerformanceAnalyzer
+    prRule: yolo
+  verifications:
+  - *o0
+  - *o1
+  - *o2
+  - *o3
+  context: >
+    PerformanceAnalyzer — Ivy app for tracking Ivy employee performance on GitHub.
+  reviewActions: []
+  hooks:
+  - name: SlackNotify
+    when: after
+    promptwares:
+    - MakePr
+    condition: ''
+    action: pwsh -NoProfile -File D:\Tendril\Hooks\NotifySlack.ps1
+  repoPaths:
+  - D:\Repos\_Ivy\PerformanceAnalyzer
 verifications:
 - name: DotnetBuild
   prompt: Run `dotnet build --warnaserror` in the plan's worktree directory (not the original repo) and verify it succeeds with zero errors and zero warnings.


### PR DESCRIPTION
## Changes

Added a new `PerformanceAnalyzer` project entry to the Tendril config.yaml in `Ivy.Tendril.TeamIvyConfig`. The project uses Violet color, standard .NET verifications (DotnetBuild, DotnetFormat, DotnetTest, CheckResult), yolo PR rule, and SlackNotify hook. Also cloned the PerformanceAnalyzer repo locally and updated the runtime config.yaml with macOS paths.

## Files Modified

- `src/tendril/Ivy.Tendril.TeamIvyConfig/config.yaml` — Added PerformanceAnalyzer project entry after the Services project block

## Commits

- `14da2ed3f` — [00200] Add PerformanceAnalyzer project to tendril config