### PR TITLE
[00002] Unify OAuth Flow for Connected Accounts

### DIFF
--- a/src/Ivy/Auth/DefaultAuthApp.cs
+++ b/src/Ivy/Auth/DefaultAuthApp.cs
@@ -144,20 +144,17 @@ public class OAuthFlowView(AuthOption option) : ViewBase
     public override object? Build()
     {
         var args = this.UseService<AppContext>();
-        var registry = this.UseService<IOAuthCallbackRegistry>();
+        var loginRegistry = this.UseService<IOAuthLoginRegistry>();
         var auth = this.UseService<IAuthProvider>();
 
-        var state = this.UseState(() => registry.RegisterPending(args.ConnectionId, option.Id ?? ""));
+        var loginId = this.UseState(() => loginRegistry.RegisterPending(args.ConnectionId, option.Id ?? ""));
 
-        var oauthUriBuilder = new UriBuilder($"{args.BaseUrl.TrimEnd('/')}/ivy/auth/oauth-login")
-        {
-            Query = $"optionId={Uri.EscapeDataString(option.Id ?? "")}&callbackId={Uri.EscapeDataString(state.Value)}&connectionId={Uri.EscapeDataString(args.ConnectionId)}"
-        };
+        var oauthUri = $"{args.BaseUrl.TrimEnd('/')}/ivy/auth/oauth-login?loginId={Uri.EscapeDataString(loginId.Value)}";
         return new Button(option.Name)
             .Secondary()
             .Icon(option.Icon)
             .Width(Size.Full())
-            .Url(oauthUriBuilder.ToString())
+            .Url(oauthUri)
             .Target(LinkTarget.Self)
             .OpenInNewTab(auth.OpenOAuthLoginInNewTab);
     }

--- a/src/Ivy/Core/Auth/AuthController.cs
+++ b/src/Ivy/Core/Auth/AuthController.cs
@@ -138,7 +138,9 @@ public class AuthController() : Controller
         }
 
         var path = (serverArgs.BasePath ?? "").Trim().Replace('\\', '/').TrimStart('/').TrimEnd('/');
-        var redirectUrl = string.IsNullOrEmpty(path) ? "/?oauthLogin=1" : $"/{path}/?oauthLogin=1";
+        var isConnectedAccount = !string.IsNullOrWhiteSpace(pending.Provider);
+        var queryParam = isConnectedAccount ? "connectedAccountLogin=1" : "oauthLogin=1";
+        var redirectUrl = string.IsNullOrEmpty(path) ? $"/?{queryParam}" : $"/{path}/?{queryParam}";
 
         if (string.IsNullOrWhiteSpace(pending.Provider))
         {

--- a/src/Ivy/Core/Auth/AuthController.cs
+++ b/src/Ivy/Core/Auth/AuthController.cs
@@ -21,6 +21,7 @@ public class AuthController() : Controller
         [FromQuery] string optionId,
         [FromQuery] string callbackId,
         [FromQuery] string connectionId,
+        [FromQuery] string? provider,
         [FromServices] AppSessionStore sessionStore,
         [FromServices] ServerArgs serverArgs,
         [FromServices] ILogger<AuthController> logger)
@@ -37,22 +38,6 @@ public class AuthController() : Controller
             return BadRequest("Authentication error");
         }
 
-        var authService = appSession.AppServices.GetService<IAuthService>();
-        if (authService == null)
-        {
-            logger.LogWarning("OAuth login failed: Auth service not configured for connection {ConnectionId}", SanitizeForLog(connectionId));
-            return BadRequest("Authentication error");
-        }
-
-        // Find the auth option by ID
-        var options = authService.GetAuthOptions();
-        var option = options.FirstOrDefault(o => o.Id == optionId);
-        if (option == null)
-        {
-            logger.LogWarning("OAuth login failed: Auth option '{OptionId}' not found for connection {ConnectionId}", SanitizeForLog(optionId), SanitizeForLog(connectionId));
-            return BadRequest("Authentication error");
-        }
-
         // Construct the OAuth callback endpoint
         var scheme = HttpContext.Request.Scheme;
         if (HttpContext.Request.Headers.TryGetValue("X-Forwarded-Proto", out var forwardedProto))
@@ -62,16 +47,57 @@ public class AuthController() : Controller
         var host = HttpContext.Request.Host.Value ?? throw new InvalidOperationException("Host not found in request");
         var callback = WebhookEndpoint.CreateAuthCallback(callbackId, scheme, host, serverArgs.BasePath);
 
