### PR TITLE
Fix KBD styling in buttons to inherit parent colors

### DIFF
--- a/src/frontend/src/widgets/button/ButtonWidget.tsx
+++ b/src/frontend/src/widgets/button/ButtonWidget.tsx
@@ -256,7 +256,7 @@ export const ButtonWidget: React.FC<ButtonWidgetProps> = ({
             </Badge>
           )}
           {shortcutKey && title && (
-            <kbd className="ml-1 px-1 py-0.5 text-[0.65rem] font-medium text-muted-foreground bg-muted border border-border rounded-selector">
+            <kbd className="ml-1 px-1 py-0.5 text-[0.65rem] font-medium border border-current/20 rounded-selector opacity-70">
               {shortcutDisplay}
             </kbd>
           )}


### PR DESCRIPTION
## Summary
- Removed `text-muted-foreground` and `bg-muted` from KBD elements inside buttons so they inherit the button's text color and have no independent background
- Added `border-current/20` to use the inherited text color at 20% opacity for the border
- Added `opacity-70` to subtly differentiate the shortcut badge from the button label

## Test plan
- [ ] Verify KBD badges in primary, secondary, destructive, and ghost button variants all inherit the correct text color
- [ ] Confirm the KBD border is visible but subtle across all variants
- [ ] Check dark mode rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)