### PR TITLE
[00003] Fix inline code scaling in markdown renderer

### DIFF
--- a/src/frontend/src/lib/styles.ts
+++ b/src/frontend/src/lib/styles.ts
@@ -765,7 +765,7 @@ export const typography: Record<string, string> = {
   blockquote: "border-l-2 pl-6 italic",
 
   // Code
-  code: "relative rounded bg-muted px-[0.25rem] py-[0.05rem] font-mono text-[0.875em] font-semibold h-fit",
+  code: "relative rounded bg-muted px-[0.25rem] py-[0.05rem] font-mono font-semibold h-fit",
 
   // Table
   table: "w-full border-collapse border border-border",


### PR DESCRIPTION
## Summary

Removed the `text-[0.875em]` size reduction class from inline code styling in the markdown renderer. This allows inline code to scale proportionally with parent text rather than being compounded at 87.5% size, fixing scaling issues in headings, density modes, and nested elements.

## API Changes

None.

## Files Modified

- `src/frontend/src/lib/styles.ts` — Updated typography.code className to remove `text-[0.875em]`

## Commits

- `347e837d3` — Fix inline code scaling in markdown renderer

---
Source: https://github.com/Ivy-Interactive/Ivy-Tendril/issues/61