### PR TITLE
[03301] Add cross-links from Integrations pages to Configuration

### DIFF
--- a/src/tendril/Ivy.Tendril.Docs/Docs/03_Configuration/01_Setup.md
+++ b/src/tendril/Ivy.Tendril.Docs/Docs/03_Configuration/01_Setup.md
@@ -56,7 +56,7 @@ coworkers:
 
 | Field | Purpose |
 |-------|---------|
-| `codingAgent` | Agent runtime (`claude`, `codex`, `gemini`, …). |
+| `codingAgent` | Agent runtime. See [Claude Code](../06_Integrations/02_ClaudeCode.md), [Codex](../06_Integrations/03_Codex.md), or [Gemini](../06_Integrations/04_Gemini.md) for details. |
 | `maxConcurrentJobs` | Cap on parallel agent runs (worktrees). |
 | `projects` | Registered repositories and their settings. |
 | `coworkers` | GitHub users for PR assignment / team features. |

--- a/src/tendril/Ivy.Tendril.Docs/Docs/06_Integrations/02_ClaudeCode.md
+++ b/src/tendril/Ivy.Tendril.Docs/Docs/06_Integrations/02_ClaudeCode.md
@@ -24,6 +24,8 @@ codingAgent: claude
 
 Or select it in **Settings > General > Coding Agent**.
 
+For more details on `config.yaml` structure and settings, see [Setup & Settings](../03_Configuration/01_Setup.md).
+
 ## Requirements
 
 - The Claude CLI must be installed and available as `claude` on your PATH

--- a/src/tendril/Ivy.Tendril.Docs/Docs/06_Integrations/03_Codex.md
+++ b/src/tendril/Ivy.Tendril.Docs/Docs/06_Integrations/03_Codex.md
@@ -23,6 +23,8 @@ codingAgent: codex
 
 Or select it in **Settings > General > Coding Agent**.
 
+For more details on `config.yaml` structure and settings, see [Setup & Settings](../03_Configuration/01_Setup.md).
+
 ## Profiles
 
 Tendril maps effort levels to Codex models:

--- a/src/tendril/Ivy.Tendril.Docs/Docs/06_Integrations/04_Gemini.md
+++ b/src/tendril/Ivy.Tendril.Docs/Docs/06_Integrations/04_Gemini.md
@@ -22,6 +22,8 @@ codingAgent: gemini
 
 Or select it in **Settings > General > Coding Agent**.
 
+For more details on `config.yaml` structure and settings, see [Setup & Settings](../03_Configuration/01_Setup.md).
+
 ## Profiles
 
 Tendril maps effort levels to Gemini models:


### PR DESCRIPTION
# Summary

## Changes

Added cross-reference links between coding agent integration pages and the Configuration documentation. Users reading integration pages (Claude Code, Codex, Gemini) now have direct links to the Configuration section, and the Configuration page now links back to the specific agent pages for more details.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril.Docs/Docs/06_Integrations/02_ClaudeCode.md` — Added link to Setup & Settings
- `src/tendril/Ivy.Tendril.Docs/Docs/06_Integrations/03_Codex.md` — Added link to Setup & Settings  
- `src/tendril/Ivy.Tendril.Docs/Docs/06_Integrations/04_Gemini.md` — Added link to Setup & Settings
- `src/tendril/Ivy.Tendril.Docs/Docs/03_Configuration/01_Setup.md` — Added reciprocal links to all three agent pages

## Commits

- a8b85f8bd [03301] Add cross-links from Integrations pages to Configuration