### PR TITLE
Fix build errors from Spectre.Console and pnpm upgrades

### DIFF
--- a/src/Ivy.Agent.Filter.Eval.Console/RunCommand.cs
+++ b/src/Ivy.Agent.Filter.Eval.Console/RunCommand.cs
@@ -17,7 +17,7 @@ public class RunCommand : AsyncCommand<RunCommand.Settings>
         public string TestFile { get; init; } = string.Empty;
     }
 
-    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellation)
     {
         if (!File.Exists(settings.TestFile))
         {

--- a/src/Ivy.Agent.Filter.Eval.Console/VerifyCommand.cs
+++ b/src/Ivy.Agent.Filter.Eval.Console/VerifyCommand.cs
@@ -12,7 +12,7 @@ public class VerifyCommand : Command<VerifyCommand.Settings>
         public string TestFile { get; init; } = string.Empty;
     }
 
-    public override int Execute(CommandContext context, Settings settings)
+    public override int Execute(CommandContext context, Settings settings, CancellationToken cancellation)
     {
         if (!File.Exists(settings.TestFile))
         {

--- a/src/Ivy/Build/Ivy.ExternalWidget.targets
+++ b/src/Ivy/Build/Ivy.ExternalWidget.targets
@@ -11,7 +11,7 @@
   <Target Name="NpmInstall" BeforeTargets="BuildFrontend" Condition="Exists('frontend/package.json')"
           Inputs="frontend\package.json;frontend\pnpm-lock.yaml"
           Outputs="frontend\node_modules\.package-lock.json">
-    <Exec Command="vp install" WorkingDirectory="frontend" />
+    <Exec Command="vp install" WorkingDirectory="frontend" EnvironmentVariables="CI=true" />
   </Target>
 
   <Target Name="BuildFrontend" BeforeTargets="AssignTargetPaths" Condition="Exists('frontend/package.json')"


### PR DESCRIPTION
## Summary
- Add `CancellationToken` parameter to `VerifyCommand.Execute` and `RunCommand.ExecuteAsync` to match updated Spectre.Console.Cli abstract method signatures
- Set `CI=true` environment variable for `vp install` in `Ivy.ExternalWidget.targets` so pnpm doesn't prompt for node_modules purge confirmation in non-interactive MSBuild contexts

## Test plan
- [x] `dotnet build` succeeds for all projects in the repo
- [x] Widget frontends (Xterm, DiffView, ClaudeJsonRenderer) install and build correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)