### PR TITLE
[03348] Remove repository overlap blocking from MakePlan

### DIFF
--- a/src/tendril/Ivy.Tendril/Promptwares/MakePlan/MakePlan.ps1
+++ b/src/tendril/Ivy.Tendril/Promptwares/MakePlan/MakePlan.ps1
@@ -62,12 +62,6 @@ if ($Description -notmatch '\[FORCE\]') {
     }
 }
 
-$activePlans = & "$programFolder/Tools/Find-ActivePlans.ps1" `
-    -PlansDirectory $script:PlansDir -Repos $repos
-if ($activePlans) {
-    $firmwareValues["ActivePlans"] = $activePlans
-}
-
 $promptFile = PrepareFirmware $PSScriptRoot $logFile $programFolder $firmwareValues
 
 $agent = GetAgentCommand -Promptware "MakePlan"

--- a/src/tendril/Ivy.Tendril/Promptwares/MakePlan/Program.md
+++ b/src/tendril/Ivy.Tendril/Promptwares/MakePlan/Program.md
@@ -122,13 +122,6 @@ The plan ID is pre-allocated by the launcher script and provided in the firmware
   gh search issues "<keyword>" --repo <owner>/<repo> --json title,url,number,state
   ```
   Derive the repo owner/name from the repos in `config.yaml`. If an issue already covers the task, reference it in the plan and avoid creating workaround plans.
-- **Check for concurrent active plans on overlapping repos.** Check the `ActivePlans` firmware value. If present, it contains plans in Building/Executing state (format: `folderName|title|state|repos` per line). After determining this plan's repos, check for overlap with the listed active plans. If `ActivePlans` is absent, no active plans were found — skip this check.
-
-  If overlapping active plans are found, add a warning to the `## Questions` section of the plan revision:
-
-  > **Warning:** Plans \<IDs\> are currently executing on overlapping repositories. Review their changes before executing this plan to avoid conflicts.
-
-  This makes concurrent execution visible so the reviewer can decide whether to wait or proceed.
 
 ### 3.5. Validate Code State
 


### PR DESCRIPTION
# Summary

## Changes

Removed repository overlap blocking from MakePlan while preserving explicit `dependsOn` dependency blocking in ExecutePlan. This eliminates unnecessary friction when multiple independent plans execute on the same repository, relying instead on explicit dependency declarations for true blocking relationships.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Promptwares/MakePlan/MakePlan.ps1` — Removed call to `Find-ActivePlans.ps1` that populated the `ActivePlans` firmware value
- `src/tendril/Ivy.Tendril/Promptwares/MakePlan/Program.md` — Removed instruction for checking concurrent active plans on overlapping repos


## Commits

- 59a8a1fea