### PR TITLE
Add hover styles for buttons in text input suffixes

### DIFF
--- a/src/frontend/src/widgets/inputs/TextInputWidget/variants/DefaultVariant.tsx
+++ b/src/frontend/src/widgets/inputs/TextInputWidget/variants/DefaultVariant.tsx
@@ -87,7 +87,7 @@ export const DefaultVariant: React.FC<DefaultVariantProps> = ({
         {hasPrefix && (
           <div
             className={cn(
-              "flex items-center px-3 bg-muted text-muted-foreground rounded-tl-[var(--radius-fields)] rounded-bl-[var(--radius-fields)]",
+              "flex items-center px-3 bg-muted text-muted-foreground rounded-tl-[var(--radius-fields)] rounded-bl-[var(--radius-fields)] [&_button]:rounded [&_button]:px-1 [&_button]:hover:bg-accent [&_button]:cursor-pointer [&_button]:transition-colors",
               !isFocused && "border-r border-input",
             )}
           >
@@ -186,7 +186,7 @@ export const DefaultVariant: React.FC<DefaultVariantProps> = ({
         {hasSuffix && (
           <div
             className={cn(
-              "flex items-center px-3 bg-muted text-muted-foreground rounded-tr-[var(--radius-fields)] rounded-br-[var(--radius-fields)]",
+              "flex items-center px-3 bg-muted text-muted-foreground rounded-tr-[var(--radius-fields)] rounded-br-[var(--radius-fields)] [&_button]:rounded [&_button]:px-1 [&_button]:hover:bg-accent [&_button]:cursor-pointer [&_button]:transition-colors",
               !isFocused && "border-l border-input",
             )}
           >

--- a/src/frontend/src/widgets/inputs/TextInputWidget/variants/SearchVariant.tsx
+++ b/src/frontend/src/widgets/inputs/TextInputWidget/variants/SearchVariant.tsx
@@ -121,7 +121,7 @@ export const SearchVariant: React.FC<SearchVariantProps> = ({
         {hasPrefix && (
           <div
             className={cn(
-              "flex items-center px-3 bg-muted text-muted-foreground rounded-tl-[var(--radius-fields)] rounded-bl-[var(--radius-fields)]",
+              "flex items-center px-3 bg-muted text-muted-foreground rounded-tl-[var(--radius-fields)] rounded-bl-[var(--radius-fields)] [&_button]:rounded [&_button]:px-1 [&_button]:hover:bg-accent [&_button]:cursor-pointer [&_button]:transition-colors",
               !isFocused && "border-r border-input",
             )}
           >
@@ -198,7 +198,7 @@ export const SearchVariant: React.FC<SearchVariantProps> = ({
         {hasSuffix && (
           <div
             className={cn(
-              "flex items-center px-3 bg-muted text-muted-foreground rounded-tr-[var(--radius-fields)] rounded-br-[var(--radius-fields)]",
+              "flex items-center px-3 bg-muted text-muted-foreground rounded-tr-[var(--radius-fields)] rounded-br-[var(--radius-fields)] [&_button]:rounded [&_button]:px-1 [&_button]:hover:bg-accent [&_button]:cursor-pointer [&_button]:transition-colors",
               !isFocused && "border-l border-input",
             )}
           >


### PR DESCRIPTION
## Summary
- Buttons in the prefix/suffix slots of text input widgets were missing hover background colors
- Added Tailwind child-selector utilities (`[&_button]`) to prefix and suffix container divs in both `DefaultVariant.tsx` and `SearchVariant.tsx`
- Buttons now get `rounded`, `px-1`, `hover:bg-accent`, `cursor-pointer`, and `transition-colors` styling

## Test plan
- [ ] Place a button in the suffix slot of a text input widget and verify hover background appears
- [ ] Place a button in the prefix slot and verify the same
- [ ] Test with both default and search variants
- [ ] Verify no visual regression on inputs without buttons in prefix/suffix

🤖 Generated with [Claude Code](https://claude.com/claude-code)