### PR TITLE
Match DataTable badge sizing with BadgeWidget

### DIFF
--- a/src/frontend/src/lib/theme.ts
+++ b/src/frontend/src/lib/theme.ts
@@ -56,6 +56,7 @@ export interface ThemeColors {
   input: string;
   ring: string;
   radius: string;
+  radiusSelectors: string;
 
   // Semantic colors
   success: string;
@@ -140,6 +141,7 @@ export function getThemeColors(): ThemeColors {
     input: getCSSVariable("--input"),
     ring: getCSSVariable("--ring"),
     radius: getCSSVariable("--radius"),
+    radiusSelectors: getCSSVariable("--radius-selectors"),
 
     // Semantic colors
     success: getCSSVariable("--success"),

--- a/src/frontend/src/widgets/dataTables/hooks/useTableTheme.ts
+++ b/src/frontend/src/widgets/dataTables/hooks/useTableTheme.ts
@@ -65,6 +65,10 @@ export const useTableTheme = ({
       textGroupHeader: colors.mutedForeground || (isDark ? "#a1a1aa" : "#6b7280"),
       // Icon foreground color
       fgIconHeader: colors.mutedForeground || (isDark ? "#9ca3af" : "#6b7280"),
+      // Badge/bubble styling to match BadgeWidget
+      roundingRadius: parseFloat(colors.radiusSelectors) || 4,
+      bubbleHeight: 20,
+      bubblePadding: 8,
     }),
   });
 


### PR DESCRIPTION
## Summary
- Set `roundingRadius` from `--radius-selectors` CSS variable to match BadgeWidget's `rounded-selector`
- Set `bubbleHeight` and `bubblePadding` to match BadgeWidget medium density sizing
- Added `radiusSelectors` to ThemeColors for design system radius access

🤖 Generated with [Claude Code](https://claude.com/claude-code)