-        try
+        if (string.IsNullOrWhiteSpace(provider))
         {
-            // Get the OAuth URI and redirect to it
-            var uri = await authService.GetOAuthUriAsync(option, callback, HttpContext.RequestAborted);
-            return Redirect(uri.ToString());
+            // Main auth flow
+            var authService = appSession.AppServices.GetService<IAuthService>();
+            if (authService == null)
+            {
+                logger.LogWarning("OAuth login failed: Auth service not configured for connection {ConnectionId}", SanitizeForLog(connectionId));
+                return BadRequest("Authentication error");
+            }
+
+            // Find the auth option by ID
+            var options = authService.GetAuthOptions();
+            var option = options.FirstOrDefault(o => o.Id == optionId);
+            if (option == null)
+            {
+                logger.LogWarning("OAuth login failed: Auth option '{OptionId}' not found for connection {ConnectionId}", SanitizeForLog(optionId), SanitizeForLog(connectionId));
+                return BadRequest("Authentication error");
+            }
+
+            try
+            {
+                // Get the OAuth URI and redirect to it
+                var uri = await authService.GetOAuthUriAsync(option, callback, HttpContext.RequestAborted);
+                return Redirect(uri.ToString());
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "OAuth login failed: Error initiating OAuth for option '{OptionId}' on connection {ConnectionId}", optionId.Replace("\n", "").Replace("\r", ""), connectionId.Replace("\n", "").Replace("\r", ""));
+                return BadRequest("Authentication error");
+            }
         }
-        catch (Exception ex)
+        else
         {
-            logger.LogError(ex, "OAuth login failed: Error initiating OAuth for option '{OptionId}' on connection {ConnectionId}", optionId.Replace("\n", "").Replace("\r", ""), connectionId.Replace("\n", "").Replace("\r", ""));
-            return BadRequest("Authentication error");
+            // Connected account flow
+            var connectedAccountsService = appSession.AppServices.GetService<IConnectedAccountsService>();
+            if (connectedAccountsService == null)
+            {
+                logger.LogWarning("OAuth login failed: Connected accounts service not configured");
+                return BadRequest("Connected accounts not configured");
+            }
+
+            try
+            {
+                var uri = await connectedAccountsService.ConnectAccountAsync(provider, callback, HttpContext.RequestAborted);
+                return Redirect(uri.ToString());
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "OAuth login failed: Error initiating connected account OAuth for provider '{Provider}' on connection {ConnectionId}", SanitizeForLog(provider), SanitizeForLog(connectionId));
+                return BadRequest("Authentication error");
+            }
         }
     }
 
@@ -111,46 +137,93 @@ public class AuthController() : Controller
             return BadRequest("Invalid or expired OAuth state. Please try logging in again.");
         }
 
