### PR TITLE
[01495] ivy-tree-children missing gap between nested items

### DIFF
--- a/src/frontend/src/widgets/tree/TreeItem.tsx
+++ b/src/frontend/src/widgets/tree/TreeItem.tsx
@@ -5,9 +5,11 @@ import Icon from "@/components/Icon";
 import { cn } from "@/lib/utils";
 import { MenuItem } from "@/types/widgets";
 import { ActionRenderer } from "@/widgets/rowAction";
+import { Densities } from "@/types/density";
 
 interface TreeItemWidgetProps {
   item: MenuItem;
+  density?: Densities;
   rowActions?: MenuItem[];
   hasSiblingWithChildren?: boolean;
   isNested?: boolean;
@@ -17,6 +19,7 @@ interface TreeItemWidgetProps {
 
 export const TreeItem: React.FC<TreeItemWidgetProps> = ({
   item,
+  density,
   rowActions,
   hasSiblingWithChildren,
   isNested,
@@ -25,6 +28,8 @@ export const TreeItem: React.FC<TreeItemWidgetProps> = ({
 }) => {
   const [isOpen, setIsOpen] = React.useState(item.expanded ?? false);
   const hasChildren = item.children && item.children.length > 0;
+  const gapClass =
+    density === Densities.Small ? "gap-0.5" : density === Densities.Large ? "gap-1.5" : "gap-1";
 
   React.useEffect(() => {
     setIsOpen(item.expanded ?? false);
@@ -122,11 +127,12 @@ export const TreeItem: React.FC<TreeItemWidgetProps> = ({
           )}
         </div>
         <CollapsibleContent className="overflow-hidden transition-all data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down">
-          <div className="ivy-tree-children pl-[1rem] ml-2 border-l border-border/50">
+          <div className={cn("ivy-tree-children flex flex-col pl-[1rem] ml-2 border-l border-border/50", gapClass)}>
             {item.children!.map((child) => (
               <TreeItem
                 key={child.tag || child.label}
                 item={child}
+                density={density}
                 onItemClick={onItemClick}
                 rowActions={rowActions}
                 hasSiblingWithChildren={item.children!.some(

--- a/src/frontend/src/widgets/tree/TreeItem.tsx
+++ b/src/frontend/src/widgets/tree/TreeItem.tsx
@@ -127,7 +127,12 @@ export const TreeItem: React.FC<TreeItemWidgetProps> = ({
           )}
         </div>
         <CollapsibleContent className="overflow-hidden transition-all data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down">
-          <div className={cn("ivy-tree-children flex flex-col pl-[1rem] ml-2 border-l border-border/50", gapClass)}>
+          <div
+            className={cn(
+              "ivy-tree-children flex flex-col pl-[1rem] ml-2 border-l border-border/50",
+              gapClass,
+            )}
+          >
             {item.children!.map((child) => (
               <TreeItem
                 key={child.tag || child.label}

--- a/src/frontend/src/widgets/tree/TreeWidget.tsx
+++ b/src/frontend/src/widgets/tree/TreeWidget.tsx
@@ -56,6 +56,7 @@ export const TreeWidget: React.FC<TreeWidgetProps> = ({
         <TreeItem
           key={item.tag || item.label}
           item={item}
+          density={density}
           onItemClick={onItemClick}
           rowActions={rowActions}
           hasSiblingWithChildren={items.some((i) => i.children && i.children.length > 0)}


### PR DESCRIPTION
## Summary

Added density-based gap spacing to the `ivy-tree-children` container in `TreeItem.tsx`, matching the gap behavior already present on the root `ivy-tree` container in `TreeWidget.tsx`. The `density` prop is now threaded from `TreeWidget` through `TreeItem` to recursive children.

## API Changes

- `TreeItemWidgetProps.density?: Densities` — new optional prop on `TreeItem` component

## Files Modified

- **src/frontend/src/widgets/tree/TreeWidget.tsx** — passes `density` prop to each `<TreeItem>`
- **src/frontend/src/widgets/tree/TreeItem.tsx** — accepts `density` prop, computes gap class, applies `flex flex-col` + gap to `ivy-tree-children` div, passes `density` to recursive children

## Commits

- `ebf3a7f18` [01495] Add density-based gap to ivy-tree-children container
- `c889fabe4` [01495] Fix formatting in TreeItem.tsx