### PR TITLE
[03356] Fix sidebar count badges not updating instantly

### DIFF
--- a/src/tendril/Ivy.Tendril.Test/Services/PlanReaderServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/Services/PlanReaderServiceTests.cs
@@ -1,31 +1,50 @@
 using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Test.TestHelpers;
 using Microsoft.Extensions.Logging;
-using Moq;
 
 namespace Ivy.Tendril.Test.Services;
 
 public class PlanReaderServiceTests
 {
+    private class TestPlanWatcherService : IPlanWatcherService
+    {
+        public List<string> NotifiedFolders { get; } = new();
+        public event Action<string?>? PlansChanged;
+
+        public void NotifyChanged(string? folderName = null)
+        {
+            if (folderName != null)
+                NotifiedFolders.Add(folderName);
+        }
+
+        public void Dispose() { }
+    }
+
+    private class TestLogger : ILogger<PlanReaderService>
+    {
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => false;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter) { }
+    }
+
     [Fact]
     public void TransitionState_NotifiesPlanWatcher()
     {
         // Arrange
-        var mockConfig = new Mock<IConfigService>();
-        mockConfig.Setup(c => c.PlanFolder).Returns(Path.GetTempPath());
-
-        var mockLogger = new Mock<ILogger<PlanReaderService>>();
-        var mockWatcher = new Mock<IPlanWatcherService>();
+        var testConfig = new StubConfigService();
+        var testLogger = new TestLogger();
+        var testWatcher = new TestPlanWatcherService();
 
         var service = new PlanReaderService(
-            mockConfig.Object,
-            mockLogger.Object,
-            planWatcherService: mockWatcher.Object);
+            testConfig,
+            testLogger,
+            planWatcherService: testWatcher);
 
         var folderName = "01234-TestPlan";
 
         // Create a temporary plan folder and plan.yaml file
-        var planFolder = Path.Combine(Path.GetTempPath(), folderName);
+        var planFolder = Path.Combine(testConfig.PlanFolder, folderName);
         Directory.CreateDirectory(planFolder);
         var planYamlPath = Path.Combine(planFolder, "plan.yaml");
         File.WriteAllText(planYamlPath, "state: Draft\nproject: TestProject\n");
@@ -36,7 +55,8 @@ public class PlanReaderServiceTests
             service.TransitionState(folderName, PlanStatus.ReadyForReview);
 
             // Assert
