### PR TITLE
(datatable): fix density

### DIFF
--- a/src/Ivy/Views/DataTables/DataTableBuilder.cs
+++ b/src/Ivy/Views/DataTables/DataTableBuilder.cs
@@ -579,6 +579,6 @@ public class DataTableBuilder<TModel>(
     public object[] GetMemoValues()
     {
         // Memoize based on configuration - if config hasn't changed, don't rebuild
-        return [_width!, _height!, _configuration, _refreshToken?.Token!];
+        return [_width!, _height!, _configuration, _refreshToken?.Token!, _density];
     }
 }

--- a/src/Ivy/Views/DataTables/DataTableView.cs
+++ b/src/Ivy/Views/DataTables/DataTableView.cs
@@ -59,6 +59,6 @@ public class DataTableView(
         // Memoize based on queryable and configuration
         // Don't include the queryable itself as it might change reference
         // Only memoize if all inputs are stable
-        return [(object?)width!, (object?)height!, columns, config, refreshToken?.Token!];
+        return [(object?)width!, (object?)height!, columns, config, refreshToken?.Token!, density];
     }
 }


### PR DESCRIPTION
Memoization incorrectly treated “same width/height/config” as “same table” and ignored density changes
Issue:

https://github.com/user-attachments/assets/e3408ee3-bfc5-4871-999a-076c02135a7b

Fixed:


https://github.com/user-attachments/assets/7b4a4209-badb-4355-85b3-dd86e6202ee3

P.S. Maybe we need some improvements of density usage? Filter input doesn't change in according to density, same for fonts inside the table