### PR TITLE
[03310] Warm _repoPathCache in GetRepos() to avoid redundant git processes

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/GithubServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/GithubServiceTests.cs
@@ -101,6 +101,38 @@ public class GithubServiceTests
     }
 
     [Fact]
+    public void GetRepos_Should_Warm_RepoPathCache()
+    {
+        var tempDir = CreateTempGitRepo("https://github.com/Test-Owner/Test-Repo.git");
+        try
+        {
+            var settings = new TendrilSettings
+            {
+                Projects = [new ProjectConfig { Name = "TestProject", Repos = [new RepoRef { Path = tempDir }] }]
+            };
+            var configService = new ConfigService(settings);
+            var githubService = new GithubService(configService);
+
+            // First call: GetRepos() should populate cache
+            var repos = githubService.GetRepos();
+            Assert.Single(repos);
+
+            // Second call: GetRepoConfigFromPathCached should hit the cache (no git spawn)
+            var cached = githubService.GetRepoConfigFromPathCached(tempDir);
+            Assert.NotNull(cached);
+            Assert.Equal("Test-Owner", cached.Owner);
+            Assert.Equal("Test-Repo", cached.Name);
+
+            // Verify it's the same instance (proving cache hit, not re-computation)
+            Assert.Same(repos[0], cached);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
     public async Task SearchIssuesAsync_Returns_Error_When_Command_Fails()
     {
         var configService = new ConfigService(new TendrilSettings());

--- a/src/tendril/Ivy.Tendril/Apps/PullRequest/Dialogs/FollowUpDialog.cs
+++ b/src/tendril/Ivy.Tendril/Apps/PullRequest/Dialogs/FollowUpDialog.cs
@@ -1,3 +1,4 @@
+using Ivy.Core.Hooks;
 using Ivy.Tendril.Apps.Plans.Dialogs;
 using Ivy.Tendril.Services;
 

--- a/src/tendril/Ivy.Tendril/Services/GithubService.cs
+++ b/src/tendril/Ivy.Tendril/Services/GithubService.cs
@@ -30,7 +30,7 @@ public class GithubService(IConfigService config) : IGithubService
         var repos = new List<RepoConfig>();
         foreach (var repoPath in uniquePaths)
         {
-            var repoConfig = GetRepoConfigFromPath(repoPath);
+            var repoConfig = GetRepoConfigFromPathCached(repoPath);
             if (repoConfig is not null)
                 repos.Add(repoConfig);
         }


### PR DESCRIPTION
# Summary

## Changes

Modified `GithubService.GetRepos()` to call `GetRepoConfigFromPathCached()` instead of `GetRepoConfigFromPath()` when loading unique repository paths. This populates `_repoPathCache` as a side effect during `GetRepos()` execution, eliminating redundant git process spawns for subsequent calls to `GetRepoConfigFromPathCached()` with the same paths.

Added a new test `GetRepos_Should_Warm_RepoPathCache` to verify that the cache is properly warmed and that subsequent calls retrieve the same cached instance.

Fixed a pre-existing build issue by adding missing `using Ivy.Core.Hooks;` statement in `FollowUpDialog.cs`.

## API Changes

None. This is a pure optimization with no behavioral changes to public APIs.

## Files Modified

- `src/tendril/Ivy.Tendril/Services/GithubService.cs` — Changed line 33 from `GetRepoConfigFromPath()` to `GetRepoConfigFromPathCached()`
- `src/tendril/Ivy.Tendril.Test/GithubServiceTests.cs` — Added new test method `GetRepos_Should_Warm_RepoPathCache()`
- `src/tendril/Ivy.Tendril/Apps/PullRequest/Dialogs/FollowUpDialog.cs` — Added missing using statement for `Ivy.Core.Hooks`



## Commits

- b4f26cf42, 7d6cfd8ed