### PR TITLE
[03299] Apply consistent error display to all UseQuery consumers

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -484,7 +484,10 @@ public class ContentView(
             }
             else if (changesData is null)
             {
-                changesTabContent = Text.Muted("No commits yet.");
+                var errorMsg = allChangesQuery.Error is { } err
+                    ? $"Failed to load changes: {err.Message}"
+                    : "No commits yet.";
+                changesTabContent = Text.Muted(errorMsg);
             }
             else
             {
@@ -542,7 +545,9 @@ public class ContentView(
                 () => openVerification.Set(null),
                 verificationReportQuery.Loading
                     ? Text.Muted("Loading...")
-                    : new Markdown(verificationReportQuery.Value).DangerouslyAllowLocalFiles(),
+                    : verificationReportQuery.Error is { } err
+                        ? Text.Muted($"Failed to load verification report: {err.Message}")
+                        : new Markdown(verificationReportQuery.Value).DangerouslyAllowLocalFiles(),
                 verName
             ).Width(Size.Half()).Resizable();
 
@@ -552,7 +557,8 @@ public class ContentView(
                 commitQuery.Value,
                 commitQuery.Loading || commitQuery.Value is null && !string.IsNullOrEmpty(openCommit.Value),
                 commitHash,
-                () => openCommit.Set(null));
+                () => openCommit.Set(null),
+                commitQuery.Error);
         }
 
         if (openArtifact.Value is { } artifactPath)
@@ -562,7 +568,9 @@ public class ContentView(
                 () => openArtifact.Set(null),
                 artifactContentQuery.Loading
                     ? Text.Muted("Loading...")
-                    : new Markdown($"```{language.ToString().ToLowerInvariant()}\n{artifactContentQuery.Value}\n```"),
+                    : artifactContentQuery.Error is { } err
+                        ? Text.Muted($"Failed to load artifact: {err.Message}")
+                        : new Markdown($"```{language.ToString().ToLowerInvariant()}\n{artifactContentQuery.Value}\n```"),
                 Path.GetFileName(artifactPath)
             ).Width(Size.Half()).Resizable();
         }

--- a/src/tendril/Ivy.Tendril/Services/PlanContentHelpers.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanContentHelpers.cs
@@ -75,16 +75,24 @@ public static class PlanContentHelpers
     }
 
     public static object RenderCommitDetailSheet(CommitDetailData? data, bool loading, string? commitHash,
-        Action closeSheet)
+        Action closeSheet, Exception? error = null)
     {
         if (commitHash is null) return new Empty();
 
         var shortHash = commitHash.Length > 7 ? commitHash[..7] : commitHash;
         object sheetContent;
 
-        if (loading || data is null)
+        if (loading)
         {
             sheetContent = Text.Muted("Loading...");
+        }
+        else if (error is not null)
+        {
+            sheetContent = Text.Muted($"Failed to load commit: {error.Message}");
+        }
+        else if (data is null)
+        {
+            sheetContent = Text.Muted("Commit not found.");
         }
         else
         {


### PR DESCRIPTION
# Summary

## Changes

Applied consistent error display pattern to all `UseQuery` consumers in the Review app's ContentView. When asynchronous queries fail (query.Error is set), users now see actionable error messages instead of generic fallback text. Updated 4 query consumers and modified the RenderCommitDetailSheet helper method to differentiate between loading, error, and null states.

## API Changes

**Modified method signature:**
- `PlanContentHelpers.RenderCommitDetailSheet`: Added optional `error` parameter to accept query error information for display.

**Updated UI behavior:**
- `verificationReportQuery`: Now displays error message when query fails
- `artifactContentQuery`: Now displays error message when query fails  
- `allChangesQuery`: Now displays error message when loading fails
- `commitQuery`: Now displays error message through updated RenderCommitDetailSheet

## Files Modified

- `src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs` — Added error handling to 4 query consumers
- `src/tendril/Ivy.Tendril/Services/PlanContentHelpers.cs` — Updated RenderCommitDetailSheet signature to accept error parameter

## Commits

- fc743eee8 - [03299] Apply consistent error display to all UseQuery consumers