### PR TITLE
[03284] Fix sub-task worktree propagation, reference patterns, and concurrent execution

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/JobServiceRepoConcurrencyTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/JobServiceRepoConcurrencyTests.cs
@@ -1,0 +1,152 @@
+using Ivy.Tendril.Apps.Jobs;
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Test;
+
+public class JobServiceRepoConcurrencyTests : IDisposable
+{
+    private readonly string _testDir;
+
+    public JobServiceRepoConcurrencyTests()
+    {
+        _testDir = Path.Combine(Path.GetTempPath(), $"RepoConcurrency-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_testDir);
+    }
+
+    [Fact]
+    public void ExecutePlan_BlocksWhenRepoOverlaps()
+    {
+        var planA = CreatePlanFolder("PlanA", ["D:\\Repos\\MyRepo"]);
+        var planB = CreatePlanFolder("PlanB", ["D:\\Repos\\MyRepo"]);
+
+        var service = new JobService(
+            TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
+            null, 0);
+
+        service.StartJob("ExecutePlan", planA);
+        service.StartJob("ExecutePlan", planB);
+
+        var jobs = service.GetJobs();
+        var jobA = jobs.First(j => j.Args[0] == planA);
+        var jobB = jobs.First(j => j.Args[0] == planB);
+
+        Assert.Equal(JobStatus.Queued, jobA.Status);
+        Assert.Equal(JobStatus.Blocked, jobB.Status);
+        Assert.Contains("currently executing", jobB.StatusMessage);
+    }
+
+    [Fact]
+    public void ExecutePlan_AllowsWhenReposDiffer()
+    {
+        var planA = CreatePlanFolder("PlanA", ["D:\\Repos\\RepoX"]);
+        var planB = CreatePlanFolder("PlanB", ["D:\\Repos\\RepoY"]);
+
+        var service = new JobService(
+            TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
+            null, 0);
+
+        service.StartJob("ExecutePlan", planA);
+        service.StartJob("ExecutePlan", planB);
+
+        var jobs = service.GetJobs();
+        Assert.All(jobs, j => Assert.Equal(JobStatus.Queued, j.Status));
+    }
+
+    [Fact]
+    public void RepoOverlap_NormalizesWindowsPaths()
+    {
+        var planA = CreatePlanFolder("PlanA", ["D:\\Repos\\MyRepo"]);
+        var planB = CreatePlanFolder("PlanB", ["D:/Repos/MyRepo/"]);
+
+        var service = new JobService(
+            TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
+            null, 0);
+
+        service.StartJob("ExecutePlan", planA);
+        service.StartJob("ExecutePlan", planB);
+
+        var jobs = service.GetJobs();
+        var jobB = jobs.First(j => j.Args[0] == planB);
+        Assert.Equal(JobStatus.Blocked, jobB.Status);
+    }
+
+    [Fact]
+    public void RepoOverlap_HandlesMultipleRepos()
+    {
+        var planA = CreatePlanFolder("PlanA", ["D:\\Repos\\X", "D:\\Repos\\Y"]);
+        var planB = CreatePlanFolder("PlanB", ["D:\\Repos\\Y", "D:\\Repos\\Z"]);
+
+        var service = new JobService(
+            TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
+            null, 0);
+
+        service.StartJob("ExecutePlan", planA);
+        service.StartJob("ExecutePlan", planB);
+
+        var jobs = service.GetJobs();
+        var jobB = jobs.First(j => j.Args[0] == planB);
+        Assert.Equal(JobStatus.Blocked, jobB.Status);
+    }
+
+    [Fact]
+    public void ExecutePlan_NoRepos_AllowsConcurrent()
+    {
+        var planA = CreatePlanFolder("PlanA", []);
+        var planB = CreatePlanFolder("PlanB", []);
+
+        var service = new JobService(
+            TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
+            null, 0);
+
+        service.StartJob("ExecutePlan", planA);
+        service.StartJob("ExecutePlan", planB);
+
+        var jobs = service.GetJobs();
+        Assert.All(jobs, j => Assert.Equal(JobStatus.Queued, j.Status));
+    }
+
+    [Fact]
+    public void BlockedPlan_RetriesWhenBlockingPlanCompletes()
+    {
+        var planA = CreatePlanFolder("PlanA", ["D:\\Repos\\MyRepo"]);
+        var planB = CreatePlanFolder("PlanB", ["D:\\Repos\\MyRepo"]);
+
+        var service = new JobService(
+            TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
+            null, 0);
+
+        var idA = service.StartJob("ExecutePlan", planA);
+        service.StartJob("ExecutePlan", planB);
+
+        var jobsBefore = service.GetJobs();
+        var jobBBefore = jobsBefore.First(j => j.Args[0] == planB);
+        Assert.Equal(JobStatus.Blocked, jobBBefore.Status);
+
+        service.CompleteJob(idA, 0);
+
+        var jobsAfter = service.GetJobs();
+        var blockedAfter = jobsAfter.Where(j => j.Args[0] == planB && j.Status == JobStatus.Blocked).ToList();
+        Assert.Empty(blockedAfter);
+    }
+
+    private string CreatePlanFolder(string name, string[] repos)
+    {
+        var folder = Path.Combine(_testDir, name);
+        Directory.CreateDirectory(folder);
+
+        var reposList = repos.Length > 0
+            ? "\n" + string.Join("\n", repos.Select(r => $"- {r}"))
+            : " []";
+
+        File.WriteAllText(Path.Combine(folder, "plan.yaml"),
+            $"state: Executing\nproject: Auto\nrepos:{reposList}\ncommits: []\nprs: []\nverifications: []\nrelatedPlans: []\ndependsOn: []\n");
+
+        return folder;
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_testDir, true); }
+        catch { /* best effort */ }
+    }
+}

