### PR TITLE
Add SidebarContentScroll prop to SidebarLayout

### DIFF
--- a/src/Ivy/Widgets/Layouts/SidebarLayout.cs
+++ b/src/Ivy/Widgets/Layouts/SidebarLayout.cs
@@ -35,6 +35,8 @@ public record SidebarLayout : WidgetBase<SidebarLayout>
 
     [Prop] public bool Resizable { get; set; } = false;
 
+    [Prop] public Scroll SidebarContentScroll { get; set; } = Scroll.Auto;
+
     public static SidebarLayout operator |(SidebarLayout widget, object child)
     {
         throw new NotSupportedException("SidebarLayout does not support children.");
@@ -56,6 +58,11 @@ public static class SidebarLayoutExtensions
     public static SidebarLayout Padding(this SidebarLayout sidebar, int padding)
     {
         return sidebar with { MainContentPadding = padding };
+    }
+
+    public static SidebarLayout SidebarContentScroll(this SidebarLayout sidebar, Scroll scroll)
+    {
+        return sidebar with { SidebarContentScroll = scroll };
     }
 
     /// <summary>

--- a/src/frontend/src/widgets/layouts/sidebar/SidebarLayoutWidget.tsx
+++ b/src/frontend/src/widgets/layouts/sidebar/SidebarLayoutWidget.tsx
@@ -27,6 +27,7 @@ interface SidebarLayoutWidgetProps {
   width?: string; // Width of the sidebar (Size format: "Type:Value,MinType:MinValue,MaxType:MaxValue")
   open?: boolean; // Whether the sidebar starts open (default: true)
   resizable?: boolean; // Enable drag-to-resize on sidebar border
+  sidebarContentScroll?: "None" | "Auto"; // Controls whether sidebar content is wrapped in ScrollArea (default: Auto)
 }
 
 // Helper to parse a Size string to pixels
@@ -87,6 +88,7 @@ export const SidebarLayoutWidget: React.FC<SidebarLayoutWidgetProps> = ({
   width,
   open: openProp = true,
   resizable = false,
+  sidebarContentScroll = "Auto",
 }) => {
   // Parse Size format: "Type:Value,MinType:MinValue,MaxType:MaxValue"
   const [wantedWidth, minWidthStr, maxWidthStr] = (width ?? "").split(",");
@@ -228,13 +230,16 @@ export const SidebarLayoutWidget: React.FC<SidebarLayoutWidgetProps> = ({
         {hasContent(slots?.SidebarHeader) && (
           <div className="flex flex-col shrink-0 p-2 space-y-4">{slots?.SidebarHeader}</div>
         )}
-        {slots?.SidebarContent && (
-          <div className="flex-1 min-h-0 min-w-0 overflow-hidden">
-            <ScrollArea className="h-full w-full">
-              <div className="p-2 space-y-2">{slots.SidebarContent}</div>
-            </ScrollArea>
-          </div>
-        )}
+        {slots?.SidebarContent &&
+          (sidebarContentScroll === "None" ? (
+            <div className="flex-1 min-h-0 min-w-0 overflow-hidden">{slots.SidebarContent}</div>
+          ) : (
+            <div className="flex-1 min-h-0 min-w-0 overflow-hidden">
+              <ScrollArea className="h-full w-full">
+                <div className="p-2 space-y-2">{slots.SidebarContent}</div>
+              </ScrollArea>
+            </div>
+          ))}
         {hasContent(slots?.SidebarFooter) && (
           <div className="flex flex-col shrink-0">
             <div className="flex flex-col p-2 gap-4 min-h-0">{slots?.SidebarFooter}</div>


### PR DESCRIPTION
## Summary
- Add `SidebarContentScroll` prop to `SidebarLayout` (C# + TSX) that controls whether the sidebar content slot is wrapped in `ScrollArea`
- When set to `Scroll.None`, the sidebar content is rendered without `ScrollArea`, allowing nested layouts like `HeaderLayout` to manage their own scrolling
- Enables sticky sidebar headers when the header is built inside `SidebarView` using `HeaderLayout`

## Test plan
- [ ] Verify existing SidebarLayout usages (default `Scroll.Auto`) still scroll normally
- [ ] Verify `SidebarContentScroll(Scroll.None)` with a `HeaderLayout` inside the sidebar content keeps the header sticky while the list scrolls

🤖 Generated with [Claude Code](https://claude.com/claude-code)