### PR TITLE
[03445] Comment out Made with Ivy branding code in FE

### DIFF
--- a/src/frontend/src/components/App.tsx
+++ b/src/frontend/src/components/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { renderWidgetTree, loadingState } from "@/widgets/widgetRenderer";
 import { useBackend } from "@/hooks/use-backend";
 import { Toaster } from "@/components/ui/toaster";

--- a/src/frontend/src/components/App.tsx
+++ b/src/frontend/src/components/App.tsx
@@ -4,7 +4,7 @@ import { useBackend } from "@/hooks/use-backend";
 import { Toaster } from "@/components/ui/toaster";
 import { ErrorSheet } from "@/components/ErrorSheet";
 import ErrorBoundary from "./ErrorBoundary";
-import MadeWithIvy from "./MadeWithIvy";
+// import MadeWithIvy from "./MadeWithIvy"; // TODO: Branding feature commented out - can be re-enabled in the future
 import { DevTools } from "./DevTools";
 import {
   getAppArgs,
@@ -14,7 +14,7 @@ import {
   wrapAppContent,
   isDevToolsEnabled,
 } from "@/lib/utils";
-import { hasLicensedFeature } from "@/lib/license";
+// import { hasLicensedFeature } from "@/lib/license"; // TODO: Branding feature commented out - can be re-enabled in the future
 import { ConnectionModal } from "./ConnectionModal";
 import { ThemeProvider } from "./theme-provider";
 import { EventHandlerProvider } from "./event-handler";
@@ -31,11 +31,11 @@ export function App() {
 
   const { connection, widgetTree, eventHandler, subscribeToStream, disconnected, connectionState } =
     useBackend(appId, appArgs, parentId, appShell);
-  const [removeBranding, setRemoveBranding] = useState(true);
-
-  useEffect(() => {
-    hasLicensedFeature("RemoveBranding").then(setRemoveBranding);
-  }, []);
+  // const [removeBranding, setRemoveBranding] = useState(true); // TODO: Branding feature commented out - can be re-enabled in the future
+  //
+  // useEffect(() => {
+  //   hasLicensedFeature("RemoveBranding").then(setRemoveBranding);
+  // }, []);
 
   useEffect(() => {
     const handlePopState = (event: PopStateEvent) => {
@@ -61,7 +61,8 @@ export function App() {
           <EventHandlerProvider eventHandler={eventHandler}>
             <StreamHandlerProvider subscribeToStream={subscribeToStream}>
               <>
-                {!removeBranding && <MadeWithIvy />}
+                {/* {!removeBranding && <MadeWithIvy />} */}
+                {/* TODO: Branding feature commented out - can be re-enabled in the future */}
                 {isDevToolsEnabled() && <DevTools />}
                 {wrapAppContent(renderWidgetTree(widgetTree || loadingState()))}
                 <ErrorSheet />

--- a/src/frontend/src/widgets/internal/SidebarNewsWidget.tsx
+++ b/src/frontend/src/widgets/internal/SidebarNewsWidget.tsx
@@ -2,7 +2,7 @@ import { cn } from "@/lib/utils";
 import { validateLinkUrl } from "@/lib/url";
 import { useEffect, useState } from "react";
 import * as React from "react";
-import { hasLicensedFeature } from "@/lib/license";
+// import { hasLicensedFeature } from "@/lib/license"; // TODO: Branding check commented out - can be re-enabled in the future
 import { Card } from "@/components/ui/card";
 
 export interface SidebarNewsWidgetProps {
@@ -25,18 +25,18 @@ const fetchNewsData = async (): Promise<NewsArticle[]> => {
 };
 
 const SidebarNewsWidget = ({ feedUrl }: SidebarNewsWidgetProps) => {
-  const [removeBranding, setRemoveBranding] = useState(true);
+  // const [removeBranding, setRemoveBranding] = useState(true); // TODO: Branding check commented out - can be re-enabled in the future
   const [articles, setArticles] = useState<NewsArticle[] | null>(null);
 
-  useEffect(() => {
-    hasLicensedFeature("RemoveBranding").then(setRemoveBranding);
-  }, []);
+  // useEffect(() => { // TODO: Branding check commented out - can be re-enabled in the future
+  //   hasLicensedFeature("RemoveBranding").then(setRemoveBranding);
+  // }, []);
 
   useEffect(() => {
     fetchNewsData().then(setArticles);
   }, [feedUrl]);
 
-  if (removeBranding) return null;
+  // if (removeBranding) return null; // TODO: Branding check commented out - can be re-enabled in the future
 
   if (!articles || articles.length === 0) return null;
 


### PR DESCRIPTION
# Summary

## Changes

Commented out the "Made with Ivy" branding features in the frontend codebase, allowing them to be re-enabled in the future without deletion. The MadeWithIvy component and SidebarNewsWidget branding checks have been commented out with TODO markers.

## API Changes

None.

## Files Modified

- `src/frontend/src/components/App.tsx` — Commented out MadeWithIvy import, removeBranding state/effect, and component render
- `src/frontend/src/widgets/internal/SidebarNewsWidget.tsx` — Commented out removeBranding state/effect and early return check

## Commits

- 0a89dd923, cd6c5add4
