### PR TITLE
[00008] Add tooltips to barchart in DashboardApp

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/DashboardApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/DashboardApp.cs
@@ -172,7 +172,8 @@ public class DashboardApp : ViewBase
             .Measure(costMeasureName, e => e.Sum(f => (double)f.Cost))
             .Measure(tokensMeasureName, e => e.Sum(f => (double)f.Tokens))
             .Height(Size.Px(350))
-            .Width(Size.Full());
+            .Width(Size.Full())
+            .Tooltip();
 
         var content = Layout.Vertical().Gap(2)
                       | dataTable


### PR DESCRIPTION
# Summary

## Changes

Added `.Tooltip()` method call to the barchart configuration in DashboardApp.cs. This enables tooltip functionality on the hourly cost and token burn chart, allowing users to see exact values when hovering over bars.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Apps/DashboardApp.cs` (line 175-176) — Added `.Tooltip()` to barchart configuration chain

## Commits

- 5d8d8954d [00008] Add tooltips to barchart in DashboardApp