### PR TITLE
[03349] Fix Assignee Dropdown Showing Labels in Import Issues Dialog

### DIFF
--- a/src/tendril/Ivy.Tendril/AppShell/Dialogs/ImportIssuesDialog.cs
+++ b/src/tendril/Ivy.Tendril/AppShell/Dialogs/ImportIssuesDialog.cs
@@ -27,9 +27,12 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
         var reposError = UseState<string?>(null);
 
         var assigneesQuery = UseQuery<string[], string>(
-            selectedRepo.Value ?? "",
-            async (repoName, _) =>
+            $"assignees:{selectedRepo.Value ?? ""}",
+            async (key, _) =>
             {
+                // Strip the "assignees:" prefix to get the actual repo name
+                var repoName = key.StartsWith("assignees:") ? key.Substring("assignees:".Length) : key;
+
                 if (string.IsNullOrEmpty(repoName))
                 {
                     assigneesError.Set(null);
@@ -51,9 +54,12 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
         );
 
         var labelsQuery = UseQuery<string[], string>(
-            selectedRepo.Value ?? "",
-            async (repoName, _) =>
+            $"labels:{selectedRepo.Value ?? ""}",
+            async (key, _) =>
             {
+                // Strip the "labels:" prefix to get the actual repo name
+                var repoName = key.StartsWith("labels:") ? key.Substring("labels:".Length) : key;
+
                 if (string.IsNullOrEmpty(repoName))
                 {
                     labelsError.Set(null);


### PR DESCRIPTION
# Summary

## Changes

Fixed a bug in the Import Issues dialog where the Assignee dropdown was displaying GitHub labels instead of users. The root cause was that both `assigneesQuery` and `labelsQuery` used the same cache key (`selectedRepo.Value`), causing UseQuery to conflate the two queries and mix up their cached data. Added unique prefixes to the query keys to ensure proper separation.

## API Changes

None.

## Files Modified

- **src/tendril/Ivy.Tendril/AppShell/Dialogs/ImportIssuesDialog.cs**
  - Modified `assigneesQuery` to use key `$"assignees:{selectedRepo.Value ?? ""}"`
  - Modified `labelsQuery` to use key `$"labels:{selectedRepo.Value ?? ""}"`
  - Updated fetcher functions to strip the prefix before processing

## Commits

- 6ca50236d [03349] Fix assignee dropdown showing labels by using unique query keys