### PR TITLE
[00003] Split JobsChanged event into structure and property events

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/Hooks/UseStartJobTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/Hooks/UseStartJobTests.cs
@@ -14,6 +14,8 @@ public class UseStartJobTests
         public List<(string Type, string[] Args)> StartedJobs { get; } = new();
 #pragma warning disable CS0067
         public event Action? JobsChanged;
+        public event Action? JobsStructureChanged;
+        public event Action? JobPropertyChanged;
         public event Action<JobNotification>? NotificationReady;
 #pragma warning restore CS0067
 

--- a/src/tendril/Ivy.Tendril.Test/InboxControllerTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/InboxControllerTests.cs
@@ -162,6 +162,8 @@ public class InboxControllerTests
 
 #pragma warning disable CS0067
         public event Action? JobsChanged;
+        public event Action? JobsStructureChanged;
+        public event Action? JobPropertyChanged;
         public event Action<JobNotification>? NotificationReady;
 #pragma warning restore CS0067
     }

--- a/src/tendril/Ivy.Tendril.Test/JobServiceEventSplitTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/JobServiceEventSplitTests.cs
@@ -1,0 +1,108 @@
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Test;
+
+public class JobServiceEventSplitTests
+{
+    private static JobService CreateService()
+    {
+        SynchronizationContext.SetSynchronizationContext(null);
+        return new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
+    }
+
+    [Fact]
+    public void CompleteJob_RaisesJobsStructureChanged()
+    {
+        var service = CreateService();
+        var id = service.CreateTestJob("ExecutePlan", "test-plan");
+
+        var structureChangedFired = false;
+        var propertyChangedFired = false;
+        service.JobsStructureChanged += () => structureChangedFired = true;
+        service.JobPropertyChanged += () => propertyChangedFired = true;
+
+        service.CompleteJob(id, 0);
+
+        Assert.True(structureChangedFired);
+        Assert.False(propertyChangedFired);
+    }
+
+    [Fact]
+    public void CompleteJob_AlsoRaisesJobsChanged_ForBackwardCompatibility()
+    {
+        var service = CreateService();
+        var id = service.CreateTestJob("ExecutePlan", "test-plan");
+
+        var jobsChangedFired = false;
+        service.JobsChanged += () => jobsChangedFired = true;
+
+        service.CompleteJob(id, 0);
+
+        Assert.True(jobsChangedFired);
+    }
+
+    [Fact]
+    public void DeleteJob_RaisesJobsStructureChanged()
+    {
+        var service = CreateService();
+        var id = service.CreateTestJob("ExecutePlan", "test-plan");
+        service.CompleteJob(id, 0);
+
+        var structureChangedFired = false;
+        var propertyChangedFired = false;
+        service.JobsStructureChanged += () => structureChangedFired = true;
+        service.JobPropertyChanged += () => propertyChangedFired = true;
+
+        service.DeleteJob(id);
+
+        Assert.True(structureChangedFired);
+        Assert.False(propertyChangedFired);
+    }
+
+    [Fact]
+    public void StopJob_RaisesJobsStructureChanged()
+    {
+        var service = CreateService();
+        var id = service.CreateTestJob("ExecutePlan", "test-plan");
+
+        var structureChangedFired = false;
+        var propertyChangedFired = false;
+        service.JobsStructureChanged += () => structureChangedFired = true;
+        service.JobPropertyChanged += () => propertyChangedFired = true;
+
+        service.StopJob(id);
+
+        Assert.True(structureChangedFired);
+        Assert.False(propertyChangedFired);
+    }
+
+    [Fact]
+    public void ClearCompletedJobs_RaisesJobsStructureChanged()
+    {
+        var service = CreateService();
+        var id = service.CreateTestJob("ExecutePlan", "test-plan");
+        service.CompleteJob(id, 0);
+
+        var structureChangedFired = false;
+        service.JobsStructureChanged += () => structureChangedFired = true;
+
+        service.ClearCompletedJobs();
+
+        Assert.True(structureChangedFired);
+    }
+
+    [Fact]
+    public void ClearFailedJobs_RaisesJobsStructureChanged()
+    {
+        var service = CreateService();
+        var id = service.CreateTestJob("ExecutePlan", "test-plan");
+        service.CompleteJob(id, 1);
+
+        var structureChangedFired = false;
+        service.JobsStructureChanged += () => structureChangedFired = true;
+
+        service.ClearFailedJobs();
+
+        Assert.True(structureChangedFired);
+    }
+}

--- a/src/tendril/Ivy.Tendril.Test/PlanCountsServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/PlanCountsServiceTests.cs
@@ -234,6 +234,8 @@ public class PlanCountsServiceTests : IDisposable
 
 #pragma warning disable CS0067
         public event Action? JobsChanged;
