### PR TITLE
[03331] Improve failure status reporting for MakePlan

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/JobsApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/JobsApp.cs
@@ -203,11 +203,7 @@ public class JobsApp : ViewBase
                 BadgeColorMapping = projectColors
             })
             .Renderer(t => t.PlanId, new LinkDisplayRenderer())
-            .Renderer(t => t.StatusMessage, new TextDisplayRenderer
-            {
-                TooltipColumn = nameof(JobItemRow.ErrorContext),
-                TruncateAt = 200
-            })
+            .Renderer(t => t.StatusMessage, new TextDisplayRenderer())
             .Hidden(t => t.Id)
             .Hidden(t => t.LastOutputTimestamp)
             .Hidden(t => t.ErrorContext)

--- a/src/tendril/Ivy.Tendril/Promptwares/MakePlan/MakePlan.ps1
+++ b/src/tendril/Ivy.Tendril/Promptwares/MakePlan/MakePlan.ps1
@@ -80,6 +80,8 @@ if ($agent.Executable -eq "claude") {
     $extraArgs += @("--session-id", $sessionId)
 }
 $heartbeat = Start-Heartbeat
+$agentExitCode = 0
+$agentException = $null
 try {
     $rawLogFile = [System.IO.Path]::ChangeExtension($logFile, ".raw.jsonl")
     $startTs = (Get-Date).ToUniversalTime().ToString("o")
@@ -103,6 +105,16 @@ try {
         Add-Content -Path $rawLogFile -Value $line -Encoding UTF8
         $_
     }
+
+    if ($LASTEXITCODE -ne 0) {
+        $agentExitCode = $LASTEXITCODE
+    }
+}
+catch {
+    $agentException = $_
+    $errorMsg = "[tendril] PowerShell Exception: $($_.Exception.Message)"
+    Add-Content -Path $rawLogFile -Value $errorMsg -Encoding UTF8
+    Write-Host $errorMsg -ForegroundColor Red
 }
 finally {
     Stop-Heartbeat $heartbeat
@@ -151,6 +163,51 @@ else {
     }
     else {
         Write-Host "ERROR: Plan $planIdFormatted was not created. No plan folder or trash entry found." -ForegroundColor Red
+
+        # Create failure artifact
+        $errorLines = @()
+        if (Test-Path $rawLogFile) {
+            $rawContent = Get-Content $rawLogFile -ErrorAction SilentlyContinue
+            $errorLines = $rawContent | Where-Object { $_ -match '\[stderr\]|ERROR|Exception|failed' } | Select-Object -Last 20
+        }
+
+        $exitCodeOrException = if ($agentException) {
+            "PowerShell Exception: $($agentException.Exception.Message)"
+        } elseif ($agentExitCode -ne 0) {
+            "$agentExitCode"
+        } else {
+            "0 (but no plan created)"
+        }
+
+        & "$programFolder/Tools/Get-FailureArtifact.ps1" `
+            -PlanId $planIdFormatted `
+            -Description $Description `
+            -Project $Project `
+            -ExitCodeOrException $exitCodeOrException `
+            -ErrorLines $errorLines
+
         exit 1
     }
+}
+
+# Also create failure artifact if agent threw exception or had non-zero exit (but somehow continued)
+if ($agentException -or $agentExitCode -ne 0) {
+    $errorLines = @()
+    if (Test-Path $rawLogFile) {
+        $rawContent = Get-Content $rawLogFile -ErrorAction SilentlyContinue
+        $errorLines = $rawContent | Where-Object { $_ -match '\[stderr\]|ERROR|Exception|failed' } | Select-Object -Last 20
+    }
+
+    $exitCodeOrException = if ($agentException) {
+        "PowerShell Exception: $($agentException.Exception.Message)"
+    } else {
+        "$agentExitCode"
+    }
+
+    & "$programFolder/Tools/Get-FailureArtifact.ps1" `
+        -PlanId $planIdFormatted `
+        -Description $Description `
+        -Project $Project `
+        -ExitCodeOrException $exitCodeOrException `
+        -ErrorLines $errorLines
 }

--- a/src/tendril/Ivy.Tendril/Promptwares/MakePlan/Tools/Get-FailureArtifact.ps1
+++ b/src/tendril/Ivy.Tendril/Promptwares/MakePlan/Tools/Get-FailureArtifact.ps1
@@ -1,0 +1,59 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$PlanId,
+    [Parameter(Mandatory = $true)]
+    [string]$Description,
+    [string]$Project = "Auto",
+    [string]$ExitCodeOrException = "1",
+    [string[]]$ErrorLines = @()
+)
+
+$failedDir = Join-Path $env:TENDRIL_HOME "Failed"
+if (-not (Test-Path $failedDir)) {
+    New-Item -ItemType Directory -Path $failedDir | Out-Null
+}
+
+$safeTitle = $Description -replace '\[FORCE\]', '' -replace '\[YOLO\]', '' -replace '[^a-zA-Z0-9-]', '-'
+$safeTitle = $safeTitle.Substring(0, [Math]::Min(60, $safeTitle.Length))
+
+$failureFile = Join-Path $failedDir "$PlanId-$safeTitle.md"
+
+$now = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+$errorOutput = if ($ErrorLines.Count -gt 0) {
+    ($ErrorLines | Select-Object -Last 20) -join "`n"
+} else {
+    "(No error output captured)"
+}
+
+$content = @"
+---
+date: $now
+planId: $PlanId
+request: "$Description"
+project: "$Project"
+exitCode: $ExitCodeOrException
+---
+
+# MakePlan Failure
+
+**Plan ID:** $PlanId
+**Request:** $Description
+**Project:** $Project
+**Exit Code:** $ExitCodeOrException
+
+## Error Output
+
+``````
+$errorOutput
+``````
+
+## Investigation Steps
+
+1. Check if this is a duplicate detection issue - search Plans/ for similar titles
+2. Check if code assertion validation failed - review Validate-CodeAssertion output
+3. Check if config.yaml project/repo configuration is invalid
+4. Review full agent output in MakePlan/Logs/ directory
+"@
+
+Set-Content -Path $failureFile -Value $content -Force -Encoding UTF8
+Write-Host "Failure artifact written: $failureFile" -ForegroundColor Red

