### PR TITLE
[00002] Add Connected Accounts Support for Independent OAuth Providers

### DIFF
--- a/src/Ivy/Auth/ConnectedAccountsService.cs
+++ b/src/Ivy/Auth/ConnectedAccountsService.cs
@@ -1,0 +1,149 @@
+using Ivy.Core;
+using Ivy.Core.Auth;
+using Ivy.Core.Server;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+// ReSharper disable once CheckNamespace
+namespace Ivy;
+
+public class ConnectedAccountsService : IConnectedAccountsService
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IAuthSession _authSession;
+    private readonly AppSessionStore _sessionStore;
+
+    public ConnectedAccountsService(
+        IServiceProvider serviceProvider,
+        IAuthSession authSession,
+        AppSessionStore sessionStore)
+    {
+        _serviceProvider = serviceProvider;
+        _authSession = authSession;
+        _sessionStore = sessionStore;
+    }
+
+    public string[] GetAvailableProviders()
+    {
+        // Get all keyed IAuthProvider registrations
+        var keyedProviders = _serviceProvider.GetKeyedServices<IAuthProvider>(null);
+        return keyedProviders
+            .Select(kvp => kvp.ToString() ?? string.Empty)
+            .Where(key => !string.IsNullOrEmpty(key))
+            .ToArray();
+    }
+
+    public async Task<Uri> ConnectAccountAsync(string provider, WebhookEndpoint callback, CancellationToken cancellationToken = default)
+    {
+        var authProvider = _serviceProvider.GetKeyedService<IAuthProvider>(provider)
+            ?? throw new InvalidOperationException($"Connected account provider '{provider}' is not registered.");
+
+        var connectedSession = _authSession.ConnectedAccounts.TryGetValue(provider, out var existing)
+            ? existing
+            : new AuthSession(httpMessageHandler: null);
+
+        var authOptions = authProvider.GetAuthOptions();
+        if (authOptions.Length == 0)
+        {
+            throw new InvalidOperationException($"Provider '{provider}' has no auth options configured.");
+        }
+
+        // Use first auth option by default
+        return await authProvider.GetOAuthUriAsync(connectedSession, authOptions[0], callback, cancellationToken);
+    }
+
+    public async Task<AuthToken?> HandleConnectCallbackAsync(string provider, HttpRequest request, CancellationToken cancellationToken = default)
+    {
+        var authProvider = _serviceProvider.GetKeyedService<IAuthProvider>(provider)
+            ?? throw new InvalidOperationException($"Connected account provider '{provider}' is not registered.");
+
+        var connectedSession = _authSession.ConnectedAccounts.TryGetValue(provider, out var existing)
+            ? existing
+            : new AuthSession(httpMessageHandler: null);
+
+        var token = await authProvider.HandleOAuthCallbackAsync(connectedSession, request, cancellationToken);
+        if (token != null)
+        {
+            connectedSession.AuthToken = token;
+            _authSession.AddConnectedAccount(provider, connectedSession);
+
+            // Persist to cookies
+            _sessionStore.RegisterAuthSessionCookies(_authSession);
+        }
+
+        return token;
+    }
+
+    public async Task DisconnectAccountAsync(string provider, CancellationToken cancellationToken = default)
+    {
+        if (!_authSession.ConnectedAccounts.ContainsKey(provider))
+        {
+            return;
+        }
+
+        _authSession.RemoveConnectedAccount(provider);
+
+        // Persist to cookies
+        _sessionStore.RegisterAuthSessionCookies(_authSession, connectedAccountsToDelete: [provider]);
+
+        await Task.CompletedTask;
+    }
+
+    public IAuthSession? GetAccountSession(string provider)
+    {
+        return _authSession.ConnectedAccounts.TryGetValue(provider, out var session)
+            ? session
+            : null;
+    }
+
+    public async Task RefreshAllAsync(CancellationToken cancellationToken = default)
+    {
+        var refreshTasks = new List<Task>();
+
+        foreach (var (provider, session) in _authSession.ConnectedAccounts)
+        {
+            if (session.AuthToken == null || string.IsNullOrEmpty(session.AuthToken.AccessToken))
+            {
+                continue;
+            }
+
+            var authProvider = _serviceProvider.GetKeyedService<IAuthProvider>(provider);
+            if (authProvider == null)
+            {
+                continue;
+            }
+
+            // Check if token needs refresh (within 5 minutes of expiry)
+            var lifetime = await authProvider.GetAccessTokenLifetimeAsync(session, cancellationToken);
+            if (lifetime?.Expires == null || lifetime.Expires > DateTimeOffset.UtcNow.AddMinutes(5))
+            {
+                continue;
+            }
+
+            refreshTasks.Add(RefreshConnectedAccountAsync(provider, authProvider, session, cancellationToken));
+        }
+
+        await Task.WhenAll(refreshTasks);
+    }
+
+    private async Task RefreshConnectedAccountAsync(string provider, IAuthProvider authProvider, IAuthSession session, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var refreshedToken = await authProvider.RefreshAccessTokenAsync(session, cancellationToken);
+            if (refreshedToken != null)
+            {
+                session.AuthToken = refreshedToken;
+                _authSession.AddConnectedAccount(provider, session);
+
+                // Persist to cookies
+                _sessionStore.RegisterAuthSessionCookies(_authSession);
+            }
+        }
+        catch (Exception)
+        {
+            // Log error and continue - don't fail all refreshes if one fails
+            // TODO: Add logging
+        }
+    }
+}

