### PR TITLE
[00006] Fix AuthController cookie prefix bug in SetAuthCookies

### DIFF
--- a/src/Ivy/Core/Auth/AuthController.cs
+++ b/src/Ivy/Core/Auth/AuthController.cs
@@ -173,7 +173,7 @@ public class AuthController() : Controller
 
         if (request.TriggerMachineReload)
         {
-            if (cookies.TryGet("access_token", out var authTokenValue) && !string.IsNullOrEmpty(authTokenValue))
+            if (cookies.TryGet(CookieRegistryExtensions.PrefixCookieName("access_token"), out var authTokenValue) && !string.IsNullOrEmpty(authTokenValue))
             {
                 // Trigger reload for all sessions with the same machineId on login
                 if (HttpContext.Request.Headers.TryGetValue("X-Machine-Id", out var loginHeaderValue))


### PR DESCRIPTION
# Summary

## Changes

Fixed a critical bug in AuthController.cs where `SetAuthCookies` failed to read the access token when `Server.AuthCookiePrefix` is set. The method now uses `CookieRegistryExtensions.PrefixCookieName()` to respect the configured cookie prefix, enabling proper multi-tab authentication and synchronization in applications using the prefix feature.

## API Changes

None.

## Files Modified

- `src/Ivy/Core/Auth/AuthController.cs` — Updated line 176 to use `CookieRegistryExtensions.PrefixCookieName("access_token")` instead of hardcoded `"access_token"`

## Commits

- eab254750 [00006] Fix AuthController cookie prefix bug in SetAuthCookies