### PR TITLE
[03320] Make AddConnectionsFromAssembly() idempotent to prevent duplicate service registrations

### DIFF
--- a/src/Ivy.Tests/ServerConfigurationTests.cs
+++ b/src/Ivy.Tests/ServerConfigurationTests.cs
@@ -86,6 +86,20 @@ public class ServerConfigurationTests
     }
 
     [Fact]
+    public void AddConnectionsFromAssembly_CalledMultipleTimes_DoesNotRegisterServicesTwice()
+    {
+        var server = new Server(new ServerArgs());
+
+        server.AddConnectionsFromAssembly(typeof(ServerConfigurationTests).Assembly);
+        var serviceCountAfterFirstCall = server.Services.Count;
+
+        server.AddConnectionsFromAssembly(typeof(ServerConfigurationTests).Assembly);
+        var serviceCountAfterSecondCall = server.Services.Count;
+
+        Assert.Equal(serviceCountAfterFirstCall, serviceCountAfterSecondCall);
+    }
+
+    [Fact]
     public void TestConnectionValidation_PresetSecrets_AvailableInConfigurationAfterLoading()
     {
         var server = new Server(new ServerArgs());

--- a/src/Ivy/Server.cs
+++ b/src/Ivy/Server.cs
@@ -176,6 +176,7 @@ public class Server
 
     public void AddConnectionsFromAssembly(Assembly? assembly = null)
     {
+        if (_presetsLoaded) return;
         _presetsLoaded = true;
         assembly ??= Assembly.GetEntryAssembly();
 


### PR DESCRIPTION
# Summary

## Changes

Made `AddConnectionsFromAssembly()` idempotent by adding an early return guard that prevents duplicate service registrations when the method is called multiple times. Added a new test to verify service registration idempotency.

## API Changes

None. The method signature and public behavior remain unchanged. The method now simply returns early if already executed, maintaining backward compatibility.

## Files Modified

- `src/Ivy/Server.cs` — Added idempotency guard (`if (_presetsLoaded) return;`) to `AddConnectionsFromAssembly()` method
- `src/Ivy.Tests/ServerConfigurationTests.cs` — Added new test `AddConnectionsFromAssembly_CalledMultipleTimes_DoesNotRegisterServicesTwice()` to verify idempotency

## Commits

- 8864f1bc1 [03320] Make AddConnectionsFromAssembly() idempotent to prevent duplicate service registrations