--- a/src/Ivy/Auth/IAuthSession.cs
+++ b/src/Ivy/Auth/IAuthSession.cs
@@ -14,15 +14,26 @@ public interface IAuthSession : IAuthTokenHandlerSession
 
     public event Action<string>? BrokeredSessionAdded;
     public event Action<string>? BrokeredSessionRemoved;
+
+    public IReadOnlyDictionary<string, IAuthSession> ConnectedAccounts { get; }
+
+    public void AddConnectedAccount(string provider, IAuthSession session);
+    public void RemoveConnectedAccount(string provider);
+    public void ClearConnectedAccounts();
+
+    public event Action<string>? ConnectedAccountAdded;
+    public event Action<string>? ConnectedAccountRemoved;
 }
 
 public class AuthSession(
     AuthToken? authToken = null,
     string? authSessionData = null,
     TunneledHttpMessageHandler? httpMessageHandler = null,
-    Dictionary<string, IAuthTokenHandlerSession>? brokeredSessions = null) : AuthTokenHandlerSession(authToken, authSessionData, httpMessageHandler), IAuthSession
+    Dictionary<string, IAuthTokenHandlerSession>? brokeredSessions = null,
+    Dictionary<string, IAuthSession>? connectedAccounts = null) : AuthTokenHandlerSession(authToken, authSessionData, httpMessageHandler), IAuthSession
 {
     private readonly Dictionary<string, IAuthTokenHandlerSession> _brokeredSessions = brokeredSessions ?? [];
+    private readonly Dictionary<string, IAuthSession> _connectedAccounts = connectedAccounts ?? [];
 
     [ActivatorUtilitiesConstructor]
     public AuthSession(TunneledHttpMessageHandler? httpMessageHandler = null) : this(null, null, httpMessageHandler)
@@ -61,11 +72,45 @@ public class AuthSession(
             BrokeredSessionRemoved?.Invoke(provider);
         }
     }
+
+    public IReadOnlyDictionary<string, IAuthSession> ConnectedAccounts => _connectedAccounts;
+
+    public event Action<string>? ConnectedAccountAdded;
+    public event Action<string>? ConnectedAccountRemoved;
+
+    public void AddConnectedAccount(string provider, IAuthSession session)
+    {
+        var isNew = !_connectedAccounts.ContainsKey(provider);
+        _connectedAccounts[provider] = session;
+        if (isNew)
+        {
+            ConnectedAccountAdded?.Invoke(provider);
+        }
+    }
+
+    public void RemoveConnectedAccount(string provider)
+    {
+        if (_connectedAccounts.Remove(provider))
+        {
+            ConnectedAccountRemoved?.Invoke(provider);
+        }
+    }
+
+    public void ClearConnectedAccounts()
+    {
+        var providers = _connectedAccounts.Keys.ToList();
+        _connectedAccounts.Clear();
+        foreach (var provider in providers)
+        {
+            ConnectedAccountRemoved?.Invoke(provider);
+        }
+    }
 }
 
 public readonly struct AuthSessionSnapshot
 {
     public readonly AuthToken? AuthToken { get; init; }
     public readonly IReadOnlyDictionary<string, IAuthTokenHandlerSession> BrokeredSessions { get; init; }
+    public readonly IReadOnlyDictionary<string, IAuthSession> ConnectedAccounts { get; init; }
     public readonly string? AuthSessionData { get; init; }
 }

