### PR TITLE
[00191] Add Prefix/Suffix slot support to CodeInput, FeedbackInput, and IconInput

### DIFF
--- a/src/Ivy.Test/InputWidgetTests.cs
+++ b/src/Ivy.Test/InputWidgetTests.cs
@@ -548,4 +548,136 @@ public class InputPrefixSuffixSlotTests
         Assert.NotNull(slot);
         Assert.Same(button, slot!.Children[0]);
     }
+
+    [Fact]
+    public void CodeInput_Prefix_AddsPrefixSlot()
+    {
+        CodeInputBase input = new CodeInput<string>();
+        var withPrefix = input.Prefix("$");
+
+        var slot = FindSlot(withPrefix, "Prefix");
+        Assert.NotNull(slot);
+        Assert.Equal("$", slot!.Children[0]);
+    }
+
+    [Fact]
+    public void CodeInput_Suffix_AddsSuffixSlot()
+    {
+        CodeInputBase input = new CodeInput<string>();
+        var withSuffix = input.Suffix("lang");
+
+        var slot = FindSlot(withSuffix, "Suffix");
+        Assert.NotNull(slot);
+        Assert.Equal("lang", slot!.Children[0]);
+    }
+
+    [Fact]
+    public void CodeInput_PrefixAndSuffix_Coexist()
+    {
+        CodeInputBase input = new CodeInput<string>();
+        var both = input.Prefix("//").Suffix("lang");
+
+        Assert.NotNull(FindSlot(both, "Prefix"));
+        Assert.NotNull(FindSlot(both, "Suffix"));
+    }
+
+    [Fact]
+    public void CodeInput_Prefix_AcceptsWidgetContent()
+    {
+        CodeInputBase input = new CodeInput<string>();
+        var button = new Button("Click");
+        var withPrefix = input.Prefix(button);
+
+        var slot = FindSlot(withPrefix, "Prefix");
+        Assert.NotNull(slot);
+        Assert.Same(button, slot!.Children[0]);
+    }
+
+    [Fact]
+    public void FeedbackInput_Prefix_AddsPrefixSlot()
+    {
+        FeedbackInputBase input = new FeedbackInput<int>();
+        var withPrefix = input.Prefix("Rate:");
+
+        var slot = FindSlot(withPrefix, "Prefix");
+        Assert.NotNull(slot);
+        Assert.Equal("Rate:", slot!.Children[0]);
+    }
+
+    [Fact]
+    public void FeedbackInput_Suffix_AddsSuffixSlot()
+    {
+        FeedbackInputBase input = new FeedbackInput<int>();
+        var withSuffix = input.Suffix("/5");
+
+        var slot = FindSlot(withSuffix, "Suffix");
+        Assert.NotNull(slot);
+        Assert.Equal("/5", slot!.Children[0]);
+    }
+
+    [Fact]
+    public void FeedbackInput_PrefixAndSuffix_Coexist()
+    {
+        FeedbackInputBase input = new FeedbackInput<int>();
+        var both = input.Prefix("Rate:").Suffix("/5");
+
+        Assert.NotNull(FindSlot(both, "Prefix"));
+        Assert.NotNull(FindSlot(both, "Suffix"));
+    }
+
+    [Fact]
+    public void FeedbackInput_Prefix_AcceptsWidgetContent()
+    {
+        FeedbackInputBase input = new FeedbackInput<int>();
+        var button = new Button("Click");
+        var withPrefix = input.Prefix(button);
+
+        var slot = FindSlot(withPrefix, "Prefix");
+        Assert.NotNull(slot);
+        Assert.Same(button, slot!.Children[0]);
+    }
+
+    [Fact]
+    public void IconInput_Prefix_AddsPrefixSlot()
+    {
+        IconInputBase input = new IconInput<Icons>();
+        var withPrefix = input.Prefix("Icon:");
+
+        var slot = FindSlot(withPrefix, "Prefix");
+        Assert.NotNull(slot);
+        Assert.Equal("Icon:", slot!.Children[0]);
+    }
+
+    [Fact]
+    public void IconInput_Suffix_AddsSuffixSlot()
+    {
+        IconInputBase input = new IconInput<Icons>();
+        var withSuffix = input.Suffix("selected");
+
+        var slot = FindSlot(withSuffix, "Suffix");
+        Assert.NotNull(slot);
+        Assert.Equal("selected", slot!.Children[0]);
+    }
+
+    [Fact]
+    public void IconInput_PrefixAndSuffix_Coexist()
+    {
+        IconInputBase input = new IconInput<Icons>();
+        var both = input.Prefix("Icon:").Suffix("selected");
+
+        Assert.NotNull(FindSlot(both, "Prefix"));
+        Assert.NotNull(FindSlot(both, "Suffix"));
+    }
+
+    [Fact]
+    public void IconInput_Prefix_AcceptsWidgetContent()
+    {
+        IconInputBase input = new IconInput<Icons>();
+        var button = new Button("Click");
+        var withPrefix = input.Prefix(button);
+
+        var slot = FindSlot(withPrefix, "Prefix");
+        Assert.NotNull(slot);
+        Assert.Same(button, slot!.Children[0]);
+    }
 }