--- a/src/tendril/Ivy.Tendril/Apps/PullRequest/Dialogs/FollowUpDialog.cs
+++ b/src/tendril/Ivy.Tendril/Apps/PullRequest/Dialogs/FollowUpDialog.cs
@@ -1,3 +1,4 @@
+using Ivy.Core.Hooks;
 using Ivy.Tendril.Apps.Plans.Dialogs;
 using Ivy.Tendril.Services;
 

--- a/src/tendril/Ivy.Tendril/Apps/PullRequest/Dialogs/FollowUpDialog.cs
+++ b/src/tendril/Ivy.Tendril/Apps/PullRequest/Dialogs/FollowUpDialog.cs
@@ -1,6 +1,5 @@
 using Ivy.Core.Hooks;
 using Ivy.Tendril.Apps.Plans.Dialogs;
-using Ivy.Tendril.Services;
 
 namespace Ivy.Tendril.Apps.PullRequest.Dialogs;
 

--- a/src/tendril/Ivy.Tendril/Services/JobService.cs
+++ b/src/tendril/Ivy.Tendril/Services/JobService.cs
@@ -575,6 +575,20 @@ public class JobService : IJobService
                 RaiseJobsChanged();
                 return id;
             }
+
+            // Check for concurrent execution on same repos
+            var (concurrentOk, concurrentReason) = CheckRepositoryConcurrency(planFolder);
+            if (!concurrentOk)
+            {
+                job.Status = JobStatus.Blocked;
+                job.StatusMessage = concurrentReason;
+                job.CompletedAt = DateTime.UtcNow;
+                ResetPlanStateToBlocked(job);
+                var blockedNotification = new JobNotification("Job Blocked", $"{planFile}: {concurrentReason}", false);
+                RaiseNotification(blockedNotification);
+                RaiseJobsChanged();
+                return id;
+            }
         }
 
         // Ensure any pending plan state writes are flushed to disk before scripts read plan.yaml
@@ -899,28 +913,33 @@ public class JobService : IJobService
             if (string.IsNullOrEmpty(planFolder)) continue;
 
             var (ok, _) = CheckDependencies(planFolder);
-            if (ok)
-            {
-                // Remove the blocked job entry — only one thread succeeds
-                if (!_jobs.TryRemove(blockedJob.Id, out _))
-                    continue; // Another thread already handled this job
+            if (!ok)
+                continue;
 
-                // Skip if there's already an active job for this plan
-                if (HasActiveJobForPlan(planFolder))
-                    continue;
+            // Also check concurrency before retrying
+            var (concurrentOk, _) = CheckRepositoryConcurrency(planFolder);
+            if (!concurrentOk)
+                continue;
 
-                // Transition plan to Building before re-launching (ExecutePlan.ps1 requires it)
-                SetPlanStateByFolder(planFolder, "Building");
+            // Remove the blocked job entry — only one thread succeeds
+            if (!_jobs.TryRemove(blockedJob.Id, out _))
+                continue; // Another thread already handled this job
 
-                // Re-start the job — skip dependency check since we just verified
-                StartJobSkipDepCheck(blockedJob.Type, blockedJob.Args);
+            // Skip if there's already an active job for this plan
+            if (HasActiveJobForPlan(planFolder))
+                continue;
 
-                var notification = new JobNotification(
-                    "Job Unblocked",
-                    $"{blockedJob.PlanFile}: dependencies now satisfied, auto-restarting",
-                    true);
-                RaiseNotification(notification);
-            }
+            // Transition plan to Building before re-launching (ExecutePlan.ps1 requires it)
+            SetPlanStateByFolder(planFolder, "Building");
+
+            // Re-start the job — skip dependency check since we just verified
+            StartJobSkipDepCheck(blockedJob.Type, blockedJob.Args);
+
+            var notification = new JobNotification(
+                "Job Unblocked",
+                $"{blockedJob.PlanFile}: dependencies now satisfied, auto-restarting",
+                true);
+            RaiseNotification(notification);
         }
     }
 
