### PR TITLE
[03365] Replace safeTitle extraction with regex in PlanReaderService

### DIFF
--- a/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
+++ b/src/tendril/Ivy.Tendril/Services/PlanReaderService.cs
@@ -15,6 +15,7 @@ public class PlanReaderService(
     IPlanWatcherService? planWatcherService = null) : IPlanReaderService
 {
     private static readonly Regex FolderNameRegex = new(@"^(\d{5})-(.+)$", RegexOptions.Compiled);
+    private static readonly Regex SafeTitleRegex = new(@"^\d{5}-(.+)", RegexOptions.Compiled);
     private readonly IConfigService _config = config;
 
     private readonly ILogger<PlanReaderService> _logger = logger;
@@ -1053,10 +1054,7 @@ public class PlanReaderService(
         var planId = WorktreeLifecycleLogger.ExtractPlanId(planFolderPath);
 
         // Extract safe title from plan folder name for branch deletion
-        var planFolderName = Path.GetFileName(planFolderPath);
-        var safeTitle = planFolderName.Length > 6 && planFolderName[5] == '-'
-            ? planFolderName.Substring(6)
-            : "Unknown";
+        var safeTitle = ExtractSafeTitle(planFolderPath);
         var branchName = $"tendril/{planId}-{safeTitle}";
 
         foreach (var wtDir in Directory.GetDirectories(worktreesDir))
@@ -1136,6 +1134,16 @@ public class PlanReaderService(
                 lifecycleLogger?.LogCleanupFailed(planId, wtDir, ex.Message);
             }
         }
+    }
+
+    /// <summary>
+    ///     Extracts the safe title from a plan folder path using regex pattern matching.
+    /// </summary>
+    internal static string ExtractSafeTitle(string planFolderPath)
+    {
+        var folderName = Path.GetFileName(planFolderPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+        var match = SafeTitleRegex.Match(folderName);
+        return match.Success ? match.Groups[1].Value : "Unknown";
     }
 
     internal static void ClearReadOnlyAttributes(string directoryPath)


### PR DESCRIPTION
# Summary

## Changes

Replaced string manipulation-based safe title extraction with a compiled regex pattern in `PlanReaderService.RemoveWorktrees()`. Added a new public static method `ExtractSafeTitle()` for reusable plan folder name parsing that follows the pattern established by `WorktreeLifecycleLogger.ExtractPlanId()`.

## API Changes

**New Methods:**
- `PlanReaderService.ExtractSafeTitle(string planFolderPath)` — static method that extracts the safe title portion from a plan folder path using regex matching. Returns the title after the 5-digit plan ID, or "Unknown" if parsing fails.

## Files Modified

- `src/tendril/Ivy.Tendril/Services/PlanReaderService.cs`
  - Added `SafeTitleRegex` static field (line 18)
  - Added `ExtractSafeTitle()` method (lines 1142-1147)
  - Updated `RemoveWorktrees()` to use `ExtractSafeTitle()` instead of string manipulation (line 1057)

## Commits

- 39d5beb35 [03365] Replace safeTitle extraction with regex in PlanReaderService