### PR TITLE
[03319] Improve secret validation defense-in-depth for preset loading failures

### DIFF
--- a/src/Ivy/Server.cs
+++ b/src/Ivy/Server.cs
@@ -995,7 +995,7 @@ public class Server
             {
                 var config = app.Services.GetRequiredService<IConfiguration>();
                 var missing = hasSecrets.GetSecrets()
-                    .Where(s => !s.Optional && s.Preset == null && string.IsNullOrEmpty(config[s.Key]))
+                    .Where(s => !s.Optional && string.IsNullOrEmpty(config[s.Key]))
                     .Select(s => s.Key)
                     .ToList();
 
@@ -1087,7 +1087,7 @@ public class Server
         Dictionary<string, List<string>> missingByProvider)
     {
         var missing = provider.GetSecrets()
-            .Where(s => !s.Optional && s.Preset == null && string.IsNullOrEmpty(config[s.Key]))
+            .Where(s => !s.Optional && string.IsNullOrEmpty(config[s.Key]))
             .Select(s => s.Key)
             .ToList();
 


### PR DESCRIPTION
# Summary

## Changes

Applied defense-in-depth improvement to secret validation logic in Server.cs by removing the `s.Preset == null` condition from both TestConnection (line 1000) and CheckProvider (line 1092) validation methods. This ensures all required secrets are validated against the configuration regardless of whether they have presets defined, catching edge cases where preset loading might silently fail.

## API Changes

None - this is an internal validation change with no public API impact.

## Files Modified

- `src/Ivy/Server.cs` (lines 998 and 1090) — Simplified secret validation by removing preset check condition

## Commits

- 23ca4a84e [03319] Improve secret validation defense-in-depth by checking all required secrets