### PR TITLE
[03290] Add onLinkClick support to HtmlRenderer

### DIFF
--- a/src/frontend/src/components/HtmlRenderer.test.tsx
+++ b/src/frontend/src/components/HtmlRenderer.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { HtmlRenderer } from "./HtmlRenderer";
+
+let container: HTMLDivElement;
+let root: Root;
+
+function mount(element: React.ReactElement) {
+  act(() => {
+    root.render(element);
+  });
+}
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+describe("HtmlRenderer link handling", () => {
+  it("renders custom protocol links when onLinkClick is provided", () => {
+    const onLinkClick = vi.fn();
+    const content = '<a href="plan://03290">Plan 03290</a>';
+    mount(<HtmlRenderer content={content} onLinkClick={onLinkClick} />);
+
+    const link = container.querySelector("a");
+    expect(link).not.toBeNull();
+    expect(link!.getAttribute("href")).toBe("plan://03290");
+    expect(link!.textContent).toBe("Plan 03290");
+  });
+
+  it("replaces invalid custom protocols with # when onLinkClick is not provided", () => {
+    const content = '<a href="plan://03290">Plan 03290</a>';
+    mount(<HtmlRenderer content={content} />);
+
+    const link = container.querySelector("a");
+    expect(link).not.toBeNull();
+    expect(link!.getAttribute("href")).toBe("#");
+  });
+
+  it("calls onLinkClick when link is clicked", () => {
+    const onLinkClick = vi.fn();
+    const content = '<a href="plan://03290">Plan 03290</a>';
+    mount(<HtmlRenderer content={content} onLinkClick={onLinkClick} />);
+
+    const link = container.querySelector("a");
+    expect(link).not.toBeNull();
+
+    act(() => {
+      link!.click();
+    });
+
+    expect(onLinkClick).toHaveBeenCalledTimes(1);
+    expect(onLinkClick).toHaveBeenCalledWith("plan://03290");
+  });
+});

--- a/src/frontend/src/components/HtmlRenderer.tsx
+++ b/src/frontend/src/components/HtmlRenderer.tsx
@@ -5,10 +5,12 @@ import { validateLinkUrl } from "@/lib/url";
 interface HtmlRendererProps {
   content: string;
   allowedTags?: string[];
+  onLinkClick?: (url: string) => void;
 }
 
 export const HtmlRenderer: React.FC<HtmlRendererProps> = ({
   content,
+  onLinkClick,
   allowedTags = [
     "p",
     "div",
@@ -124,9 +126,20 @@ export const HtmlRenderer: React.FC<HtmlRendererProps> = ({
             return <div>{children}</div>;
           case "a": {
             const href = element.getAttribute("href");
-            const safeHref = validateLinkUrl(href);
+            const safeHref = validateLinkUrl(href, { allowCustomProtocols: !!onLinkClick });
             return (
-              <a className={typography.a} href={safeHref} target="_blank" rel="noopener noreferrer">
+              <a
+                className={typography.a}
+                href={safeHref}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={(e) => {
+                  if (onLinkClick) {
+                    e.preventDefault();
+                    onLinkClick(safeHref);
+                  }
+                }}
+              >
                 {children}
               </a>
             );

--- a/src/frontend/src/widgets/primitives/HtmlWidget.tsx
+++ b/src/frontend/src/widgets/primitives/HtmlWidget.tsx
@@ -10,6 +10,7 @@ interface HtmlWidgetProps {
   dangerouslyAllowScripts?: boolean;
   width?: string;
   height?: string;
+  onLinkClick?: (url: string) => void;
 }
 
 export const HtmlWidget: React.FC<HtmlWidgetProps> = ({
@@ -19,6 +20,7 @@ export const HtmlWidget: React.FC<HtmlWidgetProps> = ({
   dangerouslyAllowScripts = false,
   width,
   height,
+  onLinkClick,
 }) => {
   const getScaleStyle = (s: Densities): React.CSSProperties => {
     switch (s) {
@@ -85,6 +87,7 @@ export const HtmlWidget: React.FC<HtmlWidgetProps> = ({
       <HtmlRenderer
         content={content}
         key={id}
+        onLinkClick={onLinkClick}
         allowedTags={[
           "p",
           "div",


### PR DESCRIPTION
# Summary

## Changes

Added `onLinkClick` support to `HtmlRenderer` component to enable custom URL protocol handling (e.g., `plan://`, `tel:`). When the `onLinkClick` prop is provided, custom protocol links are preserved and clickable instead of being sanitized to `#`. This matches the pattern previously implemented in `MarkdownRenderer` (plan 03213).

## API Changes

**HtmlRenderer.tsx:**
- Added `onLinkClick?: (url: string) => void` prop to `HtmlRendererProps`
- Link rendering now passes `allowCustomProtocols: !!onLinkClick` to `validateLinkUrl()`
- Click handler intercepts navigation and calls `onLinkClick` when provided

**HtmlWidget.tsx:**
- Added `onLinkClick?: (url: string) => void` prop to `HtmlWidgetProps`
- Passes `onLinkClick` to `HtmlRenderer` component

## Files Modified

**Implementation:**
- `src/frontend/src/components/HtmlRenderer.tsx` - Added onLinkClick prop and custom protocol support
- `src/frontend/src/widgets/primitives/HtmlWidget.tsx` - Added onLinkClick prop passthrough

**Tests:**
- `src/frontend/src/components/HtmlRenderer.test.tsx` (new) - Component tests for link handling

## Commits

- 4fd0277a6 [03290] Add onLinkClick support to HtmlRenderer