### PR TITLE
[03292] Add MCP Tool for Plan State Transitions

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/Mcp/PlanToolsTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/Mcp/PlanToolsTests.cs
@@ -1,0 +1,245 @@
+using Ivy.Tendril.Mcp.Tools;
+using Xunit;
+
+namespace Ivy.Tendril.Test.Mcp;
+
+public class PlanToolsTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string _originalTendrilHome;
+
+    public PlanToolsTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"tendril-test-{Guid.NewGuid()}");
+        Directory.CreateDirectory(_tempDir);
+        _originalTendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME") ?? "";
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", _tempDir);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", _originalTendrilHome);
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, true);
+    }
+
+    [Fact]
+    public void TestTransitionPlanSuccess()
+    {
+        // Arrange
+        var plansDir = Path.Combine(_tempDir, "Plans");
+        var planFolder = Path.Combine(plansDir, "00001-TestPlan");
+        Directory.CreateDirectory(planFolder);
+
+        var planYaml = """
+            state: Draft
+            project: TestProject
+            level: NiceToHave
+            title: Test Plan
+            repos: []
+            commits: []
+            prs: []
+            created: 2026-04-01T10:00:00.0000000Z
+            updated: 2026-04-01T10:00:00.0000000Z
+            verifications: []
+            relatedPlans: []
+            dependsOn: []
+            executionProfile: balanced
+            initialPrompt: Test prompt
+            sourceUrl:
+            priority: 0
+            """;
+
+        File.WriteAllText(Path.Combine(planFolder, "plan.yaml"), planYaml);
+
+        // Act
+        var result = PlanTools.TransitionPlan("00001", "Icebox");
+
+        // Assert
+        Assert.Contains("Successfully transitioned", result);
+        Assert.Contains("Draft to Icebox", result);
+
+        var updatedYaml = File.ReadAllText(Path.Combine(planFolder, "plan.yaml"));
+        Assert.Contains("state: Icebox", updatedYaml);
+    }
+
+    [Fact]
+    public void TestTransitionPlanInvalidState()
+    {
+        // Arrange
+        var plansDir = Path.Combine(_tempDir, "Plans");
+        var planFolder = Path.Combine(plansDir, "00001-TestPlan");
+        Directory.CreateDirectory(planFolder);
+
+        var planYaml = """
+            state: Draft
+            project: TestProject
+            level: NiceToHave
+            title: Test Plan
+            repos: []
+            commits: []
+            prs: []
+            created: 2026-04-01T10:00:00.0000000Z
+            updated: 2026-04-01T10:00:00.0000000Z
+            verifications: []
+            relatedPlans: []
+            dependsOn: []
+            executionProfile: balanced
+            initialPrompt: Test prompt
+            sourceUrl:
+            priority: 0
+            """;
+
+        File.WriteAllText(Path.Combine(planFolder, "plan.yaml"), planYaml);
+
+        // Act
+        var result = PlanTools.TransitionPlan("00001", "InvalidState");
+
+        // Assert
+        Assert.Contains("Error: Invalid state", result);
+        Assert.Contains("InvalidState", result);
+    }
+
+    [Fact]
+    public void TestTransitionPlanNonexistentPlan()
+    {
+        // Arrange
+        var plansDir = Path.Combine(_tempDir, "Plans");
+        Directory.CreateDirectory(plansDir);
+
+        // Act
+        var result = PlanTools.TransitionPlan("99999", "Draft");
+
+        // Assert
+        Assert.Contains("Error: Plan '99999' not found", result);
+    }
+
+    [Fact]
+    public void TestTransitionPlanPreservesFields()
+    {
+        // Arrange
+        var plansDir = Path.Combine(_tempDir, "Plans");
+        var planFolder = Path.Combine(plansDir, "00001-TestPlan");
+        Directory.CreateDirectory(planFolder);
+
+        var planYaml = """
+            state: Draft
+            project: TestProject
+            level: Critical
+            title: Test Plan With Many Fields
+            repos:
+            - D:\Repos\TestRepo
+            commits:
+            - abc123
+            prs:
+            - https://github.com/test/repo/pull/1
+            created: 2026-04-01T10:00:00.0000000Z
+            updated: 2026-04-01T10:00:00.0000000Z
+            verifications:
+            - name: DotnetBuild
+              status: Pending
+            - name: DotnetTest
+              status: Skipped
+            relatedPlans:
+            - D:\Plans\00002-RelatedPlan
+            dependsOn:
+            - D:\Plans\00003-Dependency
+            executionProfile: performance
+            initialPrompt: Test prompt with details
+            sourceUrl: https://example.com
+            priority: 10
+            sessionId: session-123
+            """;
+
+        File.WriteAllText(Path.Combine(planFolder, "plan.yaml"), planYaml);
+
+        // Act
+        var result = PlanTools.TransitionPlan("00001", "Executing");
+
+        // Assert
+        Assert.Contains("Successfully transitioned", result);
+
+        var updatedYaml = File.ReadAllText(Path.Combine(planFolder, "plan.yaml"));
+        Assert.Contains("state: Executing", updatedYaml);
+        Assert.Contains("project: TestProject", updatedYaml);
+        Assert.Contains("level: Critical", updatedYaml);
+        Assert.Contains("title: Test Plan With Many Fields", updatedYaml);
+        Assert.Contains("- D:\\Repos\\TestRepo", updatedYaml);
+        Assert.Contains("- abc123", updatedYaml);
+        Assert.Contains("https://github.com/test/repo/pull/1", updatedYaml);
+        Assert.Contains("name: DotnetBuild", updatedYaml);
+        Assert.Contains("status: Pending", updatedYaml);
+        Assert.Contains("- D:\\Plans\\00002-RelatedPlan", updatedYaml);
+        Assert.Contains("- D:\\Plans\\00003-Dependency", updatedYaml);
+        Assert.Contains("executionProfile: performance", updatedYaml);
+        Assert.Contains("initialPrompt: Test prompt with details", updatedYaml);
+        Assert.Contains("sourceUrl: https://example.com", updatedYaml);
+        Assert.Contains("priority: 10", updatedYaml);
+        Assert.Contains("sessionId: session-123", updatedYaml);
+    }
+
+    [Fact]
+    public void TestTransitionPlanUpdatesTimestamp()
+    {
+        // Arrange
+        var plansDir = Path.Combine(_tempDir, "Plans");
+        var planFolder = Path.Combine(plansDir, "00001-TestPlan");
+        Directory.CreateDirectory(planFolder);
+
+        var oldTimestamp = DateTime.UtcNow.AddHours(-1);
+        var planYaml = $"""
+            state: Draft
+            project: TestProject
+            level: NiceToHave
+            title: Test Plan
+            repos: []
+            commits: []
+            prs: []
+            created: {oldTimestamp:O}
+            updated: {oldTimestamp:O}
+            verifications: []
+            relatedPlans: []
+            dependsOn: []
+            executionProfile: balanced
+            initialPrompt: Test prompt
+            sourceUrl:
+            priority: 0
+            """;
+
+        File.WriteAllText(Path.Combine(planFolder, "plan.yaml"), planYaml);
+
+        // Act
+        var beforeTransition = DateTime.UtcNow;
+        var result = PlanTools.TransitionPlan("00001", "Icebox");
+        var afterTransition = DateTime.UtcNow;
+
+        // Assert
+        Assert.Contains("Successfully transitioned", result);
+
+        var updatedYaml = File.ReadAllText(Path.Combine(planFolder, "plan.yaml"));
+
+        // Extract the updated timestamp
+        var updatedMatch = System.Text.RegularExpressions.Regex.Match(updatedYaml, @"updated: (.+)");
+        Assert.True(updatedMatch.Success, "Updated timestamp not found in YAML");
+
+        var updatedTimestamp = DateTime.Parse(updatedMatch.Groups[1].Value);
+
+        // Verify the timestamp was updated to a recent time
+        Assert.True(updatedTimestamp >= beforeTransition, "Updated timestamp should be after transition started");
+        Assert.True(updatedTimestamp <= afterTransition.AddSeconds(1), "Updated timestamp should be before transition completed");
+        Assert.True(updatedTimestamp > oldTimestamp, "Updated timestamp should be newer than original");
+    }
+
+    [Fact]
+    public void TestTransitionPlanTendrilHomeNotSet()
+    {
+        // Arrange
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", null);
+
+        // Act
+        var result = PlanTools.TransitionPlan("00001", "Draft");
+
+        // Assert
+        Assert.Contains("Error: TENDRIL_HOME is not set", result);
+    }
+}

