### PR TITLE
[01510] Extract density gap class to shared utility

### DIFF
--- a/src/frontend/src/components/ui/density-scale.ts
+++ b/src/frontend/src/components/ui/density-scale.ts
@@ -17,3 +17,9 @@ export const densityText = {
   Medium: "text-sm",
   Large: "text-base",
 } as const;
+
+export const densityTreeGap = {
+  Small: "gap-0.5",
+  Medium: "gap-1",
+  Large: "gap-1.5",
+} as const;

--- a/src/frontend/src/widgets/tree/TreeItem.tsx
+++ b/src/frontend/src/widgets/tree/TreeItem.tsx
@@ -6,6 +6,7 @@ import { cn } from "@/lib/utils";
 import { MenuItem } from "@/types/widgets";
 import { ActionRenderer } from "@/widgets/rowAction";
 import { Densities } from "@/types/density";
+import { densityTreeGap } from "@/components/ui/density-scale";
 
 interface TreeItemWidgetProps {
   item: MenuItem;
@@ -28,8 +29,7 @@ export const TreeItem: React.FC<TreeItemWidgetProps> = ({
 }) => {
   const [isOpen, setIsOpen] = React.useState(item.expanded ?? false);
   const hasChildren = item.children && item.children.length > 0;
-  const gapClass =
-    density === Densities.Small ? "gap-0.5" : density === Densities.Large ? "gap-1.5" : "gap-1";
+  const gapClass = densityTreeGap[density ?? Densities.Medium];
 
   React.useEffect(() => {
     setIsOpen(item.expanded ?? false);

--- a/src/frontend/src/widgets/tree/TreeWidget.tsx
+++ b/src/frontend/src/widgets/tree/TreeWidget.tsx
@@ -4,6 +4,7 @@ import { MenuItem } from "@/types/widgets";
 import { TreeItem } from "./TreeItem";
 import { useEventHandler } from "@/components/event-handler";
 import { Densities } from "@/types/density";
+import { densityTreeGap } from "@/components/ui/density-scale";
 
 const EMPTY_ARRAY: never[] = [];
 
@@ -47,8 +48,7 @@ export const TreeWidget: React.FC<TreeWidgetProps> = ({
     [eventHandler, id, events],
   );
 
-  const gapClass =
-    density === Densities.Small ? "gap-0.5" : density === Densities.Large ? "gap-1.5" : "gap-1";
+  const gapClass = densityTreeGap[density];
 
   return (
     <div className={cn("ivy-tree flex flex-col w-full", gapClass)} role="tree">


### PR DESCRIPTION
## Summary

### Changes

Extracted the duplicated density-to-gap-class ternary from `TreeWidget.tsx` and `TreeItem.tsx` into a shared `densityTreeGap` constant in `density-scale.ts`. Both tree files now use a simple map lookup instead of inline ternaries, eliminating drift risk.

### API Changes

- **New export:** `densityTreeGap` from `src/frontend/src/components/ui/density-scale.ts` — maps `Densities` enum keys to Tailwind gap classes (`gap-0.5`, `gap-1`, `gap-1.5`).

### Files Modified

- `src/frontend/src/components/ui/density-scale.ts` — added `densityTreeGap` constant
- `src/frontend/src/widgets/tree/TreeWidget.tsx` — replaced inline ternary with `densityTreeGap[density]`
- `src/frontend/src/widgets/tree/TreeItem.tsx` — replaced inline ternary with `densityTreeGap[density ?? Densities.Medium]`

## Commits

- b75112ca3 — [01510] Extract density gap class to shared densityTreeGap utility