### PR TITLE
[01100] Auth cookie prefix support in framework

### DIFF
--- a/src/Ivy.Tests/Auth/AuthCookiePrefixTests.cs
+++ b/src/Ivy.Tests/Auth/AuthCookiePrefixTests.cs
@@ -1,0 +1,69 @@
+using Ivy.Core.Auth;
+
+namespace Ivy.Tests.Auth;
+
+public class AuthCookiePrefixTests : IDisposable
+{
+    public AuthCookiePrefixTests()
+    {
+        Server.AuthCookiePrefix = null;
+    }
+
+    public void Dispose()
+    {
+        Server.AuthCookiePrefix = null;
+    }
+
+    [Fact]
+    public void PrefixCookieName_NoPrefix_ReturnsOriginalName()
+    {
+        Server.AuthCookiePrefix = null;
+        Assert.Equal("access_token", CookieRegistryExtensions.PrefixCookieName("access_token"));
+    }
+
+    [Fact]
+    public void PrefixCookieName_EmptyPrefix_ReturnsOriginalName()
+    {
+        Server.AuthCookiePrefix = "";
+        Assert.Equal("access_token", CookieRegistryExtensions.PrefixCookieName("access_token"));
+    }
+
+    [Fact]
+    public void PrefixCookieName_WithPrefix_ReturnsPrefixedName()
+    {
+        Server.AuthCookiePrefix = "clerk";
+        Assert.Equal("clerk__access_token", CookieRegistryExtensions.PrefixCookieName("access_token"));
+    }
+
+    [Fact]
+    public void PrefixCookieName_WithPrefix_AllCoreNames()
+    {
+        Server.AuthCookiePrefix = "basic";
+        Assert.Equal("basic__access_token", CookieRegistryExtensions.PrefixCookieName("access_token"));
+        Assert.Equal("basic__refresh_token", CookieRegistryExtensions.PrefixCookieName("refresh_token"));
+        Assert.Equal("basic__auth_tag", CookieRegistryExtensions.PrefixCookieName("auth_tag"));
+        Assert.Equal("basic__auth_session_data", CookieRegistryExtensions.PrefixCookieName("auth_session_data"));
+    }
+
+    [Fact]
+    public void PrefixCookieName_WithPrefix_BrokeredSessionCookies()
+    {
+        Server.AuthCookiePrefix = "clerk";
+        Assert.Equal("clerk__google_access_token", CookieRegistryExtensions.PrefixCookieName("google_access_token"));
+        Assert.Equal("clerk__google_refresh_token", CookieRegistryExtensions.PrefixCookieName("google_refresh_token"));
+        Assert.Equal("clerk__google_auth_tag", CookieRegistryExtensions.PrefixCookieName("google_auth_tag"));
+    }
+
+    [Fact]
+    public void PrefixCookieName_DoubleUnderscoreDelimiter_AvoidsSingleUnderscoreAmbiguity()
+    {
+        Server.AuthCookiePrefix = "app";
+        var prefixed = CookieRegistryExtensions.PrefixCookieName("google_access_token");
+        Assert.Equal("app__google_access_token", prefixed);
+        Assert.Contains("__", prefixed);
+        // The first __ separates prefix from cookie name
+        var parts = prefixed.Split("__", 2);
+        Assert.Equal("app", parts[0]);
+        Assert.Equal("google_access_token", parts[1]);
+    }
+}

