### PR TITLE
[01108] Adopt cookie prefixes in auth examples

### DIFF
--- a/src/auth/examples/Auth0Example/Program.cs
+++ b/src/auth/examples/Auth0Example/Program.cs
@@ -15,4 +15,6 @@ server.UseAppShell(settings);
 
 server.SetMetaTitle("Auth0 Example");
 
+Server.AuthCookiePrefix = "auth0";
+
 await server.RunAsync();

--- a/src/auth/examples/AutheliaExample/Program.cs
+++ b/src/auth/examples/AutheliaExample/Program.cs
@@ -15,4 +15,6 @@ server.UseAppShell(settings);
 
 server.SetMetaTitle("Authelia Example");
 
+Server.AuthCookiePrefix = "authelia";
+
 await server.RunAsync();

--- a/src/auth/examples/BasicAuthExample/Program.cs
+++ b/src/auth/examples/BasicAuthExample/Program.cs
@@ -15,4 +15,6 @@ server.UseAppShell(settings);
 
 server.SetMetaTitle("BasicAuth Example");
 
+Server.AuthCookiePrefix = "basic";
+
 await server.RunAsync();

--- a/src/auth/examples/ClerkExample/Program.cs
+++ b/src/auth/examples/ClerkExample/Program.cs
@@ -16,6 +16,8 @@ server.UseAppShell(settings);
 
 server.SetMetaTitle("Clerk Example");
 
+Server.AuthCookiePrefix = "clerk";
+
 server.UseConfiguration(config =>
 {
     if (ProcessHelper.IsProduction())

--- a/src/auth/examples/GitHubExample/Program.cs
+++ b/src/auth/examples/GitHubExample/Program.cs
@@ -15,4 +15,6 @@ server.UseAppShell(settings);
 
 server.SetMetaTitle("GitHub Example");
 
+Server.AuthCookiePrefix = "github";
+
 await server.RunAsync();

--- a/src/auth/examples/MicrosoftEntraExample/Program.cs
+++ b/src/auth/examples/MicrosoftEntraExample/Program.cs
@@ -15,4 +15,6 @@ server.UseAppShell(settings);
 
 server.SetMetaTitle("Microsoft Entra Example");
 
+Server.AuthCookiePrefix = "entra";
+
 await server.RunAsync();

--- a/src/auth/examples/SliplaneExample/Program.cs
+++ b/src/auth/examples/SliplaneExample/Program.cs
@@ -16,5 +16,7 @@ server.UseAppShell(settings);
 
 server.SetMetaTitle("Sliplane Example");
 
+Server.AuthCookiePrefix = "sliplane";
+
 await server.RunAsync();
 

--- a/src/auth/examples/SupabaseExample/Program.cs
+++ b/src/auth/examples/SupabaseExample/Program.cs
@@ -15,4 +15,6 @@ server.UseAppShell(settings);
 
 server.SetMetaTitle("Supabase Example");
 
+Server.AuthCookiePrefix = "supabase";
+
 await server.RunAsync();


### PR DESCRIPTION
## Problem

The authentication examples in src/auth/examples do not configure cookie prefixes. When developers run multiple auth examples simultaneously on localhost (e.g., on different ports), the authentication cookies collide because they share the same domain and cookie names. This causes login conflicts and confusing authentication state across examples.

The `Server.AuthCookiePrefix` property was recently added (plan 01100) to solve this problem by namespacing authentication cookies. The documentation explains that setting a prefix (e.g., `Server.AuthCookiePrefix = "clerk"`) isolates each app's cookies using a double-underscore delimiter (`clerk__access_token`, `clerk__refresh_token`, etc.).

The auth examples should demonstrate this best practice by configuring appropriate cookie prefixes.

## Solution

Add `Server.AuthCookiePrefix` configuration to each auth example's Program.cs file. The prefix should be set before `server.RunAsync()` is called and should match the provider name in lowercase.

**Changes made:**

1. **Auth0Example/Program.cs** - Added `Server.AuthCookiePrefix = "auth0";`
2. **AutheliaExample/Program.cs** - Added `Server.AuthCookiePrefix = "authelia";`
3. **BasicAuthExample/Program.cs** - Added `Server.AuthCookiePrefix = "basic";`
4. **ClerkExample/Program.cs** - Added `Server.AuthCookiePrefix = "clerk";`
5. **GitHubExample/Program.cs** - Added `Server.AuthCookiePrefix = "github";`
6. **MicrosoftEntraExample/Program.cs** - Added `Server.AuthCookiePrefix = "entra";`
7. **SliplaneExample/Program.cs** - Added `Server.AuthCookiePrefix = "sliplane";`
8. **SupabaseExample/Program.cs** - Added `Server.AuthCookiePrefix = "supabase";`

## Commits

- 45f025d26 [01108] Add AuthCookiePrefix to all auth examples