--- a/src/Ivy/Widgets/Inputs/CodeInput.cs
+++ b/src/Ivy/Widgets/Inputs/CodeInput.cs
@@ -174,5 +174,16 @@ public static class CodeInputExtensions
         return widget.OnFocus(_ => { onFocus(); return ValueTask.CompletedTask; });
     }
 
+    private static object[] WithSlot(CodeInputBase widget, string slotName, object? value)
+    {
+        var others = widget.Children.Where(c => c is not Slot s || s.Name != slotName);
+        var result = value != null ? others.Append(new Slot(slotName, value)) : others;
+        return result.ToArray();
+    }
 
+    public static CodeInputBase Prefix(this CodeInputBase widget, object prefix)
+        => widget with { Children = WithSlot(widget, "Prefix", prefix) };
+
+    public static CodeInputBase Suffix(this CodeInputBase widget, object suffix)
+        => widget with { Children = WithSlot(widget, "Suffix", suffix) };
 }

--- a/src/Ivy/Widgets/Inputs/FeedbackInput.cs
+++ b/src/Ivy/Widgets/Inputs/FeedbackInput.cs
@@ -154,5 +154,16 @@ public static class FeedbackInputExtensions
     public static FeedbackInputBase Thumbs(this FeedbackInputBase widget) => widget with { Variant = FeedbackInputVariant.Thumbs };
     public static FeedbackInputBase Emojis(this FeedbackInputBase widget) => widget with { Variant = FeedbackInputVariant.Emojis };
 
+    private static object[] WithSlot(FeedbackInputBase widget, string slotName, object? value)
+    {
+        var others = widget.Children.Where(c => c is not Slot s || s.Name != slotName);
+        var result = value != null ? others.Append(new Slot(slotName, value)) : others;
+        return result.ToArray();
+    }
 
+    public static FeedbackInputBase Prefix(this FeedbackInputBase widget, object prefix)
+        => widget with { Children = WithSlot(widget, "Prefix", prefix) };
+
+    public static FeedbackInputBase Suffix(this FeedbackInputBase widget, object suffix)
+        => widget with { Children = WithSlot(widget, "Suffix", suffix) };
 }

--- a/src/Ivy/Widgets/Inputs/IconInput.cs
+++ b/src/Ivy/Widgets/Inputs/IconInput.cs
@@ -127,5 +127,16 @@ public static class IconInputExtensions
             return ValueTask.CompletedTask;
         });
 
+    private static object[] WithSlot(IconInputBase widget, string slotName, object? value)
+    {
+        var others = widget.Children.Where(c => c is not Slot s || s.Name != slotName);
+        var result = value != null ? others.Append(new Slot(slotName, value)) : others;
+        return result.ToArray();
+    }
 
+    public static IconInputBase Prefix(this IconInputBase widget, object prefix)
+        => widget with { Children = WithSlot(widget, "Prefix", prefix) };
+
+    public static IconInputBase Suffix(this IconInputBase widget, object suffix)
+        => widget with { Children = WithSlot(widget, "Suffix", suffix) };
 }

