### PR TITLE
[00003] Add Connected Accounts Support for Independent OAuth Providers

### DIFF
--- a/src/Ivy.Tests/Auth/AuthHelperConnectedAccountTests.cs
+++ b/src/Ivy.Tests/Auth/AuthHelperConnectedAccountTests.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 using Ivy.Core.Auth;
 using Microsoft.AspNetCore.Http;

--- a/src/Ivy.Tests/Auth/AuthHelperConnectedAccountTests.cs
+++ b/src/Ivy.Tests/Auth/AuthHelperConnectedAccountTests.cs
@@ -1,0 +1,179 @@
+using System.Collections;
+using System.Diagnostics.CodeAnalysis;
+using Ivy.Core.Auth;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Net.Http.Headers;
+
+namespace Ivy.Tests.Auth;
+
+[Collection("AuthCookiePrefix")]
+public class AuthHelperConnectedAccountTests : IDisposable
+{
+    public AuthHelperConnectedAccountTests()
+    {
+        Server.AuthCookiePrefix = null;
+    }
+
+    public void Dispose()
+    {
+        Server.AuthCookiePrefix = null;
+    }
+
+    [Fact]
+    public void ExtractConnectedAccountsFromCookies_ExtractsConnPrefixedCookies()
+    {
+        Server.AuthCookiePrefix = null;
+        var cookies = new TestRequestCookieCollection(new Dictionary<string, string>
+        {
+            ["access_token"] = "main-token",
+            ["conn_github_access_token"] = "github-token",
+            ["conn_github_refresh_token"] = "github-refresh",
+            ["conn_github_auth_tag"] = "github-tag",
+        });
+
+        var result = AuthHelper.ExtractConnectedAccountsFromCookies(cookies);
+
+        Assert.Single(result);
+        Assert.True(result.ContainsKey("github"));
+        Assert.Equal("github-token", result["github"].AuthToken?.AccessToken);
+        Assert.Equal("github-refresh", result["github"].AuthToken?.RefreshToken);
+        Assert.Equal("github-tag", result["github"].AuthToken?.Tag);
+    }
+
+    [Fact]
+    public void ExtractConnectedAccountsFromCookies_ReturnsIAuthSessionInstances()
+    {
+        Server.AuthCookiePrefix = null;
+        var cookies = new TestRequestCookieCollection(new Dictionary<string, string>
+        {
+            ["access_token"] = "main-token",
+            ["conn_slack_access_token"] = "slack-token",
+        });
+
+        var result = AuthHelper.ExtractConnectedAccountsFromCookies(cookies);
+
+        Assert.Single(result);
+        Assert.IsAssignableFrom<IAuthSession>(result["slack"]);
+    }
+
+    [Fact]
+    public void ExtractConnectedAccountsFromCookies_IgnoresNonConnectedCookies()
+    {
+        Server.AuthCookiePrefix = null;
+        var cookies = new TestRequestCookieCollection(new Dictionary<string, string>
+        {
+            ["access_token"] = "main-token",
+            ["google_access_token"] = "google-brokered-token",
+            ["conn_github_access_token"] = "github-connected-token",
+        });
+
+        var result = AuthHelper.ExtractConnectedAccountsFromCookies(cookies);
+
+        Assert.Single(result);
+        Assert.True(result.ContainsKey("github"));
+        Assert.False(result.ContainsKey("google"));
+    }
+
+    [Fact]
+    public void ExtractConnectedAccountsFromCookies_WithPrefix_ExtractsOwnPrefixedConnCookies()
+    {
+        Server.AuthCookiePrefix = "clerk";
+        var cookies = new TestRequestCookieCollection(new Dictionary<string, string>
+        {
+            ["clerk__access_token"] = "main-token",
+            ["clerk__conn_github_access_token"] = "github-token",
+            ["basic__conn_slack_access_token"] = "should-be-ignored",
+        });
+
+        var result = AuthHelper.ExtractConnectedAccountsFromCookies(cookies);
+
+        Assert.Single(result);
+        Assert.True(result.ContainsKey("github"));
+        Assert.False(result.ContainsKey("slack"));
+    }
+
+    [Fact]
+    public void ExtractBrokeredSessionsFromCookies_ExcludesConnPrefixedCookies()
+    {
+        Server.AuthCookiePrefix = null;
+        var cookies = new TestRequestCookieCollection(new Dictionary<string, string>
+        {
+            ["access_token"] = "main-token",
+            ["google_access_token"] = "google-token",
+            ["conn_github_access_token"] = "github-connected-token",
+        });
+
+        var result = AuthHelper.ExtractBrokeredSessionsFromCookies(cookies);
+
+        Assert.Single(result);
+        Assert.True(result.ContainsKey("google"));
+        Assert.False(result.ContainsKey("conn_github"));
+        Assert.False(result.ContainsKey("github"));
+    }
+
+    [Fact]
+    public void ExtractConnectedAccountsFromCookieHeader_ExtractsConnPrefixedCookies()
+    {
+        Server.AuthCookiePrefix = null;
+        var cookieHeader = CookieHeaderValue.ParseList(new[]
+        {
+            "access_token=main-token; conn_github_access_token=github-token; conn_github_refresh_token=github-refresh"
+        }).ToList();
+
+        var result = AuthHelper.ExtractConnectedAccountsFromCookieHeader(cookieHeader);
+
+        Assert.Single(result);
+        Assert.True(result.ContainsKey("github"));
+        Assert.Equal("github-token", result["github"].AuthToken?.AccessToken);
+        Assert.Equal("github-refresh", result["github"].AuthToken?.RefreshToken);
+    }
+
+    [Fact]
+    public void ExtractBrokeredSessionsFromCookieHeader_ExcludesConnPrefixedCookies()
+    {
+        Server.AuthCookiePrefix = null;
+        var cookieHeader = CookieHeaderValue.ParseList(new[]
+        {
+            "access_token=main-token; google_access_token=google-token; conn_github_access_token=github-token"
+        }).ToList();
+
+        var result = AuthHelper.ExtractBrokeredSessionsFromCookieHeader(cookieHeader);
+
+        Assert.Single(result);
+        Assert.True(result.ContainsKey("google"));
+        Assert.False(result.ContainsKey("github"));
+    }
+
+    private class TestRequestCookieCollection : IRequestCookieCollection
+    {
+        private readonly Dictionary<string, string> _cookies;
+
+        public TestRequestCookieCollection(Dictionary<string, string> cookies)
+        {
+            _cookies = cookies;
+        }
+
+        public string? this[string key] => _cookies.TryGetValue(key, out var value) ? value : null;
+
+        public int Count => _cookies.Count;
+
+        public ICollection<string> Keys => _cookies.Keys;
+
+        public bool ContainsKey(string key) => _cookies.ContainsKey(key);
+
+        public bool TryGetValue(string key, [NotNullWhen(true)] out string? value)
+        {
+            if (_cookies.TryGetValue(key, out var v))
+            {
+                value = v;
+                return true;
+            }
+            value = null;
+            return false;
+        }
+
+        public IEnumerator<KeyValuePair<string, string>> GetEnumerator() => _cookies.GetEnumerator();
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/src/Ivy.Tests/Auth/ConnectedAccountLifecycleTests.cs
+++ b/src/Ivy.Tests/Auth/ConnectedAccountLifecycleTests.cs
@@ -1,0 +1,71 @@
+namespace Ivy.Tests.Auth;
+
+public class ConnectedAccountLifecycleTests
+{
+    [Fact]
+    public void ConnectedAccounts_PersistThroughMainAuthLogout()
+    {
+        var session = new AuthSession(authToken: new AuthToken("main-token"));
+        var githubSession = new AuthSession(authToken: new AuthToken("github-token"));
+        session.AddConnectedAccount("github", githubSession);
+        session.AddBrokeredSession("google", new AuthTokenHandlerSession(authToken: new AuthToken("google-brokered")));
+
+        // Simulate logout: clear main token and brokered sessions
+        session.AuthToken = null;
+        session.ClearBrokeredSessions();
+
+        // Connected accounts should persist
+        Assert.Single(session.ConnectedAccounts);
+        Assert.True(session.ConnectedAccounts.ContainsKey("github"));
+        Assert.Equal("github-token", session.ConnectedAccounts["github"].AuthToken?.AccessToken);
+
+        // Brokered sessions should be cleared
+        Assert.Empty(session.BrokeredSessions);
+    }
+
+    [Fact]
+    public void ConnectedAccounts_ClearedOnlyWhenExplicitlyDisconnected()
+    {
+        var session = new AuthSession(authToken: new AuthToken("main-token"));
+        var githubSession = new AuthSession(authToken: new AuthToken("github-token"));
+        var slackSession = new AuthSession(authToken: new AuthToken("slack-token"));
+        session.AddConnectedAccount("github", githubSession);
+        session.AddConnectedAccount("slack", slackSession);
+
+        // Disconnect only github
+        session.RemoveConnectedAccount("github");
+
+        Assert.Single(session.ConnectedAccounts);
+        Assert.False(session.ConnectedAccounts.ContainsKey("github"));
+        Assert.True(session.ConnectedAccounts.ContainsKey("slack"));
+    }
+
+    [Fact]
+    public void ClearConnectedAccounts_RemovesAll()
+    {
+        var session = new AuthSession(authToken: new AuthToken("main-token"));
+        session.AddConnectedAccount("github", new AuthSession(authToken: new AuthToken("github-token")));
+        session.AddConnectedAccount("slack", new AuthSession(authToken: new AuthToken("slack-token")));
+
+        session.ClearConnectedAccounts();
+
+        Assert.Empty(session.ConnectedAccounts);
+    }
+
+    [Fact]
+    public void ClearConnectedAccounts_FiresEventsForEachProvider()
+    {
+        var session = new AuthSession(authToken: null);
+        session.AddConnectedAccount("github", new AuthSession(authToken: null));
+        session.AddConnectedAccount("slack", new AuthSession(authToken: null));
+
+        var removedProviders = new List<string>();
+        session.ConnectedAccountRemoved += provider => removedProviders.Add(provider);
+
+        session.ClearConnectedAccounts();
+
+        Assert.Equal(2, removedProviders.Count);
+        Assert.Contains("github", removedProviders);
+        Assert.Contains("slack", removedProviders);
+    }
+}

--- a/src/Ivy.Tests/Auth/ConnectedAccountSessionTests.cs
+++ b/src/Ivy.Tests/Auth/ConnectedAccountSessionTests.cs
@@ -1,0 +1,115 @@
+namespace Ivy.Tests.Auth;
+
+public class ConnectedAccountSessionTests
+{
+    [Fact]
+    public void ConnectedAccounts_ReturnFullIAuthSession()
+    {
+        var session = new AuthSession(authToken: null);
+        var connectedSession = new AuthSession(authToken: new AuthToken("connected-token", "connected-refresh"));
+        session.AddConnectedAccount("github", connectedSession);
+
+        var account = session.ConnectedAccounts["github"];
+
+        Assert.IsAssignableFrom<IAuthSession>(account);
+        Assert.Equal("connected-token", account.AuthToken?.AccessToken);
+        Assert.Equal("connected-refresh", account.AuthToken?.RefreshToken);
+    }
+
+    [Fact]
+    public void ConnectedAccounts_CanHaveOwnBrokeredSessions()
+    {
+        var connectedSession = new AuthSession(authToken: new AuthToken("connected-token"));
+        connectedSession.AddBrokeredSession("sub-provider", new AuthTokenHandlerSession(authToken: new AuthToken("sub-token")));
+
+        var session = new AuthSession(authToken: null);
+        session.AddConnectedAccount("github", connectedSession);
+
+        var account = session.ConnectedAccounts["github"];
+        Assert.Single(account.BrokeredSessions);
+        Assert.True(account.BrokeredSessions.ContainsKey("sub-provider"));
+        Assert.Equal("sub-token", account.BrokeredSessions["sub-provider"].AuthToken?.AccessToken);
+    }
+
+    [Fact]
+    public void ConnectedAccount_TokenRefreshUpdatesSession()
+    {
+        var connectedSession = new AuthSession(authToken: new AuthToken("old-token"));
+        var session = new AuthSession(authToken: null);
+        session.AddConnectedAccount("github", connectedSession);
+
+        // Simulate token refresh
+        var newToken = new AuthToken("new-token", "new-refresh");
+        session.ConnectedAccounts["github"].AuthToken = newToken;
+
+        Assert.Equal("new-token", session.ConnectedAccounts["github"].AuthToken?.AccessToken);
+        Assert.Equal("new-refresh", session.ConnectedAccounts["github"].AuthToken?.RefreshToken);
+    }
+
+    [Fact]
+    public void AddConnectedAccount_FiresAddedEvent()
+    {
+        var session = new AuthSession(authToken: null);
+        string? addedProvider = null;
+        session.ConnectedAccountAdded += provider => addedProvider = provider;
+
+        session.AddConnectedAccount("github", new AuthSession(authToken: null));
+
+        Assert.Equal("github", addedProvider);
+    }
+
+    [Fact]
+    public void AddConnectedAccount_DoesNotFireEventOnUpdate()
+    {
+        var session = new AuthSession(authToken: null);
+        session.AddConnectedAccount("github", new AuthSession(authToken: new AuthToken("old-token")));
+
+        var eventFired = false;
+        session.ConnectedAccountAdded += _ => eventFired = true;
+
+        session.AddConnectedAccount("github", new AuthSession(authToken: new AuthToken("new-token")));
+
+        Assert.False(eventFired);
+    }
+
+    [Fact]
+    public void RemoveConnectedAccount_FiresRemovedEvent()
+    {
+        var session = new AuthSession(authToken: null);
+        session.AddConnectedAccount("github", new AuthSession(authToken: null));
+
+        string? removedProvider = null;
+        session.ConnectedAccountRemoved += provider => removedProvider = provider;
+
+        session.RemoveConnectedAccount("github");
+
+        Assert.Equal("github", removedProvider);
+    }
+
+    [Fact]
+    public void RemoveConnectedAccount_DoesNotFireEventIfNotPresent()
+    {
+        var session = new AuthSession(authToken: null);
+
+        var eventFired = false;
+        session.ConnectedAccountRemoved += _ => eventFired = true;
+
+        session.RemoveConnectedAccount("nonexistent");
+
+        Assert.False(eventFired);
+    }
+
+    [Fact]
+    public void ConnectedAccount_ConstructorPreInitialization()
+    {
+        var preInitialized = new Dictionary<string, IAuthSession>
+        {
+            ["github"] = new AuthSession(authToken: new AuthToken("pre-init-token"))
+        };
+
+        var session = new AuthSession(connectedAccounts: preInitialized);
+
+        Assert.Single(session.ConnectedAccounts);
+        Assert.Equal("pre-init-token", session.ConnectedAccounts["github"].AuthToken?.AccessToken);
+    }
+}

--- a/src/Ivy.Tests/Auth/ConnectedAccountsServiceTests.cs
+++ b/src/Ivy.Tests/Auth/ConnectedAccountsServiceTests.cs
@@ -1,4 +1,3 @@
-using Ivy.Core.Auth;
 using Ivy.Core.Server;
 using Microsoft.Extensions.DependencyInjection;
 

--- a/src/Ivy.Tests/Auth/ConnectedAccountsServiceTests.cs
+++ b/src/Ivy.Tests/Auth/ConnectedAccountsServiceTests.cs
@@ -1,0 +1,112 @@
+using Ivy.Core.Auth;
+using Ivy.Core.Server;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Ivy.Tests.Auth;
+
+public class ConnectedAccountsServiceTests
+{
+    private static IServiceProvider CreateEmptyServiceProvider()
+    {
+        var services = new ServiceCollection();
+        return services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public void GetAvailableProviders_ReturnsEmptyWhenNoConnectedAccounts()
+    {
+        var authSession = new AuthSession(authToken: null);
+        var sessionStore = new AppSessionStore();
+        var service = new ConnectedAccountsService(authSession, CreateEmptyServiceProvider(), null!, sessionStore);
+
+        var providers = service.GetAvailableProviders();
+        Assert.Empty(providers);
+    }
+
+    [Fact]
+    public void GetAvailableProviders_ReturnsConnectedAccountKeys()
+    {
+        var authSession = new AuthSession(authToken: null);
+        var githubSession = new AuthSession(authToken: new AuthToken("github-token"));
+        authSession.AddConnectedAccount("github", githubSession);
+
+        var sessionStore = new AppSessionStore();
+        var service = new ConnectedAccountsService(authSession, CreateEmptyServiceProvider(), null!, sessionStore);
+
+        var providers = service.GetAvailableProviders();
+        Assert.Single(providers);
+        Assert.Equal("github", providers[0]);
+    }
+
+    [Fact]
+    public void GetAccountSession_ReturnsNullWhenNotConnected()
+    {
+        var authSession = new AuthSession(authToken: null);
+        var sessionStore = new AppSessionStore();
+        var service = new ConnectedAccountsService(authSession, CreateEmptyServiceProvider(), null!, sessionStore);
+
+        var session = service.GetAccountSession("github");
+        Assert.Null(session);
+    }
+
+    [Fact]
+    public void GetAccountSession_ReturnsSessionWhenConnected()
+    {
+        var authSession = new AuthSession(authToken: null);
+        var githubSession = new AuthSession(authToken: new AuthToken("github-token"));
+        authSession.AddConnectedAccount("github", githubSession);
+
+        var sessionStore = new AppSessionStore();
+        var service = new ConnectedAccountsService(authSession, CreateEmptyServiceProvider(), null!, sessionStore);
+
+        var session = service.GetAccountSession("github");
+        Assert.NotNull(session);
+        Assert.Equal("github-token", session.AuthToken?.AccessToken);
+    }
+
+    [Fact]
+    public void DisconnectAccountAsync_RemovesConnectedAccount()
+    {
+        var authSession = new AuthSession(authToken: null);
+        var githubSession = new AuthSession(authToken: new AuthToken("github-token"));
+        authSession.AddConnectedAccount("github", githubSession);
+
+        // Directly test the session management since DisconnectAccountAsync also triggers cookie updates
+        authSession.RemoveConnectedAccount("github");
+
+        Assert.Empty(authSession.ConnectedAccounts);
+    }
+
+    [Fact]
+    public async Task DisconnectAccountAsync_DoesNothingWhenNotConnected()
+    {
+        var authSession = new AuthSession(authToken: null);
+        var sessionStore = new AppSessionStore();
+        var service = new ConnectedAccountsService(authSession, CreateEmptyServiceProvider(), null!, sessionStore);
+
+        await service.DisconnectAccountAsync("github");
+        Assert.Empty(authSession.ConnectedAccounts);
+    }
+
+    [Fact]
+    public async Task ConnectAccountAsync_ThrowsWhenProviderNotRegistered()
+    {
+        var authSession = new AuthSession(authToken: null);
+        var sessionStore = new AppSessionStore();
+        var service = new ConnectedAccountsService(authSession, CreateEmptyServiceProvider(), null!, sessionStore);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => service.ConnectAccountAsync("github", null!));
+    }
+
+    [Fact]
+    public async Task HandleConnectCallbackAsync_ThrowsWhenProviderNotRegistered()
+    {
+        var authSession = new AuthSession(authToken: null);
+        var sessionStore = new AppSessionStore();
+        var service = new ConnectedAccountsService(authSession, CreateEmptyServiceProvider(), null!, sessionStore);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => service.HandleConnectCallbackAsync("github", null!));
+    }
+}

--- a/src/Ivy.Tests/Auth/CookieRegistryExtensionsConnectedTests.cs
+++ b/src/Ivy.Tests/Auth/CookieRegistryExtensionsConnectedTests.cs
@@ -1,0 +1,90 @@
+using Ivy.Core.Auth;
+
+namespace Ivy.Tests.Auth;
+
+[Collection("AuthCookiePrefix")]
+public class CookieRegistryExtensionsConnectedTests : IDisposable
+{
+    public CookieRegistryExtensionsConnectedTests()
+    {
+        Server.AuthCookiePrefix = null;
+    }
+
+    public void Dispose()
+    {
+        Server.AuthCookiePrefix = null;
+    }
+
+    [Fact]
+    public void AddCookiesForConnectedAccounts_WritesCookiesWithConnPrefix()
+    {
+        Server.AuthCookiePrefix = null;
+        var cookies = new CookieJar();
+        var connectedAccounts = new Dictionary<string, IAuthSession>
+        {
+            ["github"] = new AuthSession(authToken: new AuthToken("github-access", "github-refresh", "github-tag"))
+        };
+
+        cookies.AddCookiesForConnectedAccounts(connectedAccounts);
+
+        Assert.True(cookies.TryGet("conn_github_access_token", out var accessToken));
+        Assert.Equal("github-access", accessToken);
+        Assert.True(cookies.TryGet("conn_github_refresh_token", out var refreshToken));
+        Assert.Equal("github-refresh", refreshToken);
+        Assert.True(cookies.TryGet("conn_github_auth_tag", out var tag));
+        Assert.Equal("github-tag", tag);
+    }
+
+    [Fact]
+    public void AddCookiesForConnectedAccounts_WithPrefix_UsesPrefixedNames()
+    {
+        Server.AuthCookiePrefix = "clerk";
+        var cookies = new CookieJar();
+        var connectedAccounts = new Dictionary<string, IAuthSession>
+        {
+            ["github"] = new AuthSession(authToken: new AuthToken("github-access"))
+        };
+
+        cookies.AddCookiesForConnectedAccounts(connectedAccounts);
+
+        Assert.True(cookies.TryGet("clerk__conn_github_access_token", out var accessToken));
+        Assert.Equal("github-access", accessToken);
+        Assert.False(cookies.TryGet("conn_github_access_token", out _));
+    }
+
+    [Fact]
+    public void AddCookiesForConnectedAccounts_HandlesNullTokens()
+    {
+        Server.AuthCookiePrefix = null;
+        var cookies = new CookieJar();
+        var connectedAccounts = new Dictionary<string, IAuthSession>
+        {
+            ["github"] = new AuthSession(authToken: null)
+        };
+
+        cookies.AddCookiesForConnectedAccounts(connectedAccounts);
+
+        // Should attempt to delete cookies (empty value)
+        Assert.True(cookies.TryGet("conn_github_access_token", out var value));
+        Assert.Equal(string.Empty, value);
+    }
+
+    [Fact]
+    public void AddCookiesForConnectedAccounts_MultipleProviders()
+    {
+        Server.AuthCookiePrefix = null;
+        var cookies = new CookieJar();
+        var connectedAccounts = new Dictionary<string, IAuthSession>
+        {
+            ["github"] = new AuthSession(authToken: new AuthToken("github-access")),
+            ["slack"] = new AuthSession(authToken: new AuthToken("slack-access"))
+        };
+
+        cookies.AddCookiesForConnectedAccounts(connectedAccounts);
+
+        Assert.True(cookies.TryGet("conn_github_access_token", out var githubToken));
+        Assert.Equal("github-access", githubToken);
+        Assert.True(cookies.TryGet("conn_slack_access_token", out var slackToken));
+        Assert.Equal("slack-access", slackToken);
+    }
+}

--- a/src/Ivy/Auth/AuthService.cs
+++ b/src/Ivy/Auth/AuthService.cs
@@ -172,15 +172,15 @@ public class AuthService : AuthTokenHandlerService, IAuthService
         {
             // Pass removed providers so their cookies get deleted
             var cookieJarId = _sessionStore.RegisterAuthSessionCookies(_authSession, removedProviders);
-            _client.SetAuthCookies(cookieJarId, reloadPage: false, triggerMachineReload: null, triggerMachineBrokeredRefresh: true);
+            _client.SetAuthCookies(cookieJarId, reloadPage: false, triggerMachineReload: null, triggerMachineAuthSync: true);
         }
 
         return BrokeredSessionsResult.Success(filteredSessions);
     }
 
