### PR TITLE
[01515] Add bottom margin to tree item children container

### DIFF
--- a/src/frontend/src/widgets/tree/TreeItem.tsx
+++ b/src/frontend/src/widgets/tree/TreeItem.tsx
@@ -129,7 +129,7 @@ export const TreeItem: React.FC<TreeItemWidgetProps> = ({
         <CollapsibleContent className="overflow-hidden transition-all data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down">
           <div
             className={cn(
-              "ivy-tree-children flex flex-col pl-[1rem] ml-2 border-l border-border/50",
+              "ivy-tree-children flex flex-col pl-[1rem] ml-2 border-l border-border/50 mt-0.5",
               gapClass,
             )}
           >


### PR DESCRIPTION
## Summary

Added a `mt-0.5` (2px) top margin to the `ivy-tree-children` container in TreeItem.tsx. This creates a subtle visual separation between parent nodes and their children in the Tree widget, making the hierarchy easier to read in dense trees.

## API Changes

None.

## Files Modified

- **src/frontend/src/widgets/tree/TreeItem.tsx** — Added `mt-0.5` class to the children container div

## Commits

- c3d7c2f94 — [01515] Add bottom margin to tree item children container