### PR TITLE
[03339] Fix focus ring borders when using affixes in input widgets

### DIFF
--- a/src/frontend/src/widgets/inputs/DateRangeInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/DateRangeInputWidget.tsx
@@ -326,13 +326,13 @@ export const DateRangeInputWidget: React.FC<DateRangeInputWidgetProps> = ({
           )}
         >
           {hasPrefix && (
-            <div className="flex items-center px-3 bg-muted text-muted-foreground border-r border-input rounded-tl-[var(--radius-fields)] rounded-bl-[var(--radius-fields)]">
+            <div className={cn("flex items-center px-3 bg-muted text-muted-foreground rounded-tl-[var(--radius-fields)] rounded-bl-[var(--radius-fields)]", !isOpen && "border-r border-input")}>
               {prefixContent}
             </div>
           )}
           <div className="flex-1 relative w-full">{triggerContent}</div>
           {hasSuffix && (
-            <div className="flex items-center px-3 bg-muted text-muted-foreground border-l border-input rounded-tr-[var(--radius-fields)] rounded-br-[var(--radius-fields)]">
+            <div className={cn("flex items-center px-3 bg-muted text-muted-foreground rounded-tr-[var(--radius-fields)] rounded-br-[var(--radius-fields)]", !isOpen && "border-l border-input")}>
               {suffixContent}
             </div>
           )}

--- a/src/frontend/src/widgets/inputs/DateRangeInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/DateRangeInputWidget.tsx
@@ -326,13 +326,23 @@ export const DateRangeInputWidget: React.FC<DateRangeInputWidgetProps> = ({
           )}
         >
           {hasPrefix && (
-            <div className={cn("flex items-center px-3 bg-muted text-muted-foreground rounded-tl-[var(--radius-fields)] rounded-bl-[var(--radius-fields)]", !isOpen && "border-r border-input")}>
+            <div
+              className={cn(
+                "flex items-center px-3 bg-muted text-muted-foreground rounded-tl-[var(--radius-fields)] rounded-bl-[var(--radius-fields)]",
+                !isOpen && "border-r border-input",
+              )}
+            >
               {prefixContent}
             </div>
           )}
           <div className="flex-1 relative w-full">{triggerContent}</div>
           {hasSuffix && (
-            <div className={cn("flex items-center px-3 bg-muted text-muted-foreground rounded-tr-[var(--radius-fields)] rounded-br-[var(--radius-fields)]", !isOpen && "border-l border-input")}>
+            <div
+              className={cn(
+                "flex items-center px-3 bg-muted text-muted-foreground rounded-tr-[var(--radius-fields)] rounded-br-[var(--radius-fields)]",
+                !isOpen && "border-l border-input",
+              )}
+            >
               {suffixContent}
             </div>
           )}

--- a/src/frontend/src/widgets/inputs/SelectSingleVariant.tsx
+++ b/src/frontend/src/widgets/inputs/SelectSingleVariant.tsx
@@ -318,13 +318,23 @@ export const SelectSingleVariant: React.FC<SelectInputWidgetProps> = ({
           )}
         >
           {hasPrefix && (
-            <div className={cn("flex items-center px-3 bg-muted text-muted-foreground rounded-tl-[var(--radius-fields)] rounded-bl-[var(--radius-fields)]", !isOpen && "border-r border-input")}>
+            <div
+              className={cn(
+                "flex items-center px-3 bg-muted text-muted-foreground rounded-tl-[var(--radius-fields)] rounded-bl-[var(--radius-fields)]",
+                !isOpen && "border-r border-input",
+              )}
+            >
               {prefixContent}
             </div>
           )}
           <div className="flex-1 relative w-full">{selectContent}</div>
           {hasSuffix && (
-            <div className={cn("flex items-center px-3 bg-muted text-muted-foreground rounded-tr-[var(--radius-fields)] rounded-br-[var(--radius-fields)]", !isOpen && "border-l border-input")}>
+            <div
+              className={cn(
+                "flex items-center px-3 bg-muted text-muted-foreground rounded-tr-[var(--radius-fields)] rounded-br-[var(--radius-fields)]",
+                !isOpen && "border-l border-input",
+              )}
+            >
               {suffixContent}
             </div>
           )}

