### PR TITLE
[01494] Theme mode buttons in Ivy Studio should change preview app theme

### DIFF
--- a/src/frontend/src/components/DevTools.tsx
+++ b/src/frontend/src/components/DevTools.tsx
@@ -3,6 +3,7 @@ import "./devtools.css";
 import { CallSite } from "@/types/widgets";
 import { widgetCallSiteRegistry } from "@/widgets/widgetRenderer";
 import { LuSend, LuPlus, LuChevronUp } from "react-icons/lu";
+import { setThemeGlobal } from "@/components/theme-provider";
 
 interface WidgetInfo {
   id: string;
@@ -65,6 +66,12 @@ export function DevTools() {
     const handler = (e: MessageEvent) => {
       if (e.data?.type === "DEVTOOLS_SET_ENABLED") {
         setEnabled(e.data.token === "true");
+      }
+      if (e.data?.type === "SET_THEME_MODE") {
+        const mode = e.data.mode;
+        if (mode === "light" || mode === "dark") {
+          setThemeGlobal(mode);
+        }
       }
     };
     window.addEventListener("message", handler);


### PR DESCRIPTION
## Summary

Added a `SET_THEME_MODE` postMessage channel from Ivy Studio to the preview iframe, so clicking the Light/Dark buttons in the Theme Editor panel now switches the preview app's actual theme mode in sync. This follows the same postMessage pattern already used for `DEVTOOLS_SET_ENABLED` and `APPLY_THEME`.

## API Changes

- `DevTools.tsx`: Now handles `SET_THEME_MODE` postMessage to call `setThemeGlobal()`

## Files Modified

**Ivy-Framework repo (preview app listener):**
- `src/frontend/src/components/DevTools.tsx` — handle SET_THEME_MODE message

## Commits

- `7876b862f` [01494] Listen for SET_THEME_MODE postMessage in DevTools