### PR TITLE
[03468] Fix logging configuration override in UseWebApplicationBuilder

### DIFF
--- a/src/Ivy/Server.cs
+++ b/src/Ivy/Server.cs
@@ -595,9 +595,22 @@ public class Server
 
         builder.Configuration.AddConfiguration(Configuration);
 
+        // Set default logging first (can be overridden by user builder mods)
+        builder.Logging.ClearProviders();
+        builder.Logging.AddConsole();
+
         foreach (var mod in _builderMods)
         {
             mod(builder);
+        }
+
+        // Set minimum level after user mods (users can still override with AddFilter)
+        builder.Logging.SetMinimumLevel(!_args.Verbose ? LogLevel.Warning : LogLevel.Information);
+
+        // Suppress hosting startup errors when not verbose (we handle IOException with a friendly message)
+        if (!_args.Verbose)
+        {
+            builder.Logging.AddFilter("Microsoft.Extensions.Hosting.Internal.Host", LogLevel.None);
         }
 
         // CLI-only commands need DI but never call app.StartAsync(),
@@ -695,17 +708,6 @@ public class Server
             {
                 options.HttpsPort = 443;
             });
-        }
-
-        builder.Logging.ClearProviders();
-        builder.Logging.AddConsole();
-
-        builder.Logging.SetMinimumLevel(!_args.Verbose ? LogLevel.Warning : LogLevel.Information);
-
-        // Suppress hosting startup errors when not verbose (we handle IOException with a friendly message)
-        if (!_args.Verbose)
-        {
-            builder.Logging.AddFilter("Microsoft.Extensions.Hosting.Internal.Host", LogLevel.None);
         }
 
         var app = builder.Build();


### PR DESCRIPTION
# Summary

## Changes

Fixed logging configuration ordering in Server.cs so that custom logging providers configured via `UseWebApplicationBuilder` are no longer overridden by the default console logger.

## API Changes

None. The fix changes internal ordering only - no public API changes.

## Files Modified

- **src/Ivy/Server.cs** - Moved default logging setup (ClearProviders + AddConsole) to before the builder modifications loop, allowing user-configured logging to take precedence.

## Commits

- aca6e92c5 [03468] Fix logging configuration override in UseWebApplicationBuilder