-    public void SetAuthCookies(bool reloadPage = true, bool? triggerMachineReload = null, bool triggerMachineBrokeredRefresh = false)
+    public void SetAuthCookies(bool reloadPage = true, bool? triggerMachineReload = null, bool triggerMachineAuthSync = false)
     {
         var cookieJarId = _sessionStore.RegisterAuthSessionCookies(_authSession);
-        _client.SetAuthCookies(cookieJarId, reloadPage, triggerMachineReload, triggerMachineBrokeredRefresh);
+        _client.SetAuthCookies(cookieJarId, reloadPage, triggerMachineReload, triggerMachineAuthSync);
     }
 }

--- a/src/Ivy/Auth/AuthService.cs
+++ b/src/Ivy/Auth/AuthService.cs
@@ -90,6 +90,7 @@ public class AuthService : AuthTokenHandlerService, IAuthService
 
         _authSession.AuthToken = null;
         _authSession.ClearBrokeredSessions();
+        // NOTE: Do NOT clear connected accounts - they persist independently of main auth
 
         // Pass the captured providers to delete their cookies
         var cookieJarId = _sessionStore.RegisterAuthSessionCookies(_authSession, providersToDelete);

--- a/src/Ivy/Auth/AuthSessionExtensions.cs
+++ b/src/Ivy/Auth/AuthSessionExtensions.cs
@@ -31,13 +31,15 @@ public static class AuthSessionExtensions
         {
             AuthToken = authSession.AuthToken,
             BrokeredSessions = new Dictionary<string, IAuthTokenHandlerSession>(authSession.BrokeredSessions),
+            ConnectedAccounts = new Dictionary<string, IAuthSession>(authSession.ConnectedAccounts),
             AuthSessionData = authSession.AuthSessionData,
         };
 
     public static bool HasChangedSince(this IAuthSession authSession, AuthSessionSnapshot snapshot)
         => authSession.AuthToken != snapshot.AuthToken ||
            authSession.AuthSessionData != snapshot.AuthSessionData ||
