### PR TITLE
[00193] Add Prefix/Suffix slot support to SliderInput

### DIFF
--- a/src/Ivy.Test/InputWidgetTests.cs
+++ b/src/Ivy.Test/InputWidgetTests.cs
@@ -324,6 +324,28 @@ public class InputPrefixSuffixSlotTests
     }
 
     [Fact]
+    public void SliderInput_Prefix_AddsPrefixSlot()
+    {
+        var state = new MockState<int>(50);
+        var input = state.ToSliderInput().Prefix("$");
+
+        var slot = FindSlot(input, "Prefix");
+        Assert.NotNull(slot);
+        Assert.Equal("$", slot!.Children[0]);
+    }
+
+    [Fact]
+    public void SliderInput_Suffix_AddsSuffixSlot()
+    {
+        var state = new MockState<int>(50);
+        var input = state.ToSliderInput().Suffix("kg");
+
+        var slot = FindSlot(input, "Suffix");
+        Assert.NotNull(slot);
+        Assert.Equal("kg", slot!.Children[0]);
+    }
+
+    [Fact]
     public void NumberRangeInput_Prefix_AddsPrefixSlot()
     {
         NumberRangeInputBase input = new NumberRangeInput<int>();

--- a/src/frontend/src/widgets/inputs/NumberInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/NumberInputWidget.tsx
@@ -120,6 +120,7 @@ const SliderVariant = memo(
     onValueChange,
     onBlur,
     onFocus,
+    slots,
     "data-testid": dataTestId,
   }: NumberInputBaseProps) => {
     const isBytesFormat = formatStyle === "Bytes";
@@ -161,7 +162,13 @@ const SliderVariant = memo(
       [max, isBytesFormat],
     );
 
-    return (
+    const prefixContent = slots?.Prefix;
+    const suffixContent = slots?.Suffix;
+    const hasPrefix = (prefixContent?.length ?? 0) > 0;
+    const hasSuffix = (suffixContent?.length ?? 0) > 0;
+    const hasSlots = hasPrefix || hasSuffix;
+
+    const sliderContent = (
       <div className="relative w-full flex-1 flex flex-col gap-1 pt-6 pb-2 my-auto justify-center">
         <Slider
           min={min}
@@ -196,6 +203,31 @@ const SliderVariant = memo(
         {invalid && (
           <div className="absolute right-2.5 translate-y-1/2 -top-1.5">
             <InvalidIcon message={invalid} />
+          </div>
+        )}
+      </div>
+    );
+
+    if (!hasSlots) {
+      return sliderContent;
+    }
+
+    return (
+      <div
+        className={cn(
+          "flex items-stretch w-full flex-1 rounded-field border border-input bg-transparent shadow-sm dark:bg-white/5 dark:border-white/10",
+          disabled && "cursor-not-allowed opacity-50",
+        )}
+      >
+        {hasPrefix && (
+          <div className="flex items-center px-3 bg-muted text-muted-foreground border-r border-input rounded-tl-[var(--radius-fields)] rounded-bl-[var(--radius-fields)]">
+            {prefixContent}
+          </div>
+        )}
+        <div className="flex-1 px-3">{sliderContent}</div>
+        {hasSuffix && (
+          <div className="flex items-center px-3 bg-muted text-muted-foreground border-l border-input rounded-tr-[var(--radius-fields)] rounded-br-[var(--radius-fields)]">
+            {suffixContent}
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

Added prefix/suffix slot rendering support to the `SliderVariant` component in `NumberInputWidget.tsx`. The C# backend already supported `.Prefix()` and `.Suffix()` on `NumberInputBase` (used by both Number and Slider variants), but the frontend `SliderVariant` ignored the `slots` prop. Now when slots are present, the slider is wrapped in a styled flex container with prefix/suffix regions matching the `NumberVariant` visual pattern. When no slots are present, the slider renders unchanged.

## API Changes

None. The C# API (`state.ToSliderInput().Prefix("$").Suffix("kg")`) already compiled and sent slot data — this change makes the frontend render it.

## Files Modified

- **Frontend:**
  - `src/frontend/src/widgets/inputs/NumberInputWidget.tsx` — Added `slots` to `SliderVariant` destructured props; added conditional prefix/suffix container rendering

- **Tests:**
  - `src/Ivy.Test/InputWidgetTests.cs` — Added `SliderInput_Prefix_AddsPrefixSlot` and `SliderInput_Suffix_AddsSuffixSlot` tests

## Commits

- c50d8e7df [00193] Add prefix/suffix slot support to SliderInput

🤖 Generated with [Tendril](https://github.com/Ivy-Interactive)