### PR TITLE
Fix typography.small to use Tailwind text-sm

### DIFF
--- a/src/frontend/src/lib/styles.ts
+++ b/src/frontend/src/lib/styles.ts
@@ -740,7 +740,7 @@ export const typography: Record<string, string> = {
 
   // Size variants
   large: "text-lg font-semibold",
-  small: "text-large-body leading-none",
+  small: "text-sm",
   muted: "text-base text-muted-foreground",
 
   // Semantic variants


### PR DESCRIPTION
## Summary

- Replaced `typography.small` from `"text-large-body leading-none"` to `"text-sm"`
- Removes `leading-none` which could cause overlapping multi-line text
- Uses standard Tailwind `text-sm` (14px) instead of custom `text-large-body` CSS variable, consistent with how other typography variants use Tailwind classes

## Test plan

- [ ] Verify `Text.P().Small()` renders at 14px with normal line-height
- [ ] Check multi-line small text no longer overlaps
- [ ] Verify no visual regressions in components using the small density

🤖 Generated with [Claude Code](https://claude.com/claude-code)