-           !BrokeredSessionsEqual(authSession.BrokeredSessions, snapshot.BrokeredSessions);
+           !BrokeredSessionsEqual(authSession.BrokeredSessions, snapshot.BrokeredSessions) ||
+           !ConnectedAccountsEqual(authSession.ConnectedAccounts, snapshot.ConnectedAccounts);
 
     private static bool BrokeredSessionsEqual(
         IReadOnlyDictionary<string, IAuthTokenHandlerSession> current,
@@ -53,6 +55,29 @@ public static class AuthSessionExtensions
             }
 
             // Compare the sessions by their auth tokens
+            if (kvp.Value.AuthToken != snapshotSession.AuthToken ||
+                kvp.Value.AuthSessionData != snapshotSession.AuthSessionData)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool ConnectedAccountsEqual(
+        IReadOnlyDictionary<string, IAuthSession> current,
+        IReadOnlyDictionary<string, IAuthSession> snapshot)
+    {
+        if (current.Count != snapshot.Count) return false;
+
+        foreach (var kvp in current)
+        {
+            if (!snapshot.TryGetValue(kvp.Key, out var snapshotSession))
+            {
+                return false;
+            }
+
             if (kvp.Value.AuthToken != snapshotSession.AuthToken ||
                 kvp.Value.AuthSessionData != snapshotSession.AuthSessionData)
             {

--- a/src/Ivy/Auth/ConnectedAccountsService.cs
+++ b/src/Ivy/Auth/ConnectedAccountsService.cs
@@ -1,0 +1,150 @@
+using Ivy.Core;
+using Ivy.Core.Auth;
+using Ivy.Core.Server;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+// ReSharper disable once CheckNamespace
+namespace Ivy;
+
+public class ConnectedAccountsService : IConnectedAccountsService
+{
+    private readonly IAuthSession _authSession;
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IClientProvider _client;
+    private readonly AppSessionStore _sessionStore;
+    private readonly ILogger<ConnectedAccountsService> _logger;
+
+    public ConnectedAccountsService(
+        IAuthSession authSession,
+        IServiceProvider serviceProvider,
+        IClientProvider client,
+        AppSessionStore sessionStore,
+        ILogger<ConnectedAccountsService>? logger = null)
+    {
+        _authSession = authSession;
+        _serviceProvider = serviceProvider;
+        _client = client;
+        _sessionStore = sessionStore;
+        _logger = logger ?? NullLogger<ConnectedAccountsService>.Instance;
+    }
+
+    public string[] GetAvailableProviders()
+    {
+        return _authSession.ConnectedAccounts.Keys.ToArray();
+    }
+
+    public async Task<Uri> ConnectAccountAsync(string provider, WebhookEndpoint callback, CancellationToken cancellationToken = default)
+    {
+        var authProvider = _serviceProvider.GetKeyedService<IAuthProvider>(provider);
+        if (authProvider == null)
+        {
+            throw new InvalidOperationException($"Connected account provider '{provider}' is not registered.");
+        }
+
+        var connectedSession = _authSession.ConnectedAccounts.TryGetValue(provider, out var existing)
+            ? existing
+            : new AuthSession(authToken: null);
+
+        var authOptions = authProvider.GetAuthOptions();
+        var option = authOptions.FirstOrDefault() ?? new AuthOption(AuthFlow.OAuth, Name: provider);
+
+        var uri = await authProvider.GetOAuthUriAsync(connectedSession, option, callback, cancellationToken);
+
+        if (connectedSession.AuthSessionData != null)
+        {
+            _authSession.AddConnectedAccount(provider, connectedSession);
+            SetConnectedAccountCookies();
+        }
+
+        return uri;
+    }
+
+    public async Task<AuthToken?> HandleConnectCallbackAsync(string provider, HttpRequest request, CancellationToken cancellationToken = default)
+    {
+        var authProvider = _serviceProvider.GetKeyedService<IAuthProvider>(provider);
+        if (authProvider == null)
+        {
+            throw new InvalidOperationException($"Connected account provider '{provider}' is not registered.");
+        }
+
+        var connectedSession = _authSession.ConnectedAccounts.TryGetValue(provider, out var existing)
+            ? existing
+            : new AuthSession(authToken: null);
+
+        var token = await authProvider.HandleOAuthCallbackAsync(connectedSession, request, cancellationToken);
+        connectedSession.AuthToken = token;
+
+        if (token != null)
+        {
+            _authSession.AddConnectedAccount(provider, connectedSession);
+            SetConnectedAccountCookies();
+        }
+
+        return token;
+    }
+
+    public async Task DisconnectAccountAsync(string provider, CancellationToken cancellationToken = default)
+    {
+        if (_authSession.ConnectedAccounts.TryGetValue(provider, out var session))
+        {
+            var authProvider = _serviceProvider.GetKeyedService<IAuthProvider>(provider);
+            if (authProvider != null)
+            {
+                try
+                {
+                    await authProvider.LogoutAsync(session, cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Error logging out from connected account provider '{Provider}'", provider);
+                }
+            }
+
+            _authSession.RemoveConnectedAccount(provider);
+            SetConnectedAccountCookies();
+        }
+    }
+
+    public IAuthSession? GetAccountSession(string provider)
+    {
+        return _authSession.ConnectedAccounts.TryGetValue(provider, out var session) ? session : null;
+    }
+
+    public async Task RefreshAllAsync(CancellationToken cancellationToken = default)
+    {
+        var providers = _authSession.ConnectedAccounts.Keys.ToList();
+        foreach (var provider in providers)
+        {
+            var authProvider = _serviceProvider.GetKeyedService<IAuthProvider>(provider);
+            if (authProvider == null)
+            {
+                continue;
+            }
+
+            var session = _authSession.ConnectedAccounts[provider];
+            try
+            {
+                var newToken = await authProvider.RefreshAccessTokenAsync(session, cancellationToken);
+                if (newToken != null)
+                {
+                    session.AuthToken = newToken;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Error refreshing connected account '{Provider}'", provider);
+            }
+        }
+
+        SetConnectedAccountCookies();
+    }
+
+    private void SetConnectedAccountCookies()
+    {
+        var cookieJarId = _sessionStore.RegisterAuthSessionCookies(_authSession);
+        _client.SetAuthCookies(cookieJarId, reloadPage: false, triggerMachineReload: null);
+    }
+}

--- a/src/Ivy/Auth/ConnectedAccountsService.cs
+++ b/src/Ivy/Auth/ConnectedAccountsService.cs
@@ -17,6 +17,9 @@ public class ConnectedAccountsService : IConnectedAccountsService
     private readonly AppSessionStore _sessionStore;
     private readonly ILogger<ConnectedAccountsService> _logger;
 
+    public event Action<string>? AccountConnected;
+    public event Action<string>? AccountDisconnected;
+
     public ConnectedAccountsService(
         IAuthSession authSession,
         IServiceProvider serviceProvider,
@@ -29,6 +32,9 @@ public class ConnectedAccountsService : IConnectedAccountsService
         _client = client;
         _sessionStore = sessionStore;
         _logger = logger ?? NullLogger<ConnectedAccountsService>.Instance;
+
+        _authSession.ConnectedAccountAdded += provider => AccountConnected?.Invoke(provider);
+        _authSession.ConnectedAccountRemoved += provider => AccountDisconnected?.Invoke(provider);
     }
 
     public string[] GetAvailableProviders()

--- a/src/Ivy/Auth/ConnectedAccountsService.cs
+++ b/src/Ivy/Auth/ConnectedAccountsService.cs
@@ -104,7 +104,7 @@ public class ConnectedAccountsService : IConnectedAccountsService
             }
 
             _authSession.RemoveConnectedAccount(provider);
-            SetConnectedAccountCookies();
+            SetConnectedAccountCookies(disconnectedProviders: [provider]);
         }
     }
 
@@ -142,9 +142,9 @@ public class ConnectedAccountsService : IConnectedAccountsService
         SetConnectedAccountCookies();
     }
 
-    private void SetConnectedAccountCookies()
+    private void SetConnectedAccountCookies(IEnumerable<string>? disconnectedProviders = null)
     {
-        var cookieJarId = _sessionStore.RegisterAuthSessionCookies(_authSession);
+        var cookieJarId = _sessionStore.RegisterAuthSessionCookies(_authSession, disconnectedProviders: disconnectedProviders);
         _client.SetAuthCookies(cookieJarId, reloadPage: false, triggerMachineReload: null);
     }
 }

--- a/src/Ivy/Auth/ConnectedAccountsService.cs
+++ b/src/Ivy/Auth/ConnectedAccountsService.cs
@@ -80,7 +80,7 @@ public class ConnectedAccountsService : IConnectedAccountsService
         if (token != null)
         {
             _authSession.AddConnectedAccount(provider, connectedSession);
-            SetConnectedAccountCookies();
+            SetConnectedAccountCookies(triggerMachineAuthSync: true);
         }
 
         return token;
@@ -104,7 +104,7 @@ public class ConnectedAccountsService : IConnectedAccountsService
             }
 
             _authSession.RemoveConnectedAccount(provider);
-            SetConnectedAccountCookies(connectedProvidersToDelete: [provider]);
+            SetConnectedAccountCookies(connectedProvidersToDelete: [provider], triggerMachineAuthSync: true);
         }
     }
 
@@ -142,9 +142,9 @@ public class ConnectedAccountsService : IConnectedAccountsService
         SetConnectedAccountCookies();
     }
 
-    private void SetConnectedAccountCookies(IEnumerable<string>? connectedProvidersToDelete = null)
+    private void SetConnectedAccountCookies(IEnumerable<string>? connectedProvidersToDelete = null, bool triggerMachineAuthSync = false)
     {
         var cookieJarId = _sessionStore.RegisterAuthSessionCookies(_authSession, connectedProvidersToDelete: connectedProvidersToDelete);
-        _client.SetAuthCookies(cookieJarId, reloadPage: false, triggerMachineReload: null);
+        _client.SetAuthCookies(cookieJarId, reloadPage: false, triggerMachineReload: null, triggerMachineAuthSync: triggerMachineAuthSync);
     }
 }

--- a/src/Ivy/Auth/ConnectedAccountsService.cs
+++ b/src/Ivy/Auth/ConnectedAccountsService.cs
@@ -104,7 +104,7 @@ public class ConnectedAccountsService : IConnectedAccountsService
             }
 
             _authSession.RemoveConnectedAccount(provider);
-            SetConnectedAccountCookies(disconnectedProviders: [provider]);
+            SetConnectedAccountCookies(connectedProvidersToDelete: [provider]);
         }
     }
 
@@ -142,9 +142,9 @@ public class ConnectedAccountsService : IConnectedAccountsService
         SetConnectedAccountCookies();
     }
 
-    private void SetConnectedAccountCookies(IEnumerable<string>? disconnectedProviders = null)
+    private void SetConnectedAccountCookies(IEnumerable<string>? connectedProvidersToDelete = null)
     {
-        var cookieJarId = _sessionStore.RegisterAuthSessionCookies(_authSession, disconnectedProviders: disconnectedProviders);
+        var cookieJarId = _sessionStore.RegisterAuthSessionCookies(_authSession, connectedProvidersToDelete: connectedProvidersToDelete);
         _client.SetAuthCookies(cookieJarId, reloadPage: false, triggerMachineReload: null);
     }
 }

--- a/src/Ivy/Auth/ConnectedAccountsService.cs
+++ b/src/Ivy/Auth/ConnectedAccountsService.cs
@@ -119,35 +119,6 @@ public class ConnectedAccountsService : IConnectedAccountsService
         return _authSession.ConnectedAccounts.TryGetValue(provider, out var session) ? session : null;
     }
 
