### PR TITLE
Add spinner and skeleton variants to Loading widget

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/27_Loading.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/27_Loading.md
@@ -1,0 +1,48 @@
+---
+searchHints:
+  - loading
+  - spinner
+  - loader
+  - waiting
+  - progress
+  - skeleton
+  - busy
+---
+
+# Loading
+
+<Ingress>
+Signal that something is happening. The Loading [widget](../../01_Onboarding/02_Concepts/03_Widgets.md) renders a compact spinner by default, or a randomized skeleton placeholder when you want to hint at the shape of the content that's on its way.
+</Ingress>
+
+The `Loading` widget has two variants selected via a fluent API:
+
+- `new Loading()` — the default spinner with a "Loading..." label.
+- `new Loading().Spinner()` — explicit spinner, equivalent to the default.
+- `new Loading().Skeleton()` — a randomized skeleton placeholder layout. The layout is randomized once per mount and stays stable across re-renders.
+
+For a modal loading experience with async work and cancellation, see the [`UseLoading`](../../03_Hooks/02_Core/23_UseLoading.md) hook instead.
+
+## Spinner
+
+The spinner variant is a small animated circle followed by a "Loading..." label. Use it for short waits where you don't need to hint at the shape of the incoming content.
+
+```csharp demo-below
+new Loading()
+```
+
+```csharp demo-below
+new Loading().Spinner()
+```
+
+## Skeleton
+
+The skeleton variant renders a title bar and a few placeholder lines of random widths, suggesting that textual content is on its way. Use it when you want the loading state to roughly mirror the shape of the content that will replace it.
+
+```csharp demo-below
+new Loading().Skeleton()
+```
+
+If you need full control over the placeholder layout, reach for the [`Skeleton`](09_Skeleton.md) widget directly.
+
+<WidgetDocs Type="Ivy.Loading" ExtensionTypes="Ivy.LoadingExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Primitives/Loading.cs"/>

--- a/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/LoadingApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/LoadingApp.cs
@@ -16,17 +16,23 @@ public class LoadingApp : SampleBase
             loadingView,
             Layout.Vertical()
             | Text.H2("Loading")
-            | Text.P("The Loading widget is a static indeterminate progress indicator for inline use. It has two variants selected via fluent methods: a spinner (default) and a randomized skeleton view.")
+            | Text.P("The Loading widget is a static indeterminate progress indicator for inline use. It has two variants selected via fluent methods: a spinner (default) and a randomized skeleton placeholder. The skeleton layout is randomized once per mount and stays stable across re-renders.")
             | new Card(
                 Layout.Vertical()
-                | Text.H3("Spinner (default)")
-                | Text.P("Use new Loading() or new Loading().Spinner() for an explicit spinner.")
+                | Text.H3("Default")
+                | Text.Code("new Loading()")
                 | new Loading()
-            ).Title("Spinner")
+            ).Title("Default (Spinner)")
+            | new Card(
+                Layout.Vertical()
+                | Text.H3("Spinner")
+                | Text.Code("new Loading().Spinner()")
+                | new Loading().Spinner()
+            ).Title("Spinner (explicit)")
             | new Card(
                 Layout.Vertical()
                 | Text.H3("Skeleton")
-                | Text.P("Use new Loading().Skeleton() to render a randomized skeleton placeholder layout.")
+                | Text.Code("new Loading().Skeleton()")
                 | new Loading().Skeleton()
             ).Title("Skeleton")
             | Text.H2("UseLoading")

--- a/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/LoadingApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/LoadingApp.cs
@@ -16,8 +16,19 @@ public class LoadingApp : SampleBase
             loadingView,
             Layout.Vertical()
             | Text.H2("Loading")
