### PR TITLE
[03308] Add tendril Label to MakePr Pull Requests

### DIFF
--- a/src/tendril/Ivy.Tendril/Promptwares/MakePr/Tools/Run-MakePr.ps1
+++ b/src/tendril/Ivy.Tendril/Promptwares/MakePr/Tools/Run-MakePr.ps1
@@ -184,7 +184,7 @@ if (Test-Path $worktreesDir) {
             }
 
             # Create PR
-            $prUrl = gh pr create --repo $ownerRepo --base $defaultBranch --head $branch --title $prTitle --body $prBody
+            $prUrl = gh pr create --repo $ownerRepo --base $defaultBranch --head $branch --title $prTitle --body $prBody --label "tendril"
             Write-Host "  PR created: $prUrl" -ForegroundColor Green
             $prUrls += $prUrl
 


### PR DESCRIPTION
# Summary

## Changes

Modified the MakePr pull request creation command to automatically add the `tendril` label to all PRs created by Tendril. This enables easy filtering and identification of Tendril-created PRs on GitHub.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Promptwares/MakePr/Tools/Run-MakePr.ps1` — Added `--label "tendril"` parameter to `gh pr create` command

---

## Commits

- 2330bef66 [03308] Add tendril label to MakePr pull requests