-    public async Task RefreshAllAsync(CancellationToken cancellationToken = default)
-    {
-        var providers = _authSession.ConnectedAccounts.Keys.ToList();
-        foreach (var provider in providers)
-        {
-            var authProvider = _serviceProvider.GetKeyedService<IAuthProvider>(provider);
-            if (authProvider == null)
-            {
-                continue;
-            }
-
-            var session = _authSession.ConnectedAccounts[provider];
-            try
-            {
-                var newToken = await authProvider.RefreshAccessTokenAsync(session, cancellationToken);
-                if (newToken != null)
-                {
-                    session.AuthToken = newToken;
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Error refreshing connected account '{Provider}'", provider);
-            }
-        }
-
-        SetConnectedAccountCookies();
-    }
-
     private void SetConnectedAccountCookies(IEnumerable<string>? connectedProvidersToDelete = null, bool triggerMachineAuthSync = false)
     {
         var cookieJarId = _sessionStore.RegisterAuthSessionCookies(_authSession, connectedProvidersToDelete: connectedProvidersToDelete);

--- a/src/Ivy/Auth/IAuthService.cs
+++ b/src/Ivy/Auth/IAuthService.cs
@@ -20,5 +20,5 @@ public interface IAuthService : IAuthTokenHandlerService
 
     Task<BrokeredSessionsResult> GetBrokeredSessionsAsync(bool skipCache = false, CancellationToken cancellationToken = default);
 
-    internal void SetAuthCookies(bool reloadPage = true, bool? triggerMachineReload = null, bool triggerMachineBrokeredRefresh = false);
+    internal void SetAuthCookies(bool reloadPage = true, bool? triggerMachineReload = null, bool triggerMachineAuthSync = false);
 }

--- a/src/Ivy/Auth/IAuthSession.cs
+++ b/src/Ivy/Auth/IAuthSession.cs
@@ -14,15 +14,26 @@ public interface IAuthSession : IAuthTokenHandlerSession
 
     public event Action<string>? BrokeredSessionAdded;
     public event Action<string>? BrokeredSessionRemoved;
+
+    public IReadOnlyDictionary<string, IAuthSession> ConnectedAccounts { get; }
+
+    public void AddConnectedAccount(string provider, IAuthSession session);
+    public void RemoveConnectedAccount(string provider);
+    public void ClearConnectedAccounts();
+
+    public event Action<string>? ConnectedAccountAdded;
+    public event Action<string>? ConnectedAccountRemoved;
 }
 
 public class AuthSession(
     AuthToken? authToken = null,
     string? authSessionData = null,
     TunneledHttpMessageHandler? httpMessageHandler = null,
-    Dictionary<string, IAuthTokenHandlerSession>? brokeredSessions = null) : AuthTokenHandlerSession(authToken, authSessionData, httpMessageHandler), IAuthSession
+    Dictionary<string, IAuthTokenHandlerSession>? brokeredSessions = null,
+    Dictionary<string, IAuthSession>? connectedAccounts = null) : AuthTokenHandlerSession(authToken, authSessionData, httpMessageHandler), IAuthSession
 {
     private readonly Dictionary<string, IAuthTokenHandlerSession> _brokeredSessions = brokeredSessions ?? [];
+    private readonly Dictionary<string, IAuthSession> _connectedAccounts = connectedAccounts ?? [];
 
     [ActivatorUtilitiesConstructor]
     public AuthSession(TunneledHttpMessageHandler? httpMessageHandler = null) : this(null, null, httpMessageHandler)
@@ -61,11 +72,45 @@ public class AuthSession(
             BrokeredSessionRemoved?.Invoke(provider);
         }
     }
+
+    public IReadOnlyDictionary<string, IAuthSession> ConnectedAccounts => _connectedAccounts;
+
+    public event Action<string>? ConnectedAccountAdded;
+    public event Action<string>? ConnectedAccountRemoved;
+
+    public void AddConnectedAccount(string provider, IAuthSession session)
+    {
+        var isNew = !_connectedAccounts.ContainsKey(provider);
+        _connectedAccounts[provider] = session;
+        if (isNew)
+        {
+            ConnectedAccountAdded?.Invoke(provider);
+        }
+    }
+
+    public void RemoveConnectedAccount(string provider)
+    {
+        if (_connectedAccounts.Remove(provider))
+        {
+            ConnectedAccountRemoved?.Invoke(provider);
+        }
+    }
+
+    public void ClearConnectedAccounts()
+    {
+        var providers = _connectedAccounts.Keys.ToList();
+        _connectedAccounts.Clear();
+        foreach (var provider in providers)
+        {
+            ConnectedAccountRemoved?.Invoke(provider);
+        }
+    }
 }
 
 public readonly struct AuthSessionSnapshot
 {
     public readonly AuthToken? AuthToken { get; init; }
     public readonly IReadOnlyDictionary<string, IAuthTokenHandlerSession> BrokeredSessions { get; init; }
+    public readonly IReadOnlyDictionary<string, IAuthSession> ConnectedAccounts { get; init; }
     public readonly string? AuthSessionData { get; init; }
 }

--- a/src/Ivy/Auth/IConnectedAccountsService.cs
+++ b/src/Ivy/Auth/IConnectedAccountsService.cs
@@ -16,8 +16,6 @@ public interface IConnectedAccountsService
 
     IAuthSession? GetAccountSession(string provider);
 
-    Task RefreshAllAsync(CancellationToken cancellationToken = default);
-
     event Action<string>? AccountConnected;
     event Action<string>? AccountDisconnected;
 }

--- a/src/Ivy/Auth/IConnectedAccountsService.cs
+++ b/src/Ivy/Auth/IConnectedAccountsService.cs
@@ -17,4 +17,7 @@ public interface IConnectedAccountsService
     IAuthSession? GetAccountSession(string provider);
 
     Task RefreshAllAsync(CancellationToken cancellationToken = default);
+
+    event Action<string>? AccountConnected;
+    event Action<string>? AccountDisconnected;
 }

--- a/src/Ivy/Auth/IConnectedAccountsService.cs
+++ b/src/Ivy/Auth/IConnectedAccountsService.cs
@@ -1,0 +1,20 @@
+using Ivy.Core;
+using Microsoft.AspNetCore.Http;
+
+// ReSharper disable once CheckNamespace
+namespace Ivy;
+
+public interface IConnectedAccountsService
+{
+    string[] GetAvailableProviders();
+
+    Task<Uri> ConnectAccountAsync(string provider, WebhookEndpoint callback, CancellationToken cancellationToken = default);
+
+    Task<AuthToken?> HandleConnectCallbackAsync(string provider, HttpRequest request, CancellationToken cancellationToken = default);
+
+    Task DisconnectAccountAsync(string provider, CancellationToken cancellationToken = default);
+
+    IAuthSession? GetAccountSession(string provider);
+
+    Task RefreshAllAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Ivy/Client/ClientExtensions.cs
+++ b/src/Ivy/Client/ClientExtensions.cs
@@ -70,8 +70,8 @@ public static class ClientExtensions
         public required bool ReloadPage { get; set; }
         [DataMember(Name = "triggerMachineReload")]
         public required bool TriggerMachineReload { get; set; }
-        [DataMember(Name = "triggerMachineBrokeredRefresh")]
-        public required bool TriggerMachineBrokeredRefresh { get; set; }
+        [DataMember(Name = "triggerMachineAuthSync")]
+        public required bool TriggerMachineAuthSync { get; set; }
     }
 
     public class SetRootAppIdMessage
@@ -144,7 +144,7 @@ public static class ClientExtensions
         client.Sender.Send("SetTitle", title);
     }
 
-    public static void SetAuthCookies(this IClientProvider client, CookieJarId cookieJarId, bool reloadPage, bool? triggerMachineReload = null, bool triggerMachineBrokeredRefresh = false)
+    public static void SetAuthCookies(this IClientProvider client, CookieJarId cookieJarId, bool reloadPage, bool? triggerMachineReload = null, bool triggerMachineAuthSync = false)
     {
         client.Sender.Send(
             "SetAuthCookies",
@@ -153,7 +153,7 @@ public static class ClientExtensions
                 ["cookieJarId"] = cookieJarId.Value,
                 ["reloadPage"] = reloadPage,
                 ["triggerMachineReload"] = triggerMachineReload ?? reloadPage,
-                ["triggerMachineBrokeredRefresh"] = triggerMachineBrokeredRefresh
+                ["triggerMachineAuthSync"] = triggerMachineAuthSync
             });
     }
 
@@ -162,9 +162,9 @@ public static class ClientExtensions
         client.Sender.Send("ReloadPage", new Dictionary<string, object?>());
     }
 
-    public static void RefreshAuthFromCookies(this IClientProvider client)
+    public static void SyncAuthFromCookies(this IClientProvider client)
     {
-        client.Sender.Send("RefreshAuthFromCookies", new Dictionary<string, object?>());
+        client.Sender.Send("SyncAuthFromCookies", new Dictionary<string, object?>());
     }
 
     public static void SetRootAppId(this IClientProvider client, string rootAppId)

--- a/src/Ivy/Core/Apps/AppSession.cs
+++ b/src/Ivy/Core/Apps/AppSession.cs
@@ -43,6 +43,12 @@ public class AppSession : IAsyncDisposable
     internal HashSet<string>? ActiveBrokeredRefreshLoops { get; set; }
     internal ConcurrentDictionary<string, CancellationTokenSource>? BrokeredRefreshCancellations { get; set; }
 
+    // Connected account session state
+    internal Action<string>? ConnectedAccountAddedHandler { get; set; }
+    internal Action<string>? ConnectedAccountRemovedHandler { get; set; }
+    internal HashSet<string>? ActiveConnectedAccountRefreshLoops { get; set; }
+    internal ConcurrentDictionary<string, CancellationTokenSource>? ConnectedAccountRefreshCancellations { get; set; }
+
     public async ValueTask DisposeAsync()
     {
         _isDisposed = true;

--- a/src/Ivy/Core/Auth/AuthController.cs
+++ b/src/Ivy/Core/Auth/AuthController.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Ivy.Core.Auth;
 
-public record SetAuthCookiesRequest(string CookieJarId, string? ConnectionId, bool TriggerMachineReload, bool TriggerMachineBrokeredRefresh = false);
+public record SetAuthCookiesRequest(string CookieJarId, string? ConnectionId, bool TriggerMachineReload, bool TriggerMachineAuthSync = false);
 
 public class AuthController() : Controller
 {
@@ -193,12 +193,12 @@ public class AuthController() : Controller
             }
         }
 
-        if (request.TriggerMachineBrokeredRefresh)
+        if (request.TriggerMachineAuthSync)
         {
             if (HttpContext.Request.Headers.TryGetValue("X-Machine-Id", out var headerValue))
             {
                 var machineId = headerValue.ToString();
-                TriggerMachineAuthRefresh(sessionStore, SanitizeForLog(machineId), SanitizeForLog(request.ConnectionId), logger);
+                TriggerMachineAuthSync(sessionStore, SanitizeForLog(machineId), SanitizeForLog(request.ConnectionId), logger);
             }
         }
 
@@ -273,7 +273,7 @@ public class AuthController() : Controller
         }
     }
 
