### PR TITLE
[03313] Remove Program.WriteCrashLog forwarding method

### DIFF
--- a/src/tendril/Ivy.Tendril/Program.cs
+++ b/src/tendril/Ivy.Tendril/Program.cs
@@ -143,8 +143,6 @@ public class Program
         }
     }
 
-    internal static void WriteCrashLog(string message) => CrashLog.Write(message);
-
     private static string GetMemoryStats()
     {
         try

--- a/src/tendril/Ivy.Tendril/Services/InboxWatcherService.cs
+++ b/src/tendril/Ivy.Tendril/Services/InboxWatcherService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using Ivy.Helpers;
 
 namespace Ivy.Tendril.Services;
 
@@ -32,7 +33,7 @@ public class InboxWatcherService : IInboxWatcherService
 
         _watcher.Created += OnFileCreated;
         _watcher.Error += (_, e) =>
-            Program.WriteCrashLog($"[{DateTime.UtcNow:O}] InboxWatcher FSW error: {e.GetException()}");
+            CrashLog.Write($"[{DateTime.UtcNow:O}] InboxWatcher FSW error: {e.GetException()}");
 
         _pollTimer = new Timer(OnPollTimer, null, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(30));
     }
@@ -51,7 +52,7 @@ public class InboxWatcherService : IInboxWatcherService
         }
         catch (Exception ex)
         {
-            Program.WriteCrashLog($"[{DateTime.UtcNow:O}] InboxWatcher.OnFileCreated exception: {ex}");
+            CrashLog.Write($"[{DateTime.UtcNow:O}] InboxWatcher.OnFileCreated exception: {ex}");
         }
     }
 
@@ -63,7 +64,7 @@ public class InboxWatcherService : IInboxWatcherService
         }
         catch (Exception ex)
         {
-            Program.WriteCrashLog($"[{DateTime.UtcNow:O}] InboxWatcher.OnPollTimer exception: {ex}");
+            CrashLog.Write($"[{DateTime.UtcNow:O}] InboxWatcher.OnPollTimer exception: {ex}");
         }
     }
 

--- a/src/tendril/Ivy.Tendril/Services/JobService.cs
+++ b/src/tendril/Ivy.Tendril/Services/JobService.cs
@@ -698,7 +698,7 @@ public class JobService : IJobService
             }
             catch (Exception ex)
             {
-                Program.WriteCrashLog($"[{DateTime.UtcNow:O}] OutputDataReceived exception for job {id}: {ex}");
+                CrashLog.Write($"[{DateTime.UtcNow:O}] OutputDataReceived exception for job {id}: {ex}");
             }
         };
         process.ErrorDataReceived += (_, e) =>
@@ -713,7 +713,7 @@ public class JobService : IJobService
             }
             catch (Exception ex)
             {
-                Program.WriteCrashLog($"[{DateTime.UtcNow:O}] ErrorDataReceived exception for job {id}: {ex}");
+                CrashLog.Write($"[{DateTime.UtcNow:O}] ErrorDataReceived exception for job {id}: {ex}");
             }
         };
 
@@ -761,7 +761,7 @@ public class JobService : IJobService
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Job {JobId}: Monitor task exception", id);
-                Program.WriteCrashLog($"[{DateTime.UtcNow:O}] JobService process monitor exception for job {id}: {ex}");
+                CrashLog.Write($"[{DateTime.UtcNow:O}] JobService process monitor exception for job {id}: {ex}");
                 CompleteJob(id, null, timedOut: false);
             }
         });

--- a/src/tendril/Ivy.Tendril/Services/PlanWatcherService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanWatcherService.cs
@@ -1,3 +1,4 @@
+using Ivy.Helpers;
 using Timer = System.Timers.Timer;
 
 namespace Ivy.Tendril.Services;
@@ -48,7 +49,7 @@ public class PlanWatcherService : IPlanWatcherService
         _watcher.Renamed += (_, _) => ScheduleDebounce(null);
         _watcher.Error += (_, e) =>
         {
-            Program.WriteCrashLog($"[{DateTime.UtcNow:O}] PlanWatcher FSW error: {e.GetException()}");
+            CrashLog.Write($"[{DateTime.UtcNow:O}] PlanWatcher FSW error: {e.GetException()}");
             ScheduleDebounce(null);
         };
 

--- a/src/tendril/Ivy.Tendril/TendrilServer.cs
+++ b/src/tendril/Ivy.Tendril/TendrilServer.cs
@@ -1,4 +1,5 @@
 using System.ClientModel;
+using Ivy.Helpers;
 using Ivy.Tendril.AppShell;
 using Ivy.Tendril.Services;
 using Microsoft.Extensions.AI;
@@ -182,7 +183,7 @@ public static class TendrilServer
                 }
                 catch (Exception ex)
                 {
-                    Program.WriteCrashLog($"[{DateTime.UtcNow:O}] Telemetry startup exception: {ex}");
+                    CrashLog.Write($"[{DateTime.UtcNow:O}] Telemetry startup exception: {ex}");
                 }
             });
             app.UseAssets(server.Args, app.Services.GetRequiredService<ILogger<Server>>(), "Assets", "tendril/assets");


### PR DESCRIPTION
# Summary

## Changes

Removed the `Program.WriteCrashLog` forwarding method and updated all 4 call sites to use `CrashLog.Write` directly. This decouples the Tendril services from the Program class, improving code clarity and reducing unnecessary indirection.

## API Changes

- Removed: `Program.WriteCrashLog(string message)` method

## Files Modified

- `src/tendril/Ivy.Tendril/Program.cs` - Removed the forwarding method (line 146)
- `src/tendril/Ivy.Tendril/TendrilServer.cs` - Added `using Ivy.Helpers;` and replaced 1 call to `Program.WriteCrashLog` with `CrashLog.Write`
- `src/tendril/Ivy.Tendril/Services/InboxWatcherService.cs` - Added `using Ivy.Helpers;` and replaced 3 calls to `Program.WriteCrashLog` with `CrashLog.Write`
- `src/tendril/Ivy.Tendril/Services/JobService.cs` - Replaced 3 calls to `Program.WriteCrashLog` with `CrashLog.Write` (import already present)
- `src/tendril/Ivy.Tendril/Services/PlanWatcherService.cs` - Added `using Ivy.Helpers;` and replaced 1 call to `Program.WriteCrashLog` with `CrashLog.Write`

## Commits

- f1c2c01a0