### PR TITLE
[00003] Add Desktop Launch Option To Auth Examples

### DIFF
--- a/src/auth/examples/Auth0Example/Auth0Example.csproj
+++ b/src/auth/examples/Auth0Example/Auth0Example.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\Ivy\Ivy.csproj" />
+    <ProjectReference Include="..\..\..\Ivy.Desktop\Ivy.Desktop.csproj" />
     <ProjectReference Include="..\..\..\Ivy.Analyser\Ivy.Analyser.csproj">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/auth/examples/Auth0Example/Program.cs
+++ b/src/auth/examples/Auth0Example/Program.cs
@@ -35,4 +35,5 @@ if (launchDesktop)
 else
 {
     await server.RunAsync();
+    return 0;
 }

--- a/src/auth/examples/Auth0Example/Program.cs
+++ b/src/auth/examples/Auth0Example/Program.cs
@@ -1,4 +1,5 @@
 using Ivy;
+using Ivy.Desktop;
 
 var server = new Server();
 
@@ -17,4 +18,21 @@ server.SetMetaTitle("Auth0 Example");
 
 Server.AuthCookiePrefix = "auth0";
 
-await server.RunAsync();
+// Check for desktop launch flag
+var launchDesktop = args.Contains("--desktop") || args.Contains("-d");
+
+if (launchDesktop)
+{
+    var window = new DesktopWindow(server)
+        .Title("Auth0 Example")
+        .AppId("Auth0Example")
+        .Size(1200, 800)
+        .MinSize(800, 600)
+        .UseDevTools();
+
+    return window.Run();
+}
+else
+{
+    await server.RunAsync();
+}

--- a/src/auth/examples/AutheliaExample/AutheliaExample.csproj
+++ b/src/auth/examples/AutheliaExample/AutheliaExample.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\Ivy\Ivy.csproj" />
+    <ProjectReference Include="..\..\..\Ivy.Desktop\Ivy.Desktop.csproj" />
     <ProjectReference Include="..\..\..\Ivy.Analyser\Ivy.Analyser.csproj">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/auth/examples/AutheliaExample/Program.cs
+++ b/src/auth/examples/AutheliaExample/Program.cs
@@ -35,4 +35,5 @@ if (launchDesktop)
 else
 {
     await server.RunAsync();
+    return 0;
 }

--- a/src/auth/examples/AutheliaExample/Program.cs
+++ b/src/auth/examples/AutheliaExample/Program.cs
@@ -1,4 +1,5 @@
 using Ivy;
+using Ivy.Desktop;
 
 var server = new Server();
 
@@ -17,4 +18,21 @@ server.SetMetaTitle("Authelia Example");
 
 Server.AuthCookiePrefix = "authelia";
 
-await server.RunAsync();
+// Check for desktop launch flag
+var launchDesktop = args.Contains("--desktop") || args.Contains("-d");
+
+if (launchDesktop)
+{
+    var window = new DesktopWindow(server)
+        .Title("Authelia Example")
+        .AppId("AutheliaExample")
+        .Size(1200, 800)
+        .MinSize(800, 600)
+        .UseDevTools();
+
+    return window.Run();
+}
+else
+{
+    await server.RunAsync();
+}

--- a/src/auth/examples/BasicAuthExample/BasicAuthExample.csproj
+++ b/src/auth/examples/BasicAuthExample/BasicAuthExample.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\Ivy\Ivy.csproj" />
+    <ProjectReference Include="..\..\..\Ivy.Desktop\Ivy.Desktop.csproj" />
     <ProjectReference Include="..\..\..\Ivy.Analyser\Ivy.Analyser.csproj">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/auth/examples/BasicAuthExample/Program.cs
+++ b/src/auth/examples/BasicAuthExample/Program.cs
@@ -35,4 +35,5 @@ if (launchDesktop)
 else
 {
     await server.RunAsync();
+    return 0;
 }

--- a/src/auth/examples/BasicAuthExample/Program.cs
+++ b/src/auth/examples/BasicAuthExample/Program.cs
@@ -1,4 +1,5 @@
 using Ivy;
+using Ivy.Desktop;
 
 var server = new Server();
 
@@ -17,4 +18,21 @@ server.SetMetaTitle("BasicAuth Example");
 
 Server.AuthCookiePrefix = "basic";
 
-await server.RunAsync();
+// Check for desktop launch flag
+var launchDesktop = args.Contains("--desktop") || args.Contains("-d");
+
+if (launchDesktop)
+{
+    var window = new DesktopWindow(server)
+        .Title("BasicAuth Example")
+        .AppId("BasicAuthExample")
+        .Size(1200, 800)
+        .MinSize(800, 600)
+        .UseDevTools();
+
+    return window.Run();
+}
+else
+{
+    await server.RunAsync();
+}