+        public event Action? JobsStructureChanged;
+        public event Action? JobPropertyChanged;
         public event Action<JobNotification>? NotificationReady;
 #pragma warning restore CS0067
 

--- a/src/tendril/Ivy.Tendril/Apps/JobsApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/JobsApp.cs
@@ -67,13 +67,13 @@ public class JobsApp : ViewBase
 
         UseEffect(() =>
         {
-            void OnJobsChanged()
+            void OnJobsStructureChanged()
             {
                 refreshToken.Refresh();
             }
 
-            jobService.JobsChanged += OnJobsChanged;
-            return Disposable.Create(() => jobService.JobsChanged -= OnJobsChanged);
+            jobService.JobsStructureChanged += OnJobsStructureChanged;
+            return Disposable.Create(() => jobService.JobsStructureChanged -= OnJobsStructureChanged);
         });
 
         UseInterval(() =>

--- a/src/tendril/Ivy.Tendril/Services/IJobService.cs
+++ b/src/tendril/Ivy.Tendril/Services/IJobService.cs
@@ -5,6 +5,8 @@ namespace Ivy.Tendril.Services;
 public interface IJobService : IDisposable
 {
     event Action? JobsChanged;
+    event Action? JobsStructureChanged;  // Jobs added/removed or status changed
+    event Action? JobPropertyChanged;    // Only properties changed (cost, tokens)
     event Action<JobNotification>? NotificationReady;
 
     string StartJob(string type, string[] args, string? inboxFilePath);

--- a/src/tendril/Ivy.Tendril/Services/JobService.cs
+++ b/src/tendril/Ivy.Tendril/Services/JobService.cs
@@ -129,6 +129,8 @@ public class JobService : IJobService
     }
 
     public event Action? JobsChanged;
+    public event Action? JobsStructureChanged;
+    public event Action? JobPropertyChanged;
     public event Action<JobNotification>? NotificationReady;
 
     public string StartJob(string type, string[] args, string? inboxFilePath)
@@ -261,7 +263,7 @@ public class JobService : IJobService
                             j.Cost = (decimal)costCalc.TotalCost;
                             j.Tokens = costCalc.TotalTokens;
                             PersistJob(j);
-                            RaiseJobsChanged();
+                            RaiseJobsPropertyChanged();
                         }
 
                         if (jobArgs.Length > 0)
@@ -286,7 +288,7 @@ public class JobService : IJobService
         // for active display and is reloaded from DB on next startup.
         EvictStaleJobs();
 
-        RaiseJobsChanged();
+        RaiseJobsStructureChanged();
 
         // After successful completion of jobs that may unblock dependencies
         if (isSuccess && job.Type is "ExecutePlan" or "MakePr") RetryBlockedJobs();
@@ -334,7 +336,7 @@ public class JobService : IJobService
 
         CleanupInboxFile(job);
         ResetPlanState(job);
-        RaiseJobsChanged();
+        RaiseJobsStructureChanged();
 
         // Try to start queued jobs now that a slot is free
         if (wasRunning)
@@ -348,7 +350,7 @@ public class JobService : IJobService
             removed.DisposeResources();
             try { _database?.DeleteJob(id); } catch { /* Best-effort */ }
         }
-        RaiseJobsChanged();
+        RaiseJobsStructureChanged();
     }
 
     /// <summary>
@@ -387,7 +389,7 @@ public class JobService : IJobService
             try { _database?.DeleteJob(id); } catch { /* Best-effort */ }
         }
         if (completedIds.Count > 0)
-            RaiseJobsChanged();
+            RaiseJobsStructureChanged();
     }
 
     public void ClearFailedJobs()
@@ -403,7 +405,7 @@ public class JobService : IJobService
             try { _database?.DeleteJob(id); } catch { /* Best-effort */ }
         }
         if (failedIds.Count > 0)
-            RaiseJobsChanged();
+            RaiseJobsStructureChanged();
     }
 
     public List<JobItem> GetJobs()
@@ -461,6 +463,36 @@ public class JobService : IJobService
             _syncContext.Post(_ => JobsChanged?.Invoke(), null);
         else
             JobsChanged?.Invoke();
+    }
+
+    private void RaiseJobsStructureChanged()
+    {
+        if (_syncContext != null)
+            _syncContext.Post(_ =>
+            {
+                JobsStructureChanged?.Invoke();
+                JobsChanged?.Invoke();  // For backward compatibility
+            }, null);
+        else
+        {
+            JobsStructureChanged?.Invoke();
+            JobsChanged?.Invoke();
+        }
+    }
+
+    private void RaiseJobsPropertyChanged()
+    {
+        if (_syncContext != null)
+            _syncContext.Post(_ =>
+            {
+                JobPropertyChanged?.Invoke();
+                JobsChanged?.Invoke();  // For backward compatibility
+            }, null);
+        else
+        {
+            JobPropertyChanged?.Invoke();
+            JobsChanged?.Invoke();
+        }
     }
 
     private void RaiseNotification(JobNotification notification)
