### PR TITLE
(security): fix alerts

### DIFF
--- a/src/Ivy/Auth/AuthService.cs
+++ b/src/Ivy/Auth/AuthService.cs
@@ -171,8 +171,8 @@ public class AuthService : AuthTokenHandlerService, IAuthService
         if (hasChanges)
         {
             // Pass removed providers so their cookies get deleted
-            var cookieJarId = _sessionStore.RegisterAuthSessionCookies(_authSession, removedProviders);
-            _client.SetAuthCookies(cookieJarId, reloadPage: false, triggerMachineReload: null, triggerMachineAuthSync: true);
+            var cookieJarId = _sessionStore.RegisterAuthSessionCookies(_authSession, removedProviders, triggerMachineAuthSync: true);
+            _client.SetAuthCookies(cookieJarId, reloadPage: false, triggerMachineReload: null);
         }
 
         return BrokeredSessionsResult.Success(filteredSessions);
@@ -180,7 +180,7 @@ public class AuthService : AuthTokenHandlerService, IAuthService
 
     public void SetAuthCookies(bool reloadPage = true, bool? triggerMachineReload = null, bool triggerMachineAuthSync = false)
     {
-        var cookieJarId = _sessionStore.RegisterAuthSessionCookies(_authSession);
-        _client.SetAuthCookies(cookieJarId, reloadPage, triggerMachineReload, triggerMachineAuthSync);
+        var cookieJarId = _sessionStore.RegisterAuthSessionCookies(_authSession, triggerMachineAuthSync: triggerMachineAuthSync);
+        _client.SetAuthCookies(cookieJarId, reloadPage, triggerMachineReload);
     }
 }

--- a/src/Ivy/Auth/ConnectedAccountsService.cs
+++ b/src/Ivy/Auth/ConnectedAccountsService.cs
@@ -121,7 +121,10 @@ public class ConnectedAccountsService : IConnectedAccountsService
 
     private void SetConnectedAccountCookies(IEnumerable<string>? connectedProvidersToDelete = null, bool triggerMachineAuthSync = false)
     {
-        var cookieJarId = _sessionStore.RegisterAuthSessionCookies(_authSession, connectedProvidersToDelete: connectedProvidersToDelete);
-        _client.SetAuthCookies(cookieJarId, reloadPage: false, triggerMachineReload: null, triggerMachineAuthSync: triggerMachineAuthSync);
+        var cookieJarId = _sessionStore.RegisterAuthSessionCookies(
+            _authSession,
+            connectedProvidersToDelete: connectedProvidersToDelete,
+            triggerMachineAuthSync: triggerMachineAuthSync);
+        _client.SetAuthCookies(cookieJarId, reloadPage: false, triggerMachineReload: null);
     }
 }

--- a/src/Ivy/Client/ClientExtensions.cs
+++ b/src/Ivy/Client/ClientExtensions.cs
@@ -70,8 +70,6 @@ public static class ClientExtensions
         public required bool ReloadPage { get; set; }
         [DataMember(Name = "triggerMachineReload")]
         public required bool TriggerMachineReload { get; set; }
-        [DataMember(Name = "triggerMachineAuthSync")]
-        public required bool TriggerMachineAuthSync { get; set; }
     }
 
     public class SetRootAppIdMessage
@@ -144,7 +142,7 @@ public static class ClientExtensions
         client.Sender.Send("SetTitle", title);
     }
 
-    public static void SetAuthCookies(this IClientProvider client, CookieJarId cookieJarId, bool reloadPage, bool? triggerMachineReload = null, bool triggerMachineAuthSync = false)
+    public static void SetAuthCookies(this IClientProvider client, CookieJarId cookieJarId, bool reloadPage, bool? triggerMachineReload = null)
     {
         client.Sender.Send(
             "SetAuthCookies",
@@ -153,7 +151,6 @@ public static class ClientExtensions
                 ["cookieJarId"] = cookieJarId.Value,
                 ["reloadPage"] = reloadPage,
                 ["triggerMachineReload"] = triggerMachineReload ?? reloadPage,
-                ["triggerMachineAuthSync"] = triggerMachineAuthSync
             });
     }
 

--- a/src/Ivy/Core/Auth/AuthController.cs
+++ b/src/Ivy/Core/Auth/AuthController.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Ivy.Core.Auth;
 
-public record SetAuthCookiesRequest(string CookieJarId, string? ConnectionId, bool TriggerMachineReload, bool TriggerMachineAuthSync = false);
+public record SetAuthCookiesRequest(string CookieJarId, string? ConnectionId, bool TriggerMachineReload);
 
 public class AuthController() : Controller
 {
@@ -166,7 +166,8 @@ public class AuthController() : Controller
             sessionStore,
             new CookieJarId(request.CookieJarId),
             CookieJarIntents.SetAuthCookies,
-            out var cookies) is { } errorResponse)
+            out var cookies,
+            out var triggerMachineAuthSync) is { } errorResponse)
         {
             return errorResponse;
         }
