### PR TITLE
Support optional TENDRIL_PLANS env var

### DIFF
--- a/src/tendril/Ivy.Tendril.TeamIvyConfig/Hooks/CleanupWorktrees.ps1
+++ b/src/tendril/Ivy.Tendril.TeamIvyConfig/Hooks/CleanupWorktrees.ps1
@@ -19,7 +19,7 @@ if (-not $env:TENDRIL_CONFIG -and $env:TENDRIL_HOME) {
 $sharedPath = Join-Path (Split-Path (Split-Path $PSScriptRoot)) "Ivy.Tendril/Promptwares/.shared"
 . (Join-Path $sharedPath "Utils.ps1")
 
-$plansDir = Join-Path $env:TENDRIL_HOME "Plans"
+$plansDir = if ($env:TENDRIL_PLANS) { $env:TENDRIL_PLANS } else { Join-Path $env:TENDRIL_HOME "Plans" }
 if (-not (Test-Path $plansDir)) {
     Write-Host "Plans directory not found: $plansDir" -ForegroundColor Yellow
     exit 0

--- a/src/tendril/Ivy.Tendril/Commands/DoctorCommand.cs
+++ b/src/tendril/Ivy.Tendril/Commands/DoctorCommand.cs
@@ -483,7 +483,9 @@ public static class DoctorCommand
             return 1;
         }
 
-        var plansDir = Path.Combine(tendrilHome, "Plans");
+        var plansDir = Environment.GetEnvironmentVariable("TENDRIL_PLANS")?.Trim() is { Length: > 0 } plans
+            ? plans
+            : Path.Combine(tendrilHome, "Plans");
         if (!Directory.Exists(plansDir))
         {
             Console.Error.WriteLine($"Plans directory not found: {plansDir}");

--- a/src/tendril/Ivy.Tendril/Mcp/Tools/PlanTools.cs
+++ b/src/tendril/Ivy.Tendril/Mcp/Tools/PlanTools.cs
@@ -198,6 +198,9 @@ public sealed class PlanTools
 
     private static string? GetPlansDirectory()
     {
+        var plans = Environment.GetEnvironmentVariable("TENDRIL_PLANS")?.Trim();
+        if (!string.IsNullOrEmpty(plans))
+            return plans;
         var home = GetTendrilHome();
         return home == null ? null : Path.Combine(home, "Plans");
     }

--- a/src/tendril/Ivy.Tendril/Promptwares/.shared/Utils.ps1
+++ b/src/tendril/Ivy.Tendril/Promptwares/.shared/Utils.ps1
@@ -23,7 +23,7 @@ if (-not $env:TENDRIL_CONFIG) {
 }
 
 $script:ConfigPath = $env:TENDRIL_CONFIG
-$script:PlansDir = Join-Path $env:TENDRIL_HOME "Plans"
+$script:PlansDir = if ($env:TENDRIL_PLANS) { $env:TENDRIL_PLANS } else { Join-Path $env:TENDRIL_HOME "Plans" }
 
 $script:CachedConfigContent = $null
 $script:CachedConfigYaml = $null

--- a/src/tendril/Ivy.Tendril/Promptwares/MakePlan/Tools/Backfill-RecommendationFields.ps1
+++ b/src/tendril/Ivy.Tendril/Promptwares/MakePlan/Tools/Backfill-RecommendationFields.ps1
@@ -8,13 +8,13 @@
     are missing these fields. Uses an LLM to classify each recommendation.
 
 .PARAMETER PlansDirectory
-    Path to the plans directory. Defaults to $env:TENDRIL_HOME parent + Plans.
+    Path to the plans directory. Defaults to $env:TENDRIL_PLANS or $env:TENDRIL_HOME/Plans.
 
 .PARAMETER DryRun
     If set, prints what would be changed without modifying files.
 #>
 param(
-    [string]$PlansDirectory = (Join-Path (Split-Path $env:TENDRIL_HOME -Parent) "Plans"),
+    [string]$PlansDirectory = $(if ($env:TENDRIL_PLANS) { $env:TENDRIL_PLANS } else { Join-Path $env:TENDRIL_HOME "Plans" }),
     [switch]$DryRun
 )
 

--- a/src/tendril/Ivy.Tendril/Promptwares/MakePlan/Tools/Doctor-Plans.ps1
+++ b/src/tendril/Ivy.Tendril/Promptwares/MakePlan/Tools/Doctor-Plans.ps1
@@ -10,13 +10,13 @@
     - Nested worktree detection
     - Overall health status
 .PARAMETER PlansDirectory
-    Path to the plans directory (default: $env:TENDRIL_HOME/Plans)
+    Path to the plans directory (default: $env:TENDRIL_PLANS or $env:TENDRIL_HOME/Plans)
 .PARAMETER ShowOnlyUnhealthy
     Only show plans with health issues
 #>
 
 param(
-    [string]$PlansDirectory = "$env:TENDRIL_HOME\Plans",
+    [string]$PlansDirectory = $(if ($env:TENDRIL_PLANS) { $env:TENDRIL_PLANS } else { "$env:TENDRIL_HOME\Plans" }),
     [switch]$ShowOnlyUnhealthy
 )
 

--- a/src/tendril/Ivy.Tendril/Promptwares/MakePlan/Tools/Remove-DeepNestedPlanArtifacts.ps1
+++ b/src/tendril/Ivy.Tendril/Promptwares/MakePlan/Tools/Remove-DeepNestedPlanArtifacts.ps1
@@ -13,7 +13,7 @@
     This script is destructive and should only be run once as an operational cleanup.
 
 .PARAMETER PlansDirectory
-    Root Plans directory to scan. Defaults to $env:TENDRIL_PLANS_DIRECTORY.
+    Root Plans directory to scan. Defaults to $env:TENDRIL_PLANS or $env:TENDRIL_HOME/Plans.
 
 .PARAMETER WhatIf
     Show what would be deleted without actually deleting.
@@ -30,7 +30,7 @@
     Run cleanup and show detailed progress.
 #>
 param(
-    [string]$PlansDirectory = $env:TENDRIL_PLANS_DIRECTORY,
+    [string]$PlansDirectory = $(if ($env:TENDRIL_PLANS) { $env:TENDRIL_PLANS } else { Join-Path $env:TENDRIL_HOME "Plans" }),
     [switch]$WhatIf,
     [switch]$Verbose
 )

--- a/src/tendril/Ivy.Tendril/Promptwares/MakePlan/Tools/Validate-RecommendationsYaml.ps1
+++ b/src/tendril/Ivy.Tendril/Promptwares/MakePlan/Tools/Validate-RecommendationsYaml.ps1
@@ -1,6 +1,6 @@
 param(
     [Parameter(Mandatory=$false)]
-    [string]$PlansDirectory = "$env:TENDRIL_HOME/Plans",
+    [string]$PlansDirectory = $(if ($env:TENDRIL_PLANS) { $env:TENDRIL_PLANS } else { "$env:TENDRIL_HOME/Plans" }),
 
     [Parameter(Mandatory=$false)]
     [switch]$Fix,

--- a/src/tendril/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/tendril/Ivy.Tendril/Services/ConfigService.cs
@@ -237,7 +237,7 @@ public class ConfigService : IConfigService
 
             Directory.CreateDirectory(TendrilHome);
             Directory.CreateDirectory(Path.Combine(TendrilHome, "Inbox"));
-            Directory.CreateDirectory(Path.Combine(TendrilHome, "Plans"));
+            Directory.CreateDirectory(PlanFolder);
             Directory.CreateDirectory(Path.Combine(TendrilHome, "Trash"));
             Directory.CreateDirectory(Path.Combine(TendrilHome, "Promptwares"));
             Directory.CreateDirectory(Path.Combine(TendrilHome, "Hooks"));
@@ -250,7 +250,10 @@ public class ConfigService : IConfigService
 
     public string ConfigPath { get; private set; }
 
-    public string PlanFolder => string.IsNullOrEmpty(TendrilHome) ? "" : Path.Combine(TendrilHome, "Plans");
+    public string PlanFolder =>
+        Environment.GetEnvironmentVariable("TENDRIL_PLANS")?.Trim() is { Length: > 0 } plans
+            ? plans
+            : string.IsNullOrEmpty(TendrilHome) ? "" : Path.Combine(TendrilHome, "Plans");
 
     public List<ProjectConfig> Projects => Settings.Projects;
 

--- a/src/tendril/Ivy.Tendril/Services/OnboardingSetupService.cs
+++ b/src/tendril/Ivy.Tendril/Services/OnboardingSetupService.cs
@@ -7,8 +7,11 @@ public class OnboardingSetupService(IConfigService config, IServiceProvider serv
         // Create directory structure
         Directory.CreateDirectory(tendrilHome);
         Directory.CreateDirectory(Path.Combine(tendrilHome, "Inbox"));
-        Directory.CreateDirectory(Path.Combine(tendrilHome, "Plans"));
-        await FileHelper.WriteAllTextAsync(Path.Combine(tendrilHome, "Plans", ".counter"), "1");
+        var planFolder = Environment.GetEnvironmentVariable("TENDRIL_PLANS")?.Trim() is { Length: > 0 } plans
+            ? plans
+            : Path.Combine(tendrilHome, "Plans");
+        Directory.CreateDirectory(planFolder);
+        await FileHelper.WriteAllTextAsync(Path.Combine(planFolder, ".counter"), "1");
         Directory.CreateDirectory(Path.Combine(tendrilHome, "Trash"));
         Directory.CreateDirectory(Path.Combine(tendrilHome, "Promptwares"));
         if (PromptwareDeployer.IsEmbeddedAvailable())


### PR DESCRIPTION
## Summary
- Adds optional `TENDRIL_PLANS` environment variable to decouple the Plans directory from `TENDRIL_HOME`
- When set, all code uses `TENDRIL_PLANS` as the Plans path; when unset, falls back to `TENDRIL_HOME/Plans` (no behavior change)
- Prevents recursive long-path issues when `TENDRIL_HOME` contains a junction pointing to Plans

## Changes
- **C# (4 files):** ConfigService, OnboardingSetupService, PlanTools, DoctorCommand
- **PowerShell (6 files):** Utils.ps1, CleanupWorktrees.ps1, Doctor-Plans.ps1, Validate-RecommendationsYaml.ps1, Backfill-RecommendationFields.ps1, Remove-DeepNestedPlanArtifacts.ps1

## Test plan
- [ ] Verify plans work without `TENDRIL_PLANS` set (fallback to `TENDRIL_HOME/Plans`)
- [ ] Verify plans work with `TENDRIL_PLANS` set to an external directory
- [ ] Run `doctor plans` with both configurations