### PR TITLE
[03470] Add AI coding agent icons to Icon.tsx

### DIFF
--- a/src/frontend/src/components/Icon.tsx
+++ b/src/frontend/src/components/Icon.tsx
@@ -21,8 +21,8 @@ import {
 } from "react-icons/fa";
 import { FaXTwitter } from "react-icons/fa6";
 import { IconType } from "react-icons";
-import { VscAzure } from "react-icons/vsc";
-import { SiNotion } from "react-icons/si";
+import { VscAzure, VscCode } from "react-icons/vsc";
+import { SiNotion, SiGithubcopilot, SiOpenai, SiAnthropic, SiGooglegemini } from "react-icons/si";
 
 interface IconProps {
   name?: string;
@@ -77,6 +77,11 @@ const Icon: React.FC<IconProps> = ({ name, color, size, className, style }) => {
     Github: FaGithub,
     Pinterest: FaPinterest,
     XTwitter: FaXTwitter,
+    Copilot: SiGithubcopilot,
+    OpenAI: SiOpenai,
+    ClaudeCode: SiAnthropic,
+    Gemini: SiGooglegemini,
+    OpenCode: VscCode,
   };
 
   if (name && name in reactIcons) {


### PR DESCRIPTION
# Summary

## Changes

Added frontend icon mappings for five AI coding agent icons that were already defined in the backend Icons enum. These mappings enable the icons to be rendered in the UI using react-icons library components.

## API Changes

**Modified:**
- `Icon.tsx` — Added mappings for `Copilot`, `OpenAI`, `ClaudeCode`, `Gemini`, and `OpenCode` icon types

## Files Modified

**Frontend:**
- `src/frontend/src/components/Icon.tsx` — Added imports for AI coding agent icons (SiGithubcopilot, SiOpenai, SiAnthropic, SiGooglegemini, VscCode) and added corresponding mappings in the reactIcons object

---

## Commits

- af451a59f [03470] Add AI coding agent icons to Icon.tsx