-        try
+        var path = (serverArgs.BasePath ?? "").Trim().Replace('\\', '/').TrimStart('/').TrimEnd('/');
+        var redirectUrl = string.IsNullOrEmpty(path) ? "/?oauthLogin=1" : $"/{path}/?oauthLogin=1";
+
+        if (string.IsNullOrWhiteSpace(pending.Provider))
         {
-            TunneledHttpMessageHandler? httpMessageHandler;
-            // Get the session and its HttpMessageHandler using the connectionId from the pending callback
-            if (sessionStore.Sessions.TryGetValue(pending.ConnectionId, out var appSession))
+            // Main auth flow
+            try
             {
-                httpMessageHandler = appSession.AppServices.GetService<TunneledHttpMessageHandler>();
+                TunneledHttpMessageHandler? httpMessageHandler;
+                // Get the session and its HttpMessageHandler using the connectionId from the pending callback
+                if (sessionStore.Sessions.TryGetValue(pending.ConnectionId, out var appSession))
+                {
+                    httpMessageHandler = appSession.AppServices.GetService<TunneledHttpMessageHandler>();
+                }
+                else
+                {
+                    logger.LogDebug("OAuth callback: session not found for connection {ConnectionId} (expected during redirect flow). Unable to retrieve frontend-tunneled HttpMessageHandler; Clerk auth provider may be affected.", SanitizeForLog(pending.ConnectionId));
+                    httpMessageHandler = null;
+                }
+
+                var tempSession = AuthHelper.GetAuthSession(HttpContext, httpMessageHandler);
+
+                var token = await authProvider.HandleOAuthCallbackAsync(tempSession, HttpContext.Request);
+
+                if (token == null)
+                {
+                    logger.LogWarning("OAuth callback failed: No token returned");
+                    return BadRequest("Authentication failed: no token received");
+                }
+
+                logger.LogInformation("OAuth callback successful, setting auth cookies");
+
+                var cookies = new CookieJar();
+                cookies.AddCookiesForAuthToken(token);
+                cookies.AddCookiesForAuthSessionData(tempSession.AuthSessionData);
+                cookies.AddCookiesForBrokeredSessions(tempSession.BrokeredSessions);
+                cookies.WriteToResponse(Response);
+
+                return LocalRedirect(redirectUrl);
             }
-            else
+            catch (Exception ex)
             {
-                logger.LogDebug("OAuth callback: session not found for connection {ConnectionId} (expected during redirect flow). Unable to retrieve frontend-tunneled HttpMessageHandler; Clerk auth provider may be affected.", SanitizeForLog(pending.ConnectionId));
-                httpMessageHandler = null;
+                logger.LogError(ex, "OAuth callback failed: Error processing callback");
+                return BadRequest($"Authentication error: {ex.Message}");
             }
-
-            var tempSession = AuthHelper.GetAuthSession(HttpContext, httpMessageHandler);
-
-            var token = await authProvider.HandleOAuthCallbackAsync(tempSession, HttpContext.Request);
-
-            if (token == null)
-            {
-                logger.LogWarning("OAuth callback failed: No token returned");
-                return BadRequest("Authentication failed: no token received");
-            }
-
-            logger.LogInformation("OAuth callback successful, setting auth cookies");
-
-            var cookies = new CookieJar();
-            cookies.AddCookiesForAuthToken(token);
-            cookies.AddCookiesForAuthSessionData(tempSession.AuthSessionData);
-            cookies.AddCookiesForBrokeredSessions(tempSession.BrokeredSessions);
-            cookies.WriteToResponse(Response);
-
-            var path = (serverArgs.BasePath ?? "").Trim().Replace('\\', '/').TrimStart('/').TrimEnd('/');
-            var redirectUrl = string.IsNullOrEmpty(path) ? "/?oauthLogin=1" : $"/{path}/?oauthLogin=1";
-            return LocalRedirect(redirectUrl);
         }
-        catch (Exception ex)
+        else
         {
-            logger.LogError(ex, "OAuth callback failed: Error processing callback");
-            return BadRequest($"Authentication error: {ex.Message}");
+            // Connected account flow
+            if (!sessionStore.Sessions.TryGetValue(pending.ConnectionId, out var appSession))
+            {
+                logger.LogWarning("OAuth callback failed: Session not found for connection {ConnectionId}",
+                    SanitizeForLog(pending.ConnectionId));
+                return BadRequest("Session not found");
+            }
+
+            var connectedAccountsService = appSession.AppServices.GetService<IConnectedAccountsService>();
+            if (connectedAccountsService == null)
+            {
+                logger.LogWarning("OAuth callback failed: Connected accounts service not configured");
+                return BadRequest("Connected accounts not configured");
+            }
+
+            try
+            {
+                var token = await connectedAccountsService.HandleConnectCallbackAsync(
+                    pending.Provider,
+                    HttpContext.Request,
+                    HttpContext.RequestAborted);
+
+                if (token == null)
+                {
+                    logger.LogWarning("OAuth callback failed: No token returned for provider {Provider}",
+                        SanitizeForLog(pending.Provider));
+                    return BadRequest("Authentication failed: no token received");
+                }
+
+                logger.LogInformation("Connected account callback successful for provider {Provider}",
+                    SanitizeForLog(pending.Provider));
+
+                return LocalRedirect(redirectUrl);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "OAuth callback failed: Error processing connected account callback for provider {Provider}", SanitizeForLog(pending.Provider));
+                return BadRequest($"Authentication error: {ex.Message}");
+            }
         }
     }
 

