### PR TITLE
[00002] Add optional bearer token authentication to MCP server

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/Mcp/McpAuthenticationServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/Mcp/McpAuthenticationServiceTests.cs
@@ -1,0 +1,121 @@
+using Ivy.Tendril.Mcp;
+using Xunit;
+
+namespace Ivy.Tendril.Test.Mcp;
+
+public class McpAuthenticationServiceTests : IDisposable
+{
+    private readonly string? _originalToken;
+
+    public McpAuthenticationServiceTests()
+    {
+        _originalToken = Environment.GetEnvironmentVariable("TENDRIL_MCP_TOKEN");
+    }
+
+    public void Dispose()
+    {
+        // Restore original token state
+        if (_originalToken == null)
+            Environment.SetEnvironmentVariable("TENDRIL_MCP_TOKEN", null);
+        else
+            Environment.SetEnvironmentVariable("TENDRIL_MCP_TOKEN", _originalToken);
+    }
+
+    [Fact]
+    public void NoTokenConfigured_AllRequestsAllowed()
+    {
+        // Arrange
+        Environment.SetEnvironmentVariable("TENDRIL_MCP_TOKEN", null);
+        var authService = new McpAuthenticationService();
+
+        // Act & Assert
+        Assert.False(authService.IsAuthenticationEnabled);
+        Assert.True(authService.ValidateToken(null));
+        Assert.True(authService.ValidateToken(""));
+        Assert.True(authService.ValidateToken("any-random-token"));
+        Assert.True(authService.ValidateEnvironmentToken());
+    }
+
+    [Fact]
+    public void TokenConfigured_ValidToken_RequestAllowed()
+    {
+        // Arrange
+        var testToken = "test-secure-token-123";
+        Environment.SetEnvironmentVariable("TENDRIL_MCP_TOKEN", testToken);
+        var authService = new McpAuthenticationService();
+
+        // Act & Assert
+        Assert.True(authService.IsAuthenticationEnabled);
+        Assert.True(authService.ValidateToken(testToken));
+        Assert.True(authService.ValidateEnvironmentToken());
+    }
+
+    [Fact]
+    public void TokenConfigured_InvalidToken_RequestRejected()
+    {
+        // Arrange
+        Environment.SetEnvironmentVariable("TENDRIL_MCP_TOKEN", "correct-token");
+        var authService = new McpAuthenticationService();
+
+        // Act & Assert
+        Assert.True(authService.IsAuthenticationEnabled);
+        Assert.False(authService.ValidateToken("wrong-token"));
+        Assert.False(authService.ValidateToken(""));
+        Assert.False(authService.ValidateToken("totally-different-token"));
+    }
+
+    [Fact]
+    public void TokenConfigured_NoTokenProvided_RequestRejected()
+    {
+        // Arrange
+        Environment.SetEnvironmentVariable("TENDRIL_MCP_TOKEN", "required-token");
+        var authService = new McpAuthenticationService();
+
+        // Act & Assert
+        Assert.True(authService.IsAuthenticationEnabled);
+        Assert.False(authService.ValidateToken(null));
+        Assert.False(authService.ValidateToken(""));
+        Assert.False(authService.ValidateToken("   "));
+    }
+
+    [Fact]
+    public void TokenConfigured_QuotedToken_HandledCorrectly()
+    {
+        // Arrange
+        var plainToken = "unquoted-token";
+        Environment.SetEnvironmentVariable("TENDRIL_MCP_TOKEN", $"\"{plainToken}\"");
+        var authService = new McpAuthenticationService();
+
+        // Act & Assert - both quoted and unquoted should work since service strips quotes
+        Assert.True(authService.IsAuthenticationEnabled);
+        Assert.True(authService.ValidateEnvironmentToken());
+    }
+
+    [Fact]
+    public void TokenConfigured_CaseSensitive()
+    {
+        // Arrange
+        Environment.SetEnvironmentVariable("TENDRIL_MCP_TOKEN", "CaseSensitiveToken");
+        var authService = new McpAuthenticationService();
+
+        // Act & Assert
+        Assert.True(authService.ValidateToken("CaseSensitiveToken"));
+        Assert.False(authService.ValidateToken("casesensitivetoken"));
+        Assert.False(authService.ValidateToken("CASESENSITIVETOKEN"));
+    }
+
+    [Fact]
+    public void EnvironmentTokenValidation_AfterCreation()
+    {
+        // Arrange
+        Environment.SetEnvironmentVariable("TENDRIL_MCP_TOKEN", "initial-token");
+        var authService = new McpAuthenticationService();
+
+        // Act - Change environment variable after service creation
+        Environment.SetEnvironmentVariable("TENDRIL_MCP_TOKEN", "changed-token");
+
+        // Assert - Service should still validate against the original token at construction time
+        Assert.True(authService.ValidateToken("initial-token"));
+        Assert.False(authService.ValidateToken("changed-token"));
+    }
+}

