### PR TITLE
(badge): ensure badge text color matches button text color

### DIFF
--- a/src/frontend/src/widgets/badge/BadgeWidget.color.test.ts
+++ b/src/frontend/src/widgets/badge/BadgeWidget.color.test.ts
@@ -1,0 +1,70 @@
+import type { CSSProperties } from "react";
+import { describe, it, expect } from "vitest";
+import { getColor } from "@/lib/styles";
+
+/**
+ * Mirrors the `color` prop merge in `BadgeWidget.tsx` — keep in sync when that widget changes.
+ */
+function customBadgeColorStyles(color: string | undefined): CSSProperties {
+  if (!color) return {};
+  return {
+    ...getColor(color, "backgroundColor", "background"),
+    ...getColor(color, "color", "foreground"),
+  };
+}
+
+function cssVarBase(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const m = value.match(/^var\((--[\w-]+)\)$/);
+  return m?.[1];
+}
+
+const BADGE_FLAT_COLOR_NAMES = [
+  "Black",
+  "White",
+  "Slate",
+  "Gray",
+  "Zinc",
+  "Neutral",
+  "Stone",
+  "Red",
+  "Orange",
+  "Amber",
+  "Yellow",
+  "Lime",
+  "Green",
+  "Emerald",
+  "Teal",
+  "Cyan",
+  "Sky",
+  "Blue",
+  "Indigo",
+  "Violet",
+  "Purple",
+  "Fuchsia",
+  "Pink",
+  "Rose",
+  "Primary",
+  "Secondary",
+  "Destructive",
+  "Success",
+  "Warning",
+  "Info",
+  "Muted",
+  "IvyGreen",
+] as const;
+
+describe("BadgeWidget custom color (fill + label)", () => {
+  it.each(BADGE_FLAT_COLOR_NAMES)(
+    "pairs background and text with the same token base (%s)",
+    (color) => {
+      const style = customBadgeColorStyles(color);
+      const base = cssVarBase(style.backgroundColor as string);
+      expect(
+        base,
+        `expected var(--token), got ${JSON.stringify(style.backgroundColor)}`,
+      ).toBeDefined();
+      expect(style.color).toBe(`var(${base}-foreground)`);
+    },
+  );
+});

--- a/src/frontend/src/widgets/button/ButtonWidget.tsx
+++ b/src/frontend/src/widgets/button/ButtonWidget.tsx
@@ -251,7 +251,7 @@ export const ButtonWidget: React.FC<ButtonWidgetProps> = ({
             title
           )}
           {badge && (
-            <Badge variant="outline" className="ml-1 w-min whitespace-nowrap">
+            <Badge variant="outline" className="ml-1 w-min whitespace-nowrap text-inherit">
               {badge}
             </Badge>
           )}


### PR DESCRIPTION
### Summary

Found one issue for badges presented in Buttons: they didn't respect button background color what caused pure contrast. Examples are from ButtonApp.cs

### Issue:

<img width="836" height="159" alt="Screenshot 2026-04-19 at 02 55 46" src="https://github.com/user-attachments/assets/3c9f8d93-a4a5-4435-806b-19dcc22aeec8" />

<img width="790" height="151" alt="Screenshot 2026-04-19 at 02 56 03" src="https://github.com/user-attachments/assets/a2c21674-7997-4b24-a5f3-7d3d2db0a700" />

### Solved:

<img width="543" height="109" alt="Screenshot 2026-04-19 at 02 56 18" src="https://github.com/user-attachments/assets/6698eb5b-8ec9-498f-84c0-c7b78315b4bb" />

<img width="532" height="105" alt="Screenshot 2026-04-19 at 02 56 13" src="https://github.com/user-attachments/assets/ce7a535f-ddcb-4590-b409-1d617d664b58" />

### Also: 

Also checked text color in badges when different colors set to badges in BadgeColorTestApp.cs
LGTM to me but maybe something isn't perfect (?)

<img width="1180" height="423" alt="Screenshot 2026-04-19 at 02 51 41" src="https://github.com/user-attachments/assets/00315436-0551-4d71-b877-646c49cc688d" />

<img width="1180" height="426" alt="Screenshot 2026-04-19 at 02 51 32" src="https://github.com/user-attachments/assets/2d1e62e9-cf42-4d60-a363-25879df8c959" />

Verified badges appearance in datatables - LGTM

### Probably issue - Responsive design
Responsive design for badges and buttons isn't perfect so when crop page enogh these elements (also when contain icons text etc) overlay

<img width="491" height="286" alt="Screenshot 2026-04-19 at 03 05 54" src="https://github.com/user-attachments/assets/630eb7aa-d19b-4a54-b931-099390c23641" />