--- a/src/Ivy/Auth/IConnectedAccountsService.cs
+++ b/src/Ivy/Auth/IConnectedAccountsService.cs
@@ -1,0 +1,51 @@
+using Ivy.Core;
+using Microsoft.AspNetCore.Http;
+
+// ReSharper disable once CheckNamespace
+namespace Ivy;
+
+public interface IConnectedAccountsService
+{
+    /// <summary>
+    /// Lists the keys of all registered connected account providers.
+    /// </summary>
+    string[] GetAvailableProviders();
+
+    /// <summary>
+    /// Initiates an OAuth flow for connecting an account with the specified provider.
+    /// </summary>
+    /// <param name="provider">The provider key (e.g., "github", "linear").</param>
+    /// <param name="callback">The callback endpoint to return to after OAuth completion.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The authorization URI to redirect the user to.</returns>
+    Task<Uri> ConnectAccountAsync(string provider, WebhookEndpoint callback, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Handles the OAuth callback after the user authorizes the connected account.
+    /// </summary>
+    /// <param name="provider">The provider key.</param>
+    /// <param name="request">The HTTP request containing OAuth callback parameters.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The auth token for the connected account, or null if the callback failed.</returns>
+    Task<AuthToken?> HandleConnectCallbackAsync(string provider, HttpRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Disconnects (removes) a connected account for the specified provider.
+    /// </summary>
+    /// <param name="provider">The provider key.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task DisconnectAccountAsync(string provider, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves the auth session for a connected account.
+    /// </summary>
+    /// <param name="provider">The provider key.</param>
+    /// <returns>The auth session for the connected account, or null if not connected.</returns>
+    IAuthSession? GetAccountSession(string provider);
+
+    /// <summary>
+    /// Refreshes all connected accounts that need refreshing.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task RefreshAllAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Ivy/Core/Auth/AuthHelper.cs
+++ b/src/Ivy/Core/Auth/AuthHelper.cs
@@ -12,13 +12,13 @@ namespace Ivy.Core.Auth;
 public static class AuthHelper
 {
     public static AuthSession GetAuthSession(HttpContext context, TunneledHttpMessageHandler? httpMessageHandler)
-    => GetAuthCookies(context) is (var accessToken, var refreshToken, var tag, var authSessionData, var brokeredSessions)
-        ? GetAuthSession(accessToken, refreshToken, tag, authSessionData, brokeredSessions, httpMessageHandler)
+    => GetAuthCookies(context) is (var accessToken, var refreshToken, var tag, var authSessionData, var brokeredSessions, var connectedAccounts)
+        ? GetAuthSession(accessToken, refreshToken, tag, authSessionData, brokeredSessions, connectedAccounts, httpMessageHandler)
         : new AuthSession(httpMessageHandler: httpMessageHandler);
 
     public static AuthSession GetAuthSession(ServerCallContext context, TunneledHttpMessageHandler? httpMessageHandler)
-    => GetAuthCookies(context) is (var accessToken, var refreshToken, var tag, var authSessionData, var brokeredSessions)
-        ? GetAuthSession(accessToken, refreshToken, tag, authSessionData, brokeredSessions, httpMessageHandler)
+    => GetAuthCookies(context) is (var accessToken, var refreshToken, var tag, var authSessionData, var brokeredSessions, var connectedAccounts)
+        ? GetAuthSession(accessToken, refreshToken, tag, authSessionData, brokeredSessions, connectedAccounts, httpMessageHandler)
         : new AuthSession(httpMessageHandler: httpMessageHandler);
 
     public static async Task ValidateAuthIfRequired(global::Ivy.Server server, AppSessionStore sessionStore, string connectionId, ServerCallContext context)
@@ -138,7 +138,7 @@ public static class AuthHelper
         }
     }
 
-    private static (string? AccessToken, string? RefreshToken, string? Tag, string? AuthSessionData, Dictionary<string, IAuthTokenHandlerSession> BrokeredSessions) GetAuthCookies(HttpContext context)
+    private static (string? AccessToken, string? RefreshToken, string? Tag, string? AuthSessionData, Dictionary<string, IAuthTokenHandlerSession> BrokeredSessions, Dictionary<string, IAuthSession> ConnectedAccounts) GetAuthCookies(HttpContext context)
     {
         var cookies = context.Request.Cookies;
         var accessToken = cookies[CookieRegistryExtensions.PrefixCookieName("access_token")].NullIfEmpty();
@@ -147,16 +147,17 @@ public static class AuthHelper
         var authSessionDataValue = cookies[CookieRegistryExtensions.PrefixCookieName("auth_session_data")].NullIfEmpty();
 
         var brokeredSessions = ExtractBrokeredSessionsFromCookies(cookies);
+        var connectedAccounts = ExtractConnectedAccountsFromCookies(cookies);
 
-        return (accessToken, refreshToken, tag, authSessionDataValue, brokeredSessions);
+        return (accessToken, refreshToken, tag, authSessionDataValue, brokeredSessions, connectedAccounts);
     }
 
-    private static (string? AccessToken, string? RefreshToken, string? Tag, string? AuthSessionData, Dictionary<string, IAuthTokenHandlerSession> BrokeredSessions) GetAuthCookies(ServerCallContext context)
+    private static (string? AccessToken, string? RefreshToken, string? Tag, string? AuthSessionData, Dictionary<string, IAuthTokenHandlerSession> BrokeredSessions, Dictionary<string, IAuthSession> ConnectedAccounts) GetAuthCookies(ServerCallContext context)
     {
         var cookies = context.RequestHeaders.GetValue("cookie") ?? string.Empty;
         if (string.IsNullOrEmpty(cookies))
         {
-            return (null, null, null, null, new Dictionary<string, IAuthTokenHandlerSession>());
+            return (null, null, null, null, new Dictionary<string, IAuthTokenHandlerSession>(), new Dictionary<string, IAuthSession>());
         }
 
         var cookieHeader = CookieHeaderValue.ParseList([cookies]).ToList();
@@ -177,25 +178,26 @@ public static class AuthHelper
         var authSessionDataValue = GetCookie("auth_session_data");
 
         var brokeredSessions = ExtractBrokeredSessionsFromCookieHeader(cookieHeader);
+        var connectedAccounts = ExtractConnectedAccountsFromCookieHeader(cookieHeader);
 
-        return (accessToken, refreshToken, tag, authSessionDataValue, brokeredSessions);
+        return (accessToken, refreshToken, tag, authSessionDataValue, brokeredSessions, connectedAccounts);
     }
 
-    private static AuthSession GetAuthSession(string? accessToken, string? refreshToken, string? tag, string? authSessionDataValue, Dictionary<string, IAuthTokenHandlerSession> brokeredSessions, TunneledHttpMessageHandler? httpMessageHandler)
+    private static AuthSession GetAuthSession(string? accessToken, string? refreshToken, string? tag, string? authSessionDataValue, Dictionary<string, IAuthTokenHandlerSession> brokeredSessions, Dictionary<string, IAuthSession> connectedAccounts, TunneledHttpMessageHandler? httpMessageHandler)
     {
         if (accessToken == null)
         {
-            return new(null, authSessionDataValue, httpMessageHandler, brokeredSessions);
+            return new(null, authSessionDataValue, httpMessageHandler, brokeredSessions, connectedAccounts);
         }
 
         try
         {
             var token = new AuthToken(accessToken, refreshToken, tag);
-            return new(token, authSessionDataValue, httpMessageHandler, brokeredSessions);
+            return new(token, authSessionDataValue, httpMessageHandler, brokeredSessions, connectedAccounts);
         }
         catch (Exception)
         {
-            return new(null, authSessionDataValue, httpMessageHandler, brokeredSessions);
+            return new(null, authSessionDataValue, httpMessageHandler, brokeredSessions, connectedAccounts);
         }
     }
 
@@ -210,6 +212,7 @@ public static class AuthHelper
         var accessTokenCookies = cookies.Keys
             .Where(key => key.EndsWith(suffix)
                 && key != primaryAccessToken
+                && !key.Contains("__conn_") // Exclude connected accounts
                 && (prefix.Length == 0 || key.StartsWith(prefix)))
             .ToList();
 
@@ -236,6 +239,48 @@ public static class AuthHelper
         return brokeredSessions;
     }
 
+    internal static Dictionary<string, IAuthSession> ExtractConnectedAccountsFromCookies(IRequestCookieCollection cookies)
+    {
+        var connectedAccounts = new Dictionary<string, IAuthSession>();
+
+        var primaryAccessToken = CookieRegistryExtensions.PrefixCookieName("access_token");
+        var prefix = primaryAccessToken[..^"access_token".Length];
+        var connPrefix = "conn_";
+        var suffix = "_access_token";
+
+        var accessTokenCookies = cookies.Keys
+            .Where(key => key.Contains($"__{connPrefix}") && key.EndsWith(suffix))
+            .ToList();
+
+        foreach (var accessTokenName in accessTokenCookies)
+        {
+            // Extract provider from pattern: {prefix}__conn_{provider}_access_token
+            var afterPrefix = prefix.Length > 0 ? accessTokenName[prefix.Length..] : accessTokenName;
+            if (!afterPrefix.StartsWith(connPrefix))
+            {
+                continue;
+            }
+
+            var providerPart = afterPrefix[connPrefix.Length..^suffix.Length];
+
+            var accessToken = cookies[accessTokenName].NullIfEmpty();
+            if (accessToken == null)
+            {
+                continue;
+            }
+
+            var refreshToken = cookies[CookieRegistryExtensions.PrefixCookieName($"{connPrefix}{providerPart}_refresh_token")].NullIfEmpty();
+            var tag = cookies[CookieRegistryExtensions.PrefixCookieName($"{connPrefix}{providerPart}_auth_tag")].NullIfEmpty();
+            var authSessionData = cookies[CookieRegistryExtensions.PrefixCookieName($"{connPrefix}{providerPart}_auth_session_data")].NullIfEmpty();
+
+            var authToken = new AuthToken(accessToken, refreshToken, tag);
+            var session = new AuthSession(authToken: authToken, authSessionData: authSessionData);
+            connectedAccounts[providerPart] = session;
+        }
+
+        return connectedAccounts;
+    }
+
     internal static Dictionary<string, IAuthTokenHandlerSession> ExtractBrokeredSessionsFromCookieHeader(List<CookieHeaderValue> cookieHeader)
     {
         var brokeredSessions = new Dictionary<string, IAuthTokenHandlerSession>();
@@ -257,6 +302,7 @@ public static class AuthHelper
             .Where(c => c.Name.Value != null
                 && c.Name.Value.EndsWith(suffix)
                 && c.Name.Value != primaryAccessToken
+                && !c.Name.Value.Contains("__conn_") // Exclude connected accounts
                 && (prefix.Length == 0 || c.Name.Value.StartsWith(prefix)))
             .Select(c => c.Name.Value!)
             .ToList();
@@ -282,5 +328,59 @@ public static class AuthHelper
         }
 
         return brokeredSessions;
+    }
+
+    internal static Dictionary<string, IAuthSession> ExtractConnectedAccountsFromCookieHeader(List<CookieHeaderValue> cookieHeader)
+    {
+        var connectedAccounts = new Dictionary<string, IAuthSession>();
+
+        string? GetCookie(string name)
+        {
+            var rawValue = cookieHeader
+                .FirstOrDefault(c => c.Name.Equals(name, StringComparison.OrdinalIgnoreCase))?.Value.Value;
+            return !string.IsNullOrEmpty(rawValue)
+                ? WebUtility.UrlDecode(rawValue)
+                : null;
+        }
+
+        var primaryAccessToken = CookieRegistryExtensions.PrefixCookieName("access_token");
+        var prefix = primaryAccessToken[..^"access_token".Length];
+        var connPrefix = "conn_";
+        var suffix = "_access_token";
+
+        var accessTokenCookies = cookieHeader
+            .Where(c => c.Name.Value != null
+                && c.Name.Value.Contains($"__{connPrefix}")
+                && c.Name.Value.EndsWith(suffix))
+            .Select(c => c.Name.Value!)
+            .ToList();
+
+        foreach (var accessTokenName in accessTokenCookies)
+        {
+            // Extract provider from pattern: {prefix}__conn_{provider}_access_token
+            var afterPrefix = prefix.Length > 0 ? accessTokenName[prefix.Length..] : accessTokenName;
+            if (!afterPrefix.StartsWith(connPrefix))
+            {
+                continue;
+            }
+
+            var providerPart = afterPrefix[connPrefix.Length..^suffix.Length];
+
+            var accessToken = GetCookie(accessTokenName);
+            if (accessToken == null)
+            {
+                continue;
+            }
+
+            var refreshToken = GetCookie(CookieRegistryExtensions.PrefixCookieName($"{connPrefix}{providerPart}_refresh_token"));
+            var tag = GetCookie(CookieRegistryExtensions.PrefixCookieName($"{connPrefix}{providerPart}_auth_tag"));
+            var authSessionData = GetCookie(CookieRegistryExtensions.PrefixCookieName($"{connPrefix}{providerPart}_auth_session_data"));
+
+            var authToken = new AuthToken(accessToken, refreshToken, tag);
+            var session = new AuthSession(authToken: authToken, authSessionData: authSessionData);
+            connectedAccounts[providerPart] = session;
+        }
+
+        return connectedAccounts;
     }
 }

