### PR TITLE
[03355] Document UseQuery unique key pattern

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/03_Hooks/02_Core/09_UseQuery.md
+++ b/src/Ivy.Docs.Shared/Docs/03_Hooks/02_Core/09_UseQuery.md
@@ -154,6 +154,50 @@ public class DependentQueryView : ViewBase
 }
 ```
 
+## Multiple Queries with Shared Dependencies
+
+When multiple queries depend on the same state value, use unique key prefixes to prevent cache collisions:
+
+```csharp demo-below
+public class MultiQueryView : ViewBase
+{
+    public override object? Build()
+    {
+        var selectedRepo = UseState<string?>(null);
+
+        // WRONG: Both queries share the same cache key
+        // var assignees = UseQuery(selectedRepo.Value, FetchAssignees);
+        // var labels = UseQuery(selectedRepo.Value, FetchLabels);
+
+        // CORRECT: Each query has a unique prefix
+        var assignees = UseQuery<string[], string>(
+            $"assignees:{selectedRepo.Value ?? ""}",
+            async (key, ct) =>
+            {
+                if (string.IsNullOrEmpty(selectedRepo.Value)) return [];
+                await Task.Delay(500, ct);
+                return new[] { "alice", "bob", "charlie" };
+            });
+
+        var labels = UseQuery<string[], string>(
+            $"labels:{selectedRepo.Value ?? ""}",
+            async (key, ct) =>
+            {
+                if (string.IsNullOrEmpty(selectedRepo.Value)) return [];
+                await Task.Delay(500, ct);
+                return new[] { "bug", "feature", "enhancement" };
+            });
+
+        return Layout.Vertical()
+            | selectedRepo.ToTextInput().Placeholder("Enter repo name")
+            | Text.Literal($"Assignees: {string.Join(", ", assignees.Value ?? [])}")
+            | Text.Literal($"Labels: {string.Join(", ", labels.Value ?? [])}");
+    }
+}
+```
+
+Without unique prefixes, both queries would share the same cache entry (e.g., `"my-repo"`), and whichever query completes last would overwrite the other's data.
+
 ## Tag-Based Invalidation
 
 Assign tags to queries for bulk invalidation (using [UseService](./11_UseService.md)). Tags are serializable the same way as keys.


### PR DESCRIPTION
# Summary

## Changes

Added a new FAQ section "Multiple Queries with Shared Dependencies" to the UseQuery hook documentation. The section demonstrates the unique key prefix pattern used to prevent cache collisions when multiple queries depend on the same state value.

## API Changes

None.

## Files Modified

- `src/Ivy.Docs.Shared/Docs/03_Hooks/02_Core/09_UseQuery.md` — Added new section with working code example showing both incorrect and correct patterns for handling multiple queries with shared dependencies.

## Commits

- 9329c3340 [03355] Document UseQuery unique key pattern for multiple shared dependencies