### PR TITLE
[03303] Make GitService timeout configurable

### DIFF
--- a/src/tendril/Ivy.Tendril.TeamIvyConfig/config.yaml
+++ b/src/tendril/Ivy.Tendril.TeamIvyConfig/config.yaml
@@ -1,6 +1,7 @@
 codingAgent: claude
 jobTimeout: 30
 staleOutputTimeout: 10
+gitTimeout: 10
 maxConcurrentJobs: 30
 projects:
 - name: Framework

--- a/src/tendril/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/tendril/Ivy.Tendril/Services/ConfigService.cs
@@ -130,6 +130,7 @@ public class TendrilSettings
     public string CodingAgent { get; set; } = "claude";
     public int JobTimeout { get; set; } = 30;
     public int StaleOutputTimeout { get; set; } = 10;
+    public int GitTimeout { get; set; } = 10;
     public int MaxConcurrentJobs { get; set; } = 5;
     public List<ProjectConfig> Projects { get; set; } = new();
     public List<VerificationConfig> Verifications { get; set; } = new();

--- a/src/tendril/Ivy.Tendril/Services/GitService.cs
+++ b/src/tendril/Ivy.Tendril/Services/GitService.cs
@@ -6,6 +6,13 @@ namespace Ivy.Tendril.Services;
 
 public class GitService : IGitService
 {
+    private readonly int _timeoutMs;
+
+    public GitService(IConfigService config)
+    {
+        _timeoutMs = config.Settings.GitTimeout * 1000;
+    }
+
     public string? GetCommitTitle(string repoPath, string commitHash)
     {
         try
@@ -20,7 +27,7 @@ public class GitService : IGitService
             };
             using var process = Process.Start(psi);
             var title = process?.StandardOutput.ReadLine();
-            process.WaitForExitOrKill(10000);
+            process.WaitForExitOrKill(_timeoutMs);
             return process?.ExitCode == 0 ? title : null;
         }
         catch
@@ -43,7 +50,7 @@ public class GitService : IGitService
             };
             using var process = Process.Start(psi);
             var output = process?.StandardOutput.ReadToEnd();
-            process.WaitForExitOrKill(10000);
+            process.WaitForExitOrKill(_timeoutMs);
             return process?.ExitCode == 0 ? output : null;
         }
         catch
@@ -66,7 +73,7 @@ public class GitService : IGitService
             };
             using var process = Process.Start(psi);
             var output = process?.StandardOutput.ReadToEnd();
-            process.WaitForExitOrKill(10000);
+            process.WaitForExitOrKill(_timeoutMs);
             if (process?.ExitCode != 0 || output == null) return null;
 
             return output.Split('\n', StringSplitOptions.RemoveEmptyEntries).Length;
@@ -91,7 +98,7 @@ public class GitService : IGitService
             };
             using var process = Process.Start(psi);
             var output = process?.StandardOutput.ReadToEnd();
-            process.WaitForExitOrKill(10000);
+            process.WaitForExitOrKill(_timeoutMs);
             if (process?.ExitCode != 0 || output == null) return null;
 
             var files = new List<(string Status, string FilePath)>();
@@ -124,7 +131,7 @@ public class GitService : IGitService
             };
             using var process = Process.Start(psi);
             var output = process?.StandardOutput.ReadToEnd();
-            process.WaitForExitOrKill(10000);
+            process.WaitForExitOrKill(_timeoutMs);
             return process?.ExitCode == 0 ? output : null;
         }
         catch
@@ -147,7 +154,7 @@ public class GitService : IGitService
             };
             using var process = Process.Start(psi);
             var output = process?.StandardOutput.ReadToEnd();
-            process.WaitForExitOrKill(10000);
+            process.WaitForExitOrKill(_timeoutMs);
             if (process?.ExitCode != 0 || output == null) return null;
 
             var files = new List<(string Status, string FilePath)>();

--- a/src/tendril/Ivy.Tendril/TendrilServer.cs
+++ b/src/tendril/Ivy.Tendril/TendrilServer.cs
@@ -56,8 +56,8 @@ public static class TendrilServer
         server.Services.AddSingleton<IOnboardingSetupService>(sp => sp.GetRequiredService<OnboardingSetupService>());
         server.Services.AddSingleton<GithubService>();
         server.Services.AddSingleton<IGithubService>(sp => sp.GetRequiredService<GithubService>());
-        server.Services.AddSingleton<GitService>();
-        server.Services.AddSingleton<IGitService>(sp => sp.GetRequiredService<GitService>());
+        server.Services.AddSingleton<IGitService>(sp =>
+            new GitService(sp.GetRequiredService<IConfigService>()));
         server.Services.AddSingleton<IWorktreeLifecycleLogger>(sp =>
         {
             var config = sp.GetRequiredService<IConfigService>();

--- a/src/tendril/Ivy.Tendril/example.config.yaml
+++ b/src/tendril/Ivy.Tendril/example.config.yaml
@@ -4,6 +4,7 @@
 codingAgent: claude
 jobTimeout: 30
 staleOutputTimeout: 10
+gitTimeout: 10  # Timeout in seconds for git operations (default: 10)
 maxConcurrentJobs: 5  # Maximum number of jobs to run concurrently (default: 5)
 
 # Variable Expansion Support:


### PR DESCRIPTION
# Summary

## Changes

Added a configurable `gitTimeout` setting to TendrilSettings, replacing the hardcoded 10-second timeout in GitService. GitService now accepts IConfigService via constructor injection and uses the configured timeout value for all git operations.

## API Changes

- `TendrilSettings.GitTimeout` property added (int, default: 10 seconds)
- `GitService` constructor now requires `IConfigService` parameter
- Config files updated with new `gitTimeout` setting

## Files Modified

**Core Services:**
- `Services/ConfigService.cs` - Added GitTimeout property to TendrilSettings
- `Services/GitService.cs` - Added constructor with IConfigService dependency, replaced 6 hardcoded timeout values
- `TendrilServer.cs` - Updated DI registration to pass IConfigService to GitService

**Configuration:**
- `example.config.yaml` - Documented gitTimeout setting
- `Ivy.Tendril.TeamIvyConfig/config.yaml` - Added gitTimeout setting

## Commits

- 4f7a63b67 [03303] Make GitService timeout configurable