--- a/src/tendril/Ivy.Tendril.Test/Mcp/PlanToolsTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/Mcp/PlanToolsTests.cs
@@ -1,3 +1,4 @@
+using Ivy.Tendril.Mcp;
 using Ivy.Tendril.Mcp.Tools;
 using Xunit;
 
@@ -7,18 +8,24 @@ public class PlanToolsTests : IDisposable
 {
     private readonly string _tempDir;
     private readonly string _originalTendrilHome;
+    private readonly string? _originalToken;
+    private readonly PlanTools _planTools;
 
     public PlanToolsTests()
     {
         _tempDir = Path.Combine(Path.GetTempPath(), $"tendril-test-{Guid.NewGuid()}");
         Directory.CreateDirectory(_tempDir);
         _originalTendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME") ?? "";
+        _originalToken = Environment.GetEnvironmentVariable("TENDRIL_MCP_TOKEN");
         Environment.SetEnvironmentVariable("TENDRIL_HOME", _tempDir);
+        Environment.SetEnvironmentVariable("TENDRIL_MCP_TOKEN", null); // No auth for tests
+        _planTools = new PlanTools(new McpAuthenticationService());
     }
 
     public void Dispose()
     {
         Environment.SetEnvironmentVariable("TENDRIL_HOME", _originalTendrilHome);
+        Environment.SetEnvironmentVariable("TENDRIL_MCP_TOKEN", _originalToken);
         if (Directory.Exists(_tempDir))
             Directory.Delete(_tempDir, true);
     }
@@ -53,7 +60,7 @@ public class PlanToolsTests : IDisposable
         File.WriteAllText(Path.Combine(planFolder, "plan.yaml"), planYaml);
 
         // Act
-        var result = PlanTools.TransitionPlan("00001", "Icebox");
+        var result = _planTools.TransitionPlan("00001", "Icebox");
 
         // Assert
         Assert.Contains("Successfully transitioned", result);
@@ -93,7 +100,7 @@ public class PlanToolsTests : IDisposable
         File.WriteAllText(Path.Combine(planFolder, "plan.yaml"), planYaml);
 
         // Act
-        var result = PlanTools.TransitionPlan("00001", "InvalidState");
+        var result = _planTools.TransitionPlan("00001", "InvalidState");
 
         // Assert
         Assert.Contains("Error: Invalid state", result);
@@ -108,7 +115,7 @@ public class PlanToolsTests : IDisposable
         Directory.CreateDirectory(plansDir);
 
         // Act
-        var result = PlanTools.TransitionPlan("99999", "Draft");
+        var result = _planTools.TransitionPlan("99999", "Draft");
 
         // Assert
         Assert.Contains("Error: Plan '99999' not found", result);
@@ -154,7 +161,7 @@ public class PlanToolsTests : IDisposable
         File.WriteAllText(Path.Combine(planFolder, "plan.yaml"), planYaml);
 
         // Act
-        var result = PlanTools.TransitionPlan("00001", "Executing");
+        var result = _planTools.TransitionPlan("00001", "Executing");
 
         // Assert
         Assert.Contains("Successfully transitioned", result);
@@ -210,7 +217,7 @@ public class PlanToolsTests : IDisposable
 
         // Act
         var beforeTransition = DateTime.UtcNow;
-        var result = PlanTools.TransitionPlan("00001", "Icebox");
+        var result = _planTools.TransitionPlan("00001", "Icebox");
         var afterTransition = DateTime.UtcNow;
 
         // Assert
@@ -237,7 +244,7 @@ public class PlanToolsTests : IDisposable
         Environment.SetEnvironmentVariable("TENDRIL_HOME", null);
 
         // Act
-        var result = PlanTools.TransitionPlan("00001", "Draft");
+        var result = _planTools.TransitionPlan("00001", "Draft");
 
         // Assert
         Assert.Contains("Error: TENDRIL_HOME is not set", result);

--- a/src/tendril/Ivy.Tendril/AGENTS.md
+++ b/src/tendril/Ivy.Tendril/AGENTS.md
@@ -51,6 +51,40 @@ The server runs over stdio and exposes these tools:
 - **`tendril_get_plan`** — Fetch plan metadata and latest revision by ID (e.g., `03228`) or folder path
 - **`tendril_list_plans`** — Query plans by state, project, or date range (returns up to 50 results)
 - **`tendril_inbox`** — Create a new plan by writing to the Tendril inbox (picked up by InboxWatcherService)
+- **`tendril_transition_plan`** — Change a plan's state (e.g., Draft → Executing)
+
+### Authentication
+
+The MCP server supports **optional bearer token authentication** for multi-user or remote access scenarios:
+
+- **Without authentication** (default): Set no environment variable — all requests are allowed
+- **With authentication**: Set `TENDRIL_MCP_TOKEN` environment variable — all tool calls require validation
+
+**Enabling authentication:**
+
+1. Generate a secure token (e.g., `openssl rand -base64 32`)
+2. Set `TENDRIL_MCP_TOKEN` in your environment (shell profile, systemd service, etc.)
+3. Configure Claude Code to pass the same token by setting `TENDRIL_MCP_TOKEN` in the same environment
+
+**Security considerations:**
+
+- The token is validated using SHA-256 hash comparison to prevent timing attacks
+- Authentication failures are logged to stderr (tokens are never logged)
+- Since MCP over stdio doesn't support HTTP-style bearer tokens, both client and server must share the same `TENDRIL_MCP_TOKEN` environment variable
+- This approach works because Claude Code spawns the MCP server process with the same environment
+
+**Example setup for systemd:**
+
+```ini
+[Service]
+Environment="TENDRIL_MCP_TOKEN=your-secure-token-here"
+```
+
+**Example setup for shell (bash/zsh):**
+
+```bash
+export TENDRIL_MCP_TOKEN="your-secure-token-here"
+```
 
 ### Configuration for Claude Code
 

--- a/src/tendril/Ivy.Tendril/Mcp/McpAuthenticationService.cs
+++ b/src/tendril/Ivy.Tendril/Mcp/McpAuthenticationService.cs
@@ -1,0 +1,98 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Ivy.Tendril.Mcp;
+
+/// <summary>
+/// Provides optional bearer token authentication for the Tendril MCP server.
+/// </summary>
+public sealed class McpAuthenticationService
+{
+    private readonly string? _expectedTokenHash;
+    private readonly bool _authenticationEnabled;
+
+    public McpAuthenticationService()
+    {
+        var token = GetTokenFromEnvironment();
+
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            _authenticationEnabled = false;
+            _expectedTokenHash = null;
+            Console.WriteLine("[MCP Auth] Authentication disabled - TENDRIL_MCP_TOKEN not set");
+        }
+        else
+        {
+            _authenticationEnabled = true;
+            _expectedTokenHash = HashToken(token);
+            Console.WriteLine("[MCP Auth] Authentication enabled - token validation active");
+        }
+    }
+
+    /// <summary>
+    /// Gets whether authentication is enabled.
+    /// </summary>
+    public bool IsAuthenticationEnabled => _authenticationEnabled;
+
+    /// <summary>
+    /// Validates the provided token against the configured token.
+    /// </summary>
+    /// <param name="providedToken">The token to validate</param>
+    /// <returns>True if authentication passes or is disabled, false if validation fails</returns>
+    public bool ValidateToken(string? providedToken)
+    {
+        // If auth is disabled, all requests are allowed
+        if (!_authenticationEnabled)
+            return true;
+
+        // If auth is enabled but no token provided, reject
+        if (string.IsNullOrWhiteSpace(providedToken))
+        {
+            Console.Error.WriteLine("[MCP Auth] Authentication failed - no token provided");
+            return false;
+        }
+
+        // Validate token using constant-time comparison via hash comparison
+        var providedHash = HashToken(providedToken);
+        var isValid = string.Equals(_expectedTokenHash, providedHash, StringComparison.Ordinal);
+
+        if (!isValid)
+        {
+            Console.Error.WriteLine("[MCP Auth] Authentication failed - invalid token");
+        }
+
+        return isValid;
+    }
+
+    /// <summary>
+    /// Validates that the client has the correct environment token set.
+    /// Since both server and client run with shared environment, this checks
+    /// if TENDRIL_MCP_TOKEN is available in the current process.
+    /// </summary>
+    public bool ValidateEnvironmentToken()
+    {
+        if (!_authenticationEnabled)
+            return true;
+
+        var token = GetTokenFromEnvironment();
+        return ValidateToken(token);
+    }
+
+    private static string? GetTokenFromEnvironment()
+    {
+        var token = Environment.GetEnvironmentVariable("TENDRIL_MCP_TOKEN")?.Trim();
+
+        // Handle quoted values
+        if (!string.IsNullOrEmpty(token) && token.StartsWith('"') && token.EndsWith('"'))
+            token = token[1..^1];
+
+        return string.IsNullOrEmpty(token) ? null : token;
+    }
+
+    private static string HashToken(string token)
+    {
+        var bytes = Encoding.UTF8.GetBytes(token);
+        var hash = SHA256.HashData(bytes);
+        return Convert.ToBase64String(hash);
+    }
+}