-            | Text.P("The Loading widget is a static indeterminate progress bar for inline use.")
-            | new Loading()
+            | Text.P("The Loading widget is a static indeterminate progress indicator for inline use. It has two variants selected via fluent methods: a spinner (default) and a randomized skeleton view.")
+            | new Card(
+                Layout.Vertical()
+                | Text.H3("Spinner (default)")
+                | Text.P("Use new Loading() or new Loading().Spinner() for an explicit spinner.")
+                | new Loading()
+            ).Title("Spinner")
+            | new Card(
+                Layout.Vertical()
+                | Text.H3("Skeleton")
+                | Text.P("Use new Loading().Skeleton() to render a randomized skeleton placeholder layout.")
+                | new Loading().Skeleton()
+            ).Title("Skeleton")
             | Text.H2("UseLoading")
             | Text.P(
                 "Opens a modal while async work runs. The handler is void and schedules work in the background so cancel/close events are not blocked by the serial UI event queue. Pass cancellable: true and observe ILoadingContext.CancellationToken (e.g. Task.Delay(..., ct)). Optional third argument: LoadingOptions — set CancellingDisplayDuration to control how long the \"Cancelling…\" state is shown before the dialog closes (default 800ms)."

--- a/src/Ivy/Widgets/Primitives/Loading.cs
+++ b/src/Ivy/Widgets/Primitives/Loading.cs
@@ -1,15 +1,40 @@
+using Ivy.Core;
+
 // ReSharper disable once CheckNamespace
 namespace Ivy;
 
 /// <summary>
-/// A loading indicator.
+/// Visual variants supported by the <see cref="Loading"/> widget.
+/// </summary>
+public enum LoadingType
+{
+    /// <summary>A simple animated spinner with a "Loading..." label.</summary>
+    Spinner,
+    /// <summary>A randomized skeleton placeholder layout.</summary>
+    Skeleton
+}
+
+/// <summary>
+/// A loading indicator. Renders as a spinner by default; use
+/// <see cref="LoadingExtensions.Skeleton(Loading)"/> to render a skeleton placeholder instead.
 /// </summary>
 public record Loading : WidgetBase<Loading>
 {
+    /// <summary>Initializes a new <see cref="Loading"/> with the default <see cref="LoadingType.Spinner"/> variant.</summary>
     public Loading() { }
+
+    /// <summary>The visual variant rendered by this loading indicator.</summary>
+    [Prop] public LoadingType Type { get; set; } = LoadingType.Spinner;
 }
 
+/// <summary>
+/// Fluent extension methods for configuring a <see cref="Loading"/> widget.
+/// </summary>
 public static class LoadingExtensions
 {
+    /// <summary>Returns a <see cref="Loading"/> configured to render the spinner variant.</summary>
+    public static Loading Spinner(this Loading loading) => loading with { Type = LoadingType.Spinner };
 
+    /// <summary>Returns a <see cref="Loading"/> configured to render the randomized skeleton variant.</summary>
+    public static Loading Skeleton(this Loading loading) => loading with { Type = LoadingType.Skeleton };
 }

--- a/src/frontend/src/components/Loading.tsx
+++ b/src/frontend/src/components/Loading.tsx
@@ -41,11 +41,11 @@ export function Loading({ type = "Spinner" }: LoadingProps) {
   if (type === "Skeleton") {
     return (
       <div className="flex flex-col gap-2 w-full max-w-sm" role="status" aria-label="Loading">
-        <Skeleton className="h-5 rounded-md" style={{ width: `${titleBarWidth}%` }} />
+        <Skeleton className="h-5 rounded-md bg-muted" style={{ width: `${titleBarWidth}%` }} />
         {skeletonLines.map((line, index) => (
           <Skeleton
             key={`loading-skeleton-line-${index}`}
-            className="rounded"
+            className="rounded bg-muted"
             style={{
               width: `${line.widthPercent}%`,
               height: `${line.heightPx}px`,

--- a/src/frontend/src/components/Loading.tsx
+++ b/src/frontend/src/components/Loading.tsx
@@ -1,202 +1,69 @@
-import { useMemo, useEffect, useReducer } from "react";
+import { useMemo } from "react";
+import { Loader2 } from "lucide-react";
+import { Skeleton } from "@/components/ui/skeleton";
 
-const SHAPES = [
-  undefined,
-  "M0 0 H28 V28 H0 Z", // Square
-  "M28 0H0V28C15.46 28 28 15.46 28 0Z", // Perfect quarter circle
-];
-const SHAPE_LIKELIHOODS = [0, 0.4, 0.6];
-const COLORS = ["#00CC92", "#0D4A2F", "#80E6C9"];
-const COLOR_LIKELIHOODS = [0.6, 0.2, 0.2];
-const STEP_INTERVAL_MS = 200;
-const CELLS_TO_MUTATE_PER_STEP = 2;
-const MUTATION_STEPS_FORWARD = 6;
-const PAUSE_DURATION_MS = 1000;
+interface LoadingProps {
+  type?: "Spinner" | "Skeleton";
+}
 
-type LoadingState = {
-  current: number[][];
-  history: number[][][];
-  forwardStepCount: number;
-  isReverting: boolean;
-  isPaused: boolean;
-  lastMutatedIndices: Set<number>;
-};
+interface SkeletonLine {
+  widthPercent: number;
+  heightPx: number;
+}
 
-type LoadingAction = { type: "TICK" } | { type: "PAUSE_COMPLETE" };
+const SKELETON_LINE_COUNT_MIN = 3;
+const SKELETON_LINE_COUNT_MAX = 5;
+const SKELETON_LINE_MIN_WIDTH = 40;
+const SKELETON_LINE_MAX_WIDTH = 100;
+const SKELETON_LINE_MIN_HEIGHT = 10;
+const SKELETON_LINE_MAX_HEIGHT = 14;
 
-const reducer = (state: LoadingState, action: LoadingAction): LoadingState => {
-  switch (action.type) {
-    case "PAUSE_COMPLETE":
-      return { ...state, isPaused: false };
-    case "TICK": {
-      if (!state.isReverting) {
-        if (state.forwardStepCount < MUTATION_STEPS_FORWARD) {
-          const mutableCellIndices = state.current
-            .map((cell, index) => (cell[0] !== 0 ? index : -1))
-            .filter((index) => index !== -1);
+function randomBetween(min: number, max: number): number {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
 
-          const availableForMutation = mutableCellIndices.filter(
-            (idx) => !state.lastMutatedIndices.has(idx),
-          );
-
-          if (availableForMutation.length === 0 && mutableCellIndices.length > 0) {
-            return {
-              ...state,
-              history: [...state.history, state.current],
-              forwardStepCount: state.forwardStepCount + 1,
-              lastMutatedIndices: new Set<number>(),
-            };
-          }
-
-          const cellsToMutateCount = Math.min(
-            CELLS_TO_MUTATE_PER_STEP,
-            availableForMutation.length,
-          );
-          const mutatedThisStep = new Set<number>();
-          const pickable = [...availableForMutation];
-
-          while (mutatedThisStep.size < cellsToMutateCount && pickable.length > 0) {
-            const rIdx = Math.floor(Math.random() * pickable.length);
-            mutatedThisStep.add(pickable[rIdx]);
-            pickable.splice(rIdx, 1);
-          }
-
-          if (mutatedThisStep.size > 0) {
-            const nextMatrix = state.current.map((cell, index) => {
-              if (mutatedThisStep.has(index)) {
-                return [
-                  getWeightedRandomIndex(SHAPE_LIKELIHOODS),
-                  getWeightedRandomIndex(COLOR_LIKELIHOODS),
-                  Math.floor(Math.random() * 4),
-                ];
-              }
-              return cell;
-            });
-            return {
-              ...state,
-              current: nextMatrix,
-              history: [...state.history, nextMatrix],
-              forwardStepCount: state.forwardStepCount + 1,
-              lastMutatedIndices: mutatedThisStep,
-            };
-          }
-          return { ...state, forwardStepCount: state.forwardStepCount + 1 };
-        }
-        return {
-          ...state,
-          isReverting: true,
-          lastMutatedIndices: new Set<number>(),
-        };
-      } else {
-        if (state.history.length > 1) {
-          const newHistory = state.history.slice(0, -1);
-          const nextCurrent = newHistory[newHistory.length - 1];
-          if (newHistory.length === 1) {
-            return {
-              ...state,
-              current: nextCurrent,
-              history: newHistory,
-              isReverting: false,
-              forwardStepCount: 0,
-              isPaused: true,
-              lastMutatedIndices: new Set<number>(),
-            };
-          }
-          return { ...state, current: nextCurrent, history: newHistory };
-        }
-        return state;
-      }
-    }
-    default:
-      return state;
+function generateSkeletonLayout(): SkeletonLine[] {
+  const count = randomBetween(SKELETON_LINE_COUNT_MIN, SKELETON_LINE_COUNT_MAX);
+  const lines: SkeletonLine[] = [];
+  for (let i = 0; i < count; i++) {
+    lines.push({
+      widthPercent: randomBetween(SKELETON_LINE_MIN_WIDTH, SKELETON_LINE_MAX_WIDTH),
+      heightPx: randomBetween(SKELETON_LINE_MIN_HEIGHT, SKELETON_LINE_MAX_HEIGHT),
+    });
   }
-};
+  return lines;
+}
 
-export function Loading() {
-  const initialMatrix = useMemo(
-    () => [
-      [2, 0, 0],
-      [0, 0, 0],
-      [0, 0, 0],
-      [0, 0, 0],
-      [0, 0, 0],
-      [1, 0, 0],
-      [2, 0, 3],
-      [2, 0, 2],
-      [2, 0, 3],
-      [2, 0, 2],
-      [1, 0, 0],
-      [2, 0, 1],
-      [2, 0, 0],
-      [2, 0, 1],
-      [1, 0, 0],
-      [0, 0, 0],
-      [0, 0, 0],
-      [0, 0, 0],
-      [2, 0, 1],
-      [2, 0, 0],
-    ],
-    [],
-  );
+export function Loading({ type = "Spinner" }: LoadingProps) {
+  const skeletonLines = useMemo<SkeletonLine[]>(generateSkeletonLayout, []);
+  const titleBarWidth = useMemo(() => randomBetween(30, 55), []);
 
-  const [state, dispatch] = useReducer(reducer, {
-    current: initialMatrix,
-    history: [initialMatrix],
-    forwardStepCount: 0,
-    isReverting: false,
-    isPaused: true,
-    lastMutatedIndices: new Set<number>(),
-  });
-
-  useEffect(() => {
-    if (state.isPaused) {
-      const id = setTimeout(() => dispatch({ type: "PAUSE_COMPLETE" }), PAUSE_DURATION_MS);
-      return () => clearTimeout(id);
-    } else {
-      const id = setInterval(() => dispatch({ type: "TICK" }), STEP_INTERVAL_MS);
-      return () => clearInterval(id);
-    }
-  }, [state.isPaused]);
+  if (type === "Skeleton") {
+    return (
+      <div className="flex flex-col gap-2 w-full max-w-sm" role="status" aria-label="Loading">
+        <Skeleton className="h-5 rounded-md" style={{ width: `${titleBarWidth}%` }} />
+        {skeletonLines.map((line, index) => (
+          <Skeleton
+            key={`loading-skeleton-line-${index}`}
+            className="rounded"
+            style={{
+              width: `${line.widthPercent}%`,
+              height: `${line.heightPx}px`,
+            }}
+          />
+        ))}
+      </div>
+    );
+  }
 
   return (
-    <div className="grid grid-cols-5 gap-0 w-fit">
-      {state.current.map((item: number[], index: number) => {
-        const [shapeIndex, colorIndex, rotation] = item;
-        const shape = SHAPES[shapeIndex];
-        const color = COLORS[colorIndex] || COLORS[0];
-
-        return (
-          <div key={`loading-cell-${index}`} className="w-7 h-7" style={{ margin: "-0.5px" }}>
-            {shape && (
-              <svg
-                viewBox="0 0 28 28"
-                className="w-full h-full"
-                style={{
-                  transform: `rotate(${rotation * 90}deg)`,
-                  transition: "transform 0.2s ease-in-out, fill 0.3s ease-in-out",
-                  display: "block",
-                }}
-              >
-                <path d={shape} fill={color} />
-              </svg>
-            )}
-          </div>
-        );
-      })}
+    <div
+      className="flex items-center gap-2 text-muted-foreground"
+      role="status"
+      aria-label="Loading"
+    >
+      <Loader2 className="animate-spin h-4 w-4" />
+      <p className="text-sm">Loading...</p>
     </div>
   );
 }
-
-const getWeightedRandomIndex = (likelihoods: number[]): number => {
-  const sumOfLikelihoods = likelihoods.reduce((sum, L) => sum + L, 0);
-  let randomNum = Math.random() * sumOfLikelihoods;
-
-  for (let i = 0; i < likelihoods.length; i++) {
-    if (randomNum < likelihoods[i]) {
-      return i;
-    } else {
-      randomNum -= likelihoods[i];
-    }
-  }
-  return likelihoods.length - 1;
-};

--- a/src/frontend/src/widgets/primitives/LoadingWidget.tsx
+++ b/src/frontend/src/widgets/primitives/LoadingWidget.tsx
@@ -1,22 +1,10 @@
-// import { Loading } from '@/components/Loading';
-// import React, { useState, useEffect } from 'react';
-
-// export const LoadingWidget: React.FC = () => {
-//   const [showLoader, setShowLoader] = useState(false);
-
-//   useEffect(() => {
-//     const timer = setTimeout(() => setShowLoader(true), 200);
-//     return () => clearTimeout(timer);
-//   }, []);
-
-//   return (
-//     <div className="fixed inset-0 z-100 flex items-center justify-center bg-black/30">
-//       {showLoader && <Loading />}
-//     </div>
-//   );
-// };
-
 import { Loading } from "@/components/Loading";
 import React from "react";
 
-export const LoadingWidget: React.FC = () => <Loading />;
+interface LoadingWidgetProps {
+  type?: "Spinner" | "Skeleton";
+}
+
+export const LoadingWidget: React.FC<LoadingWidgetProps> = ({ type = "Spinner" }) => (
+  <Loading type={type} />
+);


### PR DESCRIPTION
## Summary
- Replace the custom grid-based shape animation in `Loading.tsx` with two simpler variants selected via a fluent C# API: a spinner (default) and a randomized skeleton placeholder view.
- Add `LoadingType` enum and `.Spinner()` / `.Skeleton()` extension methods on the `Loading` widget.
- Update the sample app to showcase both variants side-by-side.

## Test plan
- [ ] Run the Samples app and verify the "Loading" page renders both cards — spinner animating with "Loading..." label, skeleton showing randomized placeholder bars.
- [ ] Reload the page and confirm the skeleton layout re-randomizes per mount but stays stable within a single render cycle.
- [ ] Confirm `new Loading()`, `new Loading().Spinner()`, and `new Loading().Skeleton()` all render correctly.
- [ ] `dotnet build` and `npm run build` pass (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)