@@ -193,7 +194,7 @@ public class AuthController() : Controller
             }
         }
 
-        if (request.TriggerMachineAuthSync)
+        if (triggerMachineAuthSync)
         {
             if (HttpContext.Request.Headers.TryGetValue("X-Machine-Id", out var headerValue))
             {

--- a/src/Ivy/Core/Auth/CookieRegistryExtensions.cs
+++ b/src/Ivy/Core/Auth/CookieRegistryExtensions.cs
@@ -7,9 +7,15 @@ namespace Ivy.Core.Auth;
 public static class CookieRegistryExtensions
 {
 
-    public static IActionResult? WriteCookiesToResponse(this Controller controller, AppSessionStore sessionStore, CookieJarId cookieJarId, string intent, out CookieJar cookies)
+    public static IActionResult? WriteCookiesToResponse(
+        this Controller controller,
+        AppSessionStore sessionStore,
+        CookieJarId cookieJarId,
+        string intent,
+        out CookieJar cookies,
+        out bool triggerMachineAuthSync)
     {
-        if (!sessionStore.TryRemoveCookies(cookieJarId, intent, out cookies))
+        if (!sessionStore.TryRemoveCookies(cookieJarId, intent, out cookies, out triggerMachineAuthSync))
         {
             return controller.BadRequest("Invalid or expired cookie jar ID, or intent mismatch.");
         }
@@ -18,7 +24,12 @@ public static class CookieRegistryExtensions
         return null;
     }
 
-    public static CookieJarId RegisterAuthSessionCookies(this AppSessionStore sessionStore, IAuthSession authSession, IEnumerable<string>? brokeredProvidersToDelete = null, IEnumerable<string>? connectedProvidersToDelete = null)
+    public static CookieJarId RegisterAuthSessionCookies(
+        this AppSessionStore sessionStore,
+        IAuthSession authSession,
+        IEnumerable<string>? brokeredProvidersToDelete = null,
+        IEnumerable<string>? connectedProvidersToDelete = null,
+        bool triggerMachineAuthSync = false)
     {
         var cookies = new CookieJar();
         cookies.AddCookiesForAuthToken(authSession.AuthToken, brokeredProvidersToDelete);
@@ -66,7 +77,7 @@ public static class CookieRegistryExtensions
             }
         }
 
-        return sessionStore.RegisterCookies(cookies, CookieJarIntents.SetAuthCookies);
+        return sessionStore.RegisterCookies(cookies, CookieJarIntents.SetAuthCookies, triggerMachineAuthSync);
     }
 
     public static CookieJarId RegisterAuthTokenCookies(this AppSessionStore sessionStore, AuthToken? authToken)

--- a/src/Ivy/Core/Server/AppSessionStore.cs
+++ b/src/Ivy/Core/Server/AppSessionStore.cs
@@ -11,6 +11,8 @@ class CookieJarEntry
     public required CookieJar CookieJar { get; set; }
     public required string Intent { get; set; }
     public required DateTime RegisteredAt { get; set; }
+    /// <summary>When true, set-auth-cookies propagates auth to other sessions on the same machine (stored server-side).</summary>
+    public bool TriggerMachineAuthSync { get; set; }
 }
 
 public class AppSessionStore : IDisposable
@@ -30,12 +32,18 @@ public class AppSessionStore : IDisposable
             TimeSpan.FromMinutes(1));
     }
 
-    public CookieJarId RegisterCookies(CookieJar cookieJar, string intent)
+    public CookieJarId RegisterCookies(CookieJar cookieJar, string intent, bool triggerMachineAuthSync = false)
     {
         var bytes = RandomNumberGenerator.GetBytes(32);
         var id = Convert.ToBase64String(bytes)
             .Replace("+", "-").Replace("/", "_").TrimEnd('=');
-        var entry = new CookieJarEntry { CookieJar = cookieJar, Intent = intent, RegisteredAt = DateTime.UtcNow };
+        var entry = new CookieJarEntry
+        {
+            CookieJar = cookieJar,
+            Intent = intent,
+            RegisteredAt = DateTime.UtcNow,
+            TriggerMachineAuthSync = triggerMachineAuthSync,
+        };
 
         if (!_cookieJarEntries.TryAdd(id, entry))
             throw new InvalidOperationException($"Cookie jar already registered for id '{id}'");
@@ -43,17 +51,19 @@ public class AppSessionStore : IDisposable
         return new CookieJarId(id);
     }
 