--- a/src/auth/examples/ClerkExample/ClerkExample.csproj
+++ b/src/auth/examples/ClerkExample/ClerkExample.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\Ivy\Ivy.csproj" />
+    <ProjectReference Include="..\..\..\Ivy.Desktop\Ivy.Desktop.csproj" />
     <ProjectReference Include="..\..\..\Ivy.Analyser\Ivy.Analyser.csproj">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/auth/examples/ClerkExample/Program.cs
+++ b/src/auth/examples/ClerkExample/Program.cs
@@ -53,4 +53,5 @@ if (launchDesktop)
 else
 {
     await server.RunAsync();
+    return 0;
 }

--- a/src/auth/examples/ClerkExample/Program.cs
+++ b/src/auth/examples/ClerkExample/Program.cs
@@ -1,4 +1,5 @@
 using Ivy;
+using Ivy.Desktop;
 using Microsoft.Extensions.Configuration;
 
 var server = new Server();
@@ -35,4 +36,21 @@ server.UseConfiguration(config =>
     }
 });
 
-await server.RunAsync();
+// Check for desktop launch flag
+var launchDesktop = args.Contains("--desktop") || args.Contains("-d");
+
+if (launchDesktop)
+{
+    var window = new DesktopWindow(server)
+        .Title("Clerk Example")
+        .AppId("ClerkExample")
+        .Size(1200, 800)
+        .MinSize(800, 600)
+        .UseDevTools();
+
+    return window.Run();
+}
+else
+{
+    await server.RunAsync();
+}

--- a/src/auth/examples/GitHubExample/GitHubExample.csproj
+++ b/src/auth/examples/GitHubExample/GitHubExample.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\Ivy\Ivy.csproj" />
+    <ProjectReference Include="..\..\..\Ivy.Desktop\Ivy.Desktop.csproj" />
     <ProjectReference Include="..\..\..\Ivy.Analyser\Ivy.Analyser.csproj">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/auth/examples/GitHubExample/Program.cs
+++ b/src/auth/examples/GitHubExample/Program.cs
@@ -35,4 +35,5 @@ if (launchDesktop)
 else
 {
     await server.RunAsync();
+    return 0;
 }

--- a/src/auth/examples/GitHubExample/Program.cs
+++ b/src/auth/examples/GitHubExample/Program.cs
@@ -1,4 +1,5 @@
 using Ivy;
+using Ivy.Desktop;
 
 var server = new Server();
 
@@ -17,4 +18,21 @@ server.SetMetaTitle("GitHub Example");
 
 Server.AuthCookiePrefix = "github";
 
-await server.RunAsync();
+// Check for desktop launch flag
+var launchDesktop = args.Contains("--desktop") || args.Contains("-d");
+
+if (launchDesktop)
+{
+    var window = new DesktopWindow(server)
+        .Title("GitHub Example")
+        .AppId("GitHubExample")
+        .Size(1200, 800)
+        .MinSize(800, 600)
+        .UseDevTools();
+
+    return window.Run();
+}
+else
+{
+    await server.RunAsync();
+}

--- a/src/auth/examples/MicrosoftEntraExample/MicrosoftEntraExample.csproj
+++ b/src/auth/examples/MicrosoftEntraExample/MicrosoftEntraExample.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\Ivy\Ivy.csproj" />
+    <ProjectReference Include="..\..\..\Ivy.Desktop\Ivy.Desktop.csproj" />
     <ProjectReference Include="..\..\..\Ivy.Analyser\Ivy.Analyser.csproj">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/auth/examples/MicrosoftEntraExample/Program.cs
+++ b/src/auth/examples/MicrosoftEntraExample/Program.cs
@@ -35,4 +35,5 @@ if (launchDesktop)
 else
 {
     await server.RunAsync();
+    return 0;
 }

--- a/src/auth/examples/MicrosoftEntraExample/Program.cs
+++ b/src/auth/examples/MicrosoftEntraExample/Program.cs
@@ -1,4 +1,5 @@
 using Ivy;
+using Ivy.Desktop;
 
 var server = new Server();
 
@@ -17,4 +18,21 @@ server.SetMetaTitle("Microsoft Entra Example");
 
 Server.AuthCookiePrefix = "entra";
 
-await server.RunAsync();
+// Check for desktop launch flag
+var launchDesktop = args.Contains("--desktop") || args.Contains("-d");
+
+if (launchDesktop)
+{
+    var window = new DesktopWindow(server)
+        .Title("Microsoft Entra Example")
+        .AppId("MicrosoftEntraExample")
+        .Size(1200, 800)
+        .MinSize(800, 600)
+        .UseDevTools();
+
+    return window.Run();
+}
+else
+{
+    await server.RunAsync();
+}