--- a/src/frontend/src/widgets/inputs/FeedbackInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/FeedbackInputWidget.tsx
@@ -20,6 +20,7 @@ interface FeedbackInputWidgetProps {
   allowHalf?: boolean;
   max?: number;
   density?: Densities;
+  slots?: { Prefix?: React.ReactNode[]; Suffix?: React.ReactNode[] };
 }
 
 export const FeedbackInputWidget: React.FC<FeedbackInputWidgetProps> = ({
@@ -33,6 +34,7 @@ export const FeedbackInputWidget: React.FC<FeedbackInputWidgetProps> = ({
   allowHalf = false,
   max = 5,
   density = Densities.Medium,
+  slots,
 }) => {
   const eventHandler = useEventHandler();
 
@@ -179,7 +181,13 @@ export const FeedbackInputWidget: React.FC<FeedbackInputWidgetProps> = ({
     return null;
   }, [variant, disabled, numericValue, handleChange, invalid, allowHalf, max, density]);
 
-  return (
+  const prefixContent = slots?.Prefix;
+  const suffixContent = slots?.Suffix;
+  const hasPrefix = (prefixContent?.length ?? 0) > 0;
+  const hasSuffix = (suffixContent?.length ?? 0) > 0;
+  const hasAffixes = hasPrefix || hasSuffix;
+
+  const feedbackContent = (
     <div
       onBlur={(e) => {
         if (!e.currentTarget.contains(e.relatedTarget)) {
@@ -199,6 +207,30 @@ export const FeedbackInputWidget: React.FC<FeedbackInputWidgetProps> = ({
       )}
     >
       {ratingComponent}
+    </div>
+  );
+
+  if (!hasAffixes) return feedbackContent;
+
+  return (
+    <div
+      className={cn(
+        "relative flex items-stretch rounded-field border border-input bg-transparent shadow-sm transition-colors dark:bg-white/5 dark:border-white/10",
+        invalid && "border-destructive",
+        disabled && "cursor-not-allowed opacity-50",
+      )}
+    >
+      {hasPrefix && (
+        <div className="flex items-center px-3 bg-muted text-muted-foreground border-r border-input rounded-tl-[var(--radius-fields)] rounded-bl-[var(--radius-fields)]">
+          {prefixContent}
+        </div>
+      )}
+      <div className="flex-1 px-3 py-2">{feedbackContent}</div>
+      {hasSuffix && (
+        <div className="flex items-center px-3 bg-muted text-muted-foreground border-l border-input rounded-tr-[var(--radius-fields)] rounded-br-[var(--radius-fields)]">
+          {suffixContent}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/frontend/src/widgets/inputs/IconInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/IconInputWidget.tsx
@@ -47,6 +47,7 @@ interface IconInputWidgetProps {
   events?: string[];
   density?: Densities;
   autoFocus?: boolean;
+  slots?: { Prefix?: React.ReactNode[]; Suffix?: React.ReactNode[] };
 }
 
 const ICONS_PER_ROW = 8;
@@ -61,6 +62,7 @@ export const IconInputWidget: React.FC<IconInputWidgetProps> = ({
   events = EMPTY_ARRAY,
   density = Densities.Medium,
   autoFocus,
+  slots,
 }) => {
   const eventHandler = useEventHandler();
   const [open, setOpen] = useState(false);
@@ -111,6 +113,12 @@ export const IconInputWidget: React.FC<IconInputWidgetProps> = ({
     },
     [eventHandler, id, events],
   );
+
+  const prefixContent = slots?.Prefix;
+  const suffixContent = slots?.Suffix;
+  const hasPrefix = (prefixContent?.length ?? 0) > 0;
+  const hasSuffix = (suffixContent?.length ?? 0) > 0;
+  const hasAffixes = hasPrefix || hasSuffix;
 
   const hasValue = localValue != null && localValue !== "" && localValue !== "None";
 
@@ -169,7 +177,7 @@ export const IconInputWidget: React.FC<IconInputWidgetProps> = ({
       valueTextSpan
     );
 
-  return (
+  const iconContent = (
     <div className="flex items-center gap-2 min-w-0">
       <Popover open={open} onOpenChange={handleOpenChange}>
         <PopoverTrigger asChild>
@@ -293,6 +301,30 @@ export const IconInputWidget: React.FC<IconInputWidgetProps> = ({
               <X className={xIconVariant({ density })} />
             </button>
           )}
+        </div>
+      )}
+    </div>
+  );
+
+  if (!hasAffixes) return iconContent;
+
+  return (
+    <div
+      className={cn(
+        "relative flex items-stretch rounded-field border border-input bg-transparent shadow-sm transition-colors dark:bg-white/5 dark:border-white/10",
+        invalid && "border-destructive",
+        disabled && "cursor-not-allowed opacity-50",
+      )}
+    >
+      {hasPrefix && (
+        <div className="flex items-center px-3 bg-muted text-muted-foreground border-r border-input rounded-tl-[var(--radius-fields)] rounded-bl-[var(--radius-fields)]">
+          {prefixContent}
+        </div>
+      )}
+      <div className="flex-1 px-3 py-2">{iconContent}</div>
+      {hasSuffix && (
+        <div className="flex items-center px-3 bg-muted text-muted-foreground border-l border-input rounded-tr-[var(--radius-fields)] rounded-br-[var(--radius-fields)]">
+          {suffixContent}
         </div>
       )}
     </div>

--- a/src/frontend/src/widgets/inputs/code/CodeInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/code/CodeInputWidget.tsx
@@ -46,6 +46,7 @@ interface CodeInputWidgetProps {
   height?: string;
   density?: Densities;
   autoFocus?: boolean;
+  slots?: { Prefix?: React.ReactNode[]; Suffix?: React.ReactNode[] };
 }
 
 const languageExtensions = {
@@ -78,6 +79,7 @@ export const CodeInputWidget: React.FC<CodeInputWidgetProps> = ({
   density = Densities.Medium,
   events = EMPTY_ARRAY,
   autoFocus,
+  slots,
 }) => {
   const eventHandler = useEventHandler();
   const [isFocused, setIsFocused] = useState(false);
@@ -172,7 +174,13 @@ export const CodeInputWidget: React.FC<CodeInputWidgetProps> = ({
     return [...langExtensions, minimalSetup, themeExtension];
   }, [langExtensions, minimalSetup, themeExtension]);
 
-  return (
+  const prefixContent = slots?.Prefix;
+  const suffixContent = slots?.Suffix;
+  const hasPrefix = (prefixContent?.length ?? 0) > 0;
+  const hasSuffix = (suffixContent?.length ?? 0) > 0;
+  const hasAffixes = hasPrefix || hasSuffix;
+
+  const codeEditor = (
     <div style={styles} className="relative w-full h-full overflow-hidden">
       {(showCopy || showClear || invalid) && (
         <div className="absolute top-2 right-2 z-50 flex items-center">
@@ -229,6 +237,30 @@ export const CodeInputWidget: React.FC<CodeInputWidgetProps> = ({
           basicSetup={false}
         />
       </Suspense>
+    </div>
+  );
+
+  if (!hasAffixes) return codeEditor;
+
+  return (
+    <div
+      className={cn(
+        "relative flex items-stretch rounded-field border border-input bg-transparent shadow-sm transition-colors dark:bg-white/5 dark:border-white/10",
+        invalid && "border-destructive",
+        disabled && "cursor-not-allowed opacity-50",
+      )}
+    >
+      {hasPrefix && (
+        <div className="flex items-center px-3 bg-muted text-muted-foreground border-r border-input rounded-tl-[var(--radius-fields)] rounded-bl-[var(--radius-fields)]">
+          {prefixContent}
+        </div>
+      )}
+      <div className="flex-1 min-w-0">{codeEditor}</div>
+      {hasSuffix && (
+        <div className="flex items-center px-3 bg-muted text-muted-foreground border-l border-input rounded-tr-[var(--radius-fields)] rounded-br-[var(--radius-fields)]">
+          {suffixContent}
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Problem

TextInput, NumberInput, NumberRangeInput, SelectInput, BoolInput, and DateRangeInput all support Prefix/Suffix slots, allowing users to add decorative or functional content (icons, labels, buttons) adjacent to the input. Three input types still lack this feature:

- **CodeInput**
- **FeedbackInput**
- **IconInput**

## Solution

Applied the same `WithSlot` / `Prefix()` / `Suffix()` pattern from BoolInput to each of the three remaining input types:

- Added `WithSlot`, `Prefix`, `Suffix` extension methods to CodeInput, FeedbackInput, and IconInput C# files
- Added slot rendering (prefix/suffix flex containers) to the corresponding React widget components
- Added 12 new unit tests (4 per input type) in `InputPrefixSuffixSlotTests`

## Commits

- `4b87823cf` [00191] Add Prefix/Suffix slot support to CodeInput, FeedbackInput, and IconInput

## Verifications

- ✅ DotnetBuild
- ✅ DotnetFormat
- ✅ DotnetTest
- ✅ FrontendLint
- ✅ IvyFrameworkVerification
- ✅ CheckResult

🤖 Generated with [Tendril](https://github.com/Ivy-Interactive/Ivy-Framework)