### PR TITLE
[00203] Add development branch CI triggers to code quality workflows

### DIFF
--- a/.github/workflows/backend-checks-linux.yml
+++ b/.github/workflows/backend-checks-linux.yml
@@ -3,9 +3,9 @@ permissions:
   contents: read
 on:
   push:
-    branches: [main, master]
+    branches: [main, master, development]
   pull_request:
-    branches: [main, master]
+    branches: [main, master, development]
 jobs:
   backend-checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/backend-checks-windows.yml
+++ b/.github/workflows/backend-checks-windows.yml
@@ -3,9 +3,9 @@ permissions:
   contents: read
 on:
   push:
-    branches: [main, master]
+    branches: [main, master, development]
   pull_request:
-    branches: [main, master]
+    branches: [main, master, development]
 jobs:
   backend-checks:
     runs-on: windows-latest

--- a/.github/workflows/e2e-docs-tests.yml
+++ b/.github/workflows/e2e-docs-tests.yml
@@ -1,9 +1,9 @@
 name: E2E Docs Tests
 on:
   push:
-    branches: [main, master]
+    branches: [main, master, development]
   pull_request:
-    branches: [main, master]
+    branches: [main, master, development]
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/e2e-samples-tests.yml
+++ b/.github/workflows/e2e-samples-tests.yml
@@ -3,9 +3,9 @@ permissions:
   contents: read
 on:
   push:
-    branches: [main, master]
+    branches: [main, master, development]
   pull_request:
-    branches: [main, master]
+    branches: [main, master, development]
 jobs:
   test:
     timeout-minutes: 60

--- a/.github/workflows/frontend-formatting-linting-checks.yml
+++ b/.github/workflows/frontend-formatting-linting-checks.yml
@@ -3,11 +3,11 @@ permissions:
   contents: read
 on:
   push:
-    branches: [main, master]
+    branches: [main, master, development]
     paths:
       - "src/frontend/**"
   pull_request:
-    branches: [main, master]
+    branches: [main, master, development]
     paths:
       - "src/frontend/**"
   workflow_dispatch:

--- a/.github/workflows/frontend-unit-tests.yml
+++ b/.github/workflows/frontend-unit-tests.yml
@@ -3,9 +3,9 @@ permissions:
   contents: read
 on:
   push:
-    branches: [main, master]
+    branches: [main, master, development]
   pull_request:
-    branches: [main, master]
+    branches: [main, master, development]
 jobs:
   test:
     timeout-minutes: 30

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -3,11 +3,11 @@ permissions:
   contents: read
 on:
   push:
-    branches: [main, master]
+    branches: [main, master, development]
     paths:
       - "src/frontend/**"
   pull_request:
-    branches: [main, master]
+    branches: [main, master, development]
     paths:
       - "src/frontend/**"
   workflow_dispatch:


### PR DESCRIPTION
## Changes

Added `development` to the `branches` arrays in both `push` and `pull_request` triggers across all 7 code quality GitHub Actions workflows. This ensures CI checks run on the `development` branch (the active working branch) in addition to `main` and `master`.

## Files Modified

- `.github/workflows/backend-checks-linux.yml` — added `development` to push/PR branch triggers
- `.github/workflows/backend-checks-windows.yml` — added `development` to push/PR branch triggers
- `.github/workflows/e2e-docs-tests.yml` — added `development` to push/PR branch triggers
- `.github/workflows/e2e-samples-tests.yml` — added `development` to push/PR branch triggers
- `.github/workflows/frontend-formatting-linting-checks.yml` — added `development` to push/PR branch triggers
- `.github/workflows/frontend-unit-tests.yml` — added `development` to push/PR branch triggers
- `.github/workflows/react-doctor.yml` — added `development` to push/PR branch triggers

## Commits

- cc27d718e [00203] Add development branch to CI workflow triggers