### PR TITLE
[03297] Move Decline Button Next To Accept In Recommendations

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Recommendations/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Recommendations/ContentView.cs
@@ -51,6 +51,10 @@ public class ContentView(
                      | Text.Rich()
                          .Bold($"{currentIndex + 1}/{_all.Count}", word: true)
                          .Muted("recommendations", word: true)
+                     | new Button("Decline").Icon(Icons.X).Outline().ShortcutKey("x").OnClick(() =>
+                     {
+                         showDeclineDialog.Set(true);
+                     })
                      | new Button("Accept").Icon(Icons.Check).Primary().ShortcutKey("a").OnClick(() =>
                      {
                          _planService.UpdateRecommendationState(_selected.PlanFolderName, _selected.Title, "Accepted");
@@ -95,10 +99,6 @@ public class ContentView(
 
         // Action bar (secondary actions)
         var actionBar = Layout.Horizontal().AlignContent(Align.Center).Gap(2).Padding(1)
-                        | new Button("Decline").Icon(Icons.X).Outline().ShortcutKey("x").OnClick(() =>
-                        {
-                            showDeclineDialog.Set(true);
-                        })
                         | new Button("Accept with Notes").Icon(Icons.CircleCheck).Outline().ShortcutKey("w")
                             .OnClick(() => showNotesDialog.Set(true))
                         | new Button("View Plan").Icon(Icons.ExternalLink).Outline().ShortcutKey("d").OnClick(() =>


### PR DESCRIPTION
# Summary

## Changes

Moved the Decline button from the action bar (bottom left) to the header (right side, next to Accept button) in the Recommendations app. This improves the UX by co-locating the two primary action buttons for faster decision-making.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Apps/Recommendations/ContentView.cs` — Added Decline button to header before Accept button; removed duplicate Decline button from action bar.


## Commits

- f89734247c119bf988365dccc91114ad2da1252d