### PR TITLE
[03300] Restore periodic table refresh for Jobs with recently-completed jobs

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/JobsApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/JobsApp.cs
@@ -48,6 +48,18 @@ public class JobsApp : ViewBase
             return Disposable.Create(() => jobService.JobsChanged -= OnJobsChanged);
         });
 
+        UseInterval(() =>
+        {
+            var hasActiveOrRecentJobs = jobService.GetJobs().Any(j =>
+                j.Status == JobStatus.Running ||
+                (j.Status is JobStatus.Stopped or JobStatus.Failed or JobStatus.Timeout or JobStatus.Completed
+                 && j.CompletedAt.HasValue
+                 && DateTime.UtcNow - j.CompletedAt.Value < TimeSpan.FromSeconds(5)));
+
+            if (hasActiveOrRecentJobs)
+                refreshToken.Refresh();
+        }, TimeSpan.FromSeconds(5));
+
         var updateStream = UseDataTableUpdates(
             Observable.Interval(TimeSpan.FromSeconds(1))
                 .SelectMany(_ =>


### PR DESCRIPTION
# Summary

## Changes

Added a `UseInterval` block to JobsApp.cs that triggers a full table refresh every 5 seconds when there are Running or recently-completed jobs. This restores the periodic refresh behavior that was removed in plan 03211, ensuring the table stays fresh while jobs are active or within 5 seconds of completion.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Apps/JobsApp.cs` — Added UseInterval block (lines 51-62) that checks for active/recent jobs and refreshes the table accordingly.

## Commits

- d03a36d13 [03300] Restore periodic table refresh for Jobs with recently-completed jobs