### PR TITLE
[03311] Consolidate MarkdownHelper annotation calls into single method

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/MarkdownHelperTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/MarkdownHelperTests.cs
@@ -167,4 +167,99 @@ public class MarkdownHelperTests
         var results = MarkdownHelper.FindFilesInRepos(["C:\\nonexistent\\repo"], "Target.cs");
         Assert.Empty(results);
     }
+
+    [Fact]
+    public void AnnotateAllBrokenLinks_ValidFileLink_BrokenPlanLink()
+    {
+        var tempFile = Path.GetTempFileName();
+        var tempPlansDir = Path.Combine(Path.GetTempPath(), $"plans-{Guid.NewGuid()}");
+        try
+        {
+            Directory.CreateDirectory(tempPlansDir);
+            var validFileLink = $"[valid.txt](file:///{tempFile.Replace("\\", "/")})";
+            var brokenPlanLink = "[Plan 99999](plan://99999)";
+            var markdown = $"See {validFileLink} and {brokenPlanLink}";
+
+            var result = MarkdownHelper.AnnotateAllBrokenLinks(markdown, tempPlansDir);
+
+            Assert.Contains(validFileLink, result);
+            Assert.Contains("[Plan 99999 \u26a0\ufe0f](plan://99999)", result);
+            Assert.Single(result.Split("\u26a0\ufe0f"));
+        }
+        finally
+        {
+            File.Delete(tempFile);
+            Directory.Delete(tempPlansDir, true);
+        }
+    }
+
+    [Fact]
+    public void AnnotateAllBrokenLinks_BrokenFileLink_ValidPlanLink()
+    {
+        var tempPlansDir = Path.Combine(Path.GetTempPath(), $"plans-{Guid.NewGuid()}");
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(tempPlansDir, "01234-TestPlan"));
+            var brokenFileLink = "[broken.cs](file:///C:/nonexistent/broken.cs)";
+            var validPlanLink = "[Plan 01234](plan://01234)";
+            var markdown = $"See {brokenFileLink} and {validPlanLink}";
+
+            var result = MarkdownHelper.AnnotateAllBrokenLinks(markdown, tempPlansDir);
+
+            Assert.Contains("[broken.cs \u26a0\ufe0f](file:///C:/nonexistent/broken.cs)", result);
+            Assert.Contains(validPlanLink, result);
+            Assert.Single(result.Split("\u26a0\ufe0f"));
+        }
+        finally
+        {
+            Directory.Delete(tempPlansDir, true);
+        }
+    }
+
+    [Fact]
+    public void AnnotateAllBrokenLinks_BothBroken()
+    {
+        var tempPlansDir = Path.Combine(Path.GetTempPath(), $"plans-{Guid.NewGuid()}");
+        try
+        {
+            Directory.CreateDirectory(tempPlansDir);
+            var brokenFileLink = "[broken.cs](file:///C:/nonexistent/broken.cs)";
+            var brokenPlanLink = "[Plan 99999](plan://99999)";
+            var markdown = $"See {brokenFileLink} and {brokenPlanLink}";
+
+            var result = MarkdownHelper.AnnotateAllBrokenLinks(markdown, tempPlansDir);
+
+            Assert.Contains("[broken.cs \u26a0\ufe0f](file:///C:/nonexistent/broken.cs)", result);
+            Assert.Contains("[Plan 99999 \u26a0\ufe0f](plan://99999)", result);
+            Assert.Equal(2, result.Split("\u26a0\ufe0f").Length - 1);
+        }
+        finally
+        {
+            Directory.Delete(tempPlansDir, true);
+        }
+    }
+
+    [Fact]
+    public void AnnotateAllBrokenLinks_BothValid()
+    {
+        var tempFile = Path.GetTempFileName();
+        var tempPlansDir = Path.Combine(Path.GetTempPath(), $"plans-{Guid.NewGuid()}");
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(tempPlansDir, "01234-TestPlan"));
+            var validFileLink = $"[valid.txt](file:///{tempFile.Replace("\\", "/")})";
+            var validPlanLink = "[Plan 01234](plan://01234)";
+            var markdown = $"See {validFileLink} and {validPlanLink}";
+
+            var result = MarkdownHelper.AnnotateAllBrokenLinks(markdown, tempPlansDir);
+
+            Assert.DoesNotContain("\u26a0\ufe0f", result);
+            Assert.Equal(markdown, result);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+            Directory.Delete(tempPlansDir, true);
+        }
+    }
 }

