### PR TITLE
[03353] Remove date and time from Recommendations UI

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/Recommendations/ContentView.cs
+++ b/src/tendril/Ivy.Tendril/Apps/Recommendations/ContentView.cs
@@ -70,8 +70,7 @@ public class ContentView(
 
         // Source plan info and Impact/Risk badges
         var metaRow = Layout.Horizontal().Gap(2).AlignContent(Align.Center)
-                      | Text.Muted($"Plan #{_selected.PlanId}: {_selected.PlanTitle}")
-                      | Text.Muted($"Date: {_selected.Date:yyyy-MM-dd HH:mm}");
+                      | Text.Muted($"Plan #{_selected.PlanId}: {_selected.PlanTitle}");
 
         if (_selected.Impact is { } impact)
             metaRow |= new Badge($"Impact: {impact}").Variant(impact switch


### PR DESCRIPTION
# Summary

## Changes

Removed the date and time display line from the Recommendations UI source plan metadata section. The change simplifies the UI by removing unnecessary temporal information, keeping only the plan reference number/title and optional Impact/Risk badges.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Apps/Recommendations/ContentView.cs` — Removed date/time Text.Muted line from metaRow layout (line 74)

## Commits

- 13c4fe1a0025d141a822a4da9e7cfa38c6c6834c