### PR TITLE
[00008] Fix copy button not working in inline code view on Full Prompt sheet

### DIFF
--- a/src/Ivy.Desktop/DesktopWindow.cs
+++ b/src/Ivy.Desktop/DesktopWindow.cs
@@ -317,7 +317,7 @@ public class DesktopWindow(Server server)
             .SetTitle(_title)
             .SetResizable(_resizable)
             .SetTopMost(_topMost)
-            .SetJavascriptClipboardAccessEnabled(false)
+            .SetJavascriptClipboardAccessEnabled(true)
             .SetDevToolsEnabled(_devTools)
             .SetIgnoreCertificateErrorsEnabled(true)
             .SetWebSecurityEnabled(false);

--- a/src/frontend/src/components/CopyToClipboardButton.tsx
+++ b/src/frontend/src/components/CopyToClipboardButton.tsx
@@ -55,8 +55,21 @@ const CopyToClipboardButton: React.FC<CopyToClipboardButtonProps> = ({
       await navigator.clipboard.writeText(textToCopy);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
-    } catch (err: unknown) {
-      console.error(err);
+    } catch {
+      try {
+        const textarea = document.createElement("textarea");
+        textarea.value = textToCopy;
+        textarea.style.position = "fixed";
+        textarea.style.opacity = "0";
+        document.body.appendChild(textarea);
+        textarea.select();
+        document.execCommand("copy");
+        document.body.removeChild(textarea);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      } catch (fallbackErr) {
+        console.error("Copy failed:", fallbackErr);
+      }
     }
   };
 


### PR DESCRIPTION
## Changes

Enabled JavaScript clipboard access in the Rustino desktop WebView (`SetJavascriptClipboardAccessEnabled(true)`) and added a `document.execCommand("copy")` fallback in `CopyToClipboardButton.tsx` for environments where `navigator.clipboard` is unavailable or restricted.

## Files Modified

- **src/Ivy.Desktop/DesktopWindow.cs** — Changed `SetJavascriptClipboardAccessEnabled(false)` to `true`
- **src/frontend/src/components/CopyToClipboardButton.tsx** — Added textarea-based execCommand fallback in the catch block of `handleCopy`

## Commits

- d394c7e2b [00008] Fix copy button in Full Prompt sheet by enabling JS clipboard access and adding execCommand fallback