-    private static void TriggerMachineAuthRefresh(
+    private static void TriggerMachineAuthSync(
         AppSessionStore sessionStore,
         string machineId,
         string? excludeConnectionId,
@@ -289,13 +289,13 @@ public class AuthController() : Controller
         {
             logger.LogInformation("Triggering auth refresh from cookies for session {ConnectionId}", SanitizeForLog(session.ConnectionId));
             var clientProvider = session.AppServices.GetRequiredService<IClientProvider>();
-            clientProvider.RefreshAuthFromCookies();
+            clientProvider.SyncAuthFromCookies();
         }
     }
 
-    [Route("ivy/auth/refresh-session")]
+    [Route("ivy/auth/sync-session")]
     [HttpPost]
-    public IActionResult RefreshSessionFromCookies(
+    public IActionResult SyncSessionFromCookies(
         [FromHeader(Name = "X-Connection-Id")] string connectionId,
         [FromHeader(Name = "X-Machine-Id")] string machineId,
         [FromServices] AppSessionStore sessionStore,
@@ -304,14 +304,14 @@ public class AuthController() : Controller
         // Validate session exists
         if (!sessionStore.Sessions.TryGetValue(connectionId, out var session))
         {
-            logger.LogWarning("RefreshSessionFromCookies: Session not found for {ConnectionId}", SanitizeForLog(connectionId));
+            logger.LogWarning("SyncSessionFromCookies: Session not found for {ConnectionId}", SanitizeForLog(connectionId));
             return NotFound("Session not found");
         }
 
         // Verify machine ID matches as a security check
         if (session.MachineId != machineId)
         {
-            logger.LogWarning("RefreshSessionFromCookies: Machine ID mismatch for {ConnectionId}. Expected {Expected}, got {Actual}",
+            logger.LogWarning("SyncSessionFromCookies: Machine ID mismatch for {ConnectionId}. Expected {Expected}, got {Actual}",
                 SanitizeForLog(connectionId), SanitizeForLog(session.MachineId), SanitizeForLog(machineId));
             return BadRequest("Machine ID mismatch");
         }
@@ -320,7 +320,7 @@ public class AuthController() : Controller
         var authService = session.AppServices.GetService<IAuthService>();
         if (authService == null)
         {
-            logger.LogWarning("RefreshSessionFromCookies: Auth not configured for {ConnectionId}", SanitizeForLog(connectionId));
+            logger.LogWarning("SyncSessionFromCookies: Auth not configured for {ConnectionId}", SanitizeForLog(connectionId));
             return BadRequest("Auth not configured for this session");
         }
 
@@ -336,8 +336,43 @@ public class AuthController() : Controller
         // Sync brokered sessions (fires Add/Remove events → starts/stops refresh loops)
         SyncBrokeredSessions(existingSession, freshAuthState.BrokeredSessions, logger);
 
+        // Sync connected accounts
+        SyncConnectedAccounts(existingSession, freshAuthState.ConnectedAccounts, logger);
+
         logger.LogInformation("Refreshed auth session from cookies for {ConnectionId}", SanitizeForLog(connectionId));
         return Ok();
+    }
+
+    private static void SyncConnectedAccounts(
+        IAuthSession existing,
+        IReadOnlyDictionary<string, IAuthSession> newAccounts,
+        ILogger logger)
+    {
+        var existingProviders = existing.ConnectedAccounts.Keys.ToHashSet();
+        var newProviders = newAccounts.Keys.ToHashSet();
+
+        // Remove providers no longer present
+        foreach (var provider in existingProviders.Except(newProviders))
+        {
+            logger.LogInformation("SyncConnectedAccounts: Removing provider {Provider}", SanitizeForLog(provider));
+            existing.RemoveConnectedAccount(provider);
+        }
+
+        // Add or update providers
+        foreach (var (provider, newAccount) in newAccounts)
+        {
+            if (existing.ConnectedAccounts.TryGetValue(provider, out var existingAccount))
+            {
+                // Update existing in place
+                existingAccount.AuthToken = newAccount.AuthToken;
+                existingAccount.AuthSessionData = newAccount.AuthSessionData;
+            }
+            else
+            {
+                logger.LogInformation("SyncConnectedAccounts: Adding provider {Provider}", SanitizeForLog(provider));
+                existing.AddConnectedAccount(provider, newAccount);
+            }
+        }
     }
 
     private static void SyncBrokeredSessions(

--- a/src/Ivy/Core/Auth/AuthController.cs
+++ b/src/Ivy/Core/Auth/AuthController.cs
@@ -336,7 +336,7 @@ public class AuthController() : Controller
         // Sync brokered sessions (fires Add/Remove events → starts/stops refresh loops)
         SyncBrokeredSessions(existingSession, freshAuthState.BrokeredSessions, logger);
 
-        // Sync connected accounts
+        // Sync connected accounts (fires AccountConnected/AccountDisconnected events → UI rebuilds)
         SyncConnectedAccounts(existingSession, freshAuthState.ConnectedAccounts, logger);
 
         logger.LogInformation("Refreshed auth session from cookies for {ConnectionId}", SanitizeForLog(connectionId));

--- a/src/Ivy/Core/Auth/AuthHelper.cs
+++ b/src/Ivy/Core/Auth/AuthHelper.cs
@@ -12,13 +12,13 @@ namespace Ivy.Core.Auth;
 public static class AuthHelper
 {
     public static AuthSession GetAuthSession(HttpContext context, TunneledHttpMessageHandler? httpMessageHandler)
-    => GetAuthCookies(context) is (var accessToken, var refreshToken, var tag, var authSessionData, var brokeredSessions)
-        ? GetAuthSession(accessToken, refreshToken, tag, authSessionData, brokeredSessions, httpMessageHandler)
+    => GetAuthCookies(context) is (var accessToken, var refreshToken, var tag, var authSessionData, var brokeredSessions, var connectedAccounts)
+        ? GetAuthSession(accessToken, refreshToken, tag, authSessionData, brokeredSessions, connectedAccounts, httpMessageHandler)
         : new AuthSession(httpMessageHandler: httpMessageHandler);
 
     public static AuthSession GetAuthSession(ServerCallContext context, TunneledHttpMessageHandler? httpMessageHandler)
-    => GetAuthCookies(context) is (var accessToken, var refreshToken, var tag, var authSessionData, var brokeredSessions)
-        ? GetAuthSession(accessToken, refreshToken, tag, authSessionData, brokeredSessions, httpMessageHandler)
+    => GetAuthCookies(context) is (var accessToken, var refreshToken, var tag, var authSessionData, var brokeredSessions, var connectedAccounts)
+        ? GetAuthSession(accessToken, refreshToken, tag, authSessionData, brokeredSessions, connectedAccounts, httpMessageHandler)
         : new AuthSession(httpMessageHandler: httpMessageHandler);
 
     public static async Task ValidateAuthIfRequired(global::Ivy.Server server, AppSessionStore sessionStore, string connectionId, ServerCallContext context)
@@ -138,7 +138,7 @@ public static class AuthHelper
         }
     }
 
-    private static (string? AccessToken, string? RefreshToken, string? Tag, string? AuthSessionData, Dictionary<string, IAuthTokenHandlerSession> BrokeredSessions) GetAuthCookies(HttpContext context)
+    private static (string? AccessToken, string? RefreshToken, string? Tag, string? AuthSessionData, Dictionary<string, IAuthTokenHandlerSession> BrokeredSessions, Dictionary<string, IAuthSession> ConnectedAccounts) GetAuthCookies(HttpContext context)
     {
         var cookies = context.Request.Cookies;
         var accessToken = cookies[CookieRegistryExtensions.PrefixCookieName("access_token")].NullIfEmpty();
@@ -147,16 +147,17 @@ public static class AuthHelper
         var authSessionDataValue = cookies[CookieRegistryExtensions.PrefixCookieName("auth_session_data")].NullIfEmpty();
 
         var brokeredSessions = ExtractBrokeredSessionsFromCookies(cookies);
+        var connectedAccounts = ExtractConnectedAccountsFromCookies(cookies);
 
-        return (accessToken, refreshToken, tag, authSessionDataValue, brokeredSessions);
+        return (accessToken, refreshToken, tag, authSessionDataValue, brokeredSessions, connectedAccounts);
     }
 
-    private static (string? AccessToken, string? RefreshToken, string? Tag, string? AuthSessionData, Dictionary<string, IAuthTokenHandlerSession> BrokeredSessions) GetAuthCookies(ServerCallContext context)
+    private static (string? AccessToken, string? RefreshToken, string? Tag, string? AuthSessionData, Dictionary<string, IAuthTokenHandlerSession> BrokeredSessions, Dictionary<string, IAuthSession> ConnectedAccounts) GetAuthCookies(ServerCallContext context)
     {
         var cookies = context.RequestHeaders.GetValue("cookie") ?? string.Empty;
         if (string.IsNullOrEmpty(cookies))
         {
-            return (null, null, null, null, new Dictionary<string, IAuthTokenHandlerSession>());
+            return (null, null, null, null, new Dictionary<string, IAuthTokenHandlerSession>(), new Dictionary<string, IAuthSession>());
         }
 
         var cookieHeader = CookieHeaderValue.ParseList([cookies]).ToList();
@@ -177,25 +178,26 @@ public static class AuthHelper
         var authSessionDataValue = GetCookie("auth_session_data");
 
         var brokeredSessions = ExtractBrokeredSessionsFromCookieHeader(cookieHeader);
+        var connectedAccounts = ExtractConnectedAccountsFromCookieHeader(cookieHeader);
 
-        return (accessToken, refreshToken, tag, authSessionDataValue, brokeredSessions);
+        return (accessToken, refreshToken, tag, authSessionDataValue, brokeredSessions, connectedAccounts);
     }
 
-    private static AuthSession GetAuthSession(string? accessToken, string? refreshToken, string? tag, string? authSessionDataValue, Dictionary<string, IAuthTokenHandlerSession> brokeredSessions, TunneledHttpMessageHandler? httpMessageHandler)
+    private static AuthSession GetAuthSession(string? accessToken, string? refreshToken, string? tag, string? authSessionDataValue, Dictionary<string, IAuthTokenHandlerSession> brokeredSessions, Dictionary<string, IAuthSession> connectedAccounts, TunneledHttpMessageHandler? httpMessageHandler)
     {
         if (accessToken == null)
         {
-            return new(null, authSessionDataValue, httpMessageHandler, brokeredSessions);
+            return new(null, authSessionDataValue, httpMessageHandler, brokeredSessions, connectedAccounts);
         }
 
         try
         {
             var token = new AuthToken(accessToken, refreshToken, tag);
-            return new(token, authSessionDataValue, httpMessageHandler, brokeredSessions);
+            return new(token, authSessionDataValue, httpMessageHandler, brokeredSessions, connectedAccounts);
         }
         catch (Exception)
         {
-            return new(null, authSessionDataValue, httpMessageHandler, brokeredSessions);
+            return new(null, authSessionDataValue, httpMessageHandler, brokeredSessions, connectedAccounts);
         }
     }
 
@@ -206,6 +208,7 @@ public static class AuthHelper
         var primaryAccessToken = CookieRegistryExtensions.PrefixCookieName("access_token");
         var suffix = "_access_token";
         var prefix = primaryAccessToken[..^"access_token".Length];
+        var connPrefix = "conn_";
 
         var accessTokenCookies = cookies.Keys
             .Where(key => key.EndsWith(suffix)
@@ -217,6 +220,13 @@ public static class AuthHelper
         {
             // Extract provider by removing prefix and suffix
             var cookieName = prefix.Length > 0 ? accessTokenName[prefix.Length..] : accessTokenName;
+
+            // Skip connected account cookies (conn_ prefix)
+            if (cookieName.StartsWith(connPrefix))
+            {
+                continue;
+            }
+
             var provider = cookieName[..^suffix.Length];
 
             var accessToken = cookies[accessTokenName].NullIfEmpty();
@@ -252,6 +262,7 @@ public static class AuthHelper
         var primaryAccessToken = CookieRegistryExtensions.PrefixCookieName("access_token");
         var suffix = "_access_token";
         var prefix = primaryAccessToken[..^"access_token".Length];
+        var connPrefix = "conn_";
 
         var accessTokenCookies = cookieHeader
             .Where(c => c.Name.Value != null
@@ -265,6 +276,13 @@ public static class AuthHelper
         {
             // Extract provider by removing prefix and suffix
             var cookieName = prefix.Length > 0 ? accessTokenName[prefix.Length..] : accessTokenName;
+
+            // Skip connected account cookies (conn_ prefix)
+            if (cookieName.StartsWith(connPrefix))
+            {
+                continue;
+            }
+
             var provider = cookieName[..^suffix.Length];
 
             var accessToken = GetCookie(accessTokenName);
@@ -282,5 +300,102 @@ public static class AuthHelper
         }
 
         return brokeredSessions;
+    }
+
+    internal static Dictionary<string, IAuthSession> ExtractConnectedAccountsFromCookies(IRequestCookieCollection cookies)
+    {
+        var connectedAccounts = new Dictionary<string, IAuthSession>();
+
+        var primaryAccessToken = CookieRegistryExtensions.PrefixCookieName("access_token");
+        var suffix = "_access_token";
+        var prefix = primaryAccessToken[..^"access_token".Length];
+        var connPrefix = "conn_";
+
+        var accessTokenCookies = cookies.Keys
+            .Where(key => key.EndsWith(suffix)
+                && key != primaryAccessToken
+                && (prefix.Length == 0 || key.StartsWith(prefix)))
+            .ToList();
+
+        foreach (var accessTokenName in accessTokenCookies)
+        {
+            var cookieName = prefix.Length > 0 ? accessTokenName[prefix.Length..] : accessTokenName;
+
+            if (!cookieName.StartsWith(connPrefix))
+            {
+                continue;
+            }
+
+            var provider = cookieName[connPrefix.Length..^suffix.Length];
+
+            var accessToken = cookies[accessTokenName].NullIfEmpty();
+            if (accessToken == null)
+            {
+                continue;
+            }
+
+            var refreshToken = cookies[CookieRegistryExtensions.PrefixCookieName($"conn_{provider}_refresh_token")].NullIfEmpty();
+            var tag = cookies[CookieRegistryExtensions.PrefixCookieName($"conn_{provider}_auth_tag")].NullIfEmpty();
+
+            var authToken = new AuthToken(accessToken, refreshToken, tag);
+            var session = new AuthSession(authToken: authToken);
+            connectedAccounts[provider] = session;
+        }
+
+        return connectedAccounts;
+    }
+
+    internal static Dictionary<string, IAuthSession> ExtractConnectedAccountsFromCookieHeader(List<CookieHeaderValue> cookieHeader)
+    {
+        var connectedAccounts = new Dictionary<string, IAuthSession>();
+
+        string? GetCookie(string name)
+        {
+            var rawValue = cookieHeader
+                .FirstOrDefault(c => c.Name.Equals(name, StringComparison.OrdinalIgnoreCase))?.Value.Value;
+            return !string.IsNullOrEmpty(rawValue)
+                ? WebUtility.UrlDecode(rawValue)
+                : null;
+        }
+
+        var primaryAccessToken = CookieRegistryExtensions.PrefixCookieName("access_token");
+        var suffix = "_access_token";
+        var prefix = primaryAccessToken[..^"access_token".Length];
+        var connPrefix = "conn_";
+
+        var accessTokenCookies = cookieHeader
+            .Where(c => c.Name.Value != null
+                && c.Name.Value.EndsWith(suffix)
+                && c.Name.Value != primaryAccessToken
+                && (prefix.Length == 0 || c.Name.Value.StartsWith(prefix)))
+            .Select(c => c.Name.Value!)
+            .ToList();
+
+        foreach (var accessTokenName in accessTokenCookies)
+        {
+            var cookieName = prefix.Length > 0 ? accessTokenName[prefix.Length..] : accessTokenName;
+
+            if (!cookieName.StartsWith(connPrefix))
+            {
+                continue;
+            }
+
+            var provider = cookieName[connPrefix.Length..^suffix.Length];
+
+            var accessToken = GetCookie(accessTokenName);
+            if (accessToken == null)
+            {
+                continue;
+            }
+
+            var refreshToken = GetCookie(CookieRegistryExtensions.PrefixCookieName($"conn_{provider}_refresh_token"));
+            var tag = GetCookie(CookieRegistryExtensions.PrefixCookieName($"conn_{provider}_auth_tag"));
+
+            var authToken = new AuthToken(accessToken, refreshToken, tag);
+            var session = new AuthSession(authToken: authToken);
+            connectedAccounts[provider] = session;
+        }
+
+        return connectedAccounts;
     }
 }

--- a/src/Ivy/Core/Auth/CheckedAuthSession.cs
+++ b/src/Ivy/Core/Auth/CheckedAuthSession.cs
@@ -7,7 +7,8 @@ public enum AuthSessionProperty
 {
     AuthToken,
     AuthSessionData,
-    BrokeredSessions
+    BrokeredSessions,
+    ConnectedAccounts
 }
 
 public enum AuthSessionAccessMode
@@ -171,6 +172,45 @@ public class CheckedAuthSession(IAuthSession innerAuthSession, Dictionary<AuthSe
     {
         add => _innerAuthSession.BrokeredSessionRemoved += value;
         remove => _innerAuthSession.BrokeredSessionRemoved -= value;
+    }
+
+    public IReadOnlyDictionary<string, IAuthSession> ConnectedAccounts
+    {
+        get
+        {
+            CheckRead(AuthSessionProperty.ConnectedAccounts);
+            return _innerAuthSession.ConnectedAccounts;
+        }
+    }
+
+    public void AddConnectedAccount(string provider, IAuthSession session)
+    {
+        CheckWrite(AuthSessionProperty.ConnectedAccounts);
+        _innerAuthSession.AddConnectedAccount(provider, session);
+    }
+
+    public void RemoveConnectedAccount(string provider)
+    {
+        CheckWrite(AuthSessionProperty.ConnectedAccounts);
+        _innerAuthSession.RemoveConnectedAccount(provider);
+    }
+
+    public void ClearConnectedAccounts()
+    {
+        CheckWrite(AuthSessionProperty.ConnectedAccounts);
+        _innerAuthSession.ClearConnectedAccounts();
+    }
+
+    public event Action<string>? ConnectedAccountAdded
+    {
+        add => _innerAuthSession.ConnectedAccountAdded += value;
+        remove => _innerAuthSession.ConnectedAccountAdded -= value;
+    }
+
+    public event Action<string>? ConnectedAccountRemoved
+    {
+        add => _innerAuthSession.ConnectedAccountRemoved += value;
+        remove => _innerAuthSession.ConnectedAccountRemoved -= value;
     }
 }
 #endif

--- a/src/Ivy/Core/Auth/ConnectedAccountTokenRefreshStrategy.cs
+++ b/src/Ivy/Core/Auth/ConnectedAccountTokenRefreshStrategy.cs
@@ -1,0 +1,102 @@
+using Ivy.Core.Server;
+using Microsoft.Extensions.Logging;
+
+namespace Ivy.Core.Auth;
+
+public class ConnectedAccountTokenRefreshStrategy : RefreshStrategy
+{
+    private readonly string _connectionId;
+    private readonly string _provider;
+    private readonly IAuthSession _parentSession;
+    private readonly IConnectedAccountsService _connectedAccountsService;
+    private readonly AppSessionStore _sessionStore;
+    private readonly IClientProvider _client;
+    private readonly ILogger _logger;
+
+    private int _consecutiveRefreshFailures;
+    private const int MaxConsecutiveRefreshFailures = 3;
+
+    public override string LoggingName { get; }
+
+    public ConnectedAccountTokenRefreshStrategy(
+        string connectionId,
+        string provider,
+        IAuthTokenHandlerService authService,
+        IAuthSession parentSession,
+        IClientProvider client,
+        IConnectedAccountsService connectedAccountsService,
+        AppSessionStore sessionStore,
+        ILogger logger) : base(authService)
+    {
+        _connectionId = connectionId;
+        _provider = provider;
+        _parentSession = parentSession;
+        _client = client;
+        _connectedAccountsService = connectedAccountsService;
+        _sessionStore = sessionStore;
+        _logger = logger;
+        LoggingName = $"ConnectedAccount[{provider}]";
+    }
+
+    public override async Task<bool> ValidateTokenAsync(CancellationToken cancellationToken = default)
+    {
+        var isValid = await base.ValidateTokenAsync(cancellationToken);
+        if (isValid)
+        {
+            _consecutiveRefreshFailures = 0;
+        }
+        return isValid;
+    }
+
+    public override async Task<bool> RefreshTokenAsync(CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation("Attempting to refresh connected account token for {Provider}", _provider);
+        var result = await _authService.RefreshAccessTokenAsync(cancellationToken);
+
+        if (result != null)
+        {
+            _logger.LogInformation("Successfully refreshed connected account token for {Provider}", _provider);
+
+            // Update parent session cookies to include the refreshed token
+            var cookieJarId = _sessionStore.RegisterAuthSessionCookies(_parentSession);
+            _client.SetAuthCookies(cookieJarId, reloadPage: false, triggerMachineReload: null);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    public override async Task<bool> OnRefreshFailedAsync()
+    {
+        _consecutiveRefreshFailures++;
+        _logger.LogWarning("ConnectedAccountRefreshLoop[{Provider}]: Refresh failed for {ConnectionId}, attempt {Attempt}/{MaxAttempts}",
+            _provider, _connectionId, _consecutiveRefreshFailures, MaxConsecutiveRefreshFailures);
+
+        if (_consecutiveRefreshFailures >= MaxConsecutiveRefreshFailures)
+        {
+            _logger.LogError("ConnectedAccountRefreshLoop[{Provider}]: {MaxAttempts} consecutive refresh failures for {ConnectionId}, disconnecting account",
+                _provider, MaxConsecutiveRefreshFailures, _connectionId);
+
+            try
+            {
+                await _connectedAccountsService.DisconnectAccountAsync(_provider);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "ConnectedAccountRefreshLoop[{Provider}]: Error disconnecting account for {ConnectionId}", _provider, _connectionId);
+            }
+
+            return false;
+        }
+
+        await Task.Delay(TimeSpan.FromSeconds(5));
+        return true;
+    }
+
+    public override Task<bool> OnTokenLostAsync()
+    {
+        _logger.LogInformation("ConnectedAccountRefreshLoop[{Provider}]: Token lost for {ConnectionId}, exiting loop", _provider, _connectionId);
+        return Task.FromResult(false);
+    }
+}

--- a/src/Ivy/Core/Auth/CookieRegistryExtensions.cs
+++ b/src/Ivy/Core/Auth/CookieRegistryExtensions.cs
@@ -18,7 +18,7 @@ public static class CookieRegistryExtensions
         return null;
     }
 
-    public static CookieJarId RegisterAuthSessionCookies(this AppSessionStore sessionStore, IAuthSession authSession, IEnumerable<string>? providersToDelete = null)
+    public static CookieJarId RegisterAuthSessionCookies(this AppSessionStore sessionStore, IAuthSession authSession, IEnumerable<string>? providersToDelete = null, IEnumerable<string>? disconnectedProviders = null)
     {
         var cookies = new CookieJar();
         cookies.AddCookiesForAuthToken(authSession.AuthToken, providersToDelete);
@@ -42,7 +42,19 @@ public static class CookieRegistryExtensions
         // Add connected accounts
         cookies.AddCookiesForConnectedAccounts(authSession.ConnectedAccounts);
 
-        // Also delete cookies for removed providers
+        // Delete cookies for disconnected connected account providers
+        if (disconnectedProviders != null)
+        {
+            var cookieOptions = CreateAuthCookieOptions();
+            foreach (var provider in disconnectedProviders)
+            {
+                cookies.Delete(PrefixCookieName($"conn_{provider}_access_token"), cookieOptions);
+                cookies.Delete(PrefixCookieName($"conn_{provider}_refresh_token"), cookieOptions);
+                cookies.Delete(PrefixCookieName($"conn_{provider}_auth_tag"), cookieOptions);
+            }
+        }
+
+        // Also delete cookies for removed brokered providers
         if (removedProviders != null && removedProviders.Count > 0)
         {
             var cookieOptions = CreateAuthCookieOptions();

--- a/src/Ivy/Core/Auth/CookieRegistryExtensions.cs
+++ b/src/Ivy/Core/Auth/CookieRegistryExtensions.cs
@@ -18,16 +18,16 @@ public static class CookieRegistryExtensions
         return null;
     }
 
-    public static CookieJarId RegisterAuthSessionCookies(this AppSessionStore sessionStore, IAuthSession authSession, IEnumerable<string>? providersToDelete = null, IEnumerable<string>? disconnectedProviders = null)
+    public static CookieJarId RegisterAuthSessionCookies(this AppSessionStore sessionStore, IAuthSession authSession, IEnumerable<string>? brokeredProvidersToDelete = null, IEnumerable<string>? connectedProvidersToDelete = null)
     {
         var cookies = new CookieJar();
-        cookies.AddCookiesForAuthToken(authSession.AuthToken, providersToDelete);
+        cookies.AddCookiesForAuthToken(authSession.AuthToken, brokeredProvidersToDelete);
         cookies.AddCookiesForAuthSessionData(authSession.AuthSessionData);
 
         // Filter out brokered session providers that have been globally removed (if machineId is provided)
         IReadOnlyDictionary<string, IAuthTokenHandlerSession> sessionsToWrite = authSession.BrokeredSessions;
-        HashSet<string>? removedProviders = providersToDelete != null
-            ? new(providersToDelete)
+        HashSet<string>? removedProviders = brokeredProvidersToDelete != null
+            ? new(brokeredProvidersToDelete)
             : null;
 
         if (removedProviders != null && removedProviders.Count > 0)
@@ -43,10 +43,10 @@ public static class CookieRegistryExtensions
         cookies.AddCookiesForConnectedAccounts(authSession.ConnectedAccounts);
 
         // Delete cookies for disconnected connected account providers
-        if (disconnectedProviders != null)
+        if (connectedProvidersToDelete != null)
         {
             var cookieOptions = CreateAuthCookieOptions();
-            foreach (var provider in disconnectedProviders)
+            foreach (var provider in connectedProvidersToDelete)
             {
                 cookies.Delete(PrefixCookieName($"conn_{provider}_access_token"), cookieOptions);
                 cookies.Delete(PrefixCookieName($"conn_{provider}_refresh_token"), cookieOptions);

--- a/src/Ivy/Core/Auth/CookieRegistryExtensions.cs
+++ b/src/Ivy/Core/Auth/CookieRegistryExtensions.cs
@@ -39,6 +39,9 @@ public static class CookieRegistryExtensions
 
         cookies.AddCookiesForBrokeredSessions(sessionsToWrite);
 
+        // Add connected accounts
+        cookies.AddCookiesForConnectedAccounts(authSession.ConnectedAccounts);
+
         // Also delete cookies for removed providers
         if (removedProviders != null && removedProviders.Count > 0)
         {
@@ -130,6 +133,45 @@ public static class CookieRegistryExtensions
         else
         {
             cookies.Append(authSessionDataName, authSessionData, cookieOptions);
+        }
+    }
+
+    public static void AddCookiesForConnectedAccounts(this CookieJar cookies, IReadOnlyDictionary<string, IAuthSession> connectedAccounts)
+    {
+        var cookieOptions = CreateAuthCookieOptions();
+
+        foreach (var (provider, session) in connectedAccounts)
+        {
+            var accessTokenName = PrefixCookieName($"conn_{provider}_access_token");
+            var refreshTokenName = PrefixCookieName($"conn_{provider}_refresh_token");
+            var tagName = PrefixCookieName($"conn_{provider}_auth_tag");
+
+            if (!string.IsNullOrEmpty(session.AuthToken?.AccessToken))
+            {
+                cookies.Append(accessTokenName, session.AuthToken.AccessToken, cookieOptions);
+            }
+            else
+            {
+                cookies.Delete(accessTokenName, CreateAuthCookieOptions());
+            }
+
+            if (!string.IsNullOrEmpty(session.AuthToken?.RefreshToken))
+            {
+                cookies.Append(refreshTokenName, session.AuthToken.RefreshToken, cookieOptions);
+            }
+            else
+            {
+                cookies.Delete(refreshTokenName, CreateAuthCookieOptions());
+            }
+
+            if (session.AuthToken?.Tag != null)
+            {
+                cookies.Append(tagName, session.AuthToken.Tag, cookieOptions);
+            }
+            else
+            {
+                cookies.Delete(tagName, CreateAuthCookieOptions());
+            }
         }
     }
 

--- a/src/Ivy/Core/Server/AppHub.cs
+++ b/src/Ivy/Core/Server/AppHub.cs
@@ -396,6 +396,58 @@ public class AppHub(
                     appState.BrokeredTokenRemovedHandler = removedHandler;
                     authSession.BrokeredSessionAdded += addedHandler;
                     authSession.BrokeredSessionRemoved += removedHandler;
+
+                    // Start refresh loops for connected accounts
+                    var connectedAccounts = authSession.ConnectedAccounts.Keys.ToList();
+                    var activeConnectedProviders = new HashSet<string>();
+                    var connectedCancellations = new ConcurrentDictionary<string, CancellationTokenSource>();
+                    appState.ActiveConnectedAccountRefreshLoops = activeConnectedProviders;
+                    appState.ConnectedAccountRefreshCancellations = connectedCancellations;
+
+                    void AddConnectedProvider(string provider)
+                    {
+                        lock (activeConnectedProviders)
+                        {
+                            if (activeConnectedProviders.Add(provider))
+                            {
+                                var cts = CancellationTokenSource.CreateLinkedTokenSource(connectionAborted);
+                                connectedCancellations[provider] = cts;
+                                _ = Task.Run(() => ConnectedAccountTokenRefreshLoopAsync(connectionId, provider, cts.Token), connectionAborted);
+                            }
+                        }
+                    }
+
+                    foreach (var connectedAccount in connectedAccounts)
+                    {
+                        AddConnectedProvider(connectedAccount);
+                    }
+
+                    Action<string> connectedAddedHandler = provider =>
+                    {
+                        if (!sessionStore.Sessions.ContainsKey(connectionId)) return;
+                        AddConnectedProvider(provider);
+                    };
+
+                    Action<string> connectedRemovedHandler = provider =>
+                    {
+                        logger.LogInformation("Cancelling connected account refresh loop for removed provider {Provider} on connection {ConnectionId}", provider, connectionId);
+
+                        if (connectedCancellations.TryRemove(provider, out var cts))
+                        {
+                            cts.Cancel();
+                            cts.Dispose();
+                        }
+
+                        lock (activeConnectedProviders)
+                        {
+                            activeConnectedProviders.Remove(provider);
+                        }
+                    };
+
+                    appState.ConnectedAccountAddedHandler = connectedAddedHandler;
+                    appState.ConnectedAccountRemovedHandler = connectedRemovedHandler;
+                    authSession.ConnectedAccountAdded += connectedAddedHandler;
+                    authSession.ConnectedAccountRemoved += connectedRemovedHandler;
                 }
             }
         }
@@ -474,6 +526,41 @@ public class AppHub(
                             catch (Exception ex)
                             {
                                 logger.LogWarning(ex, "Error cancelling brokered token refresh loop for provider {Provider} on connection {ConnectionId}", kvp.Key, Context.ConnectionId);
+                            }
+                        }
+                    }
+
+                    // Clean up connected account event subscriptions
+                    if (appState.ConnectedAccountAddedHandler != null || appState.ConnectedAccountRemovedHandler != null)
+                    {
+                        var authService2 = appState.AppServices.GetService<IAuthService>();
+                        if (authService2 != null)
+                        {
+                            var authSession2 = authService2.GetAuthSession();
+                            if (appState.ConnectedAccountAddedHandler != null)
+                            {
+                                authSession2.ConnectedAccountAdded -= appState.ConnectedAccountAddedHandler;
+                            }
+                            if (appState.ConnectedAccountRemovedHandler != null)
+                            {
+                                authSession2.ConnectedAccountRemoved -= appState.ConnectedAccountRemovedHandler;
+                            }
+                        }
+                    }
+
+                    // Cancel and dispose all connected account refresh loop cancellation tokens
+                    if (appState.ConnectedAccountRefreshCancellations != null)
+                    {
+                        foreach (var kvp in appState.ConnectedAccountRefreshCancellations)
+                        {
+                            try
+                            {
+                                kvp.Value.Cancel();
+                                kvp.Value.Dispose();
+                            }
+                            catch (Exception ex)
+                            {
+                                logger.LogWarning(ex, "Error cancelling connected account refresh loop for provider {Provider} on connection {ConnectionId}", kvp.Key, Context.ConnectionId);
                             }
                         }
                     }
@@ -753,6 +840,81 @@ public class AppHub(
 
             // Clean up: dispose the cancellation token source
             if (session.BrokeredRefreshCancellations?.TryRemove(provider, out var cts) == true)
+            {
+                cts.Dispose();
+            }
+        }
+    }
+
+    private async Task ConnectedAccountTokenRefreshLoopAsync(string connectionId, string provider, CancellationToken cancellationToken)
+    {
+        if (!sessionStore.Sessions.TryGetValue(connectionId, out var session))
+        {
+            logger.LogWarning("ConnectedAccountRefreshLoop[{Provider}]: Session not found for {ConnectionId}, exiting loop.", provider, connectionId);
+            return;
+        }
+
+        try
+        {
+            var authProvider = server.ServiceProvider!.GetKeyedService<IAuthProvider>(provider);
+            if (authProvider == null)
+            {
+                logger.LogError("ConnectedAccountRefreshLoop[{Provider}]: No auth provider registered for {ConnectionId}, exiting loop.", provider, connectionId);
+                return;
+            }
+
+            var authService = session.AppServices.GetRequiredService<IAuthService>();
+            var authSession = authService.GetAuthSession();
+
+            if (!authSession.ConnectedAccounts.TryGetValue(provider, out var connectedSession))
+            {
+                logger.LogError("ConnectedAccountRefreshLoop[{Provider}]: No connected account session found for {ConnectionId}, exiting loop.", provider, connectionId);
+                return;
+            }
+
+            var appContext = session.AppServices.GetService<AppContext>();
+            if (appContext != null)
+            {
+                await authProvider.InitializeAsync(connectedSession, appContext.Scheme, appContext.Host, appContext.BasePath, cancellationToken);
+            }
+
+            var client = session.AppServices.GetRequiredService<IClientProvider>();
+            var refreshLogger = session.AppServices.GetRequiredService<ILoggerFactory>()
+                .CreateLogger<AuthTokenHandlerService>();
+
+            var tokenService = new AuthTokenHandlerService(
+                authProvider,
+                connectedSession,
+                client,
+                sessionStore,
+                session.MachineId,
+                refreshLogger);
+
+            var connectedAccountsService = session.AppServices.GetRequiredService<IConnectedAccountsService>();
+
+            var strategy = new ConnectedAccountTokenRefreshStrategy(
+                connectionId,
+                provider,
+                tokenService,
+                authSession,
+                client,
+                connectedAccountsService,
+                sessionStore,
+                refreshLogger);
+
+            await TokenRefreshLoopAsync(strategy, connectionId, cancellationToken);
+        }
+        finally
+        {
+            if (session.ActiveConnectedAccountRefreshLoops != null)
+            {
+                lock (session.ActiveConnectedAccountRefreshLoops)
+                {
+                    session.ActiveConnectedAccountRefreshLoops.Remove(provider);
+                }
+            }
+
+            if (session.ConnectedAccountRefreshCancellations?.TryRemove(provider, out var cts) == true)
             {
                 cts.Dispose();
             }

--- a/src/Ivy/Core/Server/AppHub.cs
+++ b/src/Ivy/Core/Server/AppHub.cs
@@ -147,6 +147,13 @@ public class AppHub(
                 }
 
                 appServices.AddSingleton<IAuthService>(s => authService);
+                appServices.AddSingleton<IConnectedAccountsService>(s =>
+                    new ConnectedAccountsService(
+                        authSession,
+                        server.ServiceProvider!,
+                        clientProvider,
+                        sessionStore,
+                        server.ServiceProvider?.GetService<ILoggerFactory>()?.CreateLogger<ConnectedAccountsService>()));
 
                 oldSession = authSession.TakeSnapshot();
                 try

--- a/src/Ivy/Server.cs
+++ b/src/Ivy/Server.cs
@@ -302,6 +302,8 @@ public class Server
 
         DiscoverAndRegisterOAuthTokenHandlers();
 
+        Services.AddScoped<IConnectedAccountsService, ConnectedAccountsService>();
+
         AddApp(new AppDescriptor
         {
             Id = AppIds.Auth,
@@ -317,6 +319,12 @@ public class Server
     public Server RegisterAuthTokenHandler<T>(string provider) where T : class, IAuthTokenHandler
     {
         Services.AddKeyedSingleton<IAuthTokenHandler, T>(provider);
+        return this;
+    }
+
+    public Server RegisterConnectedAccountProvider<TProvider>(string providerKey) where TProvider : class, IAuthProvider
+    {
+        Services.AddKeyedSingleton<IAuthProvider, TProvider>(providerKey);
         return this;
     }
 

--- a/src/auth/Ivy.Auth.GitHub/GitHubAuthProvider.cs
+++ b/src/auth/Ivy.Auth.GitHub/GitHubAuthProvider.cs
@@ -149,6 +149,13 @@ public class GitHubAuthProvider : GitHubAuthTokenHandler, IAuthProvider
             using var jsonDoc = JsonDocument.Parse(responseContent);
             var root = jsonDoc.RootElement;
 
+            if (root.TryGetProperty("error", out var errorProp))
+            {
+                var error = errorProp.GetString();
+                var errorDescription = root.TryGetProperty("error_description", out var descProp) ? descProp.GetString() : null;
+                throw new GitHubOAuthException(error, errorDescription);
+            }
+
             if (root.TryGetProperty("access_token", out var accessTokenProp))
             {
                 return new GitHubTokenResponse(accessTokenProp.GetString()!);

--- a/src/auth/examples/BasicAuthExample/BasicAuthExample.csproj
+++ b/src/auth/examples/BasicAuthExample/BasicAuthExample.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -6,6 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>BasicAuthExample</RootNamespace>
+    <UserSecretsId>86bf66ae-0f90-4f54-bc09-67f50dc11f6e</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,6 +17,8 @@
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <OutputItemType>Analyzer</OutputItemType>
     </ProjectReference>
+    <ProjectReference Include="..\..\Ivy.Auth.GitHub\Ivy.Auth.GitHub.csproj" />
+    <ProjectReference Include="..\Ivy.Auth.Examples.Shared\Ivy.Auth.Examples.Shared.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/auth/examples/BasicAuthExample/Connections/Auth/GitHubConnectedAccountConnection.cs
+++ b/src/auth/examples/BasicAuthExample/Connections/Auth/GitHubConnectedAccountConnection.cs
@@ -1,0 +1,36 @@
+using Ivy;
+using Ivy.Auth.GitHub;
+using Microsoft.Extensions.Configuration;
+
+namespace BasicAuthExample.Connections.Auth;
+
+public class GitHubConnectedAccountConnection : IConnection, IHaveSecrets
+{
+    public string GetContext(string connectionPath) => string.Empty;
+
+    public string GetName() => "GitHubConnectedAccount";
+
+    public string GetNamespace() => typeof(GitHubConnectedAccountConnection).Namespace ?? "";
+
+    public string GetConnectionType() => "Auth";
+
+    public ConnectionEntity[] GetEntities() => [];
+
+    public void RegisterServices(Server server)
+    {
+        server.RegisterConnectedAccountProvider<GitHubAuthProvider>(OAuthProviders.GitHub);
+    }
+
+    public Secret[] GetSecrets() =>
+    [
+        new("GitHub:ClientId"),
+        new("GitHub:ClientSecret"),
+        new("GitHub:RedirectUri")
+    ];
+
+    public async Task<(bool ok, string? message)> TestConnection(IConfiguration config)
+    {
+        await Task.CompletedTask;
+        return (true, "GitHub connected account configured");
+    }
+}

--- a/src/auth/examples/BasicAuthExample/MainApp.cs
+++ b/src/auth/examples/BasicAuthExample/MainApp.cs
@@ -1,3 +1,4 @@
+using System.Reactive.Disposables;
 using Ivy;
 using Ivy.Auth.Examples.Shared;
 
@@ -62,8 +63,21 @@ public class ConnectedGitHubSection : ViewBase
         {
             Console.WriteLine($"Received GitHub OAuth callback, request data: {request.QueryString}");
             await _connectedAccounts.HandleConnectCallbackAsync(OAuthProviders.GitHub, request);
-            connected.Set(true);
         });
+
+        UseEffect(() =>
+        {
+            _connectedAccounts.AccountConnected += OnConnected;
+            _connectedAccounts.AccountDisconnected += OnDisconnected;
+            return Disposable.Create(() =>
+            {
+                _connectedAccounts.AccountConnected -= OnConnected;
+                _connectedAccounts.AccountDisconnected -= OnDisconnected;
+            });
+
+            void OnConnected(string provider) { if (provider == OAuthProviders.GitHub) connected.Set(true); }
+            void OnDisconnected(string provider) { if (provider == OAuthProviders.GitHub) connected.Set(false); }
+        }, [EffectTrigger.OnMount()]);
 
         var gitHubSession = _connectedAccounts.GetAccountSession(OAuthProviders.GitHub);
         var isConnected = gitHubSession?.AuthToken != null;
@@ -88,7 +102,6 @@ public class ConnectedGitHubSection : ViewBase
                 new Button("Disconnect", async () =>
                 {
                     await _connectedAccounts.DisconnectAccountAsync(OAuthProviders.GitHub);
-                    connected.Set(false);
                 }, variant: ButtonVariant.Destructive)
             ).Gap(10).AlignContent(Align.Center),
             new OAuthProviderTestView(OAuthProviders.GitHub, gitHubSession!)

--- a/src/auth/examples/BasicAuthExample/MainApp.cs
+++ b/src/auth/examples/BasicAuthExample/MainApp.cs
@@ -61,7 +61,6 @@ public class ConnectedGitHubSection : ViewBase
         var connected = UseState(() => _connectedAccounts.GetAccountSession(OAuthProviders.GitHub)?.AuthToken != null);
         var callback = UseWebhook(async request =>
         {
-            Console.WriteLine($"Received GitHub OAuth callback, request data: {request.QueryString}");
             await _connectedAccounts.HandleConnectCallbackAsync(OAuthProviders.GitHub, request);
         });
 

--- a/src/auth/examples/BasicAuthExample/MainApp.cs
+++ b/src/auth/examples/BasicAuthExample/MainApp.cs
@@ -24,7 +24,6 @@ public class MainApp : ViewBase
         }
 
         var user = userInfo.Value;
-        var gitHubSession = connectedAccounts.GetAccountSession(OAuthProviders.GitHub);
 
         return Layout.Vertical(
             // Success Header
@@ -40,7 +39,7 @@ public class MainApp : ViewBase
             ).Gap(20).AlignContent(Align.Center),
 
             // Connected Accounts section
-            new ConnectedGitHubSection(connectedAccounts, gitHubSession)
+            new ConnectedGitHubSection(connectedAccounts)
 
         ).Gap(40).Padding(50).AlignContent(Align.Center).Height(Size.Full());
     }
@@ -49,25 +48,25 @@ public class MainApp : ViewBase
 public class ConnectedGitHubSection : ViewBase
 {
     private readonly IConnectedAccountsService _connectedAccounts;
-    private readonly IAuthSession? _gitHubSession;
 
-    public ConnectedGitHubSection(IConnectedAccountsService connectedAccounts, IAuthSession? gitHubSession)
+    public ConnectedGitHubSection(IConnectedAccountsService connectedAccounts)
     {
         _connectedAccounts = connectedAccounts;
-        _gitHubSession = gitHubSession;
     }
 
     public override object? Build()
     {
         var client = UseService<IClientProvider>();
-
+        var connected = UseState(() => _connectedAccounts.GetAccountSession(OAuthProviders.GitHub)?.AuthToken != null);
         var callback = UseWebhook(async request =>
         {
             Console.WriteLine($"Received GitHub OAuth callback, request data: {request.QueryString}");
             await _connectedAccounts.HandleConnectCallbackAsync(OAuthProviders.GitHub, request);
+            connected.Set(true);
         });
 
-        var isConnected = _gitHubSession?.AuthToken != null;
+        var gitHubSession = _connectedAccounts.GetAccountSession(OAuthProviders.GitHub);
+        var isConnected = gitHubSession?.AuthToken != null;
 
         if (!isConnected)
         {
@@ -89,9 +88,10 @@ public class ConnectedGitHubSection : ViewBase
                 new Button("Disconnect", async () =>
                 {
                     await _connectedAccounts.DisconnectAccountAsync(OAuthProviders.GitHub);
+                    connected.Set(false);
                 }, variant: ButtonVariant.Destructive)
             ).Gap(10).AlignContent(Align.Center),
-            new OAuthProviderTestView(OAuthProviders.GitHub, _gitHubSession!)
+            new OAuthProviderTestView(OAuthProviders.GitHub, gitHubSession!)
         ).Gap(10);
     }
 }

--- a/src/auth/examples/BasicAuthExample/MainApp.cs
+++ b/src/auth/examples/BasicAuthExample/MainApp.cs
@@ -1,4 +1,5 @@
 using Ivy;
+using Ivy.Auth.Examples.Shared;
 
 namespace BasicAuthExample;
 
@@ -8,6 +9,7 @@ public class MainApp : ViewBase
     public override object? Build()
     {
         var auth = UseService<IAuthService>();
+        var connectedAccounts = UseService<IConnectedAccountsService>();
         var userInfo = UseState<UserInfo?>();
 
         UseEffect(async () =>
@@ -22,6 +24,7 @@ public class MainApp : ViewBase
         }
 
         var user = userInfo.Value;
+        var gitHubSession = connectedAccounts.GetAccountSession(OAuthProviders.GitHub);
 
         return Layout.Vertical(
             // Success Header
@@ -34,8 +37,61 @@ public class MainApp : ViewBase
                      Text.H3(user.FullName ?? "User"),
                      Text.Muted(user.Email)
                  ).Gap(4).AlignContent(Align.Center)
-            ).Gap(20).AlignContent(Align.Center)
+            ).Gap(20).AlignContent(Align.Center),
+
+            // Connected Accounts section
+            new ConnectedGitHubSection(connectedAccounts, gitHubSession)
 
         ).Gap(40).Padding(50).AlignContent(Align.Center).Height(Size.Full());
+    }
+}
+
+public class ConnectedGitHubSection : ViewBase
+{
+    private readonly IConnectedAccountsService _connectedAccounts;
+    private readonly IAuthSession? _gitHubSession;
+
+    public ConnectedGitHubSection(IConnectedAccountsService connectedAccounts, IAuthSession? gitHubSession)
+    {
+        _connectedAccounts = connectedAccounts;
+        _gitHubSession = gitHubSession;
+    }
+
+    public override object? Build()
+    {
+        var client = UseService<IClientProvider>();
+
+        var callback = UseWebhook(async request =>
+        {
+            Console.WriteLine($"Received GitHub OAuth callback, request data: {request.QueryString}");
+            await _connectedAccounts.HandleConnectCallbackAsync(OAuthProviders.GitHub, request);
+        });
+
+        var isConnected = _gitHubSession?.AuthToken != null;
+
+        if (!isConnected)
+        {
+            return Layout.Vertical(
+                Text.H3("Connected Accounts"),
+                new Button("Connect GitHub", async () =>
+                {
+                    var uri = await _connectedAccounts.ConnectAccountAsync(OAuthProviders.GitHub, callback);
+                    client.OpenUrl(uri.ToString());
+                }, icon: Icons.Github, variant: ButtonVariant.Outline)
+            ).Gap(10);
+        }
+
+        return Layout.Vertical(
+            Text.H3("Connected Accounts"),
+            Layout.Horizontal(
+                Text.P("GitHub").Bold(),
+                new Badge("Connected").Variant(BadgeVariant.Success),
+                new Button("Disconnect", async () =>
+                {
+                    await _connectedAccounts.DisconnectAccountAsync(OAuthProviders.GitHub);
+                }, variant: ButtonVariant.Destructive)
+            ).Gap(10).AlignContent(Align.Center),
+            new OAuthProviderTestView(OAuthProviders.GitHub, _gitHubSession!)
+        ).Gap(10);
     }
 }

