### PR TITLE
[03316] Clean verification/ during Rerun from Scratch

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/RerunDialogTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/RerunDialogTests.cs
@@ -69,7 +69,7 @@ public class RerunDialogTests
 
             Assert.False(Directory.Exists(artifactsDir));
             Assert.False(Directory.Exists(logsDir));
-            Assert.True(Directory.Exists(verificationDir));
+            Assert.False(Directory.Exists(verificationDir));
             Assert.True(Directory.Exists(revisionsDir));
         }
         finally

--- a/src/tendril/Ivy.Tendril/Apps/Review/Dialogs/RerunDialog.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Review/Dialogs/RerunDialog.cs
@@ -73,6 +73,13 @@ public class RerunDialog(
             WorktreeCleanupService.ForceDeleteDirectory(logsDir, logger);
         }
 
+        var verificationDir = Path.Combine(planFolderPath, "verification");
+        if (Directory.Exists(verificationDir))
+        {
+            logger?.LogInformation("Cleaning verification directory: {Path}", verificationDir);
+            WorktreeCleanupService.ForceDeleteDirectory(verificationDir, logger);
+        }
+
         PlanReaderService.RemoveWorktrees(planFolderPath, logger);
     }
 }


### PR DESCRIPTION
# Summary

## Changes

Added cleanup of the `verification/` directory to the `CleanPlanState` method in `RerunDialog.cs`. This ensures that when a plan is rerun from scratch, all stale verification reports from prior runs are deleted and regenerated during the new execution.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Apps/Review/Dialogs/RerunDialog.cs` — Added verification directory cleanup
- `src/tendril/Ivy.Tendril.Test/RerunDialogTests.cs` — Updated test assertion to expect verification directory deletion

## Commits

- 30cd06158