### PR TITLE
[03322] Make Server.Configuration initialization lazy to avoid redundant pipeline runs

### DIFF
--- a/src/Ivy/Server.cs
+++ b/src/Ivy/Server.cs
@@ -81,7 +81,12 @@ public class Server
     public AppRepository AppRepository { get; } = new();
     public NavigationBeaconRegistry NavigationBeaconRegistry { get; } = new();
     public IServiceCollection Services { get; } = new ServiceCollection();
-    public IConfiguration Configuration { get; private set; } = ServerUtils.GetConfiguration();
+    private IConfiguration? _configuration;
+    public IConfiguration Configuration
+    {
+        get => _configuration ??= ServerUtils.GetConfiguration();
+        private set => _configuration = value;
+    }
     public Type? AuthProviderType { get; private set; } = null;
     public ServerArgs Args => _args;
     public static Action<CookieOptions>? ConfigureAuthCookieOptions { get; set; }
@@ -128,8 +133,8 @@ public class Server
         };
 
         Services.AddSingleton(_args);
-        // capture the latest Configuration value at resolution time in case it gets replaced by UseConfiguration()
-        Services.AddSingleton(_ => Configuration);
+        // Configuration is lazily initialized on first access
+        Services.AddSingleton<IConfiguration>(_ => Configuration);
 
         AddDefaultApps();
     }


### PR DESCRIPTION
# Summary

## Changes

Replaced eager field initialization of `Server.Configuration` with lazy initialization using a backing field pattern. Configuration is now only built when first accessed, preventing redundant pipeline executions during server startup.

## API Changes

**Modified:**
- `Server.Configuration` — Changed from auto-property with eager initialization to property with lazy initialization getter

## Files Modified

- `src/Ivy/Server.cs` — Converted Configuration property to use lazy initialization pattern with `_configuration` backing field


## Commits

- a20a67889674cd3a7b40821425da59166f48c5e5