### PR TITLE
[00001] Force HTTP and non-Secure cookies in Ivy.Desktop

### DIFF
--- a/src/Ivy.Desktop/DesktopWindow.cs
+++ b/src/Ivy.Desktop/DesktopWindow.cs
@@ -6,8 +6,9 @@ using Rustino.NET;
 
 namespace Ivy.Desktop;
 
-public class DesktopWindow(Server server)
+public class DesktopWindow
 {
+    private readonly Server server;
     private string _title = Assembly.GetEntryAssembly()?.GetName().Name ?? "Ivy App";
     private int _width = 1280;
     private int _height = 800;
@@ -41,6 +42,13 @@ public class DesktopWindow(Server server)
     private int _splashWidth = 400;
     private int _splashHeight = 300;
     private string? _appId;
+
+    public DesktopWindow(Server server)
+    {
+        this.server = server;
+        // Ensure auth cookies work over HTTP in desktop mode
+        server.SetForceNonSecureCookies(true);
+    }
 
     public DesktopWindow Title(string title) { _title = title; return this; }
     public DesktopWindow Size(int width, int height) { _width = width; _height = height; return this; }
@@ -242,6 +250,9 @@ public class DesktopWindow(Server server)
     {
         CultureInfo.DefaultThreadCurrentCulture = CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo("en-US");
 
+        // Force HTTP for all desktop apps (WKWebView doesn't trust dev certs)
+        Environment.SetEnvironmentVariable("IVY_TLS", "false");
+
         server.Services.AddSingleton(this);
 
         var cts = new CancellationTokenSource();
@@ -251,11 +262,7 @@ public class DesktopWindow(Server server)
         // FindAvailablePort) completes before the first await, so Args.Port is
         // already updated to the actual port the server will bind to.
         var port = server.Args.Port;
-        var ivyTlsEnv = Environment.GetEnvironmentVariable("IVY_TLS");
-        var useTls = !string.IsNullOrEmpty(ivyTlsEnv)
-            ? ivyTlsEnv?.ToLowerInvariant() is "1" or "true" or "yes" or "on"
-            : true; // Default to true if not overridden
-        var url = $"{(useTls ? "https" : "http")}://localhost:{port}";
+        var url = $"http://localhost:{port}";  // Always HTTP in desktop mode
 
         // Show splash while the server starts
         RustinoSplashscreen? splash = null;

--- a/src/Ivy/Core/Auth/CookieRegistryExtensions.cs
+++ b/src/Ivy/Core/Auth/CookieRegistryExtensions.cs
@@ -246,7 +246,7 @@ public static class CookieRegistryExtensions
         return string.IsNullOrEmpty(prefix) ? name : $"{prefix}__{name}";
     }
 
-    private static CookieOptions CreateAuthCookieOptions(bool forceLaxSameSite = false)
+    private static CookieOptions CreateAuthCookieOptions(ServerArgs? serverArgs = null, bool forceLaxSameSite = false)
     {
         var cookieOptions = new CookieOptions
         {
@@ -257,8 +257,14 @@ public static class CookieRegistryExtensions
             Path = "/",
         };
 
-        // Apply custom configuration if provided
+        // Apply custom configuration if provided (allows apps to customize)
         global::Ivy.Server.ConfigureAuthCookieOptions?.Invoke(cookieOptions);
+
+        // Force non-secure cookies AFTER callback when running in desktop mode
+        if (serverArgs?.ForceNonSecureCookies == true || global::Ivy.Server.ForceNonSecureCookies)
+        {
+            cookieOptions.Secure = false;
+        }
 
         return cookieOptions;
     }

--- a/src/Ivy/Server.cs
+++ b/src/Ivy/Server.cs
@@ -72,6 +72,13 @@ public record ServerArgs
     /// that needs DI but should not bind a real port.
     /// </summary>
     public bool IsCliCommand => Describe || DescribeConnection != null || TestConnection != null;
+
+    /// <summary>
+    /// When true, forces all authentication cookies to have Secure=false.
+    /// This is applied AFTER ConfigureAuthCookieOptions callback to ensure
+    /// cookies work over HTTP in desktop environments.
+    /// </summary>
+    public bool ForceNonSecureCookies { get; set; } = false;
 }
 
 public class Server
@@ -91,6 +98,7 @@ public class Server
     public ServerArgs Args => _args;
     public static Action<CookieOptions>? ConfigureAuthCookieOptions { get; set; }
     public static string? AuthCookiePrefix { get; set; }
+    internal static bool ForceNonSecureCookies { get; set; }
     private IContentBuilder? _contentBuilder;
     private bool _useHotReload;
     private bool _useHttpRedirection;
@@ -138,6 +146,12 @@ public class Server
         Services.AddSingleton<IConfiguration>(_ => Configuration);
 
         AddDefaultApps();
+    }
+
+    internal void SetForceNonSecureCookies(bool force)
+    {
+        _args = _args with { ForceNonSecureCookies = force };
+        ForceNonSecureCookies = force;
     }
 
     private void AddDefaultApps()

--- a/src/Ivy/Server.cs
+++ b/src/Ivy/Server.cs
@@ -148,7 +148,7 @@ public class Server
         AddDefaultApps();
     }
 
-    internal void SetForceNonSecureCookies(bool force)
+    public void SetForceNonSecureCookies(bool force)
     {
         _args = _args with { ForceNonSecureCookies = force };
         ForceNonSecureCookies = force;


### PR DESCRIPTION
# Summary

## Changes

Implemented automatic HTTP-only mode for Ivy.Desktop apps to work around WKWebView's ~~inability to trust self-signed development certificates.~~

> edit: in my experience, local HTTPS worked just fine in `Ivy.Desktop` on macOS. But that's probably because I manually trusted the certificates.

Desktop apps now force HTTP protocol and non-secure cookies by default, eliminating the need for manual `IVY_TLS=false` configuration.

## API Changes

**New Properties:**
- `ServerArgs.ForceNonSecureCookies` - Forces all auth cookies to have `Secure=false` when set to `true`
- `Server.ForceNonSecureCookies` - Static property that controls cookie security globally

**New Methods:**
- `Server.SetForceNonSecureCookies(bool)` - Internal method to update both instance and static cookie security settings

**Modified Methods:**
- `CookieRegistryExtensions.CreateAuthCookieOptions()` - Now checks `ForceNonSecureCookies` and applies `Secure=false` after custom callback
- `DesktopWindow` constructor - Now automatically calls `SetForceNonSecureCookies(true)`
- `DesktopWindow.RunInternal()` - Sets `IVY_TLS=false` environment variable and simplifies URL to always use HTTP

## Files Modified

**Core Framework:**
- `src/Ivy/Server.cs` - Added `ForceNonSecureCookies` property and `SetForceNonSecureCookies` method
- `src/Ivy/Core/Auth/CookieRegistryExtensions.cs` - Modified cookie options creation to respect `ForceNonSecureCookies`

**Desktop:**
- `src/Ivy.Desktop/DesktopWindow.cs` - Converted to traditional constructor, set `ForceNonSecureCookies`, force HTTP protocol

## Commits

- c43b65c95 [00001] Make SetForceNonSecureCookies public
- fa1aa5406 [00001] Force HTTP and non-Secure cookies in Ivy.Desktop