### PR TITLE
Fix double border on focused text inputs

### DIFF
--- a/src/frontend/src/widgets/inputs/TextInputWidget/variants/DefaultVariant.tsx
+++ b/src/frontend/src/widgets/inputs/TextInputWidget/variants/DefaultVariant.tsx
@@ -75,8 +75,8 @@ export const DefaultVariant: React.FC<DefaultVariantProps> = ({
     <div className="relative w-full select-none" style={styles}>
       <div
         className={cn(
-          "relative flex items-stretch rounded-field border border-input bg-transparent shadow-sm transition-colors dark:bg-white/5 dark:border-white/10",
-          isFocused && "outline-none ring-1 ring-ring",
+          "relative flex items-stretch rounded-field border bg-transparent shadow-sm transition-colors dark:bg-white/5",
+          isFocused ? "border-ring outline-none dark:border-ring" : "border-input dark:border-white/10",
           props.invalid && "border-destructive",
           props.disabled && "cursor-not-allowed opacity-50",
           props.ghost &&

--- a/src/frontend/src/widgets/inputs/TextInputWidget/variants/DefaultVariant.tsx
+++ b/src/frontend/src/widgets/inputs/TextInputWidget/variants/DefaultVariant.tsx
@@ -76,7 +76,9 @@ export const DefaultVariant: React.FC<DefaultVariantProps> = ({
       <div
         className={cn(
           "relative flex items-stretch rounded-field border bg-transparent shadow-sm transition-colors dark:bg-white/5",
-          isFocused ? "border-ring outline-none dark:border-ring" : "border-input dark:border-white/10",
+          isFocused
+            ? "border-ring outline-none dark:border-ring"
+            : "border-input dark:border-white/10",
           props.invalid && "border-destructive",
           props.disabled && "cursor-not-allowed opacity-50",
           props.ghost &&
@@ -87,7 +89,7 @@ export const DefaultVariant: React.FC<DefaultVariantProps> = ({
         {hasPrefix && (
           <div
             className={cn(
-              "flex items-center px-3 bg-muted text-muted-foreground rounded-tl-[var(--radius-fields)] rounded-bl-[var(--radius-fields)]",
+              "flex items-center px-3 bg-muted text-muted-foreground rounded-tl-[var(--radius-fields)] rounded-bl-[var(--radius-fields)] [&_button]:rounded [&_button]:px-1 [&_button]:hover:bg-accent [&_button]:cursor-pointer [&_button]:transition-colors",
               !isFocused && "border-r border-input",
             )}
           >
@@ -186,7 +188,7 @@ export const DefaultVariant: React.FC<DefaultVariantProps> = ({
         {hasSuffix && (
           <div
             className={cn(
-              "flex items-center px-3 bg-muted text-muted-foreground rounded-tr-[var(--radius-fields)] rounded-br-[var(--radius-fields)]",
+              "flex items-center px-3 bg-muted text-muted-foreground rounded-tr-[var(--radius-fields)] rounded-br-[var(--radius-fields)] [&_button]:rounded [&_button]:px-1 [&_button]:hover:bg-accent [&_button]:cursor-pointer [&_button]:transition-colors",
               !isFocused && "border-l border-input",
             )}
           >

--- a/src/frontend/src/widgets/inputs/TextInputWidget/variants/SearchVariant.tsx
+++ b/src/frontend/src/widgets/inputs/TextInputWidget/variants/SearchVariant.tsx
@@ -111,7 +111,9 @@ export const SearchVariant: React.FC<SearchVariantProps> = ({
       <div
         className={cn(
           "relative flex items-stretch rounded-field border bg-transparent shadow-sm transition-colors dark:bg-white/5",
-          isFocused ? "border-ring outline-none dark:border-ring" : "border-input dark:border-white/10",
+          isFocused
+            ? "border-ring outline-none dark:border-ring"
+            : "border-input dark:border-white/10",
           props.invalid && "border-destructive",
           props.disabled && "cursor-not-allowed opacity-50",
           props.ghost &&
@@ -121,7 +123,7 @@ export const SearchVariant: React.FC<SearchVariantProps> = ({
         {hasPrefix && (
           <div
             className={cn(
-              "flex items-center px-3 bg-muted text-muted-foreground rounded-tl-[var(--radius-fields)] rounded-bl-[var(--radius-fields)]",
+              "flex items-center px-3 bg-muted text-muted-foreground rounded-tl-[var(--radius-fields)] rounded-bl-[var(--radius-fields)] [&_button]:rounded [&_button]:px-1 [&_button]:hover:bg-accent [&_button]:cursor-pointer [&_button]:transition-colors",
               !isFocused && "border-r border-input",
             )}
           >
@@ -198,7 +200,7 @@ export const SearchVariant: React.FC<SearchVariantProps> = ({
         {hasSuffix && (
           <div
             className={cn(
-              "flex items-center px-3 bg-muted text-muted-foreground rounded-tr-[var(--radius-fields)] rounded-br-[var(--radius-fields)]",
+              "flex items-center px-3 bg-muted text-muted-foreground rounded-tr-[var(--radius-fields)] rounded-br-[var(--radius-fields)] [&_button]:rounded [&_button]:px-1 [&_button]:hover:bg-accent [&_button]:cursor-pointer [&_button]:transition-colors",
               !isFocused && "border-l border-input",
             )}
           >

--- a/src/frontend/src/widgets/inputs/TextInputWidget/variants/SearchVariant.tsx
+++ b/src/frontend/src/widgets/inputs/TextInputWidget/variants/SearchVariant.tsx
@@ -110,8 +110,8 @@ export const SearchVariant: React.FC<SearchVariantProps> = ({
     <div className="relative w-full select-none" style={styles}>
       <div
         className={cn(
-          "relative flex items-stretch rounded-field border border-input bg-transparent shadow-sm transition-colors dark:bg-white/5 dark:border-white/10",
-          isFocused && "outline-none ring-1 ring-ring",
+          "relative flex items-stretch rounded-field border bg-transparent shadow-sm transition-colors dark:bg-white/5",
+          isFocused ? "border-ring outline-none dark:border-ring" : "border-input dark:border-white/10",
           props.invalid && "border-destructive",
           props.disabled && "cursor-not-allowed opacity-50",
           props.ghost &&


### PR DESCRIPTION
## Summary

- Replaced `ring-1 ring-ring` focus styling with `border-ring` border-color swap on `SearchVariant.tsx` and `DefaultVariant.tsx`
- Moves `border-input` and `dark:border-white/10` into a conditional so they only apply when unfocused
- Eliminates the double-border visual artifact when clicking/focusing text inputs

## Test plan

- [ ] Click a search input and verify only a single border appears on focus
- [ ] Verify default text inputs also show a single border on focus
- [ ] Check both light and dark modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)