### PR TITLE
Fix DataTable selected cell border using mismatched accent color

### DIFF
--- a/src/frontend/src/widgets/dataTables/hooks/useTableTheme.ts
+++ b/src/frontend/src/widgets/dataTables/hooks/useTableTheme.ts
@@ -38,16 +38,17 @@ export const useTableTheme = ({
       bgHeaderHovered: colors.accent || (isDark ? "#26262b" : "#e5e7eb"),
       textHeader: colors.foreground || (isDark ? "#f8f8f8" : "#111827"),
       // textHeaderSelected needs to contrast with accentColor background (used when column is sorted)
-      textHeaderSelected: colors.foreground || (isDark ? "#f8f8f8" : "#111827"),
+      textHeaderSelected: colors.primaryForeground || (isDark ? "#f8f8f8" : "#ffffff"),
       textDark: colors.foreground || (isDark ? "#f8f8f8" : "#111827"),
       textMedium: colors.mutedForeground || (isDark ? "#a1a1aa" : "#6b7280"),
       textLight: colors.mutedForeground || (isDark ? "#71717a" : "#9ca3af"),
       // bgIconHeader is the background color for icon areas, should be subtle
       bgIconHeader: colors.muted || (isDark ? "#26262b" : "#f3f4f6"),
-      // accentColor is used as the background for selected cells or highlights
-      accentColor: colors.secondary || (isDark ? "#26262b" : "#e5e7eb"),
+      // accentColor is used for the selected cell focus ring, sorted column header bg,
+      // fill handle, and highlighted checkbox — use primary so selection reads as deliberate
+      accentColor: colors.primary || (isDark ? "#3b82f6" : "#2563eb"),
       // accentFg is the foreground/text color used on top of accentColor backgrounds
-      accentFg: colors.muted || (isDark ? "#f8f8f8" : "#18181b"),
+      accentFg: colors.primaryForeground || (isDark ? "#f8f8f8" : "#ffffff"),
       // column focus bg color
       accentLight: colors.muted || (isDark ? "#27272a" : "#e4e4e7"),
       horizontalBorderColor: colors.border || (isDark ? "#404045" : "#d1d5db"),


### PR DESCRIPTION
## Summary
- `glide-data-grid` draws the focus ring on a selected cell using `theme.accentColor` blended with `borderColor` and `bgCell`. With `accentColor` mapped to `colors.secondary`, that blend produced an outline in a different tone than neighboring cell borders, reading as a visual glitch rather than a selection indicator.
- Switch `accentColor` to `colors.primary` in `useTableTheme` so selection (focus ring, fill handle, highlighted checkbox, sorted column header bg) reads as deliberate.
- Update `accentFg` and `textHeaderSelected` to `colors.primaryForeground` so accent-backed surfaces (notably the sorted column header) keep proper text contrast.

## Test plan
- [ ] Click a cell in a DataTable — focus ring is clearly the primary/brand color, not a washed-out border.
- [ ] Click a column header to sort — header background shifts to primary, header text stays readable.
- [ ] If fill handle is enabled, drag it — handle color matches the new accent.
- [ ] Toggle a row checkbox — highlighted state renders in primary.
- [ ] Verify both light and dark themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)