--- a/src/Ivy/Core/Auth/CheckedAuthSession.cs
+++ b/src/Ivy/Core/Auth/CheckedAuthSession.cs
@@ -7,7 +7,8 @@ public enum AuthSessionProperty
 {
     AuthToken,
     AuthSessionData,
-    BrokeredSessions
+    BrokeredSessions,
+    ConnectedAccounts
 }
 
 public enum AuthSessionAccessMode
@@ -66,6 +67,9 @@ public class CheckedAuthSessionBuilder(IAuthSession innerAuthSession)
 
     public CheckedAuthSessionBuilder WithBrokeredSessionsAccess(AuthSessionAccessMode accessMode)
         => WithAccessMode(AuthSessionProperty.BrokeredSessions, accessMode);
+
+    public CheckedAuthSessionBuilder WithConnectedAccountsAccess(AuthSessionAccessMode accessMode)
+        => WithAccessMode(AuthSessionProperty.ConnectedAccounts, accessMode);
 
     public IAuthSession Build()
     {
@@ -171,6 +175,45 @@ public class CheckedAuthSession(IAuthSession innerAuthSession, Dictionary<AuthSe
     {
         add => _innerAuthSession.BrokeredSessionRemoved += value;
         remove => _innerAuthSession.BrokeredSessionRemoved -= value;
+    }
+
+    public IReadOnlyDictionary<string, IAuthSession> ConnectedAccounts
+    {
+        get
+        {
+            CheckRead(AuthSessionProperty.ConnectedAccounts);
+            return _innerAuthSession.ConnectedAccounts;
+        }
+    }
+
+    public void AddConnectedAccount(string provider, IAuthSession session)
+    {
+        CheckWrite(AuthSessionProperty.ConnectedAccounts);
+        _innerAuthSession.AddConnectedAccount(provider, session);
+    }
+
+    public void RemoveConnectedAccount(string provider)
+    {
+        CheckWrite(AuthSessionProperty.ConnectedAccounts);
+        _innerAuthSession.RemoveConnectedAccount(provider);
+    }
+
+    public void ClearConnectedAccounts()
+    {
+        CheckWrite(AuthSessionProperty.ConnectedAccounts);
+        _innerAuthSession.ClearConnectedAccounts();
+    }
+
+    public event Action<string>? ConnectedAccountAdded
+    {
+        add => _innerAuthSession.ConnectedAccountAdded += value;
+        remove => _innerAuthSession.ConnectedAccountAdded -= value;
+    }
+
+    public event Action<string>? ConnectedAccountRemoved
+    {
+        add => _innerAuthSession.ConnectedAccountRemoved += value;
+        remove => _innerAuthSession.ConnectedAccountRemoved -= value;
     }
 }
 #endif

--- a/src/Ivy/Core/Auth/ConnectedAccountExtensions.cs
+++ b/src/Ivy/Core/Auth/ConnectedAccountExtensions.cs
@@ -1,0 +1,22 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Ivy.Core.Auth;
+
+public static class ConnectedAccountExtensions
+{
+    /// <summary>
+    /// Registers a connected account provider that can be used independently of the main auth provider.
+    /// Connected accounts persist separately and are not cleared when the user logs out of the main auth.
+    /// </summary>
+    /// <typeparam name="TProvider">The IAuthProvider implementation for this connected account.</typeparam>
+    /// <param name="server">The Ivy server instance.</param>
+    /// <param name="providerKey">The unique key for this provider (e.g., "github", "linear").</param>
+    /// <returns>The server instance for method chaining.</returns>
+    public static global::Ivy.Server AddConnectedAccountProvider<TProvider>(this global::Ivy.Server server, string providerKey)
+        where TProvider : class, IAuthProvider
+    {
+        server.Services.AddKeyedScoped<IAuthProvider>(providerKey, (sp, _) =>
+            ActivatorUtilities.CreateInstance<TProvider>(sp));
+        return server;
+    }
+}

--- a/src/Ivy/Core/Auth/CookieRegistryExtensions.cs
+++ b/src/Ivy/Core/Auth/CookieRegistryExtensions.cs
@@ -18,7 +18,7 @@ public static class CookieRegistryExtensions
         return null;
     }
 
