### PR TITLE
[00206] Remove master branch from workflow triggers

### DIFF
--- a/.github/workflows/backend-checks-linux.yml
+++ b/.github/workflows/backend-checks-linux.yml
@@ -3,9 +3,9 @@ permissions:
   contents: read
 on:
   push:
-    branches: [main, master, development]
+    branches: [main, development]
   pull_request:
-    branches: [main, master, development]
+    branches: [main, development]
 jobs:
   backend-checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/backend-checks-windows.yml
+++ b/.github/workflows/backend-checks-windows.yml
@@ -3,9 +3,9 @@ permissions:
   contents: read
 on:
   push:
-    branches: [main, master, development]
+    branches: [main, development]
   pull_request:
-    branches: [main, master, development]
+    branches: [main, development]
 jobs:
   backend-checks:
     runs-on: windows-latest

--- a/.github/workflows/e2e-docs-tests.yml
+++ b/.github/workflows/e2e-docs-tests.yml
@@ -1,9 +1,9 @@
 name: E2E Docs Tests
 on:
   push:
-    branches: [main, master, development]
+    branches: [main, development]
   pull_request:
-    branches: [main, master, development]
+    branches: [main, development]
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/e2e-samples-tests.yml
+++ b/.github/workflows/e2e-samples-tests.yml
@@ -3,9 +3,9 @@ permissions:
   contents: read
 on:
   push:
-    branches: [main, master, development]
+    branches: [main, development]
   pull_request:
-    branches: [main, master, development]
+    branches: [main, development]
 jobs:
   test:
     timeout-minutes: 60

--- a/.github/workflows/frontend-formatting-linting-checks.yml
+++ b/.github/workflows/frontend-formatting-linting-checks.yml
@@ -3,11 +3,11 @@ permissions:
   contents: read
 on:
   push:
-    branches: [main, master, development]
+    branches: [main, development]
     paths:
       - "src/frontend/**"
   pull_request:
-    branches: [main, master, development]
+    branches: [main, development]
     paths:
       - "src/frontend/**"
   workflow_dispatch:

--- a/.github/workflows/frontend-unit-tests.yml
+++ b/.github/workflows/frontend-unit-tests.yml
@@ -3,9 +3,9 @@ permissions:
   contents: read
 on:
   push:
-    branches: [main, master, development]
+    branches: [main, development]
   pull_request:
-    branches: [main, master, development]
+    branches: [main, development]
 jobs:
   test:
     timeout-minutes: 30

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -3,11 +3,11 @@ permissions:
   contents: read
 on:
   push:
-    branches: [main, master, development]
+    branches: [main, development]
     paths:
       - "src/frontend/**"
   pull_request:
-    branches: [main, master, development]
+    branches: [main, development]
     paths:
       - "src/frontend/**"
   workflow_dispatch:


### PR DESCRIPTION
## Summary

Removed the stale `master` branch from `push` and `pull_request` trigger configurations across all 7 GitHub Actions workflow files. The branch arrays were changed from `[main, master, development]` to `[main, development]`, eliminating a legacy reference to a non-existent branch.

## Files Modified

- `.github/workflows/backend-checks-linux.yml`
- `.github/workflows/backend-checks-windows.yml`
- `.github/workflows/e2e-docs-tests.yml`
- `.github/workflows/e2e-samples-tests.yml`
- `.github/workflows/frontend-formatting-linting-checks.yml`
- `.github/workflows/frontend-unit-tests.yml`
- `.github/workflows/react-doctor.yml`

## Commits

- `b7387a0c6` — [00206] Remove master branch from workflow triggers