--- a/src/Ivy.Tests/Auth/CookieRegistryExtensionsPrefixTests.cs
+++ b/src/Ivy.Tests/Auth/CookieRegistryExtensionsPrefixTests.cs
@@ -1,0 +1,102 @@
+using Ivy.Core.Auth;
+
+namespace Ivy.Tests.Auth;
+
+public class CookieRegistryExtensionsPrefixTests : IDisposable
+{
+    public CookieRegistryExtensionsPrefixTests()
+    {
+        Server.AuthCookiePrefix = null;
+    }
+
+    public void Dispose()
+    {
+        Server.AuthCookiePrefix = null;
+    }
+
+    [Fact]
+    public void AddCookiesForAuthToken_NoPrefix_UsesUnprefixedNames()
+    {
+        Server.AuthCookiePrefix = null;
+        var cookies = new CookieJar();
+        var token = new AuthToken("test-access", "test-refresh", "test-tag");
+
+        cookies.AddCookiesForAuthToken(token);
+
+        Assert.True(cookies.TryGet("access_token", out var accessToken));
+        Assert.Equal("test-access", accessToken);
+        Assert.True(cookies.TryGet("refresh_token", out var refreshToken));
+        Assert.Equal("test-refresh", refreshToken);
+        Assert.True(cookies.TryGet("auth_tag", out var tag));
+        Assert.Equal("test-tag", tag);
+    }
+
+    [Fact]
+    public void AddCookiesForAuthToken_WithPrefix_UsesPrefixedNames()
+    {
+        Server.AuthCookiePrefix = "clerk";
+        var cookies = new CookieJar();
+        var token = new AuthToken("test-access", "test-refresh", "test-tag");
+
+        cookies.AddCookiesForAuthToken(token);
+
+        Assert.True(cookies.TryGet("clerk__access_token", out var accessToken));
+        Assert.Equal("test-access", accessToken);
+        Assert.True(cookies.TryGet("clerk__refresh_token", out var refreshToken));
+        Assert.Equal("test-refresh", refreshToken);
+        Assert.True(cookies.TryGet("clerk__auth_tag", out var tag));
+        Assert.Equal("test-tag", tag);
+
+        // Should NOT have unprefixed cookies
+        Assert.False(cookies.TryGet("access_token", out _));
+    }
+
+    [Fact]
+    public void AddCookiesForAuthSessionData_WithPrefix_UsesPrefixedName()
+    {
+        Server.AuthCookiePrefix = "basic";
+        var cookies = new CookieJar();
+
+        cookies.AddCookiesForAuthSessionData("session-data-value");
+
+        Assert.True(cookies.TryGet("basic__auth_session_data", out var sessionData));
+        Assert.Equal("session-data-value", sessionData);
+        Assert.False(cookies.TryGet("auth_session_data", out _));
+    }
+
+    [Fact]
+    public void AddCookiesForBrokeredSessions_WithPrefix_UsesPrefixedNames()
+    {
+        Server.AuthCookiePrefix = "clerk";
+        var cookies = new CookieJar();
+        var brokeredSessions = new Dictionary<string, IAuthTokenHandlerSession>
+        {
+            ["google"] = new AuthTokenHandlerSession(authToken: new AuthToken("google-access", "google-refresh", "google-tag"))
+        };
+
+        cookies.AddCookiesForBrokeredSessions(brokeredSessions);
+
+        Assert.True(cookies.TryGet("clerk__google_access_token", out var accessToken));
+        Assert.Equal("google-access", accessToken);
+        Assert.True(cookies.TryGet("clerk__google_refresh_token", out var refreshToken));
+        Assert.Equal("google-refresh", refreshToken);
+        Assert.True(cookies.TryGet("clerk__google_auth_tag", out var tag));
+        Assert.Equal("google-tag", tag);
+
+        // Should NOT have unprefixed brokered cookies
+        Assert.False(cookies.TryGet("google_access_token", out _));
+    }
+
+    [Fact]
+    public void AddCookiesForAuthToken_NullToken_DeletesPrefixedNames()
+    {
+        Server.AuthCookiePrefix = "clerk";
+        var cookies = new CookieJar();
+
+        cookies.AddCookiesForAuthToken(null);
+
+        // Should attempt to delete prefixed cookies (CookieJar.Delete adds with empty value)
+        Assert.True(cookies.TryGet("clerk__access_token", out var value));
+        Assert.Equal(string.Empty, value); // Delete sets empty value
+    }
+}