--- a/src/Ivy/Core/Auth/AuthController.cs
+++ b/src/Ivy/Core/Auth/AuthController.cs
@@ -18,25 +18,38 @@ public class AuthController() : Controller
     [Route("ivy/auth/oauth-login")]
     [HttpGet]
     public async Task<IActionResult> OAuthLogin(
-        [FromQuery] string optionId,
-        [FromQuery] string callbackId,
-        [FromQuery] string connectionId,
-        [FromQuery] string? provider,
+        [FromQuery] string loginId,
+        [FromServices] IOAuthLoginRegistry loginRegistry,
+        [FromServices] IOAuthCallbackRegistry callbackRegistry,
         [FromServices] AppSessionStore sessionStore,
         [FromServices] ServerArgs serverArgs,
         [FromServices] ILogger<AuthController> logger)
     {
-        if (string.IsNullOrWhiteSpace(optionId) || string.IsNullOrWhiteSpace(callbackId) || string.IsNullOrWhiteSpace(connectionId))
+        if (string.IsNullOrWhiteSpace(loginId))
         {
-            logger.LogWarning("OAuth login failed: Missing required parameters");
+            logger.LogWarning("OAuth login failed: Missing loginId");
             return BadRequest("Authentication error");
         }
+
+        var pending = loginRegistry.GetAndRemove(loginId);
+        if (pending == null)
+        {
+            logger.LogWarning("OAuth login failed: Invalid or expired loginId");
+            return BadRequest("Invalid or expired login request. Please try again.");
+        }
+
+        var connectionId = pending.ConnectionId;
+        var optionId = pending.OptionId;
+        var provider = pending.Provider;
 
         if (!sessionStore.Sessions.TryGetValue(connectionId, out var appSession))
         {
             logger.LogWarning("OAuth login failed: Session not found for connection {ConnectionId}", SanitizeForLog(connectionId));
             return BadRequest("Authentication error");
         }
+
+        // Register callback server-side
+        var callbackId = callbackRegistry.RegisterPending(connectionId, optionId, provider);
 
         // Construct the OAuth callback endpoint
         var scheme = HttpContext.Request.Scheme;
@@ -68,13 +81,12 @@ public class AuthController() : Controller
 
             try
             {
-                // Get the OAuth URI and redirect to it
                 var uri = await authService.GetOAuthUriAsync(option, callback, HttpContext.RequestAborted);
                 return Redirect(uri.ToString());
             }
             catch (Exception ex)
             {
-                logger.LogError(ex, "OAuth login failed: Error initiating OAuth for option '{OptionId}' on connection {ConnectionId}", optionId.Replace("\n", "").Replace("\r", ""), connectionId.Replace("\n", "").Replace("\r", ""));
+                logger.LogError(ex, "OAuth login failed: Error initiating OAuth for option '{OptionId}' on connection {ConnectionId}", SanitizeForLog(optionId), SanitizeForLog(connectionId));
                 return BadRequest("Authentication error");
             }
         }

--- a/src/Ivy/Core/Auth/OAuthCallbackRegistry.cs
+++ b/src/Ivy/Core/Auth/OAuthCallbackRegistry.cs
@@ -4,12 +4,12 @@ namespace Ivy.Core.Auth;
 
 public interface IOAuthCallbackRegistry
 {
-    string RegisterPending(string connectionId, string optionId);
+    string RegisterPending(string connectionId, string optionId, string? provider = null);
 
     PendingOAuthCallback? GetAndRemove(string state);
 }
 
