### PR TITLE
[00034] Sharper inner border radius on CodeInput widget

### DIFF
--- a/src/frontend/src/widgets/inputs/code/CodeInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/code/CodeInputWidget.tsx
@@ -181,7 +181,7 @@ export const CodeInputWidget: React.FC<CodeInputWidgetProps> = ({
   const hasAffixes = hasPrefix || hasSuffix;
 
   const codeEditor = (
-    <div style={styles} className="relative w-full h-full overflow-hidden">
+    <div style={styles} className="relative w-full h-full overflow-hidden rounded-field">
       {(showCopy || showClear || invalid) && (
         <div className="absolute top-2 right-2 z-50 flex items-center">
           {showCopy && (
@@ -211,7 +211,7 @@ export const CodeInputWidget: React.FC<CodeInputWidgetProps> = ({
       )}
       <Suspense
         fallback={
-          <div className="h-full flex items-center justify-center bg-muted/20 animate-pulse rounded-field border border-input">
+          <div className="h-full flex items-center justify-center bg-muted/20 animate-pulse rounded-sm border border-input">
             <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
           </div>
         }
@@ -228,7 +228,7 @@ export const CodeInputWidget: React.FC<CodeInputWidgetProps> = ({
           data-gramm="false"
           className={cn(
             "h-full",
-            "border border-input shadow-sm rounded-field",
+            "border border-input shadow-sm rounded-sm",
             "dark:bg-white/5 dark:border-white/10",
             invalid && inputStyles.invalid,
             disabled && "opacity-50 cursor-not-allowed",


### PR DESCRIPTION
## Changes

Updated the CodeInputWidget's border radius styling to create visual hierarchy. The outer wrapper now clips to `rounded-field` while the inner CodeMirror editor uses the sharper `rounded-sm` radius (0.125rem), making the inner corners appear crisper than any parent container.

## API Changes

None - this is a purely CSS styling change with no impact to component APIs or public interfaces.

## Files Modified

- `src/frontend/src/widgets/inputs/code/CodeInputWidget.tsx` — Updated three className properties:
  - Line 184: Added `rounded-field` to outer wrapper for clipping
  - Line 214: Changed Suspense fallback from `rounded-field` to `rounded-sm`
  - Line 231: Changed inner CodeMirror from `rounded-field` to `rounded-sm`

## Commits

- `f8c8949f4` — Sharper inner border radius on CodeInput widget