--- a/src/tendril/Ivy.Tendril/Apps/Icebox/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Icebox/ContentView.cs
@@ -109,9 +109,7 @@ public class ContentView(
                 });
         else
             scrollableContent |=
-                new Markdown(MarkdownHelper.AnnotateBrokenPlanLinks(
-                        MarkdownHelper.AnnotateBrokenFileLinks(_selectedPlan.LatestRevisionContent),
-                        _planService.PlansDirectory))
+                new Markdown(MarkdownHelper.AnnotateAllBrokenLinks(_selectedPlan.LatestRevisionContent, _planService.PlansDirectory))
                     .DangerouslyAllowLocalFiles()
                     .OnLinkClick(FileLinkHelper.CreateFileLinkClickHandler(openFile, planId =>
                     {

--- a/src/tendril/Ivy.Tendril/Apps/JobsApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/JobsApp.cs
@@ -339,9 +339,7 @@ public class JobsApp : ViewBase
 
             var sheetContent = string.IsNullOrEmpty(content)
                 ? Text.P("Plan not found or empty.")
-                : (object)new Markdown(MarkdownHelper.AnnotateBrokenPlanLinks(
-                        MarkdownHelper.AnnotateBrokenFileLinks(content),
-                        planService.PlansDirectory))
+                : (object)new Markdown(MarkdownHelper.AnnotateAllBrokenLinks(content, planService.PlansDirectory))
                     .DangerouslyAllowLocalFiles()
                     .OnLinkClick(FileLinkHelper.CreateFileLinkClickHandler(openFile));
 

--- a/src/tendril/Ivy.Tendril/Apps/Plans/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Plans/ContentView.cs
@@ -223,8 +223,7 @@ public class ContentView(
         {
             var planLayout = Layout.Vertical();
             if (_selectedPlan.Status == PlanStatus.Failed) planLayout |= BuildFailureCallout(_selectedPlan);
-            var annotatedContent = MarkdownHelper.AnnotateBrokenFileLinks(_selectedPlan.LatestRevisionContent);
-            annotatedContent = MarkdownHelper.AnnotateBrokenPlanLinks(annotatedContent, _planService.PlansDirectory);
+            var annotatedContent = MarkdownHelper.AnnotateAllBrokenLinks(_selectedPlan.LatestRevisionContent, _planService.PlansDirectory);
             planLayout |= new Markdown(annotatedContent)
                 .DangerouslyAllowLocalFiles()
                 .OnLinkClick(FileLinkHelper.CreateFileLinkClickHandler(openFile, planId =>

--- a/src/tendril/Ivy.Tendril/Apps/PullRequestApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/PullRequestApp.cs
@@ -168,9 +168,7 @@ public class PullRequestApp : ViewBase
 
             var sheetContent = string.IsNullOrEmpty(content)
                 ? Text.P("Plan not found or empty.")
-                : (object)new Markdown(MarkdownHelper.AnnotateBrokenPlanLinks(
-                        MarkdownHelper.AnnotateBrokenFileLinks(content),
-                        planService.PlansDirectory))
+                : (object)new Markdown(MarkdownHelper.AnnotateAllBrokenLinks(content, planService.PlansDirectory))
                     .DangerouslyAllowLocalFiles()
                     .OnLinkClick(FileLinkHelper.CreateFileLinkClickHandler(openFile));
 

--- a/src/tendril/Ivy.Tendril/Apps/Recommendations/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Recommendations/ContentView.cs
@@ -166,9 +166,7 @@ public class ContentView(
 
             var sheetContent = string.IsNullOrEmpty(content)
                 ? Text.P("Plan not found or empty.")
-                : (object)new Markdown(MarkdownHelper.AnnotateBrokenPlanLinks(
-                        MarkdownHelper.AnnotateBrokenFileLinks(content),
-                        _planService.PlansDirectory))
+                : (object)new Markdown(MarkdownHelper.AnnotateAllBrokenLinks(content, _planService.PlansDirectory))
                     .DangerouslyAllowLocalFiles()
                     .OnLinkClick(FileLinkHelper.CreateFileLinkClickHandler(openFile));
 

--- a/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -262,8 +262,7 @@ public class ContentView(
         var planData = planContentQuery.Value;
 
         // Plan tab content (not dependent on query — uses in-memory data)
-        var reviewAnnotated = MarkdownHelper.AnnotateBrokenFileLinks(_selectedPlan.LatestRevisionContent);
-        reviewAnnotated = MarkdownHelper.AnnotateBrokenPlanLinks(reviewAnnotated, _planService.PlansDirectory);
+        var reviewAnnotated = MarkdownHelper.AnnotateAllBrokenLinks(_selectedPlan.LatestRevisionContent, _planService.PlansDirectory);
         var planTabContent = new Markdown(reviewAnnotated)
             .DangerouslyAllowLocalFiles()
             .OnLinkClick(FileLinkHelper.CreateFileLinkClickHandler(openFile, planId =>

--- a/src/tendril/Ivy.Tendril/Apps/TrashApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/TrashApp.cs
@@ -92,8 +92,7 @@ public class TrashApp : ViewBase
                                 }
                             });
 
-            var annotatedContent = MarkdownHelper.AnnotateBrokenFileLinks(selected.Content);
-            annotatedContent = MarkdownHelper.AnnotateBrokenPlanLinks(annotatedContent, planService.PlansDirectory);
+            var annotatedContent = MarkdownHelper.AnnotateAllBrokenLinks(selected.Content, planService.PlansDirectory);
             var scrollableContent = Layout.Vertical().Width(Size.Auto().Max(Size.Units(200)))
                                     | new Markdown(annotatedContent)
                                         .DangerouslyAllowLocalFiles()

--- a/src/tendril/Ivy.Tendril/Services/MarkdownHelper.cs
+++ b/src/tendril/Ivy.Tendril/Services/MarkdownHelper.cs
@@ -58,6 +58,19 @@ public static class MarkdownHelper
     }
 
     /// <summary>
+    ///     Annotates both broken file:/// and plan:// links in markdown content with warning indicators.
+    ///     Combines AnnotateBrokenFileLinks and AnnotateBrokenPlanLinks into a single call.
+    /// </summary>
+    public static string AnnotateAllBrokenLinks(string markdownContent, string plansDirectory)
+    {
+        if (string.IsNullOrEmpty(markdownContent))
+            return markdownContent;
+
+        var annotated = AnnotateBrokenFileLinks(markdownContent);
+        return AnnotateBrokenPlanLinks(annotated, plansDirectory);
+    }
+
+    /// <summary>
     ///     Searches for files with the given filename in the specified repo directories.
     /// </summary>
     public static List<string> FindFilesInRepos(IEnumerable<string> repoPaths, string fileName)


### PR DESCRIPTION
# Summary

## Changes

Consolidated duplicate MarkdownHelper annotation calls across seven apps into a single `AnnotateAllBrokenLinks()` method. This reduces code duplication and ensures both file and plan link annotations are consistently applied together.

## API Changes

**Added:**
- `MarkdownHelper.AnnotateAllBrokenLinks(string markdownContent, string plansDirectory)` - Combines `AnnotateBrokenFileLinks` and `AnnotateBrokenPlanLinks` into a single method call

**Existing methods remain unchanged:**
- `MarkdownHelper.AnnotateBrokenFileLinks(string markdownContent)` - Still available for cases needing only file link annotation
- `MarkdownHelper.AnnotateBrokenPlanLinks(string markdownContent, string plansDirectory)` - Still available for cases needing only plan link annotation

## Files Modified

**Core Services:**
- `src/tendril/Ivy.Tendril/Services/MarkdownHelper.cs` - Added new consolidated method

**App Updates (7 call sites):**
- `src/tendril/Ivy.Tendril/Apps/TrashApp.cs` - Replaced two-line pattern with single method call
- `src/tendril/Ivy.Tendril/Apps/JobsApp.cs` - Replaced nested calls with single method call
- `src/tendril/Ivy.Tendril/Apps/PullRequestApp.cs` - Replaced nested calls with single method call
- `src/tendril/Ivy.Tendril/Apps/Plans/ContentView.cs` - Replaced two-line pattern with single method call
- `src/tendril/Ivy.Tendril/Apps/Review/ContentView.cs` - Replaced two-line pattern with single method call
- `src/tendril/Ivy.Tendril/Apps/Icebox/ContentView.cs` - Replaced nested calls with single method call
- `src/tendril/Ivy.Tendril/Apps/Recommendations/ContentView.cs` - Replaced nested calls with single method call

**Tests:**
- `src/tendril/Ivy.Tendril.Test/MarkdownHelperTests.cs` - Added 4 new tests covering all valid/broken link combinations

## Commits

- b3c7c8ccb [03311] Consolidate MarkdownHelper annotation calls into single method