### PR TITLE
[03357] Show plan title in Jobs table for MakePlan jobs when available

### DIFF
--- a/src/tendril/Ivy.Tendril/Apps/JobsApp.cs
+++ b/src/tendril/Ivy.Tendril/Apps/JobsApp.cs
@@ -503,14 +503,7 @@ public class JobsApp : ViewBase
 
     private static string GetPromptDisplay(JobItem j, IPlanReaderService planService)
     {
-        // MakePlan jobs: use the -Description arg for display (PlanFile may now hold the folder name)
-        if (j.Type == "MakePlan")
-        {
-            var desc = CleanPromptText(GetFullPrompt(j) ?? j.PlanFile);
-            return desc.Length > PromptDisplayMaxLength ? desc[..PromptDisplayMaxLength] + "..." : desc;
-        }
-
-        // For other jobs, try to read the plan title
+        // Try to read the plan title first (for ALL job types)
         if (!string.IsNullOrEmpty(j.PlanFile))
         {
             var fullPath = Path.Combine(planService.PlansDirectory, j.PlanFile);
@@ -520,6 +513,13 @@ public class JobsApp : ViewBase
                 var title = CleanPromptText(plan.Title);
                 return title.Length > PromptDisplayMaxLength ? title[..PromptDisplayMaxLength] + "..." : title;
             }
+        }
+
+        // MakePlan jobs: use the -Description arg for display when no title is available yet
+        if (j.Type == "MakePlan")
+        {
+            var desc = CleanPromptText(GetFullPrompt(j) ?? j.PlanFile);
+            return desc.Length > PromptDisplayMaxLength ? desc[..PromptDisplayMaxLength] + "..." : desc;
         }
 
         // Fallback to folder name


### PR DESCRIPTION
# Summary

## Changes

Modified the `GetPromptDisplay` method in `JobsApp.cs` to prioritize displaying plan titles for all job types, including MakePlan jobs. Previously, MakePlan jobs would always show the prompt/description text even if a plan title existed. Now, once a plan is created with a title, that title is displayed instead of the original prompt.

## API Changes

None.

## Files Modified

- `src/tendril/Ivy.Tendril/Apps/JobsApp.cs` — Updated `GetPromptDisplay` method to check for plan title first (for ALL job types) before falling back to description text for MakePlan jobs or folder name.

## Commits

- 6727cbd4d [03357] Show plan title in Jobs table for MakePlan jobs when available