--- a/src/frontend/src/widgets/inputs/SelectSingleVariant.tsx
+++ b/src/frontend/src/widgets/inputs/SelectSingleVariant.tsx
@@ -318,13 +318,13 @@ export const SelectSingleVariant: React.FC<SelectInputWidgetProps> = ({
           )}
         >
           {hasPrefix && (
-            <div className="flex items-center px-3 bg-muted text-muted-foreground border-r border-input rounded-tl-[var(--radius-fields)] rounded-bl-[var(--radius-fields)]">
+            <div className={cn("flex items-center px-3 bg-muted text-muted-foreground rounded-tl-[var(--radius-fields)] rounded-bl-[var(--radius-fields)]", !isOpen && "border-r border-input")}>
               {prefixContent}
             </div>
           )}
           <div className="flex-1 relative w-full">{selectContent}</div>
           {hasSuffix && (
-            <div className="flex items-center px-3 bg-muted text-muted-foreground border-l border-input rounded-tr-[var(--radius-fields)] rounded-br-[var(--radius-fields)]">
+            <div className={cn("flex items-center px-3 bg-muted text-muted-foreground rounded-tr-[var(--radius-fields)] rounded-br-[var(--radius-fields)]", !isOpen && "border-l border-input")}>
               {suffixContent}
             </div>
           )}

