### PR TITLE
security: upgrade follow-redirects to >=1.16.0

### DIFF
--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -143,6 +143,7 @@
       "@swc/helpers": "0.5.17",
       "axios": "1.15.0",
       "dompurify": "3.3.2",
+      "follow-redirects": ">=1.16.0",
       "lodash-es": "4.18.1",
       "minimatch": "9.0.7",
       "remark-mermaid-plugin>mermaid": "11.12.1",

--- a/src/frontend/pnpm-lock.yaml
+++ b/src/frontend/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   '@swc/helpers': 0.5.17
   axios: 1.15.0
   dompurify: 3.3.2
+  follow-redirects: '>=1.16.0'
   lodash-es: 4.18.1
   minimatch: 9.0.7
   remark-mermaid-plugin>mermaid: 11.12.1
@@ -2445,8 +2446,8 @@ packages:
   flatbuffers@25.9.23:
     resolution: {integrity: sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==}
 
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -5280,7 +5281,7 @@ snapshots:
 
   axios@1.15.0(debug@4.4.3):
     dependencies:
-      follow-redirects: 1.15.11(debug@4.4.3)
+      follow-redirects: 1.16.0(debug@4.4.3)
       form-data: 4.0.5
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -5746,7 +5747,7 @@ snapshots:
 
   flatbuffers@25.9.23: {}
 
-  follow-redirects@1.15.11(debug@4.4.3):
+  follow-redirects@1.16.0(debug@4.4.3):
     optionalDependencies:
       debug: 4.4.3
 


### PR DESCRIPTION
Upgrades follow-redirects to fix a Dependabot alert. Verified with frontend and backend builds.