--- a/src/tendril/Ivy.Tendril/Services/JobService.cs
+++ b/src/tendril/Ivy.Tendril/Services/JobService.cs
@@ -1042,7 +1042,23 @@ public class JobService : IJobService
         });
         if (apiError != null) return ParseClaudeApiError(apiError);
 
-        // 3. Check for validation/assertion failures (from MakePlan/ExecutePlan)
+        // 3. Check for MakePlan-specific failures and failure artifacts
+        if (jobType == "MakePlan")
+        {
+            var makePlanError = FindPattern(outputLines, new[] {
+                @"ERROR: Plan",
+                @"WARNING: TENDRIL_HOME",
+                @"Failed to parse",
+                @"Repository path does not exist",
+            });
+            if (makePlanError != null) return makePlanError;
+
+            // Check for failure artifact
+            var failureArtifactMessage = TryReadFailureArtifact(outputLines);
+            if (failureArtifactMessage != null) return failureArtifactMessage;
+        }
+
+        // 4. Check for validation/assertion failures (from MakePlan/ExecutePlan)
         var validationError = FindPattern(outputLines, new[] {
             @"validation\s+failed",
             @"assertion\s+failed",
@@ -1051,7 +1067,7 @@ public class JobService : IJobService
         });
         if (validationError != null) return validationError;
 