--- a/src/frontend/src/widgets/inputs/TextInputWidget/variants/DefaultVariant.tsx
+++ b/src/frontend/src/widgets/inputs/TextInputWidget/variants/DefaultVariant.tsx
@@ -85,7 +85,7 @@ export const DefaultVariant: React.FC<DefaultVariantProps> = ({
       >
         {/* Prefix with background and separator */}
         {hasPrefix && (
-          <div className="flex items-center px-3 bg-muted text-muted-foreground border-r border-input rounded-tl-[var(--radius-fields)] rounded-bl-[var(--radius-fields)]">
+          <div className={cn("flex items-center px-3 bg-muted text-muted-foreground rounded-tl-[var(--radius-fields)] rounded-bl-[var(--radius-fields)]", !isFocused && "border-r border-input")}>
             {prefixContent}
           </div>
         )}
@@ -179,7 +179,7 @@ export const DefaultVariant: React.FC<DefaultVariantProps> = ({
 
         {/* Suffix with background and separator */}
         {hasSuffix && (
-          <div className="flex items-center px-3 bg-muted text-muted-foreground border-l border-input rounded-tr-[var(--radius-fields)] rounded-br-[var(--radius-fields)]">
+          <div className={cn("flex items-center px-3 bg-muted text-muted-foreground rounded-tr-[var(--radius-fields)] rounded-br-[var(--radius-fields)]", !isFocused && "border-l border-input")}>
             {suffixContent}
           </div>
         )}

--- a/src/frontend/src/widgets/inputs/TextInputWidget/variants/DefaultVariant.tsx
+++ b/src/frontend/src/widgets/inputs/TextInputWidget/variants/DefaultVariant.tsx
@@ -85,7 +85,12 @@ export const DefaultVariant: React.FC<DefaultVariantProps> = ({
       >
         {/* Prefix with background and separator */}
         {hasPrefix && (
-          <div className={cn("flex items-center px-3 bg-muted text-muted-foreground rounded-tl-[var(--radius-fields)] rounded-bl-[var(--radius-fields)]", !isFocused && "border-r border-input")}>
+          <div
+            className={cn(
+              "flex items-center px-3 bg-muted text-muted-foreground rounded-tl-[var(--radius-fields)] rounded-bl-[var(--radius-fields)]",
+              !isFocused && "border-r border-input",
+            )}
+          >
             {prefixContent}
           </div>
         )}
@@ -179,7 +184,12 @@ export const DefaultVariant: React.FC<DefaultVariantProps> = ({
 
         {/* Suffix with background and separator */}
         {hasSuffix && (
-          <div className={cn("flex items-center px-3 bg-muted text-muted-foreground rounded-tr-[var(--radius-fields)] rounded-br-[var(--radius-fields)]", !isFocused && "border-l border-input")}>
+          <div
+            className={cn(
+              "flex items-center px-3 bg-muted text-muted-foreground rounded-tr-[var(--radius-fields)] rounded-br-[var(--radius-fields)]",
+              !isFocused && "border-l border-input",
+            )}
+          >
             {suffixContent}
           </div>
         )}

--- a/src/frontend/src/widgets/inputs/TextInputWidget/variants/SearchVariant.tsx
+++ b/src/frontend/src/widgets/inputs/TextInputWidget/variants/SearchVariant.tsx
@@ -119,7 +119,7 @@ export const SearchVariant: React.FC<SearchVariantProps> = ({
         )}
       >
         {hasPrefix && (
-          <div className="flex items-center px-3 bg-muted text-muted-foreground border-r border-input rounded-tl-[var(--radius-fields)] rounded-bl-[var(--radius-fields)]">
+          <div className={cn("flex items-center px-3 bg-muted text-muted-foreground rounded-tl-[var(--radius-fields)] rounded-bl-[var(--radius-fields)]", !isFocused && "border-r border-input")}>
             {prefixContent}
           </div>
         )}
@@ -191,7 +191,7 @@ export const SearchVariant: React.FC<SearchVariantProps> = ({
         </div>
 
         {hasSuffix && (
-          <div className="flex items-center px-3 bg-muted text-muted-foreground border-l border-input rounded-tr-[var(--radius-fields)] rounded-br-[var(--radius-fields)]">
+          <div className={cn("flex items-center px-3 bg-muted text-muted-foreground rounded-tr-[var(--radius-fields)] rounded-br-[var(--radius-fields)]", !isFocused && "border-l border-input")}>
             {suffixContent}
           </div>
         )}

--- a/src/frontend/src/widgets/inputs/TextInputWidget/variants/SearchVariant.tsx
+++ b/src/frontend/src/widgets/inputs/TextInputWidget/variants/SearchVariant.tsx
@@ -119,7 +119,12 @@ export const SearchVariant: React.FC<SearchVariantProps> = ({
         )}
       >
         {hasPrefix && (
-          <div className={cn("flex items-center px-3 bg-muted text-muted-foreground rounded-tl-[var(--radius-fields)] rounded-bl-[var(--radius-fields)]", !isFocused && "border-r border-input")}>
+          <div
+            className={cn(
+              "flex items-center px-3 bg-muted text-muted-foreground rounded-tl-[var(--radius-fields)] rounded-bl-[var(--radius-fields)]",
+              !isFocused && "border-r border-input",
+            )}
+          >
             {prefixContent}
           </div>
         )}
@@ -191,7 +196,12 @@ export const SearchVariant: React.FC<SearchVariantProps> = ({
         </div>
 
         {hasSuffix && (
-          <div className={cn("flex items-center px-3 bg-muted text-muted-foreground rounded-tr-[var(--radius-fields)] rounded-br-[var(--radius-fields)]", !isFocused && "border-l border-input")}>
+          <div
+            className={cn(
+              "flex items-center px-3 bg-muted text-muted-foreground rounded-tr-[var(--radius-fields)] rounded-br-[var(--radius-fields)]",
+              !isFocused && "border-l border-input",
+            )}
+          >
             {suffixContent}
           </div>
         )}


### PR DESCRIPTION
# Summary

## Changes

Fixed a visual inconsistency where input widgets with affixes (prefix/suffix elements) displayed both an outer focus ring and competing internal separator borders simultaneously. The fix conditionally hides internal borders when inputs are focused or open, allowing the focus ring to be the dominant visual indicator.

## API Changes

None.

## Files Modified

- `src/frontend/src/widgets/inputs/TextInputWidget/variants/SearchVariant.tsx` — Updated prefix/suffix conditional borders based on `isFocused` state
- `src/frontend/src/widgets/inputs/TextInputWidget/variants/DefaultVariant.tsx` — Updated prefix/suffix conditional borders based on `isFocused` state
- `src/frontend/src/widgets/inputs/SelectSingleVariant.tsx` — Updated prefix/suffix conditional borders based on `isOpen` state
- `src/frontend/src/widgets/inputs/DateRangeInputWidget.tsx` — Updated prefix/suffix conditional borders based on `isOpen` state

## Commits

- 65ec0a851 [03339] Fix focus ring borders when using affixes in input widgets
- e3fa88179 [03339] Apply frontend formatting