### PR TITLE
[03324] Fix XamlBuilder to handle Responsive<Size> conversion

### DIFF
--- a/src/Ivy.XamlBuilder/XamlBuilder.cs
+++ b/src/Ivy.XamlBuilder/XamlBuilder.cs
@@ -285,7 +285,21 @@ public class XamlBuilder
         if (targetType.IsGenericType && targetType.GetGenericTypeDefinition() == typeof(Responsive<>))
         {
             var innerType = targetType.GetGenericArguments()[0];
-            return ConvertValue(value, innerType);
+            var innerValue = ConvertValue(value, innerType);
+
+            // Create Responsive<T> instance with Default property set
+            var responsiveInstance = Activator.CreateInstance(targetType);
+            var defaultProp = targetType.GetProperty("Default");
+            if (defaultProp != null)
+            {
+                // For init-only properties, we need to get the backing field
+                var backingField = targetType.GetField(
+                    "<Default>k__BackingField",
+                    BindingFlags.NonPublic | BindingFlags.Instance);
+                backingField?.SetValue(responsiveInstance, innerValue);
+            }
+
+            return responsiveInstance;
         }
 
         throw new InvalidOperationException($"Cannot convert '{value}' to {targetType.Name}.");

--- a/src/Ivy.XamlBuilder/XamlBuilder.cs
+++ b/src/Ivy.XamlBuilder/XamlBuilder.cs
@@ -281,6 +281,13 @@ public class XamlBuilder
                 .Select(s => int.Parse(s.Trim(), CultureInfo.InvariantCulture))
                 .ToArray();
 
+        // Handle Responsive<T> wrapper types
+        if (targetType.IsGenericType && targetType.GetGenericTypeDefinition() == typeof(Responsive<>))
+        {
+            var innerType = targetType.GetGenericArguments()[0];
+            return ConvertValue(value, innerType);
+        }
+
         throw new InvalidOperationException($"Cannot convert '{value}' to {targetType.Name}.");
     }
 


### PR DESCRIPTION
# Summary

## Changes

Added `Responsive<T>` generic type support to `XamlBuilder.ConvertValue()` by detecting generic Responsive types, extracting the inner type T, recursively converting the value to that type, and explicitly creating a `Responsive<T>` instance with the Default property set via backing field reflection. This was necessary because reflection's `PropertyInfo.SetValue()` doesn't invoke implicit conversion operators.

## API Changes

None — this is an internal fix to existing conversion logic.

## Files Modified

- **src/Ivy.XamlBuilder/XamlBuilder.cs** — Added Responsive<T> handling in ConvertValue() method with explicit instance creation

## Commits

- 34abab259 [03324] Fix Responsive<T> conversion to explicitly create instance
- 3a8320133 [03324] Add Responsive<T> support to XamlBuilder.ConvertValue