-public record PendingOAuthCallback(string ConnectionId, string OptionId, DateTime CreatedAt);
+public record PendingOAuthCallback(string ConnectionId, string OptionId, DateTime CreatedAt, string? Provider = null);
 
 public class OAuthCallbackRegistry : IOAuthCallbackRegistry
 {
@@ -18,12 +18,12 @@ public class OAuthCallbackRegistry : IOAuthCallbackRegistry
     private DateTime _lastCleanup = DateTime.UtcNow;
     private static readonly TimeSpan CleanupInterval = TimeSpan.FromMinutes(1);
 
-    public string RegisterPending(string connectionId, string optionId)
+    public string RegisterPending(string connectionId, string optionId, string? provider = null)
     {
         CleanupExpiredIfNeeded();
 
         var state = Guid.NewGuid().ToString();
-        _pending[state] = new PendingOAuthCallback(connectionId, optionId, DateTime.UtcNow);
+        _pending[state] = new PendingOAuthCallback(connectionId, optionId, DateTime.UtcNow, provider);
         return state;
     }
 

--- a/src/Ivy/Core/Auth/OAuthLoginRegistry.cs
+++ b/src/Ivy/Core/Auth/OAuthLoginRegistry.cs
@@ -1,0 +1,70 @@
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+
+namespace Ivy.Core.Auth;
+
+public interface IOAuthLoginRegistry
+{
+    string RegisterPending(string connectionId, string optionId, string? provider = null);
+
+    PendingOAuthLogin? GetAndRemove(string loginId);
+}
+
+public record PendingOAuthLogin(string ConnectionId, string OptionId, DateTime CreatedAt, string? Provider = null);
+
+public class OAuthLoginRegistry : IOAuthLoginRegistry
+{
+    private readonly ConcurrentDictionary<string, PendingOAuthLogin> _pending = new();
+    private static readonly TimeSpan Expiration = TimeSpan.FromMinutes(10);
+    private DateTime _lastCleanup = DateTime.UtcNow;
+    private static readonly TimeSpan CleanupInterval = TimeSpan.FromMinutes(1);
+
+    public string RegisterPending(string connectionId, string optionId, string? provider = null)
+    {
+        CleanupExpiredIfNeeded();
+
+        var loginId = GenerateSecureKey();
+        _pending[loginId] = new PendingOAuthLogin(connectionId, optionId, DateTime.UtcNow, provider);
+        return loginId;
+    }
+
+    public PendingOAuthLogin? GetAndRemove(string loginId)
+    {
+        if (string.IsNullOrEmpty(loginId))
+            return null;
+
+        if (_pending.TryRemove(loginId, out var login))
+        {
+            if (DateTime.UtcNow - login.CreatedAt < Expiration)
+                return login;
+        }
+
+        return null;
+    }
+
+    private static string GenerateSecureKey()
+    {
+        Span<byte> bytes = stackalloc byte[32];
+        RandomNumberGenerator.Fill(bytes);
+        return Convert.ToBase64String(bytes, Base64FormattingOptions.None)
+            .Replace('+', '-').Replace('/', '_').TrimEnd('=');
+    }
+
+    private void CleanupExpiredIfNeeded()
+    {
+        if (DateTime.UtcNow - _lastCleanup < CleanupInterval)
+            return;
+
+        _lastCleanup = DateTime.UtcNow;
+
+        var expiredKeys = _pending
+            .Where(kvp => DateTime.UtcNow - kvp.Value.CreatedAt > Expiration)
+            .Select(kvp => kvp.Key)
+            .ToList();
+
+        foreach (var key in expiredKeys)
+        {
+            _pending.TryRemove(key, out _);
+        }
+    }
+}

--- a/src/Ivy/Core/Server/AppHub.cs
+++ b/src/Ivy/Core/Server/AppHub.cs
@@ -448,6 +448,11 @@ public class AppHub(
                 }
             }
         }
