### PR TITLE
[03315] Switch to compact YAML serializer for plan.yaml writes

### DIFF
--- a/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
@@ -188,7 +188,7 @@ public class PlanReaderService(
             var planYaml = YamlHelper.Deserializer.Deserialize<PlanYaml>(yaml) ?? new PlanYaml();
             planYaml.State = newState.ToString();
             planYaml.Updated = DateTime.UtcNow;
-            FileHelper.WriteAllText(planYamlPath, YamlHelper.Serializer.Serialize(planYaml));
+            FileHelper.WriteAllText(planYamlPath, YamlHelper.SerializerCompact.Serialize(planYaml));
         });
     }
 
@@ -226,7 +226,7 @@ public class PlanReaderService(
                 var yaml = FileHelper.ReadAllText(planYamlPath);
                 var planYaml = YamlHelper.Deserializer.Deserialize<PlanYaml>(yaml) ?? new PlanYaml();
                 planYaml.Updated = DateTime.UtcNow;
-                FileHelper.WriteAllText(planYamlPath, YamlHelper.Serializer.Serialize(planYaml));
+                FileHelper.WriteAllText(planYamlPath, YamlHelper.SerializerCompact.Serialize(planYaml));
             }
         });
     }
@@ -390,7 +390,7 @@ public class PlanReaderService(
                     var yaml = FileHelper.ReadAllText(planYamlPath);
                     var planYaml = YamlHelper.Deserializer.Deserialize<PlanYaml>(yaml) ?? new PlanYaml();
                     planYaml.Updated = DateTime.UtcNow;
-                    FileHelper.WriteAllText(planYamlPath, YamlHelper.Serializer.Serialize(planYaml));
+                    FileHelper.WriteAllText(planYamlPath, YamlHelper.SerializerCompact.Serialize(planYaml));
                 }
             }
         });


### PR DESCRIPTION
# Summary

## Changes

Replaced `YamlHelper.Serializer` with `YamlHelper.SerializerCompact` at all three plan.yaml write locations in PlanReaderService.cs (lines 191, 229, 393). This change reduces verbosity by omitting empty collections (prs, commits, relatedPlans, dependsOn) and zero-value fields (priority: 0) from serialized plan.yaml files, improving file readability and reducing opportunities for misplacement during agent text-based edits.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Services/PlanReaderService.cs` — Updated three plan.yaml serialization calls to use SerializerCompact instead of Serializer

## Commits

- 6ccb8f4ec2a449e1d396c0fdd19733f3c6713910 [03315] Switch to compact YAML serializer for plan.yaml writes