### PR TITLE
[00021] Add per-row conditional RowActions to DataTable

### DIFF
--- a/src/Ivy.Test/Views/DataTables/DataTableRowActionsTests.cs
+++ b/src/Ivy.Test/Views/DataTables/DataTableRowActionsTests.cs
@@ -1,0 +1,83 @@
+namespace Ivy.Test.Views.DataTables;
+
+public class DataTableRowActionsTests
+{
+    private record TestRow(int Id, string Name, string Status);
+
+    [Fact]
+    public void RowActions_StaticOverload_StoresActions()
+    {
+        var data = new[] { new TestRow(1, "A", "Active") }.AsQueryable();
+        var actions = new[] { new MenuItem("Edit"), new MenuItem("Delete") };
+        var builder = data.ToDataTable()
+            .RowActions(actions);
+
+        var field = builder.GetType()
+            .GetField("_menuItemRowActions", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        Assert.NotNull(field);
+        var stored = field.GetValue(builder) as MenuItem[];
+        Assert.NotNull(stored);
+        Assert.Equal(2, stored.Length);
+    }
+
+    [Fact]
+    public void RowActions_FactoryOverload_StoresFactory()
+    {
+        var data = new[] { new TestRow(1, "A", "Active") }.AsQueryable();
+        var builder = data.ToDataTable()
+            .RowActions(row => row.Status == "Active"
+                ? [new MenuItem("Stop")]
+                : [new MenuItem("Start")]);
+
+        var field = builder.GetType()
+            .GetField("_rowActionsFactory", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        Assert.NotNull(field);
+        Assert.NotNull(field.GetValue(builder));
+    }
+
+    [Fact]
+    public void RowActions_FactoryOverload_ReturnsBuilder_ForChaining()
+    {
+        var data = new[] { new TestRow(1, "A", "Active") }.AsQueryable();
+        var builder = data.ToDataTable();
+        var result = builder.RowActions(row => [new MenuItem("Edit")]);
+        Assert.Same(builder, result);
+    }
+
+    [Fact]
+    public void RowActions_StaticOverload_ReturnsBuilder_ForChaining()
+    {
+        var data = new[] { new TestRow(1, "A", "Active") }.AsQueryable();
+        var builder = data.ToDataTable();
+        var result = builder.RowActions(new MenuItem("Edit"));
+        Assert.Same(builder, result);
+    }
+
+    [Fact]
+    public void RowActions_FactoryInvokedPerRow_ReturnsDifferentActions()
+    {
+        var data = new[]
+        {
+            new TestRow(1, "A", "Active"),
+            new TestRow(2, "B", "Stopped"),
+            new TestRow(3, "C", "Active"),
+        };
+
+        Func<TestRow, MenuItem[]> factory = row => row.Status == "Active"
+            ? [new MenuItem("Stop") { Tag = "stop" }]
+            : [new MenuItem("Start") { Tag = "start" }];
+
+        var actionsForRow1 = factory(data[0]);
+        var actionsForRow2 = factory(data[1]);
+        var actionsForRow3 = factory(data[2]);
+
+        Assert.Single(actionsForRow1);
+        Assert.Equal("stop", actionsForRow1[0].Tag);
+
+        Assert.Single(actionsForRow2);
+        Assert.Equal("start", actionsForRow2[0].Tag);
+
+        Assert.Single(actionsForRow3);
+        Assert.Equal("stop", actionsForRow3[0].Tag);
+    }
+}

--- a/src/Ivy/Views/DataTables/DataTableBuilder.cs
+++ b/src/Ivy/Views/DataTables/DataTableBuilder.cs
@@ -20,6 +20,7 @@ public class DataTableBuilder<TModel>(
     private Func<Event<DataTable, CellClickEventArgs>, ValueTask>? _onCellClick;
     private Func<Event<DataTable, CellClickEventArgs>, ValueTask>? _onCellActivated;
     private MenuItem[]? _menuItemRowActions;
+    private Func<TModel, MenuItem[]>? _rowActionsFactory;
     private Func<Event<DataTable, RowActionClickEventArgs>, ValueTask>? _onRowAction;
     private readonly Dictionary<string, EventHandler<object>> _cellActions = [];
     private RefreshToken? _refreshToken;
@@ -431,6 +432,12 @@ public class DataTableBuilder<TModel>(
         return this;
     }
 
+    public DataTableBuilder<TModel> RowActions(Func<TModel, MenuItem[]> factory)
+    {
+        _rowActionsFactory = factory;
+        return this;
+    }
+
     public DataTableBuilder<TModel> OnRowAction(Func<Event<DataTable, RowActionClickEventArgs>, ValueTask> handler)
     {
         _onRowAction = handler;
@@ -557,6 +564,22 @@ public class DataTableBuilder<TModel>(
             idSelectorForView = obj => _idSelectorFunc((TModel)obj);
         }
 
+        // Compute per-row actions map when a factory is provided
+        Dictionary<string, MenuItem[]>? perRowActions = null;
+        if (_rowActionsFactory != null && _idSelectorFunc != null)
+        {
+            perRowActions = new Dictionary<string, MenuItem[]>();
+            foreach (var item in queryable)
+            {
+                var id = _idSelectorFunc(item)?.ToString();
+                if (id != null)
+                {
+                    var actions = _rowActionsFactory(item);
+                    perRowActions[id] = actions;
+                }
+            }
+        }
+
         return new DataTableView(
             queryable1,
             width,
@@ -573,7 +596,8 @@ public class DataTableBuilder<TModel>(
             emptyViewFactory: _emptyViewFactory,
             headerLeftFactory: _headerLeftFactory,
             headerRightFactory: _headerRightFactory,
-            updateStream: _updateStream);
+            updateStream: _updateStream,
+            perRowActions: perRowActions);
     }
 
     public object[] GetMemoValues()

--- a/src/Ivy/Views/DataTables/DataTableView.cs
+++ b/src/Ivy/Views/DataTables/DataTableView.cs
@@ -19,7 +19,8 @@ public class DataTableView(
     FuncViewBuilder? emptyViewFactory = null,
     FuncViewBuilder? headerLeftFactory = null,
     FuncViewBuilder? headerRightFactory = null,
-    IWriteStream<DataTableCellUpdate>? updateStream = null) : ViewBase, IMemoized
+    IWriteStream<DataTableCellUpdate>? updateStream = null,
+    Dictionary<string, MenuItem[]>? perRowActions = null) : ViewBase, IMemoized
 {
     public override object? Build()
     {
@@ -35,6 +36,7 @@ public class DataTableView(
             OnCellClick = onCellClick.ToEventHandler(),
             OnCellActivated = onCellActivated.ToEventHandler(),
             RowActions = rowActions,
+            PerRowActions = perRowActions,
             OnRowAction = onRowAction.ToEventHandler(),
             UpdateStream = updateStream
         };

--- a/src/Ivy/Widgets/DataTables/DataTable.cs
+++ b/src/Ivy/Widgets/DataTables/DataTable.cs
@@ -56,6 +56,8 @@ public record DataTable : WidgetBase<DataTable>
 
     [Prop] public MenuItem[]? RowActions { get; set; }
 
+    [Prop] public Dictionary<string, MenuItem[]>? PerRowActions { get; set; }
+
     [Event] public EventHandler<Event<DataTable, CellClickEventArgs>>? OnCellClick { get; set; }
 
     [Event] public EventHandler<Event<DataTable, CellClickEventArgs>>? OnCellActivated { get; set; }

--- a/src/frontend/src/widgets/dataTables/DataTableWidget.tsx
+++ b/src/frontend/src/widgets/dataTables/DataTableWidget.tsx
@@ -60,6 +60,7 @@ export const DataTable: React.FC<DataTableWidgetProps> = ({
   density,
   events = EMPTY_EVENTS,
   rowActions,
+  perRowActions,
   updateStream,
   slots,
   "data-testid": dataTestId,
@@ -138,6 +139,7 @@ export const DataTable: React.FC<DataTableWidgetProps> = ({
             events={events}
             hasOptions={finalConfig.allowFiltering}
             rowActions={rowActions}
+            perRowActions={perRowActions}
             showAggregateFooter={hasFooter}
           />
         </TableLayout>

--- a/src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx
+++ b/src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx
@@ -34,6 +34,7 @@ interface TableEditorProps {
   events: string[];
   hasOptions?: boolean;
   rowActions?: MenuItem[];
+  perRowActions?: Record<string, MenuItem[]>;
   footer?: React.ReactNode;
   showAggregateFooter?: boolean;
 }
@@ -43,6 +44,7 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
   events,
   hasOptions = false,
   rowActions,
+  perRowActions,
   footer,
   showAggregateFooter = false,
 }) => {
@@ -121,16 +123,23 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
   });
 
   // Row hover and actions
-  const { hoverRow, actionButtonsTop, actionButtonsHeight, onItemHovered, handleRowActionClick } =
-    useRowHover({
-      widgetId,
-      events,
-      visibleRows,
-      enableRowHover: enableRowHover ?? false,
-      rowActions,
-      containerRef,
-      arrowTableRef,
-    });
+  const {
+    hoverRow,
+    actionButtonsTop,
+    actionButtonsHeight,
+    onItemHovered,
+    handleRowActionClick,
+    resolvedRowActions,
+  } = useRowHover({
+    widgetId,
+    events,
+    visibleRows,
+    enableRowHover: enableRowHover ?? false,
+    rowActions,
+    perRowActions,
+    containerRef,
+    arrowTableRef,
+  });
 
   // Link cell hover tooltip
   const {
@@ -321,7 +330,7 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
         highlightRegions={showSearchConfig ? highlightRegions : undefined}
         onItemHovered={handleItemHovered}
         getRowThemeOverride={enableRowHover || emptyRowsCount > 0 ? getRowThemeOverride : undefined}
-        rowActions={rowActions}
+        rowActions={resolvedRowActions}
         actionButtonsTop={actionButtonsTop}
         actionButtonsHeight={actionButtonsHeight}
         hoverRow={hoverRow}

--- a/src/frontend/src/widgets/dataTables/hooks/useRowHover.ts
+++ b/src/frontend/src/widgets/dataTables/hooks/useRowHover.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { GridMouseCellEventArgs, GridMouseEventArgs } from "@glideapps/glide-data-grid";
 import { useEventHandler } from "@/components/event-handler";
 import { MenuItem } from "@/types/widgets";
@@ -11,6 +11,7 @@ interface UseRowHoverProps {
   visibleRows: number;
   enableRowHover: boolean | undefined;
   rowActions?: MenuItem[];
+  perRowActions?: Record<string, MenuItem[]>;
   containerRef: React.RefObject<HTMLDivElement | null>;
   arrowTableRef: React.RefObject<arrow.Table | null>;
 }
@@ -24,6 +25,7 @@ export const useRowHover = ({
   visibleRows,
   enableRowHover,
   rowActions,
+  perRowActions,
   containerRef,
   arrowTableRef,
 }: UseRowHoverProps) => {
@@ -45,7 +47,11 @@ export const useRowHover = ({
       const newHoverRow = args.kind !== "cell" ? undefined : row;
       setHoverRow(newHoverRow);
 
-      if (rowActions?.length && newHoverRow !== undefined && containerRef.current) {
+      if (
+        (rowActions?.length || perRowActions) &&
+        newHoverRow !== undefined &&
+        containerRef.current
+      ) {
         const { bounds } = args as GridMouseCellEventArgs;
         const container = containerRef.current;
         const containerRect = container.getBoundingClientRect();
@@ -67,7 +73,7 @@ export const useRowHover = ({
         setActionButtonsHeight(snap(overlayHeight));
       }
     },
-    [enableRowHover, rowActions, visibleRows, containerRef],
+    [enableRowHover, rowActions, perRowActions, visibleRows, containerRef],
   );
 
   // Handle row action button click
@@ -90,11 +96,22 @@ export const useRowHover = ({
     [hoverRow, events, eventHandler, widgetId, arrowTableRef],
   );
 
+  // Resolve per-row actions for the currently hovered row
+  const resolvedRowActions = useMemo(() => {
+    if (!perRowActions || hoverRow === undefined) return rowActions;
+    const rowId = getHiddenKeyValue(arrowTableRef.current, hoverRow);
+    if (rowId !== null && String(rowId) in perRowActions) {
+      return perRowActions[String(rowId)];
+    }
+    return rowActions;
+  }, [perRowActions, rowActions, hoverRow, arrowTableRef]);
+
   return {
     hoverRow,
     actionButtonsTop,
     actionButtonsHeight,
     onItemHovered,
     handleRowActionClick,
+    resolvedRowActions,
   };
 };

--- a/src/frontend/src/widgets/dataTables/types/types.ts
+++ b/src/frontend/src/widgets/dataTables/types/types.ts
@@ -89,6 +89,7 @@ export interface TableProps {
   width?: string;
   height?: string;
   rowActions?: MenuItem[];
+  perRowActions?: Record<string, MenuItem[]>;
   updateStream?: { id: string };
   onCellUpdate?: (row: number, col: number, value: unknown) => void;
   "data-testid"?: string;


### PR DESCRIPTION
## Summary

Added a `RowActions(Func<TModel, MenuItem[]>)` overload to `DataTableBuilder` that evaluates per row to produce different actions based on row data. The factory results are serialized as a `Dictionary<string, MenuItem[]>` (keyed by row ID) and sent as a `PerRowActions` prop alongside the existing static `RowActions`. The frontend resolves per-row actions on hover, falling back to table-level actions when no per-row entry exists.

## API Changes

- **New method:** `DataTableBuilder<TModel>.RowActions(Func<TModel, MenuItem[]> factory)` -- per-row action factory overload
- **New prop:** `DataTable.PerRowActions` (`Dictionary<string, MenuItem[]>?`) -- per-row actions map keyed by row ID
- **New frontend prop:** `TableProps.perRowActions` (`Record<string, MenuItem[]>`) -- per-row actions in frontend types
- **Existing method unchanged:** `DataTableBuilder<TModel>.RowActions(params MenuItem[] actions)` -- static overload preserved

## Files Modified

**Backend:**
- `src/Ivy/Views/DataTables/DataTableBuilder.cs` -- Added factory field, overload, and per-row actions computation in Build()
- `src/Ivy/Views/DataTables/DataTableView.cs` -- Added perRowActions parameter pass-through
- `src/Ivy/Widgets/DataTables/DataTable.cs` -- Added PerRowActions prop

**Frontend:**
- `src/frontend/src/widgets/dataTables/types/types.ts` -- Added perRowActions to TableProps
- `src/frontend/src/widgets/dataTables/DataTableWidget.tsx` -- Destructure and pass perRowActions
- `src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx` -- Accept and pass perRowActions, use resolvedRowActions
- `src/frontend/src/widgets/dataTables/hooks/useRowHover.ts` -- Resolve per-row actions via row ID lookup

**Tests:**
- `src/Ivy.Test/Views/DataTables/DataTableRowActionsTests.cs` -- New test class with 5 tests

## Commits

- `1e4beb5b0` [00021] Add per-row conditional RowActions to DataTable