+        catch (OperationCanceledException) when (Context.ConnectionAborted.IsCancellationRequested)
+        {
+            logger.LogInformation("Client {ConnectionId} disconnected during connection setup", Context.ConnectionId);
+            return;
+        }
         catch (Exception ex)
         {
             logger.LogError(ex, "Failed to connect client {ConnectionId}", Context.ConnectionId);
@@ -520,6 +525,7 @@ public class AppHub(
                                 kvp.Value.Cancel();
                                 kvp.Value.Dispose();
                             }
+                            catch (ObjectDisposedException) { }
                             catch (Exception ex)
                             {
                                 logger.LogWarning(ex, "Error cancelling brokered token refresh loop for provider {Provider} on connection {ConnectionId}", kvp.Key, Context.ConnectionId);
@@ -555,6 +561,7 @@ public class AppHub(
                                 kvp.Value.Cancel();
                                 kvp.Value.Dispose();
                             }
+                            catch (ObjectDisposedException) { }
                             catch (Exception ex)
                             {
                                 logger.LogWarning(ex, "Error cancelling connected account refresh loop for provider {Provider} on connection {ConnectionId}", kvp.Key, Context.ConnectionId);

--- a/src/Ivy/Core/Server/AppHub.cs
+++ b/src/Ivy/Core/Server/AppHub.cs
@@ -366,12 +366,8 @@ public class AppHub(
                     // Subscribe to new brokered auth sessions being added
                     Action<string> addedHandler = provider =>
                     {
-                        // Check if connection is still active
-                        if (!sessionStore.Sessions.ContainsKey(connectionId))
-                        {
-                            return;
-                        }
-
+                        if (connectionAborted.IsCancellationRequested) return;
+                        if (!sessionStore.Sessions.ContainsKey(connectionId)) return;
                         AddProvider(provider);
                     };
 
@@ -424,6 +420,7 @@ public class AppHub(
 
                     Action<string> connectedAddedHandler = provider =>
                     {
+                        if (connectionAborted.IsCancellationRequested) return;
                         if (!sessionStore.Sessions.ContainsKey(connectionId)) return;
                         AddConnectedProvider(provider);
                     };
@@ -655,6 +652,9 @@ public class AppHub(
 
                             if (!isValid)
                             {
+                                // If validation "failed" because the connection was aborted
+                                // (and the handler swallowed the TaskCanceledException), exit cleanly.
+                                cancellationToken.ThrowIfCancellationRequested();
                                 state = TokenRefreshState.TokenInvalid;
                             }
                             else
@@ -713,6 +713,7 @@ public class AppHub(
                             }
                             else
                             {
+                                cancellationToken.ThrowIfCancellationRequested();
                                 logger.LogError("{StrategyName}RefreshLoop: Token refresh failed for {ConnectionId}.", strategy.LoggingName, connectionId);
                                 var shouldContinue = await strategy.OnRefreshFailedAsync();
                                 if (!shouldContinue)
@@ -726,7 +727,7 @@ public class AppHub(
 
                 consecutiveErrors = 0;
             }
-            catch (TaskCanceledException)
+            catch (OperationCanceledException)
             {
                 logger.LogInformation("{StrategyName}RefreshLoop: cancelled for {ConnectionId}", strategy.LoggingName, connectionId);
                 return;

--- a/src/Ivy/Server.cs
+++ b/src/Ivy/Server.cs
@@ -686,6 +686,7 @@ public class Server
         builder.Services.AddSingleton(_contentBuilder ?? new DefaultContentBuilder());
         builder.Services.AddSingleton(sessionStore);
         builder.Services.AddSingleton<IOAuthCallbackRegistry, OAuthCallbackRegistry>();
+        builder.Services.AddSingleton<IOAuthLoginRegistry, OAuthLoginRegistry>();
         builder.Services.AddSingleton<IConfiguration>(builder.Configuration);
         builder.Services.AddHealthChecks();
         builder.Services.AddQueryManager();

--- a/src/auth/Ivy.Auth.GitHub/GitHubAuthTokenHandler.cs
+++ b/src/auth/Ivy.Auth.GitHub/GitHubAuthTokenHandler.cs
@@ -50,7 +50,8 @@ public class GitHubAuthTokenHandler : IAuthTokenHandler
         }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
         {
-            _logger.LogError(ex, "Exception during GitHub token validation");
+            if (!cancellationToken.IsCancellationRequested)
+                _logger.LogError(ex, "Exception during GitHub token validation");
             return false;
         }
     }

--- a/src/auth/examples/BasicAuthExample/MainApp.cs
+++ b/src/auth/examples/BasicAuthExample/MainApp.cs
@@ -59,7 +59,7 @@ public class ConnectedGitHubSection : ViewBase
     public override object? Build()
     {
         var appContext = UseService<Ivy.AppContext>();
-        var registry = UseService<IOAuthCallbackRegistry>();
+        var loginRegistry = UseService<IOAuthLoginRegistry>();
         var connected = UseState(() => _connectedAccounts.GetAccountSession(OAuthProviders.GitHub)?.AuthToken != null);
 
         UseEffect(() =>
@@ -86,7 +86,7 @@ public class ConnectedGitHubSection : ViewBase
                 new Button("Connect GitHub")
                     .Icon(Icons.Github)
                     .Variant(ButtonVariant.Outline)
-                    .Url(BuildConnectUrl(appContext, registry, OAuthProviders.GitHub))
+                    .Url(BuildConnectUrl(appContext, loginRegistry, OAuthProviders.GitHub))
                     .OpenInNewTab()
             ).Gap(10);
         }
@@ -105,18 +105,14 @@ public class ConnectedGitHubSection : ViewBase
         ).Gap(10);
     }
 
-    private static string BuildConnectUrl(Ivy.AppContext appContext, IOAuthCallbackRegistry registry, string provider)
+    private static string BuildConnectUrl(Ivy.AppContext appContext, IOAuthLoginRegistry loginRegistry, string provider)
     {
-        var callbackId = registry.RegisterPending(
+        var loginId = loginRegistry.RegisterPending(
             appContext.ConnectionId,
             provider,
             provider
         );
 
-        return $"{appContext.BaseUrl.TrimEnd('/')}/ivy/auth/oauth-login?" +
-               $"optionId={Uri.EscapeDataString(provider)}&" +
-               $"callbackId={Uri.EscapeDataString(callbackId)}&" +
-               $"connectionId={Uri.EscapeDataString(appContext.ConnectionId)}&" +
-               $"provider={Uri.EscapeDataString(provider)}";
+        return $"{appContext.BaseUrl.TrimEnd('/')}/ivy/auth/oauth-login?loginId={Uri.EscapeDataString(loginId)}";
     }
 }

--- a/src/auth/examples/BasicAuthExample/MainApp.cs
+++ b/src/auth/examples/BasicAuthExample/MainApp.cs
@@ -87,7 +87,7 @@ public class ConnectedGitHubSection : ViewBase
                     .Icon(Icons.Github)
                     .Variant(ButtonVariant.Outline)
                     .Url(BuildConnectUrl(appContext, registry, OAuthProviders.GitHub))
-                    .Target(LinkTarget.Self)
+                    .OpenInNewTab()
             ).Gap(10);
         }
 

--- a/src/auth/examples/BasicAuthExample/MainApp.cs
+++ b/src/auth/examples/BasicAuthExample/MainApp.cs
@@ -57,12 +57,7 @@ public class ConnectedGitHubSection : ViewBase
 
     public override object? Build()
     {
-        var client = UseService<IClientProvider>();
         var connected = UseState(() => _connectedAccounts.GetAccountSession(OAuthProviders.GitHub)?.AuthToken != null);
-        var callback = UseWebhook(async request =>
-        {
-            await _connectedAccounts.HandleConnectCallbackAsync(OAuthProviders.GitHub, request);
-        });
 
         UseEffect(() =>
         {
@@ -85,11 +80,11 @@ public class ConnectedGitHubSection : ViewBase
         {
             return Layout.Vertical(
                 Text.H3("Connected Accounts"),
-                new Button("Connect GitHub", async () =>
-                {
-                    var uri = await _connectedAccounts.ConnectAccountAsync(OAuthProviders.GitHub, callback);
-                    client.OpenUrl(uri.ToString());
-                }, icon: Icons.Github, variant: ButtonVariant.Outline)
+                new Button("Connect GitHub")
+                    .Icon(Icons.Github)
+                    .Variant(ButtonVariant.Outline)
+                    .Url(BuildConnectUrl(OAuthProviders.GitHub))
+                    .Target(LinkTarget.Self)
             ).Gap(10);
         }
 
@@ -105,5 +100,23 @@ public class ConnectedGitHubSection : ViewBase
             ).Gap(10).AlignContent(Align.Center),
             new OAuthProviderTestView(OAuthProviders.GitHub, gitHubSession!)
         ).Gap(10);
+    }
+
+    private string BuildConnectUrl(string provider)
+    {
+        var appContext = UseService<AppContext>();
+        var registry = UseService<IOAuthCallbackRegistry>();
+
+        var callbackId = registry.RegisterPending(
+            appContext.ConnectionId,
+            provider,
+            provider
+        );
+
+        return $"{appContext.BaseUrl.TrimEnd('/')}/ivy/auth/oauth-login?" +
+               $"optionId={Uri.EscapeDataString(provider)}&" +
+               $"callbackId={Uri.EscapeDataString(callbackId)}&" +
+               $"connectionId={Uri.EscapeDataString(appContext.ConnectionId)}&" +
+               $"provider={Uri.EscapeDataString(provider)}";
     }
 }

--- a/src/auth/examples/BasicAuthExample/MainApp.cs
+++ b/src/auth/examples/BasicAuthExample/MainApp.cs
@@ -1,6 +1,7 @@
 using System.Reactive.Disposables;
 using Ivy;
 using Ivy.Auth.Examples.Shared;
+using Ivy.Core.Auth;
 
 namespace BasicAuthExample;
 
@@ -57,6 +58,8 @@ public class ConnectedGitHubSection : ViewBase
 
     public override object? Build()
     {
+        var appContext = UseService<Ivy.AppContext>();
+        var registry = UseService<IOAuthCallbackRegistry>();
         var connected = UseState(() => _connectedAccounts.GetAccountSession(OAuthProviders.GitHub)?.AuthToken != null);
 
         UseEffect(() =>
@@ -83,7 +86,7 @@ public class ConnectedGitHubSection : ViewBase
                 new Button("Connect GitHub")
                     .Icon(Icons.Github)
                     .Variant(ButtonVariant.Outline)
-                    .Url(BuildConnectUrl(OAuthProviders.GitHub))
+                    .Url(BuildConnectUrl(appContext, registry, OAuthProviders.GitHub))
                     .Target(LinkTarget.Self)
             ).Gap(10);
         }
@@ -102,11 +105,8 @@ public class ConnectedGitHubSection : ViewBase
         ).Gap(10);
     }
 
