### PR TITLE
[03318] Add Thickness overloads to ResponsiveExtensions

### DIFF
--- a/src/Ivy.Tests/Shared/ResponsiveTests.cs
+++ b/src/Ivy.Tests/Shared/ResponsiveTests.cs
@@ -138,6 +138,17 @@ public class ResponsiveTests
         AssertBreakpoint(responsive, bp, true);
     }
 
+    [Theory]
+    [InlineData(Breakpoint.Mobile)]
+    [InlineData(Breakpoint.Tablet)]
+    [InlineData(Breakpoint.Desktop)]
+    [InlineData(Breakpoint.Wide)]
+    public void Thickness_At_SetsCorrectBreakpoint(Breakpoint bp)
+    {
+        var responsive = new Thickness(4).At(bp);
+        AssertBreakpoint(responsive, bp, new Thickness(4));
+    }
+
     [Fact]
     public void AllValueTypes_At_And_Chain()
     {
@@ -156,6 +167,10 @@ public class ResponsiveTests
         var boolR = true.At(Breakpoint.Mobile).And(Breakpoint.Desktop, false);
         Assert.True(boolR.Mobile);
         Assert.False(boolR.Desktop);
+
+        var thicknessR = new Thickness(4).At(Breakpoint.Mobile).And(Breakpoint.Desktop, new Thickness(8));
+        Assert.Equal(new Thickness(4), thicknessR.Mobile);
+        Assert.Equal(new Thickness(8), thicknessR.Desktop);
     }
 
     private static void AssertBreakpoint<T>(Responsive<T> responsive, Breakpoint bp, T expected)

--- a/src/Ivy/Shared/Responsive.cs
+++ b/src/Ivy/Shared/Responsive.cs
@@ -80,6 +80,10 @@ public static class ResponsiveExtensions
     // bool overloads (for visibility)
     public static Responsive<bool?> At(this bool value, Breakpoint bp) => AtCore(value, bp);
     public static Responsive<bool?> And(this Responsive<bool?> r, Breakpoint bp, bool value) => AndCore(r, bp, value);
+
+    // Thickness overloads (for padding, margin)
+    public static Responsive<Thickness?> At(this Thickness value, Breakpoint bp) => AtCore(value, bp);
+    public static Responsive<Thickness?> And(this Responsive<Thickness?> r, Breakpoint bp, Thickness value) => AndCore(r, bp, value);
 }
 
 public class ResponsiveJsonConverterFactory : JsonConverterFactory


### PR DESCRIPTION
# Summary

## Changes

Added `Thickness` overloads to the `ResponsiveExtensions` class to enable responsive thickness values for padding and margin. Users can now write `new Thickness(4).At(Breakpoint.Mobile)` instead of manually constructing `Responsive<Thickness?>` objects, completing the responsive API surface.

## API Changes

**New Methods:**
- `public static Responsive<Thickness?> At(this Thickness value, Breakpoint bp)` — Creates a responsive thickness value for a specific breakpoint
- `public static Responsive<Thickness?> And(this Responsive<Thickness?> r, Breakpoint bp, Thickness value)` — Chains additional breakpoints to a responsive thickness

## Files Modified

- `src/Ivy/Shared/Responsive.cs` — Added Thickness overloads for `.At()` and `.And()` methods
- `src/Ivy.Tests/Shared/ResponsiveTests.cs` — Added `Thickness_At_SetsCorrectBreakpoint` theory test and Thickness validation in `AllValueTypes_At_And_Chain` test

## Commits

- 8c90baf68 [03318] Add Thickness overloads to ResponsiveExtensions