### PR TITLE
Add ContentScroll prop to FooterLayout

### DIFF
--- a/src/Ivy/Widgets/Layouts/FooterLayout.cs
+++ b/src/Ivy/Widgets/Layouts/FooterLayout.cs
@@ -14,8 +14,18 @@ public record FooterLayout : WidgetBase<FooterLayout>
     {
     }
 
+    [Prop] public Scroll ContentScroll { get; init; } = Scroll.Auto;
+
     public static FooterLayout operator |(FooterLayout widget, object child)
     {
         throw new NotSupportedException("FooterLayout does not support children.");
+    }
+}
+
+public static class FooterLayoutExtensions
+{
+    public static FooterLayout Scroll(this FooterLayout footerLayout, Scroll scroll = Ivy.Scroll.Auto)
+    {
+        return footerLayout with { ContentScroll = scroll };
     }
 }

--- a/src/frontend/src/widgets/layouts/FooterLayoutWidget.tsx
+++ b/src/frontend/src/widgets/layouts/FooterLayoutWidget.tsx
@@ -8,9 +8,13 @@ interface FooterLayoutWidgetProps {
     Footer?: React.ReactNode[];
     Content?: React.ReactNode[];
   };
+  contentScroll?: "None" | "Auto";
 }
 
-export const FooterLayoutWidget: React.FC<FooterLayoutWidgetProps> = ({ slots }) => {
+export const FooterLayoutWidget: React.FC<FooterLayoutWidgetProps> = ({
+  slots,
+  contentScroll = "Auto",
+}) => {
   const { isScrolled: hasMoreContent, scrollRef } = useScrollShadow(
     "[data-radix-scroll-area-viewport]",
     "top",
@@ -27,9 +31,13 @@ export const FooterLayoutWidget: React.FC<FooterLayoutWidgetProps> = ({ slots })
   return (
     <div className="h-full flex flex-col relative remove-parent-padding">
       <div ref={scrollRef} className="flex-1 min-h-0 overflow-hidden">
-        <ScrollArea className="h-full">
-          <div className="p-4">{slots.Content}</div>
-        </ScrollArea>
+        {contentScroll === "None" ? (
+          <div className="h-full">{slots.Content}</div>
+        ) : (
+          <ScrollArea className="h-full">
+            <div className="p-4">{slots.Content}</div>
+          </ScrollArea>
+        )}
       </div>
       <div
         className={cn(


### PR DESCRIPTION
## Summary
- Add `ContentScroll` prop to `FooterLayout` (C# + TSX) that controls whether the content slot is wrapped in `ScrollArea`
- When set to `Scroll.None`, content renders without `ScrollArea`, allowing child components like `TabsLayout` to manage their own scrolling with sticky tab headers
- Mirrors the existing `ContentScroll` pattern from `HeaderLayout`

## Test plan
- [ ] Verify existing FooterLayout usages (default `Scroll.Auto`) still scroll normally
- [ ] Verify `FooterLayout.Scroll(Scroll.None)` with a `TabsLayout` inside keeps tab headers sticky while tab panels scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)