@@ -567,7 +599,7 @@ public class JobService : IJobService
 
                 var blockedNotification = new JobNotification("Job Blocked", $"{planFile}: {blockReason}", false);
                 RaiseNotification(blockedNotification);
-                RaiseJobsChanged();
+                RaiseJobsStructureChanged();
                 return id;
             }
 
@@ -581,7 +613,7 @@ public class JobService : IJobService
                 ResetPlanStateToBlocked(job);
                 var blockedNotification = new JobNotification("Job Blocked", $"{planFile}: {concurrentReason}", false);
                 RaiseNotification(blockedNotification);
-                RaiseJobsChanged();
+                RaiseJobsStructureChanged();
                 return id;
             }
         }
@@ -596,7 +628,7 @@ public class JobService : IJobService
             job.Status = JobStatus.Queued;
             job.StatusMessage = $"Waiting (max {_maxConcurrentJobs} concurrent jobs)";
             lock (_queueLock) { _jobQueue.Enqueue(id, -job.Priority); }
-            RaiseJobsChanged();
+            RaiseJobsStructureChanged();
             return id;
         }
 
@@ -778,7 +810,7 @@ public class JobService : IJobService
         // Start stale output watchdog
         if (_staleOutputTimeout > TimeSpan.Zero) _ = RunStaleOutputWatchdog(id, cts);
 
-        RaiseJobsChanged();
+        RaiseJobsStructureChanged();
     }
 
     internal void RunHooks(string when, string jobType, string planFolder, string project, JobItem job)

--- a/src/tendril/Ivy.Tendril/Services/PlanCountsService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanCountsService.cs
@@ -18,7 +18,7 @@ public class PlanCountsService : IPlanCountsService
         _planWatcher = planWatcher;
         Current = ComputeCounts();
         _planWatcher.PlansChanged += OnPlansSourceChanged;
-        _jobService.JobsChanged += OnSourceChanged;
+        _jobService.JobsStructureChanged += OnSourceChanged;
     }
 
     public event Action? CountsChanged;
@@ -28,7 +28,7 @@ public class PlanCountsService : IPlanCountsService
     public void Dispose()
     {
         _planWatcher.PlansChanged -= OnPlansSourceChanged;
-        _jobService.JobsChanged -= OnSourceChanged;
+        _jobService.JobsStructureChanged -= OnSourceChanged;
     }
 
     private void OnPlansSourceChanged(string? _)


### PR DESCRIPTION
# Summary

## Changes

Split the `JobsChanged` event into two separate events (`JobsStructureChanged` and `JobPropertyChanged`) to eliminate redundant UI refreshes when only job properties (cost/tokens) are updated. Both new events also trigger the legacy `JobsChanged` event to maintain backward compatibility with existing subscribers.

## API Changes

**IJobService interface:**
- Added `event Action? JobsStructureChanged` - fires when jobs are added, removed, or change status
- Added `event Action? JobPropertyChanged` - fires when only properties change (cost, tokens)

**JobService class:**
- Added `RaiseJobsStructureChanged()` private method
- Added `RaiseJobsPropertyChanged()` private method
- Updated 10 call sites to use appropriate event type

**Subscribers updated:**
- `JobsApp`: now subscribes to `JobsStructureChanged` instead of `JobsChanged`
- `PlanCountsService`: now subscribes to `JobsStructureChanged` instead of `JobsChanged`

## Files Modified

**Core implementation:**
- `src/tendril/Ivy.Tendril/Services/IJobService.cs` - added new event definitions
- `src/tendril/Ivy.Tendril/Services/JobService.cs` - added event implementation and updated call sites
- `src/tendril/Ivy.Tendril/Apps/JobsApp.cs` - updated subscription
- `src/tendril/Ivy.Tendril/Services/PlanCountsService.cs` - updated subscription

**Tests:**
- `src/tendril/Ivy.Tendril.Test/JobServiceEventSplitTests.cs` - new test file (6 tests)
- `src/tendril/Ivy.Tendril.Test/Hooks/UseStartJobTests.cs` - updated stub to implement new events
- `src/tendril/Ivy.Tendril.Test/InboxControllerTests.cs` - updated stub to implement new events
- `src/tendril/Ivy.Tendril.Test/PlanCountsServiceTests.cs` - updated stub to implement new events


## Commits

- 488612ac9, 7016fdd1c