--- a/src/tendril/Ivy.Tendril/Mcp/Tools/PlanTools.cs
+++ b/src/tendril/Ivy.Tendril/Mcp/Tools/PlanTools.cs
@@ -15,6 +15,10 @@ public sealed class PlanTools
         .IgnoreUnmatchedProperties()
         .Build();
 
+    private static readonly ISerializer YamlSerializer = new SerializerBuilder()
+        .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        .Build();
+
     private static readonly Regex FolderNameRegex = new(@"^(\d{5})-(.+)$", RegexOptions.Compiled);
 
     [McpServerTool(Name = "tendril_get_plan"), Description("Fetch plan metadata by ID or folder path")]
@@ -134,6 +138,56 @@ public sealed class PlanTools
         return $"Plan submitted to inbox: {fileName}\nThe InboxWatcher will pick it up and create a plan automatically.";
     }
 
+    [McpServerTool(Name = "tendril_transition_plan"), Description("Transition a plan to a different state")]
+    public static string TransitionPlan(
+        [Description("Plan ID (e.g., '03228') or full folder path")] string planId,
+        [Description("Target state: Draft, Building, Updating, Executing, Completed, Failed, ReadyForReview, Skipped, Icebox, Blocked")] string targetState)
+    {
+        var plansDir = GetPlansDirectory();
+        if (plansDir == null)
+            return "Error: TENDRIL_HOME is not set.";
+
+        var planFolder = ResolvePlanFolder(plansDir, planId);
+        if (planFolder == null)
+            return $"Error: Plan '{planId}' not found.";
+
+        // Validate target state
+        var validStates = new[] { "Draft", "Building", "Updating", "Executing", "Completed",
+                                  "Failed", "ReadyForReview", "Skipped", "Icebox", "Blocked" };
+        if (!validStates.Contains(targetState, StringComparer.OrdinalIgnoreCase))
+            return $"Error: Invalid state '{targetState}'. Valid states: {string.Join(", ", validStates)}";
+
+        // Read current plan.yaml
+        var planYamlPath = Path.Combine(planFolder, "plan.yaml");
+        if (!File.Exists(planYamlPath))
+            return $"Error: plan.yaml not found in {planFolder}";
+
+        try
+        {
+            var yaml = File.ReadAllText(planYamlPath);
+            var planYaml = YamlDeserializer.Deserialize<PlanYamlDto>(yaml);
+            if (planYaml == null)
+                return "Error: Failed to parse plan.yaml";
+
+            var oldState = planYaml.State;
+
+            // Update state and timestamp
+            planYaml.State = validStates.First(s => s.Equals(targetState, StringComparison.OrdinalIgnoreCase));
+            planYaml.Updated = DateTime.UtcNow;
+
+            // Serialize and write back
+            var updatedYaml = YamlSerializer.Serialize(planYaml);
+            File.WriteAllText(planYamlPath, updatedYaml);
+
+            var folderName = Path.GetFileName(planFolder);
+            return $"Successfully transitioned plan {folderName} from {oldState} to {planYaml.State}";
+        }
+        catch (Exception ex)
+        {
+            return $"Error: Failed to update plan state: {ex.Message}";
+        }
+    }
+
     private static string? GetTendrilHome()
     {
         var home = Environment.GetEnvironmentVariable("TENDRIL_HOME")?.Trim();
@@ -247,7 +301,17 @@ public sealed class PlanTools
         public DateTime Updated { get; set; }
         public string? InitialPrompt { get; set; }
         public string? SourceUrl { get; set; }
+        public string? SessionId { get; set; }
         public List<string>? DependsOn { get; set; }
         public List<string>? RelatedPlans { get; set; }
+        public List<VerificationEntry>? Verifications { get; set; }
+        public int Priority { get; set; }
+        public string? ExecutionProfile { get; set; }
+    }
+
+    internal class VerificationEntry
+    {
+        public string Name { get; set; } = "";
+        public string Status { get; set; } = "Pending";
     }
 }


