### PR TITLE
[03306] Fix JobService.GetJobs() thread safety for Rx scheduler enumeration

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/JobServiceThreadSafetyTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/JobServiceThreadSafetyTests.cs
@@ -134,6 +134,56 @@ public class JobServiceThreadSafetyTests
         Assert.Null(ex);
     }
 
+    [Fact]
+    public void GetJobs_CalledConcurrentlyWithModifications_DoesNotThrowInvalidOperationException()
+    {
+        var service = new JobService(
+            TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
+            null, 10);
+
+        // Pre-populate with some jobs
+        for (int i = 0; i < 5; i++)
+            service.CreateTestJob("ExecutePlan", $"plan-{i}");
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        var exceptions = new System.Collections.Concurrent.ConcurrentBag<Exception>();
+
+        // Thread 1: Continuously enumerate GetJobs()
+        var enumerateTask = Task.Run(() =>
+        {
+            while (!cts.Token.IsCancellationRequested)
+            {
+                try
+                {
+                    var jobs = service.GetJobs();
+                    // Force full enumeration by accessing count/elements
+                    _ = jobs.Count;
+                }
+                catch (Exception ex)
+                {
+                    exceptions.Add(ex);
+                }
+            }
+        });
+
+        // Thread 2: Continuously add/remove jobs
+        var modifyTask = Task.Run(() =>
+        {
+            int counter = 100;
+            while (!cts.Token.IsCancellationRequested)
+            {
+                var id = service.CreateTestJob("MakePlan", $"concurrent-{counter++}");
+                Thread.Sleep(1);
+                service.DeleteJob(id);
+            }
+        });
+
+        Task.WaitAll(enumerateTask, modifyTask);
+
+        // Should complete without any InvalidOperationException
+        Assert.Empty(exceptions);
+    }
+
     private class TestSynchronizationContext : SynchronizationContext
     {
         private readonly Queue<(SendOrPostCallback Callback, object? State)> _pending = new();

--- a/src/tendril/Ivy.Tendril.Test/JobServiceThreadSafetyTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/JobServiceThreadSafetyTests.cs
@@ -135,7 +135,7 @@ public class JobServiceThreadSafetyTests
     }
 
     [Fact]
-    public void GetJobs_CalledConcurrentlyWithModifications_DoesNotThrowInvalidOperationException()
+    public async Task GetJobs_CalledConcurrentlyWithModifications_DoesNotThrowInvalidOperationException()
     {
         var service = new JobService(
             TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
@@ -178,7 +178,7 @@ public class JobServiceThreadSafetyTests
             }
         });
 
-        Task.WaitAll(enumerateTask, modifyTask);
+        await Task.WhenAll(enumerateTask, modifyTask);
 
         // Should complete without any InvalidOperationException
         Assert.Empty(exceptions);

--- a/src/tendril/Ivy.Tendril/Apps/PullRequest/Dialogs/FollowUpDialog.cs
+++ b/src/tendril/Ivy.Tendril/Apps/PullRequest/Dialogs/FollowUpDialog.cs
@@ -1,3 +1,4 @@
+using Ivy.Core.Hooks;
 using Ivy.Tendril.Apps.Plans.Dialogs;
 using Ivy.Tendril.Services;
 

--- a/src/tendril/Ivy.Tendril/Apps/PullRequest/Dialogs/FollowUpDialog.cs
+++ b/src/tendril/Ivy.Tendril/Apps/PullRequest/Dialogs/FollowUpDialog.cs
@@ -1,6 +1,5 @@
 using Ivy.Core.Hooks;
 using Ivy.Tendril.Apps.Plans.Dialogs;
-using Ivy.Tendril.Services;
 
 namespace Ivy.Tendril.Apps.PullRequest.Dialogs;
 

--- a/src/tendril/Ivy.Tendril/Services/JobService.cs
+++ b/src/tendril/Ivy.Tendril/Services/JobService.cs
@@ -413,7 +413,7 @@ public class JobService : IJobService
 
     public List<JobItem> GetJobs()
     {
-        return _jobs.Values.OrderByDescending(j => j.StartedAt ?? DateTime.MinValue).ToList();
+        return _jobs.Values.ToArray().OrderByDescending(j => j.StartedAt ?? DateTime.MinValue).ToList();
     }
 
     public JobItem? GetJob(string id)


### PR DESCRIPTION
# Summary

## Changes

Fixed a thread safety issue in `JobService.GetJobs()` where concurrent enumeration and modification of the jobs dictionary could throw `InvalidOperationException`. The fix materializes a snapshot by calling `.ToArray()` before LINQ operations. Also fixed pre-existing build errors encountered during verification.

## API Changes

None - the method signature and return type remain unchanged.

## Files Modified

**Core Services:**
- `src/tendril/Ivy.Tendril/Services/JobService.cs` - Added `.ToArray()` call to materialize snapshot before enumeration

**Tests:**
- `src/tendril/Ivy.Tendril.Test/JobServiceThreadSafetyTests.cs` - Added concurrent modification test, converted to async

**Build Fixes:**
- `src/tendril/Ivy.Tendril/Apps/PullRequest/Dialogs/FollowUpDialog.cs` - Added missing using directive for ConvertedState

## Commits

- 39e7526c4 [03306] Remove unused using statement from DotnetFormat
- 5761a0afd [03306] Fix build errors - add missing using and make test async
- c8c547fa5 [03306] Fix GetJobs() thread safety by materializing snapshot before LINQ