### PR TITLE
Fix sticky header in sidebar content

### DIFF
--- a/src/frontend/src/widgets/layouts/sidebar/SidebarLayoutWidget.tsx
+++ b/src/frontend/src/widgets/layouts/sidebar/SidebarLayoutWidget.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useCallback, useMemo, useRef, useReducer } 
 
 import Icon from "@/components/Icon";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
-import { ScrollArea } from "@/components/ui/scroll-area";
+
 import { ChevronRight, PanelLeftClose, PanelLeftOpen } from "lucide-react";
 import { MenuItem, WidgetEventHandlerType } from "@/types/widgets";
 import { useFocusable } from "@/hooks/use-focus-management";
@@ -230,9 +230,7 @@ export const SidebarLayoutWidget: React.FC<SidebarLayoutWidgetProps> = ({
         )}
         {slots?.SidebarContent && (
           <div className="flex-1 min-h-0 min-w-0 overflow-hidden">
-            <ScrollArea className="h-full w-full">
-              <div className="p-2 space-y-2">{slots.SidebarContent}</div>
-            </ScrollArea>
+            <div className="p-2 space-y-2 h-full overflow-y-auto">{slots.SidebarContent}</div>
           </div>
         )}
         {hasContent(slots?.SidebarFooter) && (


### PR DESCRIPTION
## Summary
- Replace ScrollArea wrapper in SidebarContent with a height-constrained div
- Allows HeaderLayout inside sidebar content to properly keep its header fixed while content scrolls
- Non-HeaderLayout content still scrolls via overflow-y-auto

## Test plan
- [ ] Verify sidebar search/filter header stays fixed when scrolling in Drafts, Review, Icebox, Recommendations, and Trash apps
- [ ] Verify sidebar content still scrolls properly
- [ ] Verify non-HeaderLayout sidebar content still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)