### PR TITLE
Fix search input border radius change on focus with suffix

### DIFF
--- a/src/frontend/src/widgets/inputs/TextInputWidget/variants/SearchVariant.tsx
+++ b/src/frontend/src/widgets/inputs/TextInputWidget/variants/SearchVariant.tsx
@@ -151,7 +151,7 @@ export const SearchVariant: React.FC<SearchVariantProps> = ({
             autoComplete="off"
             className={cn(
               textInputSizeVariant({ density }),
-              "pl-8 cursor-pointer border-0 shadow-none dark:bg-transparent",
+              "pl-8 cursor-pointer border-0 shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 dark:bg-transparent",
               props.invalid && inputStyles.invalidInput,
               (props.invalid || showClear) && "pr-8",
               props.shortcutKey &&


### PR DESCRIPTION
## Summary

When a `SearchVariant` text input has a suffix slot (e.g. a button), focusing the input caused the inner corners of the input element to appear rounded, making the border radius look like it changed on focus.

Root cause: the base `inputVariant` class applies `focus-visible:ring-1 focus-visible:ring-ring` to the underlying `<input>`. In `DefaultVariant.tsx` this is suppressed with `focus-visible:ring-0 focus-visible:ring-offset-0`, but `SearchVariant.tsx` was missing that override. When a suffix was present the input got `rounded-r-none`, but the focus ring still painted its own rounded corners over the joint with the suffix panel, giving the appearance that the border radius changed on focus.

Fix: add `focus-visible:ring-0 focus-visible:ring-offset-0` to the inner `<Input>` className in `SearchVariant` to match `DefaultVariant`. The outer container still shows the focus border via `border-ring`.

Closes #4241

## Test plan

- [ ] Verify focused search input with a button suffix keeps square inner corners at the suffix join
- [ ] Verify focus ring still appears on the outer container
- [ ] Verify no regression on search input without a suffix
- [ ] Verify invalid/clear/shortcut-key states still render correctly