--- a/src/auth/examples/SliplaneExample/Program.cs
+++ b/src/auth/examples/SliplaneExample/Program.cs
@@ -1,4 +1,5 @@
 using Ivy.Auth.Sliplane;
+using Ivy.Desktop;
 
 var server = new Server();
 
@@ -18,5 +19,22 @@ server.SetMetaTitle("Sliplane Example");
 
 Server.AuthCookiePrefix = "sliplane";
 
-await server.RunAsync();
+// Check for desktop launch flag
+var launchDesktop = args.Contains("--desktop") || args.Contains("-d");
+
+if (launchDesktop)
+{
+    var window = new DesktopWindow(server)
+        .Title("Sliplane Example")
+        .AppId("SliplaneExample")
+        .Size(1200, 800)
+        .MinSize(800, 600)
+        .UseDevTools();
+
+    return window.Run();
+}
+else
+{
+    await server.RunAsync();
+}
 

--- a/src/auth/examples/SliplaneExample/Program.cs
+++ b/src/auth/examples/SliplaneExample/Program.cs
@@ -36,5 +36,6 @@ if (launchDesktop)
 else
 {
     await server.RunAsync();
+    return 0;
 }
 

--- a/src/auth/examples/SliplaneExample/SliplaneExample.csproj
+++ b/src/auth/examples/SliplaneExample/SliplaneExample.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../../../Ivy/Ivy.csproj" />
+    <ProjectReference Include="../../../Ivy.Desktop/Ivy.Desktop.csproj" />
     <ProjectReference Include="../../Ivy.Auth.Sliplane/Ivy.Auth.Sliplane.csproj" />
   </ItemGroup>
 

--- a/src/auth/examples/SupabaseExample/Program.cs
+++ b/src/auth/examples/SupabaseExample/Program.cs
@@ -35,4 +35,5 @@ if (launchDesktop)
 else
 {
     await server.RunAsync();
+    return 0;
 }

--- a/src/auth/examples/SupabaseExample/Program.cs
+++ b/src/auth/examples/SupabaseExample/Program.cs
@@ -1,4 +1,5 @@
 using Ivy;
+using Ivy.Desktop;
 
 var server = new Server();
 
@@ -17,4 +18,21 @@ server.SetMetaTitle("Supabase Example");
 
 Server.AuthCookiePrefix = "supabase";
 
-await server.RunAsync();
+// Check for desktop launch flag
+var launchDesktop = args.Contains("--desktop") || args.Contains("-d");
+
+if (launchDesktop)
+{
+    var window = new DesktopWindow(server)
+        .Title("Supabase Example")
+        .AppId("SupabaseExample")
+        .Size(1200, 800)
+        .MinSize(800, 600)
+        .UseDevTools();
+
+    return window.Run();
+}
+else
+{
+    await server.RunAsync();
+}

--- a/src/auth/examples/SupabaseExample/SupabaseExample.csproj
+++ b/src/auth/examples/SupabaseExample/SupabaseExample.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\Ivy\Ivy.csproj" />
+    <ProjectReference Include="..\..\..\Ivy.Desktop\Ivy.Desktop.csproj" />
     <ProjectReference Include="..\..\..\Ivy.Analyser\Ivy.Analyser.csproj">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Problem

The auth example projects in the Ivy Framework currently only support running as a browser-based server using `Server.RunAsync()`. There is no option to launch them in a desktop window using `Ivy.Desktop.DesktopWindow`, which would provide a ~~native desktop experience with features like tray icons, native menus, and desktop integration~~ _edit_: I don't care about any of the stuff I crossed out. The actual purpose of this PR is to make it easier to test the auth system in a desktop app context. Note that some of these example projects won't work perfectly yet (mainly Clerk auth, and GitHub connected accounts).

## Solution

Add an optional `--desktop` (or `-d`) command-line parameter to each auth example's `Program.cs`. When provided, the example will launch in an Ivy.Desktop window instead of the browser.

For each of the 8 auth example projects (BasicAuth, Auth0, Authelia, Clerk, GitHub, MicrosoftEntra, Sliplane, Supabase):

1. Add Ivy.Desktop package reference to the .csproj file
2. Modify Program.cs to check for `--desktop` or `-d` in command-line args and launch accordingly

## Commits

- a36501288b4951ec8346c12e24518ad2c4346bb4 - [00003] Add desktop launch option to auth examples
- 07c692bb7d9866a53c37cc6356518d4386aaae20 - [00003] Fix return value in else branch