### PR TITLE
[03307] Audit dialogs for race condition guards

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Plans/Dialogs/CreateIssueDialog.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Plans/Dialogs/CreateIssueDialog.cs
@@ -13,6 +13,7 @@ public class CreateIssueDialog(
 {
     public override object? Build()
     {
+        var isCreating = UseState(false);
         var githubService = UseService<IGithubService>();
         var assigneesError = UseState<string?>(null);
         var labelsError = UseState<string?>(null);
@@ -113,10 +114,11 @@ public class CreateIssueDialog(
                     labelsError.Set(null);
                     dialogOpen.Set(false);
                 }),
-                new Button("Create Issue").Primary().OnClick(() =>
+                new Button("Create Issue").Primary().Disabled(isCreating.Value).OnClick(() =>
                 {
-                    if (selectedRepoState.Value is { } repo)
+                    if (selectedRepoState.Value is { } repo && !isCreating.Value)
                     {
+                        isCreating.Set(true);
                         var selectedRepo = repos.FirstOrDefault(r => r.DisplayName == repo);
                         if (selectedRepo != null)
                         {

--- a/src/tendril/Ivy.Tendril/Apps/Plans/Dialogs/CreatePlanDialog.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Plans/Dialogs/CreatePlanDialog.cs
@@ -22,6 +22,7 @@ public class CreatePlanDialog(
 
     public override object Build()
     {
+        var isCreating = UseState(false);
         var createPlanText = UseState("");
         var selectedProjects = UseState(_defaultProjects);
         var selectedPriority = UseState("Normal");
@@ -55,10 +56,11 @@ public class CreatePlanDialog(
             ),
             new DialogFooter(
                 new Button("Cancel").Outline().OnClick(onClose),
-                new Button("Create").Primary().ShortcutKey("Ctrl+Enter").OnClick(() =>
+                new Button("Create").Primary().Disabled(isCreating.Value).ShortcutKey("Ctrl+Enter").OnClick(() =>
                 {
-                    if (!string.IsNullOrWhiteSpace(createPlanText.Value))
+                    if (!string.IsNullOrWhiteSpace(createPlanText.Value) && !isCreating.Value)
                     {
+                        isCreating.Set(true);
                         var projects = selectedProjects.Value.Any() ? selectedProjects.Value : ["Auto"];
                         onCreatePlan(createPlanText.Value, projects, ParsePriority(selectedPriority.Value));
                         onClose();

--- a/src/tendril/Ivy.Tendril/Apps/Plans/Dialogs/UpdatePlanDialog.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Plans/Dialogs/UpdatePlanDialog.cs
@@ -19,6 +19,7 @@ public class UpdatePlanDialog(
 
     public override object? Build()
     {
+        var isCreating = UseState(false);
         if (!_dialogOpen.Value) return null;
 
         return new Dialog(
@@ -39,23 +40,24 @@ public class UpdatePlanDialog(
                     _updateText.Set("");
                     _dialogOpen.Set(false);
                 }),
-                new Button("Submit Update").Primary().ShortcutKey("Ctrl+Enter").OnClick(() =>
+                new Button("Submit Update").Primary().Disabled(isCreating.Value).ShortcutKey("Ctrl+Enter").OnClick(() =>
                 {
-                    if (!string.IsNullOrWhiteSpace(_updateText.Value))
+                    if (!string.IsNullOrWhiteSpace(_updateText.Value) && !isCreating.Value)
                     {
+                        isCreating.Set(true);
                         // Append >> comments to the latest revision so UpdatePlan can process them
                         var currentContent = _planService.ReadLatestRevision(_selectedPlan.FolderName);
                         var comments = string.Join("\n", _updateText.Value
                             .Split('\n')
                             .Select(line => $">> {line}"));
                         _planService.SavePlan(_selectedPlan.FolderName, currentContent + "\n\n" + comments + "\n");
-                    }
 
-                    _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Updating);
-                    _jobService.StartJob("UpdatePlan", _selectedPlan.FolderPath);
-                    _refreshPlans();
-                    _updateText.Set("");
-                    _dialogOpen.Set(false);
+                        _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Updating);
+                        _jobService.StartJob("UpdatePlan", _selectedPlan.FolderPath);
+                        _refreshPlans();
+                        _updateText.Set("");
+                        _dialogOpen.Set(false);
+                    }
                 })
             )
         ).Width(Size.Rem(30));

--- a/src/tendril/Ivy.Tendril/Apps/Review/Dialogs/CustomPrDialog.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Review/Dialogs/CustomPrDialog.cs
@@ -24,6 +24,7 @@ public class CustomPrDialog(
 
     public override object? Build()
     {
+        var isCreating = UseState(false);
         var customPrMerge = UseState(false);
         var customPrDeleteBranch = UseState(false);
         var customPrIncludeArtifacts = UseState(false);
@@ -71,30 +72,34 @@ public class CustomPrDialog(
                     customPrComment.Set("");
                     _dialogOpen.Set(false);
                 }),
-                new Button("Create PR").Primary().ShortcutKey("Ctrl+Enter").OnClick(() =>
+                new Button("Create PR").Primary().Disabled(isCreating.Value).ShortcutKey("Ctrl+Enter").OnClick(() =>
                 {
-                    var options = new Dictionary<string, object>
+                    if (!isCreating.Value)
                     {
-                        ["merge"] = customPrMerge.Value,
-                        ["deleteBranch"] = customPrDeleteBranch.Value && customPrMerge.Value,
-                        ["includeArtifacts"] = customPrIncludeArtifacts.Value,
-                        ["assignee"] = customPrAssignee.Value ?? "",
-                        ["comment"] = customPrComment.Value
-                    };
-                    var serializer = new SerializerBuilder()
-                        .WithNamingConvention(CamelCaseNamingConvention.Instance)
-                        .Build();
-                    var optionsPath = Path.Combine(_selectedPlan.FolderPath, ".custom-pr-options.yaml");
-                    FileHelper.WriteAllText(optionsPath, serializer.Serialize(options));
-                    _jobService.StartJob("MakePr", _selectedPlan.FolderPath);
-                    _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Building);
-                    _refreshPlans();
-                    customPrMerge.Set(true);
-                    customPrDeleteBranch.Set(true);
-                    customPrIncludeArtifacts.Set(true);
-                    customPrAssignee.Set(null);
-                    customPrComment.Set("");
-                    _dialogOpen.Set(false);
+                        isCreating.Set(true);
+                        var options = new Dictionary<string, object>
+                        {
+                            ["merge"] = customPrMerge.Value,
+                            ["deleteBranch"] = customPrDeleteBranch.Value && customPrMerge.Value,
+                            ["includeArtifacts"] = customPrIncludeArtifacts.Value,
+                            ["assignee"] = customPrAssignee.Value ?? "",
+                            ["comment"] = customPrComment.Value
+                        };
+                        var serializer = new SerializerBuilder()
+                            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+                            .Build();
+                        var optionsPath = Path.Combine(_selectedPlan.FolderPath, ".custom-pr-options.yaml");
+                        FileHelper.WriteAllText(optionsPath, serializer.Serialize(options));
+                        _jobService.StartJob("MakePr", _selectedPlan.FolderPath);
+                        _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Building);
+                        _refreshPlans();
+                        customPrMerge.Set(true);
+                        customPrDeleteBranch.Set(true);
+                        customPrIncludeArtifacts.Set(true);
+                        customPrAssignee.Set(null);
+                        customPrComment.Set("");
+                        _dialogOpen.Set(false);
+                    }
                 }).WithConfetti(AnimationTrigger.Click)
             )
         ).Width(Size.Rem(30));

--- a/src/tendril/Ivy.Tendril/Apps/Review/Dialogs/RerunDialog.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Review/Dialogs/RerunDialog.cs
@@ -19,6 +19,8 @@ public class RerunDialog(
 
     public override object? Build()
     {
+        var isRerunningClean = UseState(false);
+        var isRerunningCurrent = UseState(false);
         var logger = UseService<ILogger<RerunDialog>>();
 
         if (!_dialogOpen.Value) return null;
@@ -31,27 +33,35 @@ public class RerunDialog(
             ),
             new DialogFooter(
                 new Button("Cancel").Outline().ShortcutKey("Escape").OnClick(() => _dialogOpen.Set(false)),
-                new Button("Rerun from Scratch").Warning().OnClick(() =>
+                new Button("Rerun from Scratch").Warning().Disabled(isRerunningClean.Value).OnClick(() =>
                 {
-                    _dialogOpen.Set(false);
-                    _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Building);
-                    _refreshPlans();
-
-                    var folderPath = _selectedPlan.FolderPath;
-                    Task.Run(() =>
+                    if (!isRerunningClean.Value)
                     {
-                        CleanPlanState(folderPath, logger);
-                        _jobService.StartJob("ExecutePlan", folderPath, "-Note",
-                            "User requested a clean rerun. All artifacts, logs, and worktrees have been cleaned. Execute this plan from scratch.");
-                    });
+                        isRerunningClean.Set(true);
+                        _dialogOpen.Set(false);
+                        _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Building);
+                        _refreshPlans();
+
+                        var folderPath = _selectedPlan.FolderPath;
+                        Task.Run(() =>
+                        {
+                            CleanPlanState(folderPath, logger);
+                            _jobService.StartJob("ExecutePlan", folderPath, "-Note",
+                                "User requested a clean rerun. All artifacts, logs, and worktrees have been cleaned. Execute this plan from scratch.");
+                        });
+                    }
                 }),
-                new Button("Rerun with Current").Primary().ShortcutKey("Enter").AutoFocus().OnClick(() =>
+                new Button("Rerun with Current").Primary().Disabled(isRerunningCurrent.Value).ShortcutKey("Enter").AutoFocus().OnClick(() =>
                 {
-                    _dialogOpen.Set(false);
-                    _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Building);
-                    _jobService.StartJob("ExecutePlan", _selectedPlan.FolderPath, "-Note",
-                        "User requested you to execute this plan another time. Go through all code, verifications and artifacts one more time.");
-                    _refreshPlans();
+                    if (!isRerunningCurrent.Value)
+                    {
+                        isRerunningCurrent.Set(true);
+                        _dialogOpen.Set(false);
+                        _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Building);
+                        _jobService.StartJob("ExecutePlan", _selectedPlan.FolderPath, "-Note",
+                            "User requested you to execute this plan another time. Go through all code, verifications and artifacts one more time.");
+                        _refreshPlans();
+                    }
                 })
             )
         ).Width(Size.Rem(40));

--- a/src/tendril/Ivy.Tendril/Apps/Review/Dialogs/SuggestChangesDialog.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Review/Dialogs/SuggestChangesDialog.cs
@@ -20,6 +20,7 @@ public class SuggestChangesDialog(
 
     public override object? Build()
     {
+        var isCreating = UseState(false);
         if (!_dialogOpen.Value) return null;
 
         return new Dialog(
@@ -40,22 +41,23 @@ public class SuggestChangesDialog(
                     _suggestText.Set("");
                     _dialogOpen.Set(false);
                 }),
-                new Button("Submit Suggestions").Primary().ShortcutKey("Ctrl+Enter").OnClick(() =>
+                new Button("Submit Suggestions").Primary().Disabled(isCreating.Value).ShortcutKey("Ctrl+Enter").OnClick(() =>
                 {
-                    if (!string.IsNullOrWhiteSpace(_suggestText.Value))
+                    if (!string.IsNullOrWhiteSpace(_suggestText.Value) && !isCreating.Value)
                     {
+                        isCreating.Set(true);
                         var currentContent = _planService.ReadLatestRevision(_selectedPlan.FolderName);
                         var comments = string.Join("\n", _suggestText.Value
                             .Split('\n')
                             .Select(line => $">> {line}"));
                         _planService.SavePlan(_selectedPlan.FolderName, currentContent + "\n\n" + comments + "\n");
-                    }
 
-                    _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Updating);
-                    _jobService.StartJob("UpdatePlan", _selectedPlan.FolderPath);
-                    _refreshPlans();
-                    _suggestText.Set("");
-                    _dialogOpen.Set(false);
+                        _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Updating);
+                        _jobService.StartJob("UpdatePlan", _selectedPlan.FolderPath);
+                        _refreshPlans();
+                        _suggestText.Set("");
+                        _dialogOpen.Set(false);
+                    }
                 })
             )
         ).Width(Size.Rem(30));


### PR DESCRIPTION
# Summary

## Changes

Added race condition guards to 6 dialog components to prevent duplicate job creation from rapid button clicks or repeated keyboard shortcuts. Each dialog now disables its submit button and validates state before executing actions.

## API Changes

None. These are internal UI race condition fixes that don't affect public APIs.

## Files Modified

**Dialog Components:**
- `CreatePlanDialog.cs` - Added `isCreating` guard to "Create" button
- `CreateIssueDialog.cs` - Added `isCreating` guard to "Create Issue" button
- `UpdatePlanDialog.cs` - Added `isCreating` guard to "Submit Update" button
- `SuggestChangesDialog.cs` - Added `isCreating` guard to "Submit Suggestions" button
- `CustomPrDialog.cs` - Added `isCreating` guard to "Create PR" button
- `RerunDialog.cs` - Added separate guards (`isRerunningClean`, `isRerunningCurrent`) for both rerun buttons

## Commits

- 292ab3d08 [03307] Add race condition guards to dialog submit buttons