### PR TITLE
[01110] Fix auth cookie prefix filtering in brokered session extraction

### DIFF
--- a/src/Ivy.Tests/Auth/AuthCookiePrefixTests.cs
+++ b/src/Ivy.Tests/Auth/AuthCookiePrefixTests.cs
@@ -2,6 +2,7 @@ using Ivy.Core.Auth;
 
 namespace Ivy.Tests.Auth;
 
+[Collection("AuthCookiePrefix")]
 public class AuthCookiePrefixTests : IDisposable
 {
     public AuthCookiePrefixTests()

--- a/src/Ivy.Tests/Auth/AuthHelperBrokeredSessionTests.cs
+++ b/src/Ivy.Tests/Auth/AuthHelperBrokeredSessionTests.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 using Ivy.Core.Auth;
 using Microsoft.AspNetCore.Http;

--- a/src/Ivy.Tests/Auth/AuthHelperBrokeredSessionTests.cs
+++ b/src/Ivy.Tests/Auth/AuthHelperBrokeredSessionTests.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Ivy.Core.Auth;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
 
 namespace Ivy.Tests.Auth;

--- a/src/Ivy.Tests/Auth/AuthHelperBrokeredSessionTests.cs
+++ b/src/Ivy.Tests/Auth/AuthHelperBrokeredSessionTests.cs
@@ -7,6 +7,7 @@ using Microsoft.Net.Http.Headers;
 
 namespace Ivy.Tests.Auth;
 
+[Collection("AuthCookiePrefix")]
 public class AuthHelperBrokeredSessionTests : IDisposable
 {
     public AuthHelperBrokeredSessionTests()

--- a/src/Ivy.Tests/Auth/AuthHelperBrokeredSessionTests.cs
+++ b/src/Ivy.Tests/Auth/AuthHelperBrokeredSessionTests.cs
@@ -1,0 +1,159 @@
+using System.Collections;
+using System.Diagnostics.CodeAnalysis;
+using Ivy.Core.Auth;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
+using Microsoft.Net.Http.Headers;
+
+namespace Ivy.Tests.Auth;
+
+public class AuthHelperBrokeredSessionTests : IDisposable
+{
+    public AuthHelperBrokeredSessionTests()
+    {
+        Server.AuthCookiePrefix = null;
+    }
+
+    public void Dispose()
+    {
+        Server.AuthCookiePrefix = null;
+    }
+
+    [Fact]
+    public void ExtractBrokeredSessionsFromCookies_WithPrefix_IgnoresCookiesFromOtherPrefixes()
+    {
+        Server.AuthCookiePrefix = "clerk";
+        var cookies = new TestRequestCookieCollection(new Dictionary<string, string>
+        {
+            ["clerk__access_token"] = "clerk-main-token",
+            ["clerk__google_access_token"] = "clerk-google-token",
+            ["basic__access_token"] = "basic-main-token",
+            ["basic__github_access_token"] = "basic-github-token",
+        });
+
+        var result = AuthHelper.ExtractBrokeredSessionsFromCookies(cookies);
+
+        Assert.Single(result);
+        Assert.True(result.ContainsKey("google"));
+        Assert.False(result.ContainsKey("basic_"));
+        Assert.False(result.ContainsKey("github"));
+    }
+
+    [Fact]
+    public void ExtractBrokeredSessionsFromCookies_WithPrefix_ExtractsOwnPrefixedCookies()
+    {
+        Server.AuthCookiePrefix = "clerk";
+        var cookies = new TestRequestCookieCollection(new Dictionary<string, string>
+        {
+            ["clerk__access_token"] = "clerk-main-token",
+            ["clerk__google_access_token"] = "google-token",
+            ["clerk__github_access_token"] = "github-token",
+        });
+
+        var result = AuthHelper.ExtractBrokeredSessionsFromCookies(cookies);
+
+        Assert.Equal(2, result.Count);
+        Assert.True(result.ContainsKey("google"));
+        Assert.True(result.ContainsKey("github"));
+    }
+
+    [Fact]
+    public void ExtractBrokeredSessionsFromCookies_NoPrefix_ExtractsAllAccessTokenCookies()
+    {
+        Server.AuthCookiePrefix = null;
+        var cookies = new TestRequestCookieCollection(new Dictionary<string, string>
+        {
+            ["access_token"] = "main-token",
+            ["google_access_token"] = "google-token",
+            ["github_access_token"] = "github-token",
+        });
+
+        var result = AuthHelper.ExtractBrokeredSessionsFromCookies(cookies);
+
+        Assert.Equal(2, result.Count);
+        Assert.True(result.ContainsKey("google"));
+        Assert.True(result.ContainsKey("github"));
+    }
+
+    [Fact]
+    public void ExtractBrokeredSessionsFromCookieHeader_WithPrefix_IgnoresCookiesFromOtherPrefixes()
+    {
+        Server.AuthCookiePrefix = "clerk";
+        var cookieHeader = CookieHeaderValue.ParseList(new[]
+        {
+            "clerk__access_token=clerk-main-token; clerk__google_access_token=clerk-google-token; basic__access_token=basic-main-token; basic__github_access_token=basic-github-token"
+        }).ToList();
+
+        var result = AuthHelper.ExtractBrokeredSessionsFromCookieHeader(cookieHeader);
+
+        Assert.Single(result);
+        Assert.True(result.ContainsKey("google"));
+        Assert.False(result.ContainsKey("basic_"));
+        Assert.False(result.ContainsKey("github"));
+    }
+
+    [Fact]
+    public void ExtractBrokeredSessionsFromCookieHeader_WithPrefix_ExtractsOwnPrefixedCookies()
+    {
+        Server.AuthCookiePrefix = "clerk";
+        var cookieHeader = CookieHeaderValue.ParseList(new[]
+        {
+            "clerk__access_token=clerk-main-token; clerk__google_access_token=google-token; clerk__github_access_token=github-token"
+        }).ToList();
+
+        var result = AuthHelper.ExtractBrokeredSessionsFromCookieHeader(cookieHeader);
+
+        Assert.Equal(2, result.Count);
+        Assert.True(result.ContainsKey("google"));
+        Assert.True(result.ContainsKey("github"));
+    }
+
+    [Fact]
+    public void ExtractBrokeredSessionsFromCookieHeader_NoPrefix_ExtractsAllAccessTokenCookies()
+    {
+        Server.AuthCookiePrefix = null;
+        var cookieHeader = CookieHeaderValue.ParseList(new[]
+        {
+            "access_token=main-token; google_access_token=google-token; github_access_token=github-token"
+        }).ToList();
+
+        var result = AuthHelper.ExtractBrokeredSessionsFromCookieHeader(cookieHeader);
+
+        Assert.Equal(2, result.Count);
+        Assert.True(result.ContainsKey("google"));
+        Assert.True(result.ContainsKey("github"));
+    }
+
+    private class TestRequestCookieCollection : IRequestCookieCollection
+    {
+        private readonly Dictionary<string, string> _cookies;
+
+        public TestRequestCookieCollection(Dictionary<string, string> cookies)
+        {
+            _cookies = cookies;
+        }
+
+        public string? this[string key] => _cookies.TryGetValue(key, out var value) ? value : null;
+
+        public int Count => _cookies.Count;
+
+        public ICollection<string> Keys => _cookies.Keys;
+
+        public bool ContainsKey(string key) => _cookies.ContainsKey(key);
+
+        public bool TryGetValue(string key, [NotNullWhen(true)] out string? value)
+        {
+            if (_cookies.TryGetValue(key, out var v))
+            {
+                value = v;
+                return true;
+            }
+            value = null;
+            return false;
+        }
+
+        public IEnumerator<KeyValuePair<string, string>> GetEnumerator() => _cookies.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/src/Ivy.Tests/Auth/AuthHelperBrokeredSessionTests.cs
+++ b/src/Ivy.Tests/Auth/AuthHelperBrokeredSessionTests.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 using Ivy.Core.Auth;
 using Microsoft.AspNetCore.Http;

--- a/src/Ivy.Tests/Auth/CookieRegistryExtensionsPrefixTests.cs
+++ b/src/Ivy.Tests/Auth/CookieRegistryExtensionsPrefixTests.cs
@@ -2,6 +2,7 @@ using Ivy.Core.Auth;
 
 namespace Ivy.Tests.Auth;
 
+[Collection("AuthCookiePrefix")]
 public class CookieRegistryExtensionsPrefixTests : IDisposable
 {
     public CookieRegistryExtensionsPrefixTests()

--- a/src/Ivy/Core/Auth/AuthHelper.cs
+++ b/src/Ivy/Core/Auth/AuthHelper.cs
@@ -199,29 +199,24 @@ public static class AuthHelper
         }
     }
 
-    private static Dictionary<string, IAuthTokenHandlerSession> ExtractBrokeredSessionsFromCookies(IRequestCookieCollection cookies)
+    internal static Dictionary<string, IAuthTokenHandlerSession> ExtractBrokeredSessionsFromCookies(IRequestCookieCollection cookies)
     {
         var brokeredSessions = new Dictionary<string, IAuthTokenHandlerSession>();
 
         var primaryAccessToken = CookieRegistryExtensions.PrefixCookieName("access_token");
         var suffix = "_access_token";
+        var prefix = primaryAccessToken[..^"access_token".Length];
 
         var accessTokenCookies = cookies.Keys
-            .Where(key => key.EndsWith(suffix) && key != primaryAccessToken)
+            .Where(key => key.EndsWith(suffix)
+                && key != primaryAccessToken
+                && (prefix.Length == 0 || key.StartsWith(prefix)))
             .ToList();
 
         foreach (var accessTokenName in accessTokenCookies)
         {
             // Extract provider by removing prefix and suffix
-            var cookieName = accessTokenName;
-
-            // Strip prefix if present
-            var prefixLength = primaryAccessToken.Length - "access_token".Length;
-            if (prefixLength > 0 && cookieName.StartsWith(primaryAccessToken[..prefixLength]))
-            {
-                cookieName = cookieName[prefixLength..];
-            }
-
+            var cookieName = prefix.Length > 0 ? accessTokenName[prefix.Length..] : accessTokenName;
             var provider = cookieName[..^suffix.Length];
 
             var accessToken = cookies[accessTokenName].NullIfEmpty();
@@ -241,7 +236,7 @@ public static class AuthHelper
         return brokeredSessions;
     }
 
-    private static Dictionary<string, IAuthTokenHandlerSession> ExtractBrokeredSessionsFromCookieHeader(List<CookieHeaderValue> cookieHeader)
+    internal static Dictionary<string, IAuthTokenHandlerSession> ExtractBrokeredSessionsFromCookieHeader(List<CookieHeaderValue> cookieHeader)
     {
         var brokeredSessions = new Dictionary<string, IAuthTokenHandlerSession>();
 
@@ -256,24 +251,20 @@ public static class AuthHelper
 
         var primaryAccessToken = CookieRegistryExtensions.PrefixCookieName("access_token");
         var suffix = "_access_token";
+        var prefix = primaryAccessToken[..^"access_token".Length];
 
         var accessTokenCookies = cookieHeader
-            .Where(c => c.Name.Value != null && c.Name.Value.EndsWith(suffix) && c.Name.Value != primaryAccessToken)
+            .Where(c => c.Name.Value != null
+                && c.Name.Value.EndsWith(suffix)
+                && c.Name.Value != primaryAccessToken
+                && (prefix.Length == 0 || c.Name.Value.StartsWith(prefix)))
             .Select(c => c.Name.Value!)
             .ToList();
 
         foreach (var accessTokenName in accessTokenCookies)
         {
             // Extract provider by removing prefix and suffix
-            var cookieName = accessTokenName;
-
-            // Strip prefix if present
-            var prefixLength = primaryAccessToken.Length - "access_token".Length;
-            if (prefixLength > 0 && cookieName.StartsWith(primaryAccessToken[..prefixLength]))
-            {
-                cookieName = cookieName[prefixLength..];
-            }
-
+            var cookieName = prefix.Length > 0 ? accessTokenName[prefix.Length..] : accessTokenName;
             var provider = cookieName[..^suffix.Length];
 
             var accessToken = GetCookie(accessTokenName);


### PR DESCRIPTION
## Problem

After [Plan 01104](https://github.com/Ivy-Interactive/Ivy-Framework/pull?q=01104) refactored `AuthHelper.cs` to use the `PrefixCookieName()` method, the brokered session extraction methods lost their prefix-based cookie filtering. The original code filtered cookies with `key.StartsWith(pfx)`, but the refactored version only checks `key.EndsWith(suffix)`.

This causes cross-contamination when running multiple auth example apps in the same browser. For example:
1. Log into BasicAuthExample (prefix: `basic`) — sets cookie `basic__access_token`
2. Switch to ClerkExample (prefix: `clerk`) — its `ExtractBrokeredSessionsFromCookies()` finds `basic__access_token` because it ends with `_access_token`
3. The prefix stripping logic uses the *current* app's prefix length (8 chars for "clerk__"), but the cookie has a *different* prefix ("basic__")
4. For `basic__access_token`, the prefix doesn't match so it isn't stripped, yielding provider name `"basic_"` (the full cookie minus `_access_token`)
5. No handler exists for provider `"basic_"`, causing repeated warnings and errors

**Affected code:** Both `ExtractBrokeredSessionsFromCookies()` (line 202) and `ExtractBrokeredSessionsFromCookieHeader()` (line 244) in `src/Ivy/Core/Auth/AuthHelper.cs`.

## Solution

Re-add prefix filtering to both extraction methods. When a prefix is configured, only consider cookies that start with the current app's prefix. Cookies from other prefixes should be silently ignored.

**Changes:**

1. **`ExtractBrokeredSessionsFromCookies()` (line 206-211):** Add prefix filtering to the LINQ query. Compute the prefix string from the primary access token. Add a `key.StartsWith(prefix)` check when a prefix is configured.

2. **`ExtractBrokeredSessionsFromCookieHeader()` (line 257-263):** Apply the same prefix filtering.

This restores the prefix-scoping behavior that existed before the [01104] refactor, while keeping the `PrefixCookieName()` usage.

## Commits

- b94afce0a [01110] Add Collection attribute to prevent auth cookie test parallelism
- caa87a7a4 [01110] Fix auth cookie prefix filtering in brokered session extraction