-    public bool TryRemoveCookies(CookieJarId cookieJarId, string intent, out CookieJar cookieJar)
+    public bool TryRemoveCookies(CookieJarId cookieJarId, string intent, out CookieJar cookieJar, out bool triggerMachineAuthSync)
     {
         if (_cookieJarEntries.TryRemove(cookieJarId.Value, out var entry) &&
             entry.Intent == intent &&
             DateTime.UtcNow - entry.RegisteredAt <= _cookieJarLifetime)
         {
             cookieJar = entry.CookieJar;
+            triggerMachineAuthSync = entry.TriggerMachineAuthSync;
             return true;
         }
 
         cookieJar = null!;
+        triggerMachineAuthSync = false;
         return false;
     }
 

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -142,7 +142,7 @@
     "overrides": {
       "@swc/helpers": "0.5.17",
       "axios": "1.15.0",
-      "dompurify": "3.3.2",
+      "dompurify": "3.4.0",
       "follow-redirects": ">=1.16.0",
       "lodash-es": "4.18.1",
       "minimatch": "9.0.7",

--- a/src/frontend/pnpm-lock.yaml
+++ b/src/frontend/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   '@swc/helpers': 0.5.17
   axios: 1.15.0
-  dompurify: 3.3.2
+  dompurify: 3.4.0
   follow-redirects: '>=1.16.0'
   lodash-es: 4.18.1
   minimatch: 9.0.7
@@ -2333,9 +2333,8 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
-  dompurify@3.3.2:
-    resolution: {integrity: sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==}
-    engines: {node: '>=20'}
+  dompurify@3.4.0:
+    resolution: {integrity: sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -5644,7 +5643,7 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  dompurify@3.3.2:
+  dompurify@3.4.0:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -6381,7 +6380,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.13
       dayjs: 1.11.20
-      dompurify: 3.3.2
+      dompurify: 3.4.0
       katex: 0.16.25
       khroma: 2.1.0
       lodash-es: 4.18.1

--- a/src/frontend/src/hooks/use-backend.tsx
+++ b/src/frontend/src/hooks/use-backend.tsx
@@ -46,7 +46,6 @@ type SetAuthCookiesMessage = {
   cookieJarId: string;
   reloadPage: boolean;
   triggerMachineReload: boolean;
-  triggerMachineAuthSync: boolean;
 };
 
 type HttpTunnelRequestMessage = {
@@ -472,7 +471,6 @@ export const useBackend = (
         cookieJarId: message.cookieJarId,
         connectionId: currentConnectionId ?? null,
         triggerMachineReload: message.triggerMachineReload,
-        triggerMachineAuthSync: message.triggerMachineAuthSync,
       }),
       credentials: "include",
     });


### PR DESCRIPTION

### What CodeQL complained about

<img width="920" height="641" alt="Screenshot 2026-04-22 at 04 05 29" src="https://github.com/user-attachments/assets/23d9a962-68c5-4948-80cb-cfdbd6ee9d77" />

TriggerMachineAuthSync came from SetAuthCookiesRequest (JSON body). Anyone who could call PATCH /ivy/auth/set-auth-cookies with a valid cookieJarId could set that flag to true and push SyncAuthFromCookies to other sessions that share the X-Machine-Id header. The gate for that sensitive path was effectively client-controlled.

Redeeming a jar still requires a fresh server-issued id, but the rule is about not letting request fields decide whether privileged follow-up runs.

CookieJarEntry / AppSessionStore — When registering a cookie jar, the server now stores TriggerMachineAuthSync on the entry. TryRemoveCookies returns it via an out parameter (default false if redeem fails).

RegisterAuthSessionCookies — Takes triggerMachineAuthSync (default false) and passes it into RegisterCookies.

AuthService / ConnectedAccountsService — They already choose when sync is needed; that flag is passed only at RegisterAuthSessionCookies time. IClientProvider.SetAuthCookies no longer sends triggerMachineAuthSync over SignalR (it was redundant for security once the server owns the flag).

AuthController.SetAuthCookies — Drops TriggerMachineAuthSync from the request DTO and uses the value returned from WriteCookiesToResponse (i.e. from the redeemed jar).

Frontend use-backend.tsx — Stops sending triggerMachineAuthSync in the PATCH body.

<img width="997" height="507" alt="Screenshot 2026-04-22 at 04 06 18" src="https://github.com/user-attachments/assets/8c844370-4a62-4835-b3c2-1ac47339ccca" />

Bump the override from 3.3.2 to 3.4.0 (meets “≥ 3.4.0”).


P.S.

<img width="1277" height="425" alt="Screenshot 2026-04-22 at 04 07 49" src="https://github.com/user-attachments/assets/f7f13bf6-af37-46aa-9421-50b4ad61e6c2" />

These two alerts send [Ivy.Database.Generator.Toolkit/Ivy.Database.Generator.Toolkit.csproj](https://github.com/Ivy-Interactive/Ivy-Framework/blob/-/Ivy.Database.Generator.Toolkit/Ivy.Database.Generator.Toolkit.csproj) and it seems that I don't have access to it, so these two alerts weren't fixed

Also about auth changes I think it will be good to set Zack as a reviewer. 
