### PR TITLE
[03285] Remove dead ResponsiveWidth/Height fields from LayoutView

### DIFF
--- a/src/Ivy/Views/LayoutView.cs
+++ b/src/Ivy/Views/LayoutView.cs
@@ -34,8 +34,6 @@ public class LayoutView : ViewBase, IStateless
     private Thickness _borderThickness = new(0);
     private string? _testId = null;
     private GridView? _activeGrid = null;
-    private Responsive<Size>? _responsiveWidth = null;
-    private Responsive<Size>? _responsiveHeight = null;
 
     public LayoutView Gap(bool gap)
     {
@@ -453,8 +451,8 @@ public class LayoutView : ViewBase, IStateless
             BorderRadius = _borderRadius,
             BorderStyle = _borderStyle,
             BorderThickness = _borderThickness,
-            Width = _responsiveWidth ?? _width,
-            Height = _responsiveHeight ?? _height
+            Width = _width,
+            Height = _height
         };
 
         if (_testId != null) layout.TestId = _testId;


### PR DESCRIPTION
# Summary

## Changes

Removed dead code from LayoutView.cs that was left over from an incomplete fix in commit 850e14ce6. The private fields `_responsiveWidth` and `_responsiveHeight` were never assigned and only used in the Build() method with a coalesce pattern that always resolved to the actual `_width` and `_height` fields. Simplified the code by removing the dead fields and eliminating the redundant coalesce operators.

## API Changes

None.

## Files Modified

- **src/Ivy/Views/LayoutView.cs** — Removed dead fields (lines 37-38) and simplified Build() method coalesce pattern (lines 456-457)

## Commits

- 15a1dd2d9 [03285] Remove dead ResponsiveWidth/Height fields from LayoutView