--- a/src/frontend/src/hooks/use-backend.tsx
+++ b/src/frontend/src/hooks/use-backend.tsx
@@ -46,7 +46,7 @@ type SetAuthCookiesMessage = {
   cookieJarId: string;
   reloadPage: boolean;
   triggerMachineReload: boolean;
-  triggerMachineBrokeredRefresh: boolean;
+  triggerMachineAuthSync: boolean;
 };
 
 type HttpTunnelRequestMessage = {
@@ -295,7 +295,7 @@ function applyUpdateMessage(tree: WidgetNode, updates: UpdateMessage): WidgetNod
 
 async function refreshAuthFromCookies(connectionId: string | null): Promise<void> {
   try {
-    const response = await fetch(`${getIvyHost()}/ivy/auth/refresh-session`, {
+    const response = await fetch(`${getIvyHost()}/ivy/auth/sync-session`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -472,7 +472,7 @@ export const useBackend = (
         cookieJarId: message.cookieJarId,
         connectionId: currentConnectionId ?? null,
         triggerMachineReload: message.triggerMachineReload,
-        triggerMachineBrokeredRefresh: message.triggerMachineBrokeredRefresh,
+        triggerMachineAuthSync: message.triggerMachineAuthSync,
       }),
       credentials: "include",
     });
@@ -867,8 +867,8 @@ export const useBackend = (
             window.location.reload();
           });
 
-          connection.on("RefreshAuthFromCookies", () => {
-            logger.debug(`[${connection.connectionId}] RefreshAuthFromCookies`);
+          connection.on("SyncAuthFromCookies", () => {
+            logger.debug(`[${connection.connectionId}] SyncAuthFromCookies`);
             refreshAuthFromCookies(connection.connectionId);
           });
 


### PR DESCRIPTION
# Summary

## Changes

Added a connected accounts system that allows independent OAuth provider sessions to coexist with the main auth session. Connected accounts use a `conn_` cookie prefix namespace, persist through main auth logout, and provide full `IAuthSession` capabilities including their own brokered sessions.

## API Changes

- `IAuthSession`: Added `ConnectedAccounts`, `AddConnectedAccount()`, `RemoveConnectedAccount()`, `ClearConnectedAccounts()`, `ConnectedAccountAdded`, `ConnectedAccountRemoved`
- `AuthSession`: New constructor parameter `connectedAccounts`; implements all connected account interface members
- `AuthSessionSnapshot`: Added `ConnectedAccounts` property
- `IConnectedAccountsService` (new): `GetAvailableProviders()`, `ConnectAccountAsync()`, `HandleConnectCallbackAsync()`, `DisconnectAccountAsync()`, `GetAccountSession()`, `RefreshAllAsync()`
- `ConnectedAccountsService` (new): Full implementation of `IConnectedAccountsService`
- `CookieRegistryExtensions`: Added `AddCookiesForConnectedAccounts()`
- `AuthHelper`: Added `ExtractConnectedAccountsFromCookies()`, `ExtractConnectedAccountsFromCookieHeader()`; brokered session extraction now excludes `conn_` prefixed cookies
- `Server`: Added `RegisterConnectedAccountProvider<TProvider>(string providerKey)`; registered `IConnectedAccountsService` in DI
- `AuthSessionExtensions`: Snapshot and change detection now include connected accounts
- `CheckedAuthSession`: Added `ConnectedAccounts` property delegation with access checks
- `AuthSessionProperty` enum: Added `ConnectedAccounts` value

## Files Modified

**Core auth model:**
- `src/Ivy/Auth/IAuthSession.cs` - Interface + class + snapshot extended
- `src/Ivy/Auth/AuthSessionExtensions.cs` - Snapshot/comparison updated

**Cookie management:**
- `src/Ivy/Core/Auth/CookieRegistryExtensions.cs` - Connected account cookie writing
- `src/Ivy/Core/Auth/AuthHelper.cs` - Connected account cookie extraction + brokered exclusion

**Services:**
- `src/Ivy/Auth/IConnectedAccountsService.cs` (new)
- `src/Ivy/Auth/ConnectedAccountsService.cs` (new)
- `src/Ivy/Auth/AuthService.cs` - Logout preserves connected accounts
- `src/Ivy/Server.cs` - Registration method + DI

**Debug support:**
- `src/Ivy/Core/Auth/CheckedAuthSession.cs` - Delegated connected account access

**Tests:**
- `src/Ivy.Tests/Auth/ConnectedAccountsServiceTests.cs` (new)
- `src/Ivy.Tests/Auth/AuthHelperConnectedAccountTests.cs` (new)
- `src/Ivy.Tests/Auth/CookieRegistryExtensionsConnectedTests.cs` (new)
- `src/Ivy.Tests/Auth/ConnectedAccountLifecycleTests.cs` (new)
- `src/Ivy.Tests/Auth/ConnectedAccountSessionTests.cs` (new)

## Commits

- 27db09bf1 Register IConnectedAccountService in AppHub
- cf652aa3b Add GitHub account connection to basic auth example
- 290e12899 Diagnose GitHub JSON errors