### PR TITLE
[03350] Disable Continue button while checking

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Onboarding/SoftwareCheckStepView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Onboarding/SoftwareCheckStepView.cs
@@ -92,6 +92,7 @@ public class SoftwareCheckStepView(
                            .Primary()
                            .Large()
                            .Icon(Icons.ArrowRight, Align.Right)
+                           .Disabled(isChecking.Value)
                            .OnClick(() => stepperIndex.Set(stepperIndex.Value + 1))
                        : Text.Muted("Please Wait...")
                );


### PR DESCRIPTION
# Summary

## Changes

Added `.Disabled(isChecking.Value)` to the Continue button in the SoftwareCheckStepView. This prevents users from advancing to the next onboarding step while health checks are still running, ensuring validation completes before proceeding.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Apps/Onboarding/SoftwareCheckStepView.cs` — Added `.Disabled(isChecking.Value)` to Continue button (line 95)

## Commits

- [03350] Disable Continue button while checking (ab9327aa0)