### PR TITLE
[03294] Add sync strategy enforcement to ExecutePlan

### DIFF
--- a/src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
+++ b/src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
@@ -293,11 +293,32 @@ pwsh -NoProfile -Command '& "$env:TENDRIL_HOME/Promptwares/ExecutePlan/Tools/Log
 
 This creates a structured log entry in `$TENDRIL_HOME/Logs/worktrees.log` recording the worktree creation with repo path and branch metadata. Logging only happens after successful `.git` file verification (Step 2.4), ensuring only successfully created worktrees are recorded.
 
-6. Apply sync strategy (if configured in `RepoConfigs`):
-   - If `syncStrategy` is `"fetch"` (or not specified), no additional action needed (already fetched in step 1)
-   - If `syncStrategy` is `"rebase"`, after worktree creation run: `cd <worktree-path> && git fetch origin && git rebase origin/<resolved-base-branch>`
-   - If `syncStrategy` is `"merge"`, after worktree creation run: `cd <worktree-path> && git fetch origin && git merge origin/<resolved-base-branch>`
-   - Note: These sync operations should also be run before each commit created during plan execution to keep the branch up-to-date
+6. **Apply sync strategy** — REQUIRED after worktree creation and `.git` file verification:
+
+   ```bash
+   SYNC_STRATEGY="<from RepoConfigs or 'fetch' if not specified>"
+   BASE_BRANCH="<resolved-base-branch>"
+   WORKTREE_PATH="<PlanFolder>/worktrees/<repo-folder-name>"
+
+   pwsh -NoProfile -File "$env:TENDRIL_HOME/Promptwares/ExecutePlan/Tools/Apply-SyncStrategy.ps1" \
+     -WorktreePath "$WORKTREE_PATH" \
+     -SyncStrategy "$SYNC_STRATEGY" \
+     -BaseBranch "$BASE_BRANCH"
+   ```
+
+   This tool applies the configured sync strategy (fetch/rebase/merge) to keep the worktree branch synchronized with the base branch. It handles errors and logs each step.
+
+   **When to call:** After each worktree is created (Step 2.4) and before moving to the next repo.
+
+   **Note:** For `syncStrategy: "rebase"` or `syncStrategy: "merge"`, this operation should also be performed before making commits during plan execution to keep the branch up-to-date with upstream changes. Use the same tool with the same parameters.
+
+   **Error handling:**
+   - If `Apply-SyncStrategy.ps1` fails (non-zero exit code), the entire ExecutePlan run should fail
+   - Common failure scenarios:
+     - `git fetch` fails → network issue or invalid remote
+     - `git rebase` fails → conflicting changes between worktree base and origin
+     - `git merge` fails → conflicting changes or uncommitted files
+   - On failure, log the error and exit. Do NOT attempt to continue with an out-of-sync worktree.
 
 ### 2.5. Setup Frontend Dependencies (JavaScript/TypeScript Projects Only)
 

--- a/src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/Tools/Apply-SyncStrategy.ps1
+++ b/src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/Tools/Apply-SyncStrategy.ps1
@@ -1,0 +1,93 @@
+<#
+.SYNOPSIS
+    Applies sync strategy (fetch/rebase/merge) to a worktree after creation.
+
+.DESCRIPTION
+    Reads sync strategy from RepoConfigs firmware value and applies the appropriate
+    git operations to keep the worktree branch in sync with the base branch.
+
+.PARAMETER WorktreePath
+    Absolute path to the worktree directory.
+
+.PARAMETER SyncStrategy
+    Sync strategy to apply: "fetch" (default), "rebase", or "merge".
+
+.PARAMETER BaseBranch
+    Base branch name to sync with (e.g., "main", "development").
+
+.EXAMPLE
+    Apply-SyncStrategy.ps1 -WorktreePath "D:\Tendril\Plans\03294-Test\worktrees\Ivy-Framework" -SyncStrategy "rebase" -BaseBranch "development"
+#>
+
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$WorktreePath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$SyncStrategy,
+
+    [Parameter(Mandatory = $true)]
+    [string]$BaseBranch
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not (Test-Path $WorktreePath)) {
+    Write-Error "Worktree path does not exist: $WorktreePath"
+    exit 1
+}
+
+Push-Location $WorktreePath
+try {
+    Write-Host "Applying sync strategy '$SyncStrategy' for worktree: $WorktreePath" -ForegroundColor Cyan
+
+    switch ($SyncStrategy.ToLower()) {
+        "fetch" {
+            # Already fetched during worktree creation - no additional action needed
+            Write-Host "Sync strategy 'fetch': No additional action needed (already fetched during worktree creation)" -ForegroundColor Green
+        }
+
+        "rebase" {
+            Write-Host "Fetching latest from origin..." -ForegroundColor Gray
+            git fetch origin
+            if ($LASTEXITCODE -ne 0) {
+                Write-Error "git fetch failed with exit code $LASTEXITCODE"
+                exit $LASTEXITCODE
+            }
+
+            Write-Host "Rebasing onto origin/$BaseBranch..." -ForegroundColor Gray
+            git rebase "origin/$BaseBranch"
+            if ($LASTEXITCODE -ne 0) {
+                Write-Error "git rebase failed with exit code $LASTEXITCODE. Worktree may have uncommitted changes or conflicts."
+                exit $LASTEXITCODE
+            }
+
+            Write-Host "Rebase completed successfully" -ForegroundColor Green
+        }
+
+        "merge" {
+            Write-Host "Fetching latest from origin..." -ForegroundColor Gray
+            git fetch origin
+            if ($LASTEXITCODE -ne 0) {
+                Write-Error "git fetch failed with exit code $LASTEXITCODE"
+                exit $LASTEXITCODE
+            }
+
+            Write-Host "Merging origin/$BaseBranch..." -ForegroundColor Gray
+            git merge "origin/$BaseBranch" --no-edit
+            if ($LASTEXITCODE -ne 0) {
+                Write-Error "git merge failed with exit code $LASTEXITCODE. Worktree may have uncommitted changes or conflicts."
+                exit $LASTEXITCODE
+            }
+
+            Write-Host "Merge completed successfully" -ForegroundColor Green
+        }
+
+        default {
+            Write-Warning "Unknown sync strategy '$SyncStrategy' - defaulting to 'fetch' (no action)"
+        }
+    }
+}
+finally {
+    Pop-Location
+}


### PR DESCRIPTION
# Summary

## Changes

Created a PowerShell tool to enforce sync strategy application in ExecutePlan and updated Program.md to require calling it. This ensures consistent sync strategy behavior (fetch/rebase/merge) across all coding agents by moving from documentation-only guidance to mandatory tool invocation.

## API Changes

**New tool:**
- \`Apply-SyncStrategy.ps1\` — PowerShell script that applies sync strategy to worktrees
  - Parameters: \`-WorktreePath\`, \`-SyncStrategy\`, \`-BaseBranch\`
  - Handles fetch (no-op), rebase, and merge strategies with proper error handling

## Files Modified

**New files:**
- \`src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/Tools/Apply-SyncStrategy.ps1\` — sync strategy enforcement tool

**Modified files:**
- \`src/tendril/Ivy.Tendril/Promptwares/ExecutePlan/Program.md\` — updated Step 2.6 to require calling Apply-SyncStrategy.ps1 after worktree creation

## Commits

- f60d0c7e3