-    public static CookieJarId RegisterAuthSessionCookies(this AppSessionStore sessionStore, IAuthSession authSession, IEnumerable<string>? providersToDelete = null)
+    public static CookieJarId RegisterAuthSessionCookies(this AppSessionStore sessionStore, IAuthSession authSession, IEnumerable<string>? providersToDelete = null, IEnumerable<string>? connectedAccountsToDelete = null)
     {
         var cookies = new CookieJar();
         cookies.AddCookiesForAuthToken(authSession.AuthToken, providersToDelete);
@@ -39,6 +39,21 @@ public static class CookieRegistryExtensions
 
         cookies.AddCookiesForBrokeredSessions(sessionsToWrite);
 
+        // Filter out connected accounts that have been removed
+        IReadOnlyDictionary<string, IAuthSession> connectedAccountsToWrite = authSession.ConnectedAccounts;
+        HashSet<string>? removedConnectedAccounts = connectedAccountsToDelete != null
+            ? new(connectedAccountsToDelete)
+            : null;
+
+        if (removedConnectedAccounts != null && removedConnectedAccounts.Count > 0)
+        {
+            connectedAccountsToWrite = authSession.ConnectedAccounts
+                .Where(kvp => !removedConnectedAccounts.Contains(kvp.Key))
+                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+        }
+
+        cookies.AddCookiesForConnectedAccounts(connectedAccountsToWrite);
+
         // Also delete cookies for removed providers
         if (removedProviders != null && removedProviders.Count > 0)
         {
@@ -48,6 +63,19 @@ public static class CookieRegistryExtensions
                 cookies.Delete(PrefixCookieName($"{provider}_access_token"), cookieOptions);
                 cookies.Delete(PrefixCookieName($"{provider}_refresh_token"), cookieOptions);
                 cookies.Delete(PrefixCookieName($"{provider}_auth_tag"), cookieOptions);
+            }
+        }
+
+        // Also delete cookies for removed connected accounts
+        if (removedConnectedAccounts != null && removedConnectedAccounts.Count > 0)
+        {
+            var cookieOptions = CreateAuthCookieOptions();
+            foreach (var provider in removedConnectedAccounts)
+            {
+                cookies.Delete(PrefixCookieName($"conn_{provider}_access_token"), cookieOptions);
+                cookies.Delete(PrefixCookieName($"conn_{provider}_refresh_token"), cookieOptions);
+                cookies.Delete(PrefixCookieName($"conn_{provider}_auth_tag"), cookieOptions);
+                cookies.Delete(PrefixCookieName($"conn_{provider}_auth_session_data"), cookieOptions);
             }
         }
 
