### PR TITLE
Add border separator to SidebarHeader slot

### DIFF
--- a/src/frontend/src/widgets/layouts/sidebar/SidebarLayoutWidget.tsx
+++ b/src/frontend/src/widgets/layouts/sidebar/SidebarLayoutWidget.tsx
@@ -226,7 +226,9 @@ export const SidebarLayoutWidget: React.FC<SidebarLayoutWidgetProps> = ({
         style={{ width: effectiveSidebarWidth }}
       >
         {hasContent(slots?.SidebarHeader) && (
-          <div className="flex flex-col shrink-0 p-2 space-y-4">{slots?.SidebarHeader}</div>
+          <div className="flex flex-col shrink-0 p-2 space-y-4 border-b">
+            {slots?.SidebarHeader}
+          </div>
         )}
         {slots?.SidebarContent && (
           <div className="flex-1 min-h-0 min-w-0 overflow-hidden">


### PR DESCRIPTION
## Summary
- Add `border-b` to the SidebarHeader wrapper div in SidebarLayoutWidget
- Restores the visual separator between sidebar header and content that was lost when moving from HeaderLayout to the SidebarHeader slot

🤖 Generated with [Claude Code](https://claude.com/claude-code)