### PR TITLE
[00032] Tabs layout Content variant tabs should have same hover bg color as sidebar buttons

### DIFF
--- a/src/frontend/src/widgets/layouts/tabs/components/Variants.tsx
+++ b/src/frontend/src/widgets/layouts/tabs/components/Variants.tsx
@@ -144,7 +144,7 @@ export const ContentVariant: React.FC<ContentVariantProps> = ({
                 aria-selected={index === activeIndex}
                 tabIndex={0}
                 className={cn(
-                  "px-3 py-1.5 cursor-pointer transition-colors duration-300 h-[26px]",
+                  "px-3 py-1.5 cursor-pointer transition-colors duration-300 h-[26px] rounded-selector hover:bg-secondary",
                   index === activeIndex ? "text-foreground" : "text-muted-foreground",
                 )}
                 onClick={() => {


### PR DESCRIPTION
## Changes

Added hover background color styling to Content variant tabs in TabsLayout to match the sidebar button hover appearance. The Content variant tabs now display a secondary background color on hover, providing visual consistency across the UI.

## API Changes

None.

## Files Modified

- `src/frontend/src/widgets/layouts/tabs/components/Variants.tsx` — Added `rounded-selector hover:bg-secondary` classes to the Content variant tab button styling.

## Commits

- `6c6999c00`