-    private string BuildConnectUrl(string provider)
+    private static string BuildConnectUrl(Ivy.AppContext appContext, IOAuthCallbackRegistry registry, string provider)
     {
-        var appContext = UseService<AppContext>();
-        var registry = UseService<IOAuthCallbackRegistry>();
-
         var callbackId = registry.RegisterPending(
             appContext.ConnectionId,
             provider,

--- a/src/frontend/src/hooks/use-backend.tsx
+++ b/src/frontend/src/hooks/use-backend.tsx
@@ -683,13 +683,17 @@ export const useBackend = (
     // Check if this is an OAuth login redirect
     const pageParams = new URLSearchParams(window.location.search);
     const oauthLogin = pageParams.get("oauthLogin");
+    const connectedAccountLogin = pageParams.get("connectedAccountLogin");
 
     // Build SignalR connection URL
     let signalRUrl = `${getIvyHost()}/ivy/messages?appId=${latestAppIdRef.current ?? ""}&appArgs=${appArgs ?? ""}&machineId=${machineId}&parentId=${parentId ?? ""}&shell=${latestAppShellRef.current}`;
     if (oauthLogin) {
       signalRUrl += `&oauthLogin=${oauthLogin}`;
-      // Clean up the URL by removing the oauthLogin parameter
+    }
+    // Clean up auth-related query parameters from the URL
+    if (oauthLogin || connectedAccountLogin) {
       pageParams.delete("oauthLogin");
+      pageParams.delete("connectedAccountLogin");
       const newUrl = pageParams.toString()
         ? `${window.location.pathname}?${pageParams.toString()}`
         : window.location.pathname;


### PR DESCRIPTION
# Summary

## Changes

Unified the OAuth flow for connected accounts by extending the existing authentication endpoints (`/ivy/auth/oauth-login` and `/ivy/auth/callback`) to support both main authentication and connected account linking. The connected account flow now redirects through the same endpoints in the same tab instead of opening a separate tab.

## API Changes

**`IOAuthCallbackRegistry` interface:**
- `RegisterPending(string connectionId, string optionId, string? provider = null)` - Added optional `provider` parameter

**`PendingOAuthCallback` record:**
- Added `Provider` field (nullable string) to distinguish between main auth and connected account flows

**`AuthController.OAuthLogin` endpoint:**
- Added `provider` query parameter
- Branches logic based on `provider` value: null = main auth, non-null = connected account

**`AuthController.OAuthCallback` endpoint:**
- Checks `PendingOAuthCallback.Provider` field to determine flow type
- Routes to `IConnectedAccountsService.HandleConnectCallbackAsync` for connected accounts

**`ConnectedGitHubSection` in BasicAuthExample:**
- Removed webhook-based callback pattern
- Added `BuildConnectUrl()` helper method
- Changed "Connect GitHub" button to use `.Url()` with redirect to `/ivy/auth/oauth-login`

## Files Modified

**Core Authentication:**
- `src/Ivy/Core/Auth/OAuthCallbackRegistry.cs` - Extended interface and record with optional provider parameter
- `src/Ivy/Core/Auth/AuthController.cs` - Added branching logic in both OAuth endpoints

**Example Application:**
- `src/auth/examples/BasicAuthExample/MainApp.cs` - Updated ConnectedGitHubSection to use new unified flow

## Commits

- 4853ad4d6 [00002] Handle connection abort and disposed CTS gracefully in AppHub
- a2e9fb20a [00002] Open connected account OAuth login in new tab to preserve SignalR connection
- 1df55e9fc [00002] Fix token refresh loop failing on dead connections during OAuth flow
- 4f9155a5c Merge remote-tracking branch 'origin/development' into tendril/00002-UnifyOAuthFlowForConnectedAccounts
- 8cd1e76d9 [00002] Fix build errors in BasicAuthExample ConnectedGitHubSection
- 115076fe6 [00002] Unify OAuth flow for connected accounts