### PR TITLE
Fix backend CI: remove unused Ivy.Core using in Loading.cs

### DIFF
--- a/src/Ivy/Widgets/Primitives/Loading.cs
+++ b/src/Ivy/Widgets/Primitives/Loading.cs
@@ -1,5 +1,3 @@
-using Ivy.Core;
-
 // ReSharper disable once CheckNamespace
 namespace Ivy;
 


### PR DESCRIPTION
## Summary
- Removes the unused `using Ivy.Core;` directive at the top of `src/Ivy/Widgets/Primitives/Loading.cs`.
- Unblocks the `dotnet format --verify-no-changes` step in the `Backend Checks` (Linux & Windows) workflows on `development`, which is currently failing with `IDE0005: Using directive is unnecessary`.

## Test plan
- [x] `dotnet format --verify-no-changes` → exit 0
- [x] `dotnet build Ivy-Framework.slnx` → 0 warnings, 0 errors
- [ ] CI: Backend Checks (Linux) passes
- [ ] CI: Backend Checks (Windows) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)