### PR TITLE
Fix pnpm builds in deep worktree paths on Windows

### DIFF
--- a/src/widgets/Ivy.Widgets.ClaudeJsonRenderer/frontend/.gitignore
+++ b/src/widgets/Ivy.Widgets.ClaudeJsonRenderer/frontend/.gitignore
@@ -1,3 +1,2 @@
 node_modules/
 dist/
-.npmrc

--- a/src/widgets/Ivy.Widgets.ClaudeJsonRenderer/frontend/.npmrc
+++ b/src/widgets/Ivy.Widgets.ClaudeJsonRenderer/frontend/.npmrc
@@ -1,0 +1,1 @@
+virtual-store-dir-max-length=15

--- a/src/widgets/Ivy.Widgets.DiffView/frontend/.gitignore
+++ b/src/widgets/Ivy.Widgets.DiffView/frontend/.gitignore
@@ -1,3 +1,2 @@
 node_modules/
 dist/
-.npmrc

--- a/src/widgets/Ivy.Widgets.DiffView/frontend/.npmrc
+++ b/src/widgets/Ivy.Widgets.DiffView/frontend/.npmrc
@@ -1,0 +1,1 @@
+virtual-store-dir-max-length=15

--- a/src/widgets/Ivy.Widgets.Leaflet/frontend/.gitignore
+++ b/src/widgets/Ivy.Widgets.Leaflet/frontend/.gitignore
@@ -1,3 +1,2 @@
 node_modules/
 dist/
-.npmrc

--- a/src/widgets/Ivy.Widgets.Leaflet/frontend/.npmrc
+++ b/src/widgets/Ivy.Widgets.Leaflet/frontend/.npmrc
@@ -1,0 +1,1 @@
+virtual-store-dir-max-length=15

--- a/src/widgets/Ivy.Widgets.ScreenshotFeedback/frontend/.gitignore
+++ b/src/widgets/Ivy.Widgets.ScreenshotFeedback/frontend/.gitignore
@@ -1,3 +1,2 @@
 node_modules/
 dist/
-.npmrc

--- a/src/widgets/Ivy.Widgets.ScreenshotFeedback/frontend/.npmrc
+++ b/src/widgets/Ivy.Widgets.ScreenshotFeedback/frontend/.npmrc
@@ -1,0 +1,1 @@
+virtual-store-dir-max-length=15

--- a/src/widgets/Ivy.Widgets.Tiptap/frontend/.gitignore
+++ b/src/widgets/Ivy.Widgets.Tiptap/frontend/.gitignore
@@ -1,3 +1,2 @@
 node_modules/
 dist/
-.npmrc

--- a/src/widgets/Ivy.Widgets.Tiptap/frontend/.npmrc
+++ b/src/widgets/Ivy.Widgets.Tiptap/frontend/.npmrc
@@ -1,0 +1,1 @@
+virtual-store-dir-max-length=15

--- a/src/widgets/Ivy.Widgets.Xterm/frontend/.gitignore
+++ b/src/widgets/Ivy.Widgets.Xterm/frontend/.gitignore
@@ -1,3 +1,2 @@
 node_modules/
 dist/
-.npmrc

--- a/src/widgets/Ivy.Widgets.Xterm/frontend/.npmrc
+++ b/src/widgets/Ivy.Widgets.Xterm/frontend/.npmrc
@@ -1,0 +1,1 @@
+virtual-store-dir-max-length=15


### PR DESCRIPTION
## Summary
- Add `virtual-store-dir-max-length=15` to all widget `.npmrc` files to shorten pnpm virtual store folder names
- Remove `.npmrc` from widget `.gitignore` files so the setting is tracked and shared

## Context
Node.js has a bug ([nodejs/node#62043](https://github.com/nodejs/node/issues/62043)) where ESM subpath imports fail when `package.json` paths exceed 260 chars on Windows. Tendril Plan worktrees use long base paths that push pnpm's `.pnpm` folder paths over this limit, causing `ERR_PACKAGE_IMPORT_NOT_DEFINED` errors during widget builds.

## Test plan
- [x] Verified `vp build` succeeds in plan worktree after change
- [x] Confirmed `.npmrc` files contain no auth tokens