@@ -171,6 +199,59 @@ public static class CookieRegistryExtensions
             else
             {
                 cookies.Delete(tagName, CreateAuthCookieOptions());
+            }
+        }
+    }
+
+    public static void AddCookiesForConnectedAccounts(this CookieJar cookies, IReadOnlyDictionary<string, IAuthSession> connectedAccounts)
+    {
+        var cookieOptions = CreateAuthCookieOptions();
+
+        foreach (var (provider, session) in connectedAccounts)
+        {
+            var accessTokenName = PrefixCookieName($"conn_{provider}_access_token");
+            var refreshTokenName = PrefixCookieName($"conn_{provider}_refresh_token");
+            var tagName = PrefixCookieName($"conn_{provider}_auth_tag");
+            var authSessionDataName = PrefixCookieName($"conn_{provider}_auth_session_data");
+
+            // Store access token
+            if (!string.IsNullOrEmpty(session.AuthToken?.AccessToken))
+            {
+                cookies.Append(accessTokenName, session.AuthToken.AccessToken, cookieOptions);
+            }
+            else
+            {
+                cookies.Delete(accessTokenName, CreateAuthCookieOptions());
+            }
+
+            // Store refresh token if present
+            if (!string.IsNullOrEmpty(session.AuthToken?.RefreshToken))
+            {
+                cookies.Append(refreshTokenName, session.AuthToken.RefreshToken, cookieOptions);
+            }
+            else
+            {
+                cookies.Delete(refreshTokenName, CreateAuthCookieOptions());
+            }
+
+            // Store tag if present
+            if (session.AuthToken?.Tag != null)
+            {
+                cookies.Append(tagName, session.AuthToken.Tag, cookieOptions);
+            }
+            else
+            {
+                cookies.Delete(tagName, CreateAuthCookieOptions());
+            }
+
+            // Store auth session data if present
+            if (!string.IsNullOrEmpty(session.AuthSessionData))
+            {
+                cookies.Append(authSessionDataName, session.AuthSessionData, cookieOptions);
+            }
+            else
+            {
+                cookies.Delete(authSessionDataName, CreateAuthCookieOptions());
             }
         }
     }

