### PR TITLE
[00020] Fix search input focus border radius change with button suffix

### DIFF
--- a/src/frontend/src/widgets/inputs/TextInputWidget/variants/SearchVariant.tsx
+++ b/src/frontend/src/widgets/inputs/TextInputWidget/variants/SearchVariant.tsx
@@ -151,7 +151,7 @@ export const SearchVariant: React.FC<SearchVariantProps> = ({
             autoComplete="off"
             className={cn(
               textInputSizeVariant({ density }),
-              "pl-8 cursor-pointer border-0 shadow-none dark:bg-transparent",
+              "pl-8 cursor-pointer border-0 shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 dark:bg-transparent",
               props.invalid && inputStyles.invalidInput,
               (props.invalid || showClear) && "pr-8",
               props.shortcutKey &&


### PR DESCRIPTION
## Changes

Added `focus-visible:ring-0 focus-visible:ring-offset-0` CSS classes to the inner `<Input>` element's className in SearchVariant.tsx. This suppresses the browser's default focus-visible ring styling that was conflicting with the search input's border radius when focusing with a button suffix.

## API Changes

None.

## Files Modified

- `src/frontend/src/widgets/inputs/TextInputWidget/variants/SearchVariant.tsx` — Added focus-visible ring suppression classes to match the pattern already used in DefaultVariant.tsx

## Commits

- 240e14b Fix search input focus border radius change with button suffix

Closes #4241