-        // 4. Search from end for stderr lines (existing logic)
+        // 5. Search from end for stderr lines (existing logic)
         var stderrLines = new List<string>();
         for (var i = outputLines.Count - 1; i >= 0 && stderrLines.Count < 3; i--)
         {
@@ -1067,7 +1083,7 @@ public class JobService : IJobService
         if (stderrLines.Count > 0)
             return SanitizeForDisplay(string.Join(" | ", stderrLines));
 
-        // 5. Fall back to last non-progress line
+        // 6. Fall back to last non-progress line
         for (var i = outputLines.Count - 1; i >= 0; i--)
         {
             var trimmed = outputLines[i].Trim();
@@ -1121,6 +1137,56 @@ public class JobService : IJobService
         catch { }
 
         return "Claude API error (see output for details)";
+    }
+
+    private static string? TryReadFailureArtifact(List<string> outputLines)
+    {
+        try
+        {
+            // Look for failure artifact path in output (from Get-FailureArtifact.ps1)
+            var artifactLine = outputLines.FirstOrDefault(line =>
+                line.Contains("Failure artifact written:") && line.Contains("Failed"));
+
+            if (artifactLine == null) return null;
+
+            // Extract path from the line: "Failure artifact written: <path>"
+            var pathMatch = Regex.Match(artifactLine, @"Failure artifact written:\s*(.+)");
+            if (!pathMatch.Success) return null;
+
+            var artifactPath = pathMatch.Groups[1].Value.Trim();
+            if (!File.Exists(artifactPath)) return null;
+
+            // Read the failure artifact and extract error summary
+            var lines = File.ReadAllLines(artifactPath);
+            var errorOutputSection = false;
+            var errorLines = new List<string>();
+
+            foreach (var line in lines)
+            {
+                if (line.StartsWith("## Error Output"))
+                {
+                    errorOutputSection = true;
+                    continue;
+                }
+                if (line.StartsWith("## Investigation Steps"))
+                {
+                    break;
+                }
+                if (errorOutputSection && !line.StartsWith("```"))
+                {
+                    errorLines.Add(line.Trim());
+                }
+            }
+
+            if (errorLines.Count > 0)
+            {
+                var summary = string.Join(" | ", errorLines.Take(3).Where(l => l.Length > 0));
+                return string.IsNullOrWhiteSpace(summary) ? null : SanitizeForDisplay(summary);
+            }
+        }
+        catch { }
+
+        return null;
     }
 
     internal static string SanitizeForDisplay(string text)
@@ -1258,7 +1324,10 @@ public class JobService : IJobService
                 job.EnqueueOutput(
                     "[Tendril] WARNING: MakePlan completed but no plan folder or trash entry was found.");
                 job.Status = JobStatus.Failed;
-                job.StatusMessage = "No plan created";
+
+                // Check for failure artifact to provide better diagnostics
+                var failureMessage = TryReadFailureArtifact(job.OutputLines);
+                job.StatusMessage = failureMessage ?? "No plan created";
             }
         }
         catch

--- a/src/tendril/Ivy.Tendril/Services/JobService.cs
+++ b/src/tendril/Ivy.Tendril/Services/JobService.cs
@@ -1326,7 +1326,7 @@ public class JobService : IJobService
                 job.Status = JobStatus.Failed;
 
                 // Check for failure artifact to provide better diagnostics
-                var failureMessage = TryReadFailureArtifact(job.OutputLines);
+                var failureMessage = TryReadFailureArtifact(job.OutputLines.ToList());
                 job.StatusMessage = failureMessage ?? "No plan created";
             }
         }


### PR DESCRIPTION
# Summary

## Changes

Enhanced MakePlan error reporting to provide better diagnostics when plan creation fails. Implemented structured failure artifacts that capture error context, exit codes, and diagnostic information, making it easier to troubleshoot MakePlan failures without manually reviewing raw logs.

## API Changes

**New PowerShell Tool:**
- `Get-FailureArtifact.ps1` - Creates structured failure artifact markdown files in `$TENDRIL_HOME/Failed/` directory with parameters: PlanId, Description, Project, ExitCodeOrException, ErrorLines

**Modified Methods:**
- `JobService.ExtractFailureReason()` - Added MakePlan-specific error pattern detection and failure artifact integration
- `JobService.TryReadFailureArtifact()` - New private helper method to read and parse failure artifact files
- `JobService.VerifyMakePlanResult()` - Enhanced to check failure artifacts for better StatusMessage when no plan is created

**Modified PowerShell Scripts:**
- `MakePlan.ps1` - Added exception handling, exit code tracking, and failure artifact creation on errors

## Files Modified

**New Files:**
- `src/tendril/Ivy.Tendril/Promptwares/MakePlan/Tools/Get-FailureArtifact.ps1`

**Modified Files:**
- `src/tendril/Ivy.Tendril/Promptwares/MakePlan/MakePlan.ps1`
- `src/tendril/Ivy.Tendril/Services/JobService.cs`
- `src/tendril/Ivy.Tendril/Apps/JobsApp.cs` (fixed pre-existing API compatibility issue)

## Commits

- 1b54b0194