--- a/src/Ivy/Server.cs
+++ b/src/Ivy/Server.cs
@@ -654,6 +654,7 @@ public class Server
         builder.Services.AddSingleton<IConfiguration>(builder.Configuration);
         builder.Services.AddHealthChecks();
         builder.Services.AddQueryManager();
+        builder.Services.AddScoped<IConnectedAccountsService, ConnectedAccountsService>();
 
         // Register theme service if not already registered
         if (Services.All(s => s.ServiceType != typeof(IThemeService)))


### PR DESCRIPTION
# Summary

## Changes

Added a connected accounts system that allows `IAuthProvider` implementations to be registered and used independently of the main authentication provider. Connected accounts persist separately from the main auth lifecycle and support full OAuth flows, token refresh, and their own brokered sessions.

## API Changes

**New Interfaces:**
- `IConnectedAccountsService` - Service for managing connected OAuth accounts

**Extended Interfaces:**
- `IAuthSession.ConnectedAccounts` - Dictionary of connected account sessions
- `IAuthSession.AddConnectedAccount(string, IAuthSession)` - Add a connected account
- `IAuthSession.RemoveConnectedAccount(string)` - Remove a connected account
- `IAuthSession.ClearConnectedAccounts()` - Clear all connected accounts
- `IAuthSession.ConnectedAccountAdded` - Event fired when a connected account is added
- `IAuthSession.ConnectedAccountRemoved` - Event fired when a connected account is removed