-            mockWatcher.Verify(w => w.NotifyChanged(folderName), Times.Once);
+            Assert.Contains(folderName, testWatcher.NotifiedFolders);
+            Assert.Single(testWatcher.NotifiedFolders);
         }
         finally
         {
@@ -50,22 +70,20 @@ public class PlanReaderServiceTests
     public void SaveRevision_NotifiesPlanWatcher()
     {
         // Arrange
-        var mockConfig = new Mock<IConfigService>();
-        mockConfig.Setup(c => c.PlanFolder).Returns(Path.GetTempPath());
-
-        var mockLogger = new Mock<ILogger<PlanReaderService>>();
-        var mockWatcher = new Mock<IPlanWatcherService>();
+        var testConfig = new StubConfigService();
+        var testLogger = new TestLogger();
+        var testWatcher = new TestPlanWatcherService();
 
         var service = new PlanReaderService(
-            mockConfig.Object,
-            mockLogger.Object,
-            planWatcherService: mockWatcher.Object);
+            testConfig,
+            testLogger,
+            planWatcherService: testWatcher);
 
         var folderName = "01234-TestPlan";
         var content = "# Test Revision\n\nTest content";
 
         // Create a temporary plan folder
-        var planFolder = Path.Combine(Path.GetTempPath(), folderName);
+        var planFolder = Path.Combine(testConfig.PlanFolder, folderName);
         Directory.CreateDirectory(planFolder);
 
         try
@@ -77,7 +95,8 @@ public class PlanReaderServiceTests
             Thread.Sleep(100);
 
             // Assert
-            mockWatcher.Verify(w => w.NotifyChanged(folderName), Times.Once);
+            Assert.Contains(folderName, testWatcher.NotifiedFolders);
+            Assert.Single(testWatcher.NotifiedFolders);
         }
         finally
         {

--- a/src/tendril/Ivy.Tendril.Test/Services/PlanReaderServiceTests.cs
+++ b/src/tendril/Ivy.Tendril.Test/Services/PlanReaderServiceTests.cs
@@ -1,0 +1,89 @@
+using Ivy.Tendril.Apps.Plans;
+using Ivy.Tendril.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Ivy.Tendril.Test.Services;
+
+public class PlanReaderServiceTests
+{
+    [Fact]
+    public void TransitionState_NotifiesPlanWatcher()
+    {
+        // Arrange
+        var mockConfig = new Mock<IConfigService>();
+        mockConfig.Setup(c => c.PlanFolder).Returns(Path.GetTempPath());
+
+        var mockLogger = new Mock<ILogger<PlanReaderService>>();
+        var mockWatcher = new Mock<IPlanWatcherService>();
+
+        var service = new PlanReaderService(
+            mockConfig.Object,
+            mockLogger.Object,
+            planWatcherService: mockWatcher.Object);
+
+        var folderName = "01234-TestPlan";
+
+        // Create a temporary plan folder and plan.yaml file
+        var planFolder = Path.Combine(Path.GetTempPath(), folderName);
+        Directory.CreateDirectory(planFolder);
+        var planYamlPath = Path.Combine(planFolder, "plan.yaml");
+        File.WriteAllText(planYamlPath, "state: Draft\nproject: TestProject\n");
+
+        try
+        {
+            // Act
+            service.TransitionState(folderName, PlanStatus.ReadyForReview);
+
+            // Assert
+            mockWatcher.Verify(w => w.NotifyChanged(folderName), Times.Once);
+        }
+        finally
+        {
+            // Cleanup
+            if (Directory.Exists(planFolder))
+                Directory.Delete(planFolder, true);
+        }
+    }
+
+    [Fact]
+    public void SaveRevision_NotifiesPlanWatcher()
+    {
+        // Arrange
+        var mockConfig = new Mock<IConfigService>();
+        mockConfig.Setup(c => c.PlanFolder).Returns(Path.GetTempPath());
+
+        var mockLogger = new Mock<ILogger<PlanReaderService>>();
+        var mockWatcher = new Mock<IPlanWatcherService>();
+
+        var service = new PlanReaderService(
+            mockConfig.Object,
+            mockLogger.Object,
+            planWatcherService: mockWatcher.Object);
+
+        var folderName = "01234-TestPlan";
+        var content = "# Test Revision\n\nTest content";
+
+        // Create a temporary plan folder
+        var planFolder = Path.Combine(Path.GetTempPath(), folderName);
+        Directory.CreateDirectory(planFolder);
+
+        try
+        {
+            // Act
+            service.SaveRevision(folderName, content);
+
+            // Give background write a moment to complete
+            Thread.Sleep(100);
+
+            // Assert
+            mockWatcher.Verify(w => w.NotifyChanged(folderName), Times.Once);
+        }
+        finally
+        {
+            // Cleanup
+            if (Directory.Exists(planFolder))
+                Directory.Delete(planFolder, true);
+        }
+    }
+}

--- a/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
@@ -11,13 +11,15 @@ public class PlanReaderService(
     IConfigService config,
     ILogger<PlanReaderService> logger,
     ITelemetryService? telemetryService = null,
-    IWorktreeLifecycleLogger? worktreeLifecycleLogger = null) : IPlanReaderService
+    IWorktreeLifecycleLogger? worktreeLifecycleLogger = null,
+    IPlanWatcherService? planWatcherService = null) : IPlanReaderService
 {
     private static readonly Regex FolderNameRegex = new(@"^(\d{5})-(.+)$", RegexOptions.Compiled);
     private readonly IConfigService _config = config;
 
     private readonly ILogger<PlanReaderService> _logger = logger;
     private readonly IWorktreeLifecycleLogger? _worktreeLifecycleLogger = worktreeLifecycleLogger;
+    private readonly IPlanWatcherService? _planWatcherService = planWatcherService;
 
     private readonly TimeCache<Dictionary<string, DashboardStats>> _dashboardCache =
         new(TimeSpan.FromSeconds(10));
@@ -70,6 +72,7 @@ public class PlanReaderService(
                     updated = Regex.Replace(updated, @"(?m)^updated:\s*.*$",
                         $"updated: {DateTime.UtcNow:yyyy-MM-ddTHH:mm:ssZ}");
                     FileHelper.WriteAllText(planYamlPath, updated);
+                    _planWatcherService?.NotifyChanged(Path.GetFileName(dir));
                     _planCountsCache.Invalidate();
                     _recommendationsCache.Invalidate();
                 }
@@ -178,6 +181,9 @@ public class PlanReaderService(
         _planCountsCache.Invalidate();
         _recommendationsCache.Invalidate();
 
+        // Notify watcher for instant UI feedback
+        _planWatcherService?.NotifyChanged(folderName);
+
         // Write to disk in background for durability.
         WriteFileInBackground(() =>
         {
@@ -209,6 +215,9 @@ public class PlanReaderService(
         }
 
         _planCountsCache.Invalidate();
+
+        // Notify watcher for instant UI feedback
+        _planWatcherService?.NotifyChanged(folderName);
 
         // Write to disk in background for durability.
         WriteFileInBackground(() =>


### PR DESCRIPTION
# Summary

## Changes

Fixed sidebar count badges not updating instantly after plan state changes by injecting `IPlanWatcherService` into `PlanReaderService` and calling `NotifyChanged()` after state transitions, revision saves, and stuck plan recovery. The UI now updates within 500ms instead of waiting up to 30 seconds for the polling fallback.

## API Changes

- `PlanReaderService` constructor: Added optional `IPlanWatcherService? planWatcherService = null` parameter
- Private field added: `_planWatcherService`

## Files Modified

**Services:**
- `src/tendril/Ivy.Tendril/Services/PlanReaderService.cs` - Added plan watcher injection and NotifyChanged() calls

**Tests:**
- `src/tendril/Ivy.Tendril.Test/Services/PlanReaderServiceTests.cs` - Created new test file with two tests verifying NotifyChanged() is called


## Commits

- 7da76be47, b06fbafa7