### PR TITLE
fix: tendrildocs deployment Standardized

### DIFF
--- a/src/tendril/Ivy.Tendril.Docs/Dockerfile
+++ b/src/tendril/Ivy.Tendril.Docs/Dockerfile
@@ -8,28 +8,24 @@ ARG BUILD_CONFIGURATION=Release
 ARG IVY_PACKAGE_VERSION
 
 WORKDIR /src
-
-# Copy tool config and restore tools
-# Note: Use the Ivy-Framework root as build context
-COPY [".config/dotnet-tools.json", ".config/"]
-RUN dotnet tool restore
+ARG IVY_PACKAGE_VERSION
 
 # Copy projects for restoration
-COPY ["src/tendril/Ivy.Tendril.Docs/Ivy.Tendril.Docs.csproj", "tendril/Ivy.Tendril.Docs/"]
-COPY ["src/Ivy/Ivy.csproj", "Ivy/"]
-COPY ["src/Ivy.Docs.Helpers/Ivy.Docs.Helpers.csproj", "Ivy.Docs.Helpers/"]
-COPY ["src/Ivy.Analyser/Ivy.Analyser.csproj", "Ivy.Analyser/"]
-COPY ["src/Ivy.Agent.Filter/Ivy.Agent.Filter.csproj", "Ivy.Agent.Filter/"]
+COPY ["src/tendril/Ivy.Tendril.Docs/Ivy.Tendril.Docs.csproj", "src/tendril/Ivy.Tendril.Docs/"]
+COPY ["src/Ivy/Ivy.csproj", "src/Ivy/"]
+COPY ["src/Ivy.Docs.Helpers/Ivy.Docs.Helpers.csproj", "src/Ivy.Docs.Helpers/"]
+COPY ["src/Ivy.Analyser/Ivy.Analyser.csproj", "src/Ivy.Analyser/"]
+COPY ["src/Ivy.Agent.Filter/Ivy.Agent.Filter.csproj", "src/Ivy.Agent.Filter/"]
 
 # Restore
-RUN dotnet restore "tendril/Ivy.Tendril.Docs/Ivy.Tendril.Docs.csproj"
+RUN dotnet restore "src/tendril/Ivy.Tendril.Docs/Ivy.Tendril.Docs.csproj" -p:IvyPackageVersion=$IVY_PACKAGE_VERSION
 
 # Copy the rest of the source code
 COPY . .
 
 # Build and publish
-WORKDIR "/src/tendril/Ivy.Tendril.Docs"
-RUN dotnet publish "Ivy.Tendril.Docs.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
+WORKDIR "/src/src/tendril/Ivy.Tendril.Docs"
+RUN dotnet publish "Ivy.Tendril.Docs.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false /p:IvyPackageVersion=$IVY_PACKAGE_VERSION
 
 FROM base AS final
 WORKDIR /app

--- a/src/tendril/Ivy.Tendril.Docs/Ivy.Tendril.Docs.csproj
+++ b/src/tendril/Ivy.Tendril.Docs/Ivy.Tendril.Docs.csproj
@@ -11,9 +11,14 @@
         <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
     </PropertyGroup>
 
-    <ItemGroup>
+    <ItemGroup Condition="'$(IvyPackageVersion)' == ''">
         <ProjectReference Include="../../Ivy/Ivy.csproj" />
         <ProjectReference Include="../../Ivy.Docs.Helpers/Ivy.Docs.Helpers.csproj" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(IvyPackageVersion)' != ''">
+        <PackageReference Include="Ivy" Version="$(IvyPackageVersion)" />
+        <PackageReference Include="Ivy.Docs.Helpers" Version="$(IvyPackageVersion)" />
     </ItemGroup>
 
     <ItemGroup>
@@ -31,7 +36,7 @@
             <DocsInputPath>$([System.IO.Path]::Combine($(MSBuildProjectDirectory), 'Docs', '*.md'))</DocsInputPath>
             <DocsOutputPath>$([System.IO.Path]::Combine($(MSBuildProjectDirectory), 'Generated'))</DocsOutputPath>
         </PropertyGroup>
-        <Exec Command="dotnet tool restore" WorkingDirectory="$(MSBuildProjectDirectory)/../../" />
+        <Exec Command="dotnet tool restore" WorkingDirectory="$(MSBuildProjectDirectory)/../../../" />
         <Exec Command="dotnet ivy-docs-cli convert &quot;$(DocsInputPath)&quot; &quot;$(DocsOutputPath)&quot; --skip-if-not-changed" WorkingDirectory="$(MSBuildProjectDirectory)" />
         <ItemGroup>
             <Compile Include="Generated/**/*.g.cs" />
@@ -45,13 +50,20 @@
     </ItemGroup>
 
     <!-- enable ivy analyzer -->
-    <ItemGroup>
+    <ItemGroup Condition="'$(IvyPackageVersion)' == ''">
         <ProjectReference Include="../../Ivy.Analyser/Ivy.Analyser.csproj">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
             <OutputItemType>Analyzer</OutputItemType>
         </ProjectReference>
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(IvyPackageVersion)' != ''">
+        <PackageReference Include="Ivy.Analyser" Version="$(IvyPackageVersion)">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Standardizes TendrilDocs deployment by following the Ivy.Docs Dockerfile pattern (src/src hierarchy) and adding NuGet package fallback support as requested.