**Extension Methods:**
- `Server.AddConnectedAccountProvider<TProvider>(string providerKey)` - Register a connected account provider

**Cookie Naming:**
- Connected account cookies use `{prefix}__conn_{provider}_{token_type}` pattern
- Separate from primary auth (`{prefix}__{token_type}`) and brokered sessions (`{prefix}__{provider}_{token_type}`)

## Files Modified

**Core Implementation:**
- `src/Ivy/Auth/IAuthSession.cs` - Added ConnectedAccounts property and methods
- `src/Ivy/Auth/ConnectedAccountsService.cs` - Service implementation (new file)
- `src/Ivy/Auth/IConnectedAccountsService.cs` - Service interface (new file)

**Cookie Management:**
- `src/Ivy/Core/Auth/CookieRegistryExtensions.cs` - Added AddCookiesForConnectedAccounts method
- `src/Ivy/Core/Auth/AuthHelper.cs` - Added ExtractConnectedAccountsFromCookies methods

**Server Integration:**
- `src/Ivy/Core/Auth/ConnectedAccountExtensions.cs` - Extension method for registering providers (new file)
- `src/Ivy/Server.cs` - Registered ConnectedAccountsService as scoped service

**Supporting Updates:**
- `src/Ivy/Core/Auth/CheckedAuthSession.cs` - Extended to support ConnectedAccounts

---

## Commits

- [00002] Add connected accounts support for independent OAuth providers