### PR DESCRIPTION
# Summary

## Changes

Added a new MCP tool `tendril_transition_plan` to allow agents to programmatically transition plans between states (e.g., Draft → Icebox, Failed → Draft). The tool validates the plan exists, updates the state and timestamp in plan.yaml, and preserves all existing fields during serialization.

## API Changes

- **New method**: `PlanTools.TransitionPlan(string planId, string targetState)` - MCP tool for transitioning plan states
- **New property**: `PlanYamlDto.SessionId` - stores session ID from plan creation
- **New property**: `PlanYamlDto.Verifications` - list of verification entries
- **New property**: `PlanYamlDto.Priority` - numeric priority value
- **New property**: `PlanYamlDto.ExecutionProfile` - execution profile setting
- **New class**: `VerificationEntry` - represents a verification entry with name and status
- **New static field**: `PlanTools.YamlSerializer` - YAML serializer instance for writing plan files

## Files Modified

- `src/tendril/Ivy.Tendril/Mcp/Tools/PlanTools.cs` - Added TransitionPlan method, YamlSerializer, and extended PlanYamlDto
- `src/tendril/Ivy.Tendril.Test/Mcp/PlanToolsTests.cs` - Created with 6 comprehensive test cases

## Commits

- 51b299ac7 [03292] Add MCP tool for plan state transitions