### PR TITLE
[03304] Remove output trimming to show full job output

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Jobs/Models.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Jobs/Models.cs
@@ -71,19 +71,6 @@ public record JobItem
         Process = null;
         TimeoutCts = null;
     }
-
-    /// <summary>
-    ///     Trims the output buffer to the most recent lines to free memory after completion.
-    ///     Called after all completion logic (failure reason extraction, log writing, hooks)
-    ///     has finished. Retains a small tail for UI inspection of recent hook/status output.
-    /// </summary>
-    public void TrimOutput()
-    {
-        const int keepLines = 50;
-        if (OutputLines.Count <= keepLines) return;
-        var trimmed = new ConcurrentQueue<string>(OutputLines.Skip(OutputLines.Count - keepLines));
-        OutputLines = trimmed;
-    }
 }
 
 public record JobItemRow

--- a/src/tendril/Ivy.Tendril/Services/JobService.cs
+++ b/src/tendril/Ivy.Tendril/Services/JobService.cs
@@ -281,10 +281,6 @@ public class JobService : IJobService
         // Persist completed job to SQLite
         PersistJob(job);
 
-        // Free output buffer — all consumers (failure reason, hooks, log writing) are done.
-        // Output for failed jobs was already written to logs/ above.
-        job.TrimOutput();
-
         // Evict stale finished jobs from memory to prevent unbounded dictionary growth.
         // Job metadata is already persisted to SQLite; the in-memory copy is only needed
         // for active display and is reloaded from DB on next startup.
@@ -338,7 +334,6 @@ public class JobService : IJobService
 
         CleanupInboxFile(job);
         ResetPlanState(job);
-        job.TrimOutput();
         RaiseJobsChanged();
 
         // Try to start queued jobs now that a slot is free


### PR DESCRIPTION
# Summary

## Changes

Removed output trimming logic from the JobService to allow users to see the complete job output (up to 10,000 lines) instead of just the last 50 lines. This change enables full review of Claude session history, intermediate results, and tool calls in the Jobs app UI.

## API Changes

Removed the `public void TrimOutput()` method from the `JobItem` class in `Models.cs`. This method is no longer called anywhere and is now dead code.

## Files Modified

- `src/tendril/Ivy.Tendril/Apps/Jobs/Models.cs` — Removed the unused `TrimOutput()` method definition
- `src/tendril/Ivy.Tendril/Services/JobService.cs` — Removed two calls to `job.TrimOutput()`:
  - Line 286 in `CompleteJob()` method
  - Line 341 in `StopJob()` method

## Commits

- f8890c73c [03304] Remove output trimming to show full job output