### PR TITLE
(datatable): improve filter input styling

### DIFF
--- a/src/frontend/src/widgets/dataTables/DataTableOption.tsx
+++ b/src/frontend/src/widgets/dataTables/DataTableOption.tsx
@@ -131,8 +131,9 @@ export const DataTableOption: React.FC<DataTableOptionProps> = ({
         ref={containerRef}
         className={cn(
           "inline-flex items-center mb-3",
-          "border rounded-field",
-          "bg-transparent border-input",
+          "rounded-field border border-input bg-transparent shadow-sm",
+          "dark:border-white/10 dark:bg-white/5",
+          "focus-within:outline-none focus-within:ring-1 focus-within:ring-ring",
           "transition-all duration-300 ease-in-out",
           className,
         )}
@@ -140,9 +141,9 @@ export const DataTableOption: React.FC<DataTableOptionProps> = ({
         <button
           className={cn(
             "inline-flex items-center justify-center text-sm font-medium",
-            "h-9 w-9 gap-2 cursor-pointer flex-shrink-0",
-            "bg-transparent rounded-l-[var(--radius-fields)]",
-            "transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+            "h-9 w-9 shrink-0 gap-2 cursor-pointer",
+            "bg-transparent rounded-l-fields",
+            "transition-colors focus-visible:outline-none",
             expanded
               ? "bg-accent hover:bg-accent hover:text-accent-foreground"
               : "hover:bg-accent hover:text-accent-foreground",
@@ -158,14 +159,13 @@ export const DataTableOption: React.FC<DataTableOptionProps> = ({
           className={cn(
             "border-l h-9",
             "transition-all duration-300 ease-in-out",
-            expanded
-              ? "w-[450px] opacity-100 border-input/30" // Fixed width when expanded
-              : "w-0 opacity-0 border-transparent",
+            expanded ? "w-[450px] opacity-100 border-input" : "w-0 opacity-0 border-transparent",
           )}
         >
           <div
             className={cn(
               "flex h-full min-h-0 min-w-0 w-[450px] max-w-full items-stretch",
+              "overflow-hidden rounded-l-none rounded-tr-fields rounded-br-fields",
               contentClassName,
             )}
           >

--- a/src/frontend/src/widgets/dataTables/DataTableOption.tsx
+++ b/src/frontend/src/widgets/dataTables/DataTableOption.tsx
@@ -163,7 +163,12 @@ export const DataTableOption: React.FC<DataTableOptionProps> = ({
               : "w-0 opacity-0 border-transparent",
           )}
         >
-          <div className={cn("h-full w-[450px] flex items-center ", contentClassName)}>
+          <div
+            className={cn(
+              "flex h-full min-h-0 min-w-0 w-[450px] max-w-full items-stretch",
+              contentClassName,
+            )}
+          >
             {React.isValidElement(children)
               ? React.cloneElement(children as React.ReactElement<{ isExpanded?: boolean }>, {
                   isExpanded: expanded,

--- a/src/frontend/src/widgets/dataTables/options/DataTableFilterOption.tsx
+++ b/src/frontend/src/widgets/dataTables/options/DataTableFilterOption.tsx
@@ -13,6 +13,7 @@ import { Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { ColType } from "../types/types";
 import { cn } from "@/lib/utils";
+import { useThemeWithMonitoring } from "@/components/theme-provider";
 
 /**
  * DataTableFilterOption - The content component for the filter option
@@ -26,20 +27,32 @@ export const DataTableFilterOption: React.FC<{
   const [pendingFilter, setPendingFilter] = useState<Filter | null>(null);
   const [isParsing, setIsParsing] = useState(false);
   const [isQueryValid, setIsQueryValid] = useState(true);
-  const [isFocused, setIsFocused] = useState(false);
   const dropdownState = useDropdownState();
   const editorContainerRef = useRef<HTMLDivElement>(null);
+  const autocompleteOpenRef = useRef(false);
 
   const { columns, setActiveFilter, connection } = useTable();
+  const { isDark } = useThemeWithMonitoring({ monitorDOM: true });
 
   /**
    * Monitor CodeMirror's autocomplete dropdown and sync with dropdownState
    * The autocomplete is created by CodeMirror as .cm-tooltip-autocomplete
    */
   useEffect(() => {
+    const setIsOpen = dropdownState.setIsOpen;
+    let raf = 0;
+
+    const sync = () => {
+      const open = !!document.querySelector(".cm-tooltip-autocomplete");
+      if (open !== autocompleteOpenRef.current) {
+        autocompleteOpenRef.current = open;
+        setIsOpen(open);
+      }
+    };
+
     const observer = new MutationObserver(() => {
-      const autocompleteTooltip = document.querySelector(".cm-tooltip-autocomplete");
-      dropdownState.setIsOpen(!!autocompleteTooltip);
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(sync);
     });
 
     observer.observe(document.body, {
@@ -47,30 +60,11 @@ export const DataTableFilterOption: React.FC<{
       subtree: true,
     });
 
-    return () => observer.disconnect();
-  }, [dropdownState]);
-
-  /**
-   * Monitor focus/blur events on the CodeMirror editor
-   * Use focusin/focusout which bubble up from CodeMirror
-   */
-  useEffect(() => {
-    if (!editorContainerRef.current) return;
-
-    const handleFocusIn = () => setIsFocused(true);
-    const handleFocusOut = () => setIsFocused(false);
-
-    const container = editorContainerRef.current;
-
-    // Use focusin/focusout which bubble (unlike focus/blur)
-    container.addEventListener("focusin", handleFocusIn);
-    container.addEventListener("focusout", handleFocusOut);
-
     return () => {
-      container.removeEventListener("focusin", handleFocusIn);
-      container.removeEventListener("focusout", handleFocusOut);
+      cancelAnimationFrame(raf);
+      observer.disconnect();
     };
-  }, []);
+  }, [dropdownState.setIsOpen]);
 
   // Filter columns to only include filterable ones
   const queryEditorColumns = useMemo(
@@ -270,46 +264,41 @@ export const DataTableFilterOption: React.FC<{
     <div
       ref={editorContainerRef}
       onClick={handleContainerClick}
-      onKeyDown={(e) => {
-        if (e.key === "Enter" || e.key === " ") {
-          e.preventDefault();
-          handleContainerClick();
-        }
-      }}
-      role="button"
-      aria-label="Edit filter"
-      tabIndex={0}
       className={cn(
-        "flex items-center w-full h-full justify-between",
-        "rounded-tr-md rounded-br-md border transition-colors",
-        isFocused ? "border-border" : "border-transparent",
+        "relative h-full min-h-9 min-w-0 w-full flex-1",
+        "rounded-tr-md rounded-br-md",
         isExpanded ? "cursor-text" : "pointer-events-none",
       )}
     >
       <div
-        className="flex-1 min-w-0 max-w-[350px] query-editor-wrapper cursor-text"
+        className={cn(
+          "query-editor-wrapper relative cursor-text",
+          "flex h-full min-h-9 w-full max-w-full min-w-0 flex-col",
+          "rounded-field border border-input bg-background shadow-sm transition-colors",
+          "dark:border-white/10",
+          "focus-within:ring-1 focus-within:ring-ring focus-within:ring-offset-0",
+          "text-sm",
+        )}
         data-query-valid={isQueryValid}
+        data-has-clear={query ? "true" : "false"}
+        data-is-parsing={isParsing ? "true" : "false"}
         onKeyDownCapture={handleKeyDownCapture}
         onKeyDown={handleKeyDown}
-        role="searchbox"
-        tabIndex={-1}
       >
         <QueryEditor
           value={query}
           columns={queryEditorColumns}
           onChange={handleQueryChange}
           placeholder={placeholderText}
-          height={40}
-          className="font-mono border-0 shadow-none [&>.cm-editor]:border-0 [&>.cm-editor]:shadow-none [&_.cm-content]:overflow-x-auto"
+          theme={isDark ? "dark" : "light"}
+          height="100%"
+          className="block min-h-0 w-full max-w-full min-w-0 font-mono border-0 shadow-none [&>.cm-editor]:min-h-0 [&>.cm-editor]:h-full [&>.cm-editor]:w-full [&>.cm-editor]:max-w-full [&>.cm-editor]:min-w-0 [&>.cm-editor]:border-0 [&>.cm-editor]:shadow-none [&>.cm-editor]:bg-transparent [&_.cm-scroller]:min-h-0"
         />
         <style>{tableStyles.queryEditor.css}</style>
-      </div>
 
-      {/* Fixed position container for loader and clear button */}
-      <div className="flex items-center gap-2 ml-2 flex-shrink-0">
         {isParsing ? (
-          <div className="flex items-center justify-center px-4">
-            <Loader2 className="animate-spin h-4 w-4 text-gray-500" />
+          <div className="absolute right-0 top-1/2 z-10 flex h-9 -translate-y-1/2 items-center border-l border-input bg-background px-2.5">
+            <Loader2 className="h-4 w-4 shrink-0 animate-spin text-muted-foreground" />
           </div>
         ) : (
           <Button
@@ -318,8 +307,8 @@ export const DataTableFilterOption: React.FC<{
             onClick={handleClearFilter}
             disabled={!query}
             className={cn(
-              "h-9 px-3 text-sm hover:bg-muted/50 transition-all",
-              query ? "opacity-100 visible" : "opacity-0 invisible pointer-events-none",
+              "absolute right-0 top-1/2 z-10 h-9 -translate-y-1/2 shrink-0 rounded-none rounded-r-field border-l border-input bg-background px-3 text-sm shadow-none hover:bg-muted hover:text-accent-foreground",
+              query ? "" : "hidden",
             )}
           >
             Clear

--- a/src/frontend/src/widgets/dataTables/options/DataTableFilterOption.tsx
+++ b/src/frontend/src/widgets/dataTables/options/DataTableFilterOption.tsx
@@ -266,7 +266,6 @@ export const DataTableFilterOption: React.FC<{
       onClick={handleContainerClick}
       className={cn(
         "relative h-full min-h-9 min-w-0 w-full flex-1",
-        "rounded-tr-md rounded-br-md",
         isExpanded ? "cursor-text" : "pointer-events-none",
       )}
     >
@@ -274,10 +273,7 @@ export const DataTableFilterOption: React.FC<{
         className={cn(
           "query-editor-wrapper relative cursor-text",
           "flex h-full min-h-9 w-full max-w-full min-w-0 flex-col",
-          "rounded-field border border-input bg-background shadow-sm transition-colors",
-          "dark:border-white/10",
-          "focus-within:ring-1 focus-within:ring-ring focus-within:ring-offset-0",
-          "text-sm",
+          "min-h-0 overflow-hidden bg-background text-sm",
         )}
         data-query-valid={isQueryValid}
         data-has-clear={query ? "true" : "false"}
@@ -307,7 +303,7 @@ export const DataTableFilterOption: React.FC<{
             onClick={handleClearFilter}
             disabled={!query}
             className={cn(
-              "absolute right-0 top-1/2 z-10 h-9 -translate-y-1/2 shrink-0 rounded-none rounded-r-field border-l border-input bg-background px-3 text-sm shadow-none hover:bg-muted hover:text-accent-foreground",
+              "absolute right-0 top-1/2 z-10 h-9 -translate-y-1/2 shrink-0 border-l border-input bg-background px-3 text-sm shadow-none hover:bg-muted hover:text-accent-foreground focus-visible:ring-0 focus-visible:ring-offset-0",
               query ? "" : "hidden",
             )}
           >

--- a/src/frontend/src/widgets/dataTables/styles/style.ts
+++ b/src/frontend/src/widgets/dataTables/styles/style.ts
@@ -70,19 +70,102 @@ export const tableStyles = {
   // QueryEditor component
   queryEditor: {
     css: `
+      /* Fill the panel: bordered + ring box must be block-width, not content-sized (fixes shrink-wrap). */
+      .query-editor-wrapper {
+        display: flex !important;
+        flex-direction: column !important;
+        width: 100% !important;
+        max-width: 100% !important;
+        min-width: 0 !important;
+        box-sizing: border-box !important;
+      }
+
+      .query-editor-wrapper > div {
+        width: 100% !important;
+        max-width: 100% !important;
+        height: 100% !important;
+        min-height: 0 !important;
+        flex: 1 1 0%;
+        display: flex !important;
+        flex-direction: column !important;
+        box-sizing: border-box !important;
+      }
+
       .query-editor-wrapper .cm-editor {
         border: none !important;
         border-radius: 0 !important;
         box-shadow: none !important;
+        flex: 1 1 auto !important;
+        min-height: 0 !important;
+        min-width: 0 !important;
+        width: 100% !important;
+        max-width: 100% !important;
+        height: 100% !important;
+        overflow: hidden !important;
       }
       .query-editor-wrapper .cm-editor.cm-focused {
         outline: none !important;
         border: none !important;
         box-shadow: none !important;
       }
+
+      .query-editor-wrapper .cm-scroller {
+        width: 100% !important;
+        max-width: 100% !important;
+        height: 100% !important;
+        min-height: 0 !important;
+        min-width: 0 !important;
+        overflow-x: auto !important;
+        overflow-y: hidden !important;
+        overflow-y: clip !important;
+        overscroll-behavior-x: contain !important;
+        overscroll-behavior-y: none !important;
+        /* Like a one-line text input: no vertical pan/scroll; horizontal only */
+        touch-action: pan-x !important;
+        scrollbar-width: none !important;
+      }
+
+      .query-editor-wrapper .cm-scroller::-webkit-scrollbar {
+        display: none !important;
+      }
+
       .query-editor-wrapper .cm-content {
-        padding: 12px 16px 10px 16px;
-        min-height: auto;
+        box-sizing: border-box !important;
+        /* At least full scroller width; grow wider than viewport for long lines so .cm-scroller scrolls horizontally. */
+        min-width: 100% !important;
+        width: max-content !important;
+        max-width: none !important;
+        min-height: auto !important;
+        overflow-x: visible !important;
+        overflow-y: hidden !important;
+        overflow-y: clip !important;
+        padding: 8px 12px !important;
+        font-size: 0.875rem !important;
+        line-height: 1.25rem !important;
+        caret-color: var(--foreground) !important;
+      }
+
+      .query-editor-wrapper[data-has-clear="true"] .cm-content,
+      .query-editor-wrapper[data-is-parsing="true"] .cm-content {
+        padding-right: 3.25rem !important;
+      }
+
+      .query-editor-wrapper .cm-line {
+        padding: 0 !important;
+      }
+
+      .query-editor-wrapper .cm-placeholder {
+        color: var(--muted-foreground) !important;
+        font-size: 0.875rem !important;
+        line-height: 1.25rem !important;
+      }
+
+      /* Match CodeInput theme: caret must contrast in light/dark (CodeMirror draws the cursor with a border) */
+      .query-editor-wrapper .cm-cursor,
+      .query-editor-wrapper .cm-dropCursor,
+      .query-editor-wrapper .cm-cursor-primary {
+        border-left-color: var(--foreground) !important;
+        border-left-width: 2px !important;
       }
 
       /* Autocomplete dropdown styling - shadcn style */


### PR DESCRIPTION
1) Had a problem with dark/light theme: filter input didn't have contrast marker blink because of overwrited, but not complited css

2) Clear button had strange gap and had transperency

3) Auto scrolling when select text didn't work as expected (didn't auto scroll to select hidden text) 

4) Input field had pure focus styling, so it wasn't clear when input is active

https://github.com/user-attachments/assets/7e630823-ebfd-4a55-bcb1-68b83f847706

Fixed:


https://github.com/user-attachments/assets/1e4313ab-5ff1-444d-83e1-731eccaea636