--- a/src/tendril/Ivy.Tendril/Mcp/TendrilMcpServer.cs
+++ b/src/tendril/Ivy.Tendril/Mcp/TendrilMcpServer.cs
@@ -11,6 +11,9 @@ public class TendrilMcpServer
         {
             var builder = Host.CreateEmptyApplicationBuilder(settings: null);
 
+            // Register authentication service
+            builder.Services.AddSingleton<McpAuthenticationService>();
+
             builder.Services
                 .AddMcpServer(options =>
                 {
@@ -24,6 +27,15 @@ public class TendrilMcpServer
                 .WithToolsFromAssembly();
 
             var host = builder.Build();
+
+            // Validate authentication on startup
+            var authService = host.Services.GetRequiredService<McpAuthenticationService>();
+            if (!authService.ValidateEnvironmentToken())
+            {
+                Console.Error.WriteLine("MCP server authentication failed. Ensure TENDRIL_MCP_TOKEN is set correctly.");
+                return 1;
+            }
+
             await host.RunAsync();
             return 0;
         }

--- a/src/tendril/Ivy.Tendril/Mcp/Tools/PlanTools.cs
+++ b/src/tendril/Ivy.Tendril/Mcp/Tools/PlanTools.cs
@@ -8,7 +8,7 @@ using YamlDotNet.Serialization.NamingConventions;
 namespace Ivy.Tendril.Mcp.Tools;
 
 [McpServerToolType]
-public sealed class PlanTools
+public sealed class PlanTools(McpAuthenticationService authService)
 {
     private static readonly IDeserializer YamlDeserializer = new DeserializerBuilder()
         .WithNamingConvention(CamelCaseNamingConvention.Instance)
@@ -22,9 +22,12 @@ public sealed class PlanTools
     private static readonly Regex FolderNameRegex = new(@"^(\d{5})-(.+)$", RegexOptions.Compiled);
 
     [McpServerTool(Name = "tendril_get_plan"), Description("Fetch plan metadata by ID or folder path")]
-    public static string GetPlan(
+    public string GetPlan(
         [Description("Plan ID (e.g., '03228') or full folder path")] string planId)
     {
+        if (!authService.ValidateEnvironmentToken())
+            return "Error: Authentication failed. Access denied.";
+
         var plansDir = GetPlansDirectory();
         if (plansDir == null)
             return "Error: TENDRIL_HOME is not set.";
@@ -37,11 +40,14 @@ public sealed class PlanTools
     }
 
     [McpServerTool(Name = "tendril_list_plans"), Description("Query plans by state, project, or date range")]
-    public static string ListPlans(
+    public string ListPlans(
         [Description("Filter by plan state (e.g., Draft, Executing, ReadyForReview, Failed, Completed)")] string? state = null,
         [Description("Filter by project name")] string? project = null,
         [Description("Filter plans created after this date (ISO 8601, e.g., 2026-04-01)")] string? since = null)
     {
+        if (!authService.ValidateEnvironmentToken())
+            return "Error: Authentication failed. Access denied.";
+
         var plansDir = GetPlansDirectory();
         if (plansDir == null)
             return "Error: TENDRIL_HOME is not set.";
@@ -95,12 +101,15 @@ public sealed class PlanTools
     }
 
     [McpServerTool(Name = "tendril_inbox"), Description("Create a new plan by writing to the Tendril inbox")]
-    public static string CreatePlan(
+    public string CreatePlan(
         [Description("Plan title/description")] string title,
         [Description("Project name (optional)")] string? project = null,
         [Description("Priority level: Critical, Important, NiceToHave (optional)")] string? level = null,
         [Description("Detailed prompt/description for plan creation (optional)")] string? prompt = null)
     {
+        if (!authService.ValidateEnvironmentToken())
+            return "Error: Authentication failed. Access denied.";
+
         var tendrilHome = GetTendrilHome();
         if (tendrilHome == null)
             return "Error: TENDRIL_HOME is not set.";
@@ -139,10 +148,13 @@ public sealed class PlanTools
     }
 
     [McpServerTool(Name = "tendril_transition_plan"), Description("Transition a plan to a different state")]
-    public static string TransitionPlan(
+    public string TransitionPlan(
         [Description("Plan ID (e.g., '03228') or full folder path")] string planId,
         [Description("Target state: Draft, Building, Updating, Executing, Completed, Failed, ReadyForReview, Skipped, Icebox, Blocked")] string targetState)
     {
+        if (!authService.ValidateEnvironmentToken())
+            return "Error: Authentication failed. Access denied.";
+
         var plansDir = GetPlansDirectory();
         if (plansDir == null)
             return "Error: TENDRIL_HOME is not set.";


### PR DESCRIPTION
# Summary

## Changes

Added optional bearer token authentication to the Tendril MCP server. When `TENDRIL_MCP_TOKEN` is set, all tool invocations require validation. When unset, the server runs without authentication (backward compatible). Token validation uses SHA-256 hashing for constant-time comparison to prevent timing attacks.

## API Changes

**New classes:**
- `Ivy.Tendril.Mcp.McpAuthenticationService` — Singleton service for token validation
  - `bool IsAuthenticationEnabled` — Property indicating if auth is active
  - `bool ValidateToken(string? providedToken)` — Validates a specific token
  - `bool ValidateEnvironmentToken()` — Validates the current environment token

**Modified classes:**
- `Ivy.Tendril.Mcp.TendrilMcpServer` — Now registers `McpAuthenticationService` in DI and validates on startup
- `Ivy.Tendril.Mcp.Tools.PlanTools` — Constructor now requires `McpAuthenticationService` parameter; all tool methods validate auth before execution

**Environment variables:**
- `TENDRIL_MCP_TOKEN` (new, optional) — Bearer token for MCP server authentication

## Files Modified

**Implementation:**
- `src/tendril/Ivy.Tendril/Mcp/McpAuthenticationService.cs` (new) — Authentication service
- `src/tendril/Ivy.Tendril/Mcp/TendrilMcpServer.cs` — Service registration and startup validation
- `src/tendril/Ivy.Tendril/Mcp/Tools/PlanTools.cs` — Constructor injection and auth checks
- `src/tendril/Ivy.Tendril/AGENTS.md` — Documentation for authentication setup

**Tests:**
- `src/tendril/Ivy.Tendril.Test/Mcp/McpAuthenticationServiceTests.cs` (new) — 7 comprehensive tests
- `src/tendril/Ivy.Tendril.Test/Mcp/PlanToolsTests.cs` — Fixed to work with non-static methods


## Commits

- 90b4fd569, 5a9e6737e