### PR TITLE
[03344] Remove the PerformanceAnalyzer in IvyTeamConfig

### DIFF
--- a/src/tendril/Ivy.Tendril.TeamIvyConfig/config.yaml
+++ b/src/tendril/Ivy.Tendril.TeamIvyConfig/config.yaml
@@ -234,30 +234,6 @@ projects:
     action: pwsh -NoProfile -File D:\Tendril\Hooks\NotifySlack.ps1
   repoPaths:
   - D:\Repos\_Ivy\Ivy-Services
-- name: PerformanceAnalyzer
-  color: Violet
-  meta:
-    slackEmoji: ':chart_with_upwards_trend:'
-  repos:
-  - path: D:\Repos\_Ivy\PerformanceAnalyzer
-    prRule: yolo
-  verifications:
-  - *o0
-  - *o1
-  - *o2
-  - *o3
-  context: >
-    PerformanceAnalyzer — Ivy app for tracking Ivy employee performance on GitHub.
-  reviewActions: []
-  hooks:
-  - name: SlackNotify
-    when: after
-    promptwares:
-    - MakePr
-    condition: ''
-    action: pwsh -NoProfile -File D:\Tendril\Hooks\NotifySlack.ps1
-  repoPaths:
-  - D:\Repos\_Ivy\PerformanceAnalyzer
 verifications:
 - name: DotnetBuild
   prompt: Run `dotnet build --warnaserror` in the plan's worktree directory (not the original repo) and verify it succeeds with zero errors and zero warnings.


### PR DESCRIPTION
# Summary

## Changes

Removed the PerformanceAnalyzer project definition from the Tendril team configuration. The project entry (24 lines) included verifications, hooks, repository paths, and slack notifications, but is no longer needed.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril.TeamIvyConfig/config.yaml` — Removed the PerformanceAnalyzer project block (lines 237-260)


## Commits

- 304916bef