### PR TITLE
fix: tendrildocs deployment Flat

### DIFF
--- a/src/tendril/Ivy.Tendril.Docs/Dockerfile
+++ b/src/tendril/Ivy.Tendril.Docs/Dockerfile
@@ -11,20 +11,20 @@ WORKDIR /src
 ARG IVY_PACKAGE_VERSION
 
 # Copy projects for restoration
-COPY ["src/tendril/Ivy.Tendril.Docs/Ivy.Tendril.Docs.csproj", "src/tendril/Ivy.Tendril.Docs/"]
-COPY ["src/Ivy/Ivy.csproj", "src/Ivy/"]
-COPY ["src/Ivy.Docs.Helpers/Ivy.Docs.Helpers.csproj", "src/Ivy.Docs.Helpers/"]
-COPY ["src/Ivy.Analyser/Ivy.Analyser.csproj", "src/Ivy.Analyser/"]
-COPY ["src/Ivy.Agent.Filter/Ivy.Agent.Filter.csproj", "src/Ivy.Agent.Filter/"]
+COPY ["src/tendril/Ivy.Tendril.Docs/Ivy.Tendril.Docs.csproj", "tendril/Ivy.Tendril.Docs/"]
+COPY ["src/Ivy/Ivy.csproj", "Ivy/"]
+COPY ["src/Ivy.Docs.Helpers/Ivy.Docs.Helpers.csproj", "Ivy.Docs.Helpers/"]
+COPY ["src/Ivy.Analyser/Ivy.Analyser.csproj", "Ivy.Analyser/"]
+COPY ["src/Ivy.Agent.Filter/Ivy.Agent.Filter.csproj", "Ivy.Agent.Filter/"]
 
 # Restore
-RUN dotnet restore "src/tendril/Ivy.Tendril.Docs/Ivy.Tendril.Docs.csproj" -p:IvyPackageVersion=$IVY_PACKAGE_VERSION
+RUN dotnet restore "tendril/Ivy.Tendril.Docs/Ivy.Tendril.Docs.csproj" -p:IvyPackageVersion=$IVY_PACKAGE_VERSION
 
 # Copy the rest of the source code
 COPY . .
 
 # Build and publish
-WORKDIR "/src/src/tendril/Ivy.Tendril.Docs"
+WORKDIR "/src/tendril/Ivy.Tendril.Docs"
 RUN dotnet publish "Ivy.Tendril.Docs.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false /p:IvyPackageVersion=$IVY_PACKAGE_VERSION
 
 FROM base AS final

--- a/src/tendril/Ivy.Tendril.Docs/Ivy.Tendril.Docs.csproj
+++ b/src/tendril/Ivy.Tendril.Docs/Ivy.Tendril.Docs.csproj
@@ -36,7 +36,7 @@
             <DocsInputPath>$([System.IO.Path]::Combine($(MSBuildProjectDirectory), 'Docs', '*.md'))</DocsInputPath>
             <DocsOutputPath>$([System.IO.Path]::Combine($(MSBuildProjectDirectory), 'Generated'))</DocsOutputPath>
         </PropertyGroup>
-        <Exec Command="dotnet tool restore" WorkingDirectory="$(MSBuildProjectDirectory)/../../../" />
+        <Exec Command="dotnet tool restore" WorkingDirectory="$(MSBuildProjectDirectory)/../../" />
         <Exec Command="dotnet ivy-docs-cli convert &quot;$(DocsInputPath)&quot; &quot;$(DocsOutputPath)&quot; --skip-if-not-changed" WorkingDirectory="$(MSBuildProjectDirectory)" />
         <ItemGroup>
             <Compile Include="Generated/**/*.g.cs" />


### PR DESCRIPTION
Flattens the Dockerfile structure to match absolute paths /src/... as reported in Sliplane logs. Includes NuGet fallback support in .csproj.