@@ -1258,6 +1277,77 @@ public class JobService : IJobService
         {
             return (false, $"Dependency check failed: {ex.Message}");
         }
+    }
+
+    private (bool Ok, string? BlockReason) CheckRepositoryConcurrency(string planFolder)
+    {
+        try
+        {
+            var planYaml = ReadPlanYaml(planFolder);
+            if (planYaml == null)
+                return (true, null);
+
+            var repos = planYaml.Repos;
+            if (repos.Count == 0 && _configService != null)
+            {
+                var projectConfig = _configService.GetProject(planYaml.Project);
+                if (projectConfig != null)
+                    repos = projectConfig.RepoPaths;
+            }
+
+            if (repos.Count == 0)
+                return (true, null);
+
+            var activeJobs = _jobs.Values
+                .Where(j => j.Type == "ExecutePlan" &&
+                           j.Status is JobStatus.Running or JobStatus.Queued or JobStatus.Pending)
+                .ToList();
+
+            foreach (var activeJob in activeJobs)
+            {
+                var activePlanFolder = activeJob.Args.Length > 0 ? activeJob.Args[0] : "";
+                if (string.IsNullOrEmpty(activePlanFolder) || activePlanFolder == planFolder)
+                    continue;
+
+                var activePlan = ReadPlanYaml(activePlanFolder);
+                if (activePlan == null) continue;
+
+                var activeRepos = activePlan.Repos;
+                if (activeRepos.Count == 0 && _configService != null)
+                {
+                    var activeProjectConfig = _configService.GetProject(activePlan.Project);
+                    if (activeProjectConfig != null)
+                        activeRepos = activeProjectConfig.RepoPaths;
+                }
+
+                foreach (var repo in repos)
+                {
+                    var normalizedRepo = NormalizeRepoPath(repo);
+                    foreach (var activeRepo in activeRepos)
+                    {
+                        var normalizedActiveRepo = NormalizeRepoPath(activeRepo);
+                        if (normalizedRepo == normalizedActiveRepo)
+                        {
+                            var activePlanId = Path.GetFileName(activePlanFolder);
+                            var repoName = Path.GetFileName(repo);
+                            return (false, $"Plan {activePlanId} is currently executing on repository '{repoName}'. Wait for it to complete to avoid conflicting changes.");
+                        }
+                    }
+                }
+            }
+
+            return (true, null);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Concurrency check failed for plan {PlanFolder}", planFolder);
+            return (false, $"Concurrency check failed: {ex.Message}");
+        }
+    }
+
+    private static string NormalizeRepoPath(string path)
+    {
+        return path.Replace('\\', '/').TrimEnd('/').ToLowerInvariant();
     }
 
     private void RetryBlockedDependents(string completedPlanFolder)


### PR DESCRIPTION
# Summary

## Changes

Implemented three fixes to improve sub-task worktree propagation, reference pattern usage, and concurrent execution safety. Worktrees are now merged immediately after each task completes (instead of batching), sub-agents receive explicit instructions to use provided reference patterns, and ExecutePlan jobs are blocked when another plan is already executing on the same repository.

## API Changes

- `TaskHandler`: Added `MergeSingleWorktreeAsync(int taskId, string worktreePath, string displayId)` private method
- `TaskHandler`: Removed `_completionOrder` field (ConcurrentQueue<int>)
- `TaskHandler`: `MergeWorktreesAsync()` simplified to cleanup-only for failed tasks
- `JobService`: Added `CheckRepositoryConcurrency(string planFolder)` private method
- `JobService`: Added `NormalizeRepoPath(string path)` private static method

## Files Modified

### Ivy-Agent
- `Ivy.Agent.Shared/Client/TaskHandler.cs` — Inline worktree merge, removed batch merge
- `Ivy.Agent/Agents/Tools/Prompts/Task.md` — Added reference pattern instruction for sub-agents
- `Ivy.Agent.Shared.Test/Utils/WorktreeIntegrationTests.cs` — 4 new tests

### Ivy-Framework
- `src/tendril/Ivy.Tendril/Services/JobService.cs` — Repository concurrency guard
- `src/tendril/Ivy.Tendril.Test/JobServiceRepoConcurrencyTests.cs` — 6 new tests (new file)
- `src/tendril/Ivy.Tendril/Apps/PullRequest/Dialogs/FollowUpDialog.cs` — Fix pre-existing build error from plan 03283

## Commits
- ef19812cb [03284] Add repository-level concurrency guard for ExecutePlan jobs
- 5de6ab86a [03284] Fix missing using in FollowUpDialog.cs (pre-existing build error from 03283)
- d88d64e04 [03284] Fix DotnetFormat: remove unused using in FollowUpDialog.cs