### PR TITLE
[03379] Unable to copy code from code blocks in plan markdown

### DIFF
--- a/src/frontend/src/components/markdown/CodeBlock.tsx
+++ b/src/frontend/src/components/markdown/CodeBlock.tsx
@@ -83,7 +83,7 @@ export const CodeBlock = memo(
 
         return (
           <div className="relative">
-            <div className="absolute top-2 right-2 z-10">
+            <div className="absolute top-2 right-2 z-30">
               <CopyToClipboardButton textToCopy={cleanContent} />
             </div>
             <ScrollArea className="w-full">
@@ -115,7 +115,7 @@ export const CodeBlock = memo(
       if (!useHighlighter) {
         return (
           <div className="relative">
-            <div className="absolute top-2 right-2 z-10">
+            <div className="absolute top-2 right-2 z-30">
               <CopyToClipboardButton textToCopy={content} />
             </div>
             <ScrollArea className="w-full border border-border rounded-md">
@@ -146,7 +146,7 @@ export const CodeBlock = memo(
           }
         >
           <div className="relative">
-            <div className="absolute top-2 right-2 z-10">
+            <div className="absolute top-2 right-2 z-30">
               <CopyToClipboardButton textToCopy={content} />
             </div>
             <ScrollArea className="w-full border border-border rounded-md">


### PR DESCRIPTION
# Summary

## Changes

Fixed the copy-to-clipboard button in markdown code blocks being obscured by the ScrollArea's scrollbar. Increased the z-index of the copy button from `z-10` to `z-30` to ensure it appears above all scroll components (`z-20`).

## API Changes

None.

## Files Modified

- `src/frontend/src/components/markdown/CodeBlock.tsx` — Updated z-index for copy button in terminal blocks, plain code blocks, and syntax-highlighted code blocks


## Commits

- 3122238c3c7102f77c7ddc297af3fa381e13db91

Closes Ivy-Interactive/Ivy-Framework#4201