--- a/src/Ivy/Core/Auth/AuthHelper.cs
+++ b/src/Ivy/Core/Auth/AuthHelper.cs
@@ -141,10 +141,12 @@ public static class AuthHelper
     private static (string? AccessToken, string? RefreshToken, string? Tag, string? AuthSessionData, Dictionary<string, IAuthTokenHandlerSession> BrokeredSessions) GetAuthCookies(HttpContext context)
     {
         var cookies = context.Request.Cookies;
-        var accessToken = cookies["access_token"].NullIfEmpty();
-        var refreshToken = cookies["refresh_token"].NullIfEmpty();
-        var tag = cookies["auth_tag"].NullIfEmpty();
-        var authSessionDataValue = cookies["auth_session_data"].NullIfEmpty();
+        var prefix = global::Ivy.Server.AuthCookiePrefix;
+        var pfx = string.IsNullOrEmpty(prefix) ? "" : $"{prefix}__";
+        var accessToken = cookies[$"{pfx}access_token"].NullIfEmpty();
+        var refreshToken = cookies[$"{pfx}refresh_token"].NullIfEmpty();
+        var tag = cookies[$"{pfx}auth_tag"].NullIfEmpty();
+        var authSessionDataValue = cookies[$"{pfx}auth_session_data"].NullIfEmpty();
 
         var brokeredSessions = ExtractBrokeredSessionsFromCookies(cookies);
 
@@ -161,10 +163,14 @@ public static class AuthHelper
 
         var cookieHeader = CookieHeaderValue.ParseList([cookies]).ToList();
 
+        var prefix = global::Ivy.Server.AuthCookiePrefix;
+        var pfx = string.IsNullOrEmpty(prefix) ? "" : $"{prefix}__";
+
         string? GetCookie(string name)
         {
+            var prefixedName = $"{pfx}{name}";
             var rawValue = cookieHeader
-                .FirstOrDefault(c => c.Name.Equals(name, StringComparison.OrdinalIgnoreCase))?.Value.Value;
+                .FirstOrDefault(c => c.Name.Equals(prefixedName, StringComparison.OrdinalIgnoreCase))?.Value.Value;
             return !string.IsNullOrEmpty(rawValue)
                 ? WebUtility.UrlDecode(rawValue)
                 : null;
@@ -202,16 +208,21 @@ public static class AuthHelper
     {
         var brokeredSessions = new Dictionary<string, IAuthTokenHandlerSession>();
 
-        // Discover OAuth provider cookies by scanning for the pattern: {provider}_access_token
+        var prefix = global::Ivy.Server.AuthCookiePrefix;
+        var pfx = string.IsNullOrEmpty(prefix) ? "" : $"{prefix}__";
+        var suffix = "_access_token";
+        var fullPrimaryName = $"{pfx}access_token";
+
         var accessTokenCookies = cookies.Keys
-            .Where(key => key.EndsWith("_access_token") && key != "access_token")
+            .Where(key => key.StartsWith(pfx) && key.EndsWith(suffix) && key != fullPrimaryName)
             .ToList();
 
         foreach (var accessTokenName in accessTokenCookies)
         {
-            var provider = accessTokenName[..^"_access_token".Length];
-            var refreshTokenName = $"{provider}_refresh_token";
-            var tagName = $"{provider}_auth_tag";
+            var unprefixed = accessTokenName[pfx.Length..];
+            var provider = unprefixed[..^suffix.Length];
+            var refreshTokenName = $"{pfx}{provider}_refresh_token";
+            var tagName = $"{pfx}{provider}_auth_tag";
 
             var accessToken = cookies[accessTokenName].NullIfEmpty();
             if (accessToken == null)
@@ -234,6 +245,11 @@ public static class AuthHelper
     {
         var brokeredSessions = new Dictionary<string, IAuthTokenHandlerSession>();
 
+        var prefix = global::Ivy.Server.AuthCookiePrefix;
+        var pfx = string.IsNullOrEmpty(prefix) ? "" : $"{prefix}__";
+        var suffix = "_access_token";
+        var fullPrimaryName = $"{pfx}access_token";
+
         string? GetCookie(string name)
         {
             var rawValue = cookieHeader
@@ -243,17 +259,17 @@ public static class AuthHelper
                 : null;
         }
 
-        // Discover OAuth provider cookies by scanning for the pattern: {provider}_access_token
         var accessTokenCookies = cookieHeader
-            .Where(c => c.Name.Value != null && c.Name.Value.EndsWith("_access_token") && c.Name.Value != "access_token")
+            .Where(c => c.Name.Value != null && c.Name.Value.StartsWith(pfx) && c.Name.Value.EndsWith(suffix) && c.Name.Value != fullPrimaryName)
             .Select(c => c.Name.Value!)
             .ToList();
 
         foreach (var accessTokenName in accessTokenCookies)
         {
-            var provider = accessTokenName[..^"_access_token".Length];
-            var refreshTokenName = $"{provider}_refresh_token";
-            var tagName = $"{provider}_auth_tag";
+            var unprefixed = accessTokenName[pfx.Length..];
+            var provider = unprefixed[..^suffix.Length];
+            var refreshTokenName = $"{pfx}{provider}_refresh_token";
+            var tagName = $"{pfx}{provider}_auth_tag";
 
             var accessToken = GetCookie(accessTokenName);
             if (accessToken == null)

--- a/src/Ivy/Core/Auth/CookieRegistryExtensions.cs
+++ b/src/Ivy/Core/Auth/CookieRegistryExtensions.cs
@@ -45,9 +45,9 @@ public static class CookieRegistryExtensions
             var cookieOptions = CreateAuthCookieOptions();
             foreach (var provider in removedProviders)
             {
-                cookies.Delete($"{provider}_access_token", cookieOptions);
-                cookies.Delete($"{provider}_refresh_token", cookieOptions);
-                cookies.Delete($"{provider}_auth_tag", cookieOptions);
+                cookies.Delete(PrefixCookieName($"{provider}_access_token"), cookieOptions);
+                cookies.Delete(PrefixCookieName($"{provider}_refresh_token"), cookieOptions);
+                cookies.Delete(PrefixCookieName($"{provider}_auth_tag"), cookieOptions);
             }
         }
 
@@ -70,9 +70,9 @@ public static class CookieRegistryExtensions
 
     public static void AddCookiesForAuthToken(this CookieJar cookies, AuthToken? authToken, IEnumerable<string>? sessionsToDelete = null)
     {
-        var authTokenName = "access_token";
-        var refreshTokenName = "refresh_token";
-        var tagName = "auth_tag";
+        var authTokenName = PrefixCookieName("access_token");
+        var refreshTokenName = PrefixCookieName("refresh_token");
+        var tagName = PrefixCookieName("auth_tag");
 
         if (string.IsNullOrEmpty(authToken?.AccessToken))
         {
@@ -86,9 +86,9 @@ public static class CookieRegistryExtensions
                 var cookieOptions = CreateAuthCookieOptions();
                 foreach (var provider in sessionsToDelete)
                 {
-                    cookies.Delete($"{provider}_access_token", cookieOptions);
-                    cookies.Delete($"{provider}_refresh_token", cookieOptions);
-                    cookies.Delete($"{provider}_auth_tag", cookieOptions);
+                    cookies.Delete(PrefixCookieName($"{provider}_access_token"), cookieOptions);
+                    cookies.Delete(PrefixCookieName($"{provider}_refresh_token"), cookieOptions);
+                    cookies.Delete(PrefixCookieName($"{provider}_auth_tag"), cookieOptions);
                 }
             }
         }
@@ -120,7 +120,7 @@ public static class CookieRegistryExtensions
 
     public static void AddCookiesForAuthSessionData(this CookieJar cookies, string? authSessionData)
     {
-        var authSessionDataName = "auth_session_data";
+        var authSessionDataName = PrefixCookieName("auth_session_data");
 
         var cookieOptions = CreateAuthCookieOptions(forceLaxSameSite: true);
         if (authSessionData == null)
@@ -139,9 +139,9 @@ public static class CookieRegistryExtensions
 
         foreach (var (provider, session) in brokeredSessions)
         {
-            var accessTokenName = $"{provider}_access_token";
-            var refreshTokenName = $"{provider}_refresh_token";
-            var tagName = $"{provider}_auth_tag";
+            var accessTokenName = PrefixCookieName($"{provider}_access_token");
+            var refreshTokenName = PrefixCookieName($"{provider}_refresh_token");
+            var tagName = PrefixCookieName($"{provider}_auth_tag");
 
             // Store access token
             if (!string.IsNullOrEmpty(session.AuthToken?.AccessToken))
@@ -173,6 +173,12 @@ public static class CookieRegistryExtensions
                 cookies.Delete(tagName, CreateAuthCookieOptions());
             }
         }
+    }
+
+    internal static string PrefixCookieName(string name)
+    {
+        var prefix = global::Ivy.Server.AuthCookiePrefix;
+        return string.IsNullOrEmpty(prefix) ? name : $"{prefix}__{name}";
     }
 
     private static CookieOptions CreateAuthCookieOptions(bool forceLaxSameSite = false)

--- a/src/Ivy/Server.cs
+++ b/src/Ivy/Server.cs
@@ -85,6 +85,7 @@ public class Server
     public Type? AuthProviderType { get; private set; } = null;
     public ServerArgs Args => _args;
     public static Action<CookieOptions>? ConfigureAuthCookieOptions { get; set; }
+    public static string? AuthCookiePrefix { get; set; }
     private IContentBuilder? _contentBuilder;
     private bool _useHotReload;
     private bool _useHttpRedirection;


### PR DESCRIPTION
# Summary

## Changes

Added `Server.AuthCookiePrefix` static property that, when set, prefixes all auth cookie names with a double-underscore (`__`) delimiter. This allows multiple Ivy auth apps to coexist on the same domain without cookie collisions. When the prefix is null or empty, behavior is unchanged.

## API Changes

- `Server.AuthCookiePrefix` (new static property, `string?`) -- set to a unique identifier per app (e.g., `"clerk"`, `"basic"`) to namespace auth cookies
- `CookieRegistryExtensions.PrefixCookieName(string name)` (new internal static method) -- resolves a cookie name with the configured prefix

## Files Modified

- **Core auth:**
  - `src/Ivy/Server.cs` -- added `AuthCookiePrefix` property
  - `src/Ivy/Core/Auth/CookieRegistryExtensions.cs` -- added `PrefixCookieName` helper, updated all cookie write/delete operations
  - `src/Ivy/Core/Auth/AuthHelper.cs` -- updated all cookie read operations (HttpContext, gRPC, brokered session discovery)

- **Tests:**
  - `src/Ivy.Tests/Auth/AuthCookiePrefixTests.cs` -- unit tests for `PrefixCookieName`
  - `src/Ivy.Tests/Auth/CookieRegistryExtensionsPrefixTests.cs` -- integration tests for prefixed cookie writing

## Commits

- 3b0422b2e [01100] Add Server.AuthCookiePrefix property for auth cookie namespacing