### PR TITLE
Fix missing tooltip on Bar/Line/Area chart hover

### DIFF
--- a/src/frontend/src/widgets/charts/AreaChartWidget.tsx
+++ b/src/frontend/src/widgets/charts/AreaChartWidget.tsx
@@ -195,12 +195,14 @@ const AreaChartWidget: React.FC<AreaChartWidgetProps> = ({
           mutedForeground: themeColors.mutedForeground,
         }),
         formatter: (params: any) => {
+          const extractValue = (p: any) =>
+            Array.isArray(p.value) ? p.value[isVertical ? 1 : 0] : p.value;
           if (Array.isArray(params)) {
             // Multi-series: add category header from first param
             const header = params[0]?.name ? `<strong>${params[0].name}</strong><br/>` : "";
             const lines = params
               .map((p) => {
-                const value = formatTooltipValue(p.value[isVertical ? 0 : 1], tooltip);
+                const value = formatTooltipValue(extractValue(p), tooltip);
                 return `${p.marker} ${p.seriesName}: <strong>${value}</strong>`;
               })
               .join("<br/>");
@@ -208,7 +210,7 @@ const AreaChartWidget: React.FC<AreaChartWidgetProps> = ({
           }
           // Single series: add category header
           const header = params.name ? `<strong>${params.name}</strong><br/>` : "";
-          const value = formatTooltipValue(params.value[isVertical ? 0 : 1], tooltip);
+          const value = formatTooltipValue(extractValue(params), tooltip);
           return `${header}${params.marker} ${params.seriesName}: <strong>${value}</strong>`;
         },
       },

--- a/src/frontend/src/widgets/charts/BarChartWidget.tsx
+++ b/src/frontend/src/widgets/charts/BarChartWidget.tsx
@@ -249,12 +249,14 @@ const BarChartWidget: React.FC<BarChartWidgetProps> = ({
           mutedForeground: themeColors.mutedForeground,
         }),
         formatter: (params: any) => {
+          const extractValue = (p: any) =>
+            Array.isArray(p.value) ? p.value[isVertical ? 1 : 0] : p.value;
           if (Array.isArray(params)) {
             // Multi-series: add category header from first param
             const header = params[0]?.name ? `<strong>${params[0].name}</strong><br/>` : "";
             const lines = params
               .map((p) => {
-                const value = formatTooltipValue(p.value[isVertical ? 0 : 1], tooltip);
+                const value = formatTooltipValue(extractValue(p), tooltip);
                 return `${p.marker} ${p.seriesName}: <strong>${value}</strong>`;
               })
               .join("<br/>");
@@ -262,7 +264,7 @@ const BarChartWidget: React.FC<BarChartWidgetProps> = ({
           }
           // Single series: add category header
           const header = params.name ? `<strong>${params.name}</strong><br/>` : "";
-          const value = formatTooltipValue(params.value[isVertical ? 0 : 1], tooltip);
+          const value = formatTooltipValue(extractValue(params), tooltip);
           return `${header}${params.marker} ${params.seriesName}: <strong>${value}</strong>`;
         },
       },

--- a/src/frontend/src/widgets/charts/LineChartWidget.tsx
+++ b/src/frontend/src/widgets/charts/LineChartWidget.tsx
@@ -109,12 +109,14 @@ const LineChartWidget: React.FC<LineChartWidgetProps> = ({
           mutedForeground: themeColors.mutedForeground,
         }),
         formatter: (params: any) => {
+          const extractValue = (p: any) =>
+            Array.isArray(p.value) ? p.value[isVertical ? 1 : 0] : p.value;
           if (Array.isArray(params)) {
             // Multi-series: add category header from first param
             const header = params[0]?.name ? `<strong>${params[0].name}</strong><br/>` : "";
             const lines = params
               .map((p) => {
-                const value = formatTooltipValue(p.value[isVertical ? 0 : 1], tooltip);
+                const value = formatTooltipValue(extractValue(p), tooltip);
                 return `${p.marker} ${p.seriesName}: <strong>${value}</strong>`;
               })
               .join("<br/>");
@@ -122,7 +124,7 @@ const LineChartWidget: React.FC<LineChartWidgetProps> = ({
           }
           // Single series: add category header
           const header = params.name ? `<strong>${params.name}</strong><br/>` : "";
-          const value = formatTooltipValue(params.value[isVertical ? 0 : 1], tooltip);
+          const value = formatTooltipValue(extractValue(params), tooltip);
           return `${header}${params.marker} ${params.seriesName}: <strong>${value}</strong>`;
         },
       },


### PR DESCRIPTION
## Summary
- Bar/Line/Area chart tooltips silently failed to render (observed on the cost/token chart in Ivy Tendril's Dashboard app).
- The tooltip `formatter` indexed `params.value` with `[isVertical ? 0 : 1]`, but those widgets emit **scalar** series data via `data.map((d) => d[key])`. Indexing a number yielded `undefined`, and `formatTooltipValue` then called `undefined.toLocaleString()` — a thrown error which ECharts swallows, dropping the tooltip entirely.
- Regression was introduced by #03135 / commit `ec969b993` ("Add tooltip value formatting to cartesian charts"), which ported the scatter-chart indexing to cartesian widgets whose data isn't a `[x, y]` tuple.

## Fix
- Extract the value with `Array.isArray(p.value) ? p.value[isVertical ? 1 : 0] : p.value` in all three cartesian widgets (Bar, Line, Area).
- Also corrects the inverted index for the tuple case: the value axis is opposite the category axis (vertical → index 1, horizontal → index 0).
- ScatterChartWidget is untouched — its data really is `[x, y]` tuples.

## Test plan
- [x] `npm run build` in `src/frontend/` succeeds
- [ ] Manual: hover the hourly cost/token bar chart on the Ivy Tendril dashboard and confirm the tooltip renders with category header + both series values
- [ ] Manual: hover a single-series bar chart and confirm the tooltip renders
- [ ] Manual: hover a line chart and an area chart and confirm tooltips render

🤖 Generated with [Claude Code](https://claude.com/claude-code)