### PR TITLE
[00042] Text wrap in DataTable cells

### DIFF
--- a/src/Ivy/Views/DataTables/DataTableBuilder.cs
+++ b/src/Ivy/Views/DataTables/DataTableBuilder.cs
@@ -170,6 +170,13 @@ public class DataTableBuilder<TModel>(
         return this;
     }
 
+    public DataTableBuilder<TModel> WrapText(Expression<Func<TModel, object>> field, bool wrap = true)
+    {
+        var column = GetColumn(field);
+        column.Column.WrapText = wrap;
+        return this;
+    }
+
     public DataTableBuilder<TModel> Sortable(Expression<Func<TModel, object>> field, bool sortable)
     {
         var column = GetColumn(field);

--- a/src/Ivy/Widgets/DataTables/DataTableColumn.cs
+++ b/src/Ivy/Widgets/DataTables/DataTableColumn.cs
@@ -25,6 +25,8 @@ public class DataTableColumn
     [JsonPropertyName("alignContent")]
     public Align AlignContent { get; set; } = Align.Left;
 
+    public bool WrapText { get; set; } = false;
+
     public int Order { get; set; } = 0;
     public string? Icon { get; set; } = null;
     public string? Help { get; set; } = null;

--- a/src/frontend/src/widgets/dataTables/DataTableDefaults.ts
+++ b/src/frontend/src/widgets/dataTables/DataTableDefaults.ts
@@ -20,6 +20,7 @@ export const DATA_COLUMN_DEFAULTS: Partial<DataColumn> = {
   help: null,
   footer: null,
   color: null,
+  wrapText: false,
 };
 
 // DataTableConfig defaults (DataTableConfig.cs)
@@ -57,6 +58,7 @@ export function applyColumnDefaults(column: DataColumn): DataColumn {
     filterable: column.filterable ?? DATA_COLUMN_DEFAULTS.filterable,
     alignContent: column.alignContent ?? DATA_COLUMN_DEFAULTS.alignContent,
     order: column.order ?? DATA_COLUMN_DEFAULTS.order,
+    wrapText: column.wrapText ?? DATA_COLUMN_DEFAULTS.wrapText,
   } as DataColumn;
 }
 

--- a/src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx
+++ b/src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx
@@ -69,6 +69,11 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
 
   const densityConfig = DENSITY_CONFIG[density];
 
+  const hasWrappingColumns = columns.some((c) => c.wrapText && !c.hidden);
+  const effectiveRowHeight = hasWrappingColumns
+    ? densityConfig.rowHeight * 3
+    : densityConfig.rowHeight;
+
   const {
     allowColumnReordering,
     allowColumnResizing,
@@ -184,7 +189,7 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
     visibleRows,
     hasMore,
     showGroups: showGroups ?? false,
-    rowHeight: densityConfig.rowHeight,
+    rowHeight: effectiveRowHeight,
   });
 
   // Data loading
@@ -194,7 +199,7 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
     isLoading,
     hasMore,
     loadMoreData,
-    rowHeight: densityConfig.rowHeight,
+    rowHeight: effectiveRowHeight,
   });
 
   // Generate header icons map for all column icons
@@ -306,7 +311,7 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
         onVisibleRegionChanged={handleVisibleRegionChanged}
         onHeaderClicked={allowSorting ? handleHeaderMenuClick : undefined}
         theme={tableTheme}
-        rowHeight={densityConfig.rowHeight}
+        rowHeight={effectiveRowHeight}
         headerHeight={densityConfig.rowHeight}
         freezeColumns={freezeColumns ?? 0}
         getCellsForSelection={(allowCopySelection ?? true) ? true : undefined}

--- a/src/frontend/src/widgets/dataTables/types/types.ts
+++ b/src/frontend/src/widgets/dataTables/types/types.ts
@@ -42,6 +42,7 @@ export interface DataColumn {
   iconSet?: "lucide" | "custom";
   color?: string | null;
   badgeColorMapping?: Record<string, string> | null;
+  wrapText?: boolean;
 }
 
 export interface DataTableConnection {

--- a/src/frontend/src/widgets/dataTables/utils/cellContent.test.ts
+++ b/src/frontend/src/widgets/dataTables/utils/cellContent.test.ts
@@ -22,6 +22,7 @@ import {
   lookupBadgeColorMapping,
 } from "./cellContent";
 import { DataColumn, DataRow, ColType } from "../types/types";
+import { applyColumnDefaults } from "../DataTableDefaults";
 import type { LabelsBadgesCellData } from "./customRenderers";
 
 describe("cellContent utilities", () => {
@@ -815,6 +816,81 @@ describe("cellContent utilities", () => {
 
       const cell = getCellContent([0, 0], labelsColumns, [], true, getLabelsRowData3);
       expect(cell.contentAlign).toBe("right");
+    });
+  });
+
+  describe("wrapText support", () => {
+    it("should set allowWrapping on text cell when wrapText is true", () => {
+      const cell = createTextCell("hello world", false, undefined, true);
+      expect(cell.kind).toBe(GridCellKind.Text);
+      if (cell.kind === GridCellKind.Text) {
+        expect(cell.allowWrapping).toBe(true);
+      }
+    });
+
+    it("should set allowWrapping to false on text cell when wrapText is false", () => {
+      const cell = createTextCell("hello", false, undefined, false);
+      if (cell.kind === GridCellKind.Text) {
+        expect(cell.allowWrapping).toBe(false);
+      }
+    });
+
+    it("should set allowWrapping to false on text cell when wrapText is undefined", () => {
+      const cell = createTextCell("hello", false);
+      if (cell.kind === GridCellKind.Text) {
+        expect(cell.allowWrapping).toBe(false);
+      }
+    });
+
+    it("should set allowWrapping on date cell when wrapText is true", () => {
+      const cell = createDateCell("2025-01-01", "date", false, undefined, true);
+      expect(cell).not.toBeNull();
+      if (cell && cell.kind === GridCellKind.Text) {
+        expect(cell.allowWrapping).toBe(true);
+      }
+    });
+
+    it("should pass wrapText through getCellContent to text cells", () => {
+      const wrapColumns: DataColumn[] = [
+        { name: "Description", type: ColType.Text, width: 200, wrapText: true },
+      ];
+      const wrapData: DataRow[] = [{ values: ["Long text content"] }];
+      const getWrapRowData = (rowIndex: number): DataRow | null => {
+        return rowIndex >= 0 && rowIndex < wrapData.length ? wrapData[rowIndex] : null;
+      };
+
+      const cell = getCellContent([0, 0], wrapColumns, [], false, getWrapRowData);
+      expect(cell.kind).toBe(GridCellKind.Text);
+      if (cell.kind === GridCellKind.Text) {
+        expect(cell.allowWrapping).toBe(true);
+      }
+    });
+
+    it("should not wrap text by default in getCellContent", () => {
+      const noWrapColumns: DataColumn[] = [{ name: "Name", type: ColType.Text, width: 100 }];
+      const noWrapData: DataRow[] = [{ values: ["Some text"] }];
+      const getNoWrapRowData = (rowIndex: number): DataRow | null => {
+        return rowIndex >= 0 && rowIndex < noWrapData.length ? noWrapData[rowIndex] : null;
+      };
+
+      const cell = getCellContent([0, 0], noWrapColumns, [], false, getNoWrapRowData);
+      if (cell.kind === GridCellKind.Text) {
+        expect(cell.allowWrapping).toBe(false);
+      }
+    });
+  });
+
+  describe("applyColumnDefaults wrapText", () => {
+    it("should default wrapText to false when not specified", () => {
+      const column: DataColumn = { name: "Test", type: ColType.Text, width: 100 };
+      const result = applyColumnDefaults(column);
+      expect(result.wrapText).toBe(false);
+    });
+
+    it("should preserve wrapText when explicitly set to true", () => {
+      const column: DataColumn = { name: "Test", type: ColType.Text, width: 100, wrapText: true };
+      const result = applyColumnDefaults(column);
+      expect(result.wrapText).toBe(true);
     });
   });
 });

--- a/src/frontend/src/widgets/dataTables/utils/cellContent.ts
+++ b/src/frontend/src/widgets/dataTables/utils/cellContent.ts
@@ -142,6 +142,7 @@ export function createDateCell(
   columnType: string,
   editable: boolean,
   align?: Align,
+  wrapText?: boolean,
 ): GridCell | null {
   const dateValue = parseDateValue(cellValue);
 
@@ -158,6 +159,7 @@ export function createDateCell(
     allowOverlay: editable,
     readonly: !editable,
     contentAlign: align ? getContentAlign(align) : undefined,
+    allowWrapping: wrapText ?? false,
   };
 }
 
@@ -200,7 +202,12 @@ export function createBooleanCell(cellValue: boolean, editable: boolean, align?:
 /**
  * Creates a text cell
  */
-export function createTextCell(cellValue: unknown, editable: boolean, align?: Align): GridCell {
+export function createTextCell(
+  cellValue: unknown,
+  editable: boolean,
+  align?: Align,
+  wrapText?: boolean,
+): GridCell {
   const stringValue = String(cellValue);
 
   return {
@@ -210,6 +217,7 @@ export function createTextCell(cellValue: unknown, editable: boolean, align?: Al
     allowOverlay: editable,
     readonly: !editable,
     contentAlign: align ? getContentAlign(align) : undefined,
+    allowWrapping: wrapText ?? false,
   };
 }
 
@@ -409,7 +417,7 @@ export function getCellContent(
 
   // Handle Date and DateTime types
   if (isDateColumnType(columnType)) {
-    const dateCell = createDateCell(cellValue, columnType, editable, align);
+    const dateCell = createDateCell(cellValue, columnType, editable, align, column.wrapText);
     if (dateCell) {
       return dateCell;
     }
@@ -430,7 +438,7 @@ export function getCellContent(
   // Now that column.type is properly preserved from backend (#1273), we don't need this fallback
 
   // Default to text
-  return createTextCell(cellValue, editable, align);
+  return createTextCell(cellValue, editable, align, column.wrapText);
 }
 
 /**


### PR DESCRIPTION
## Changes

Added per-column text wrapping support to the DataTable widget. A new `WrapText` boolean property on `DataTableColumn` enables glide-data-grid's built-in `allowWrapping` on text and date cells. When any visible column has wrapping enabled, the DataTableEditor automatically triples the row height to accommodate multi-line content.

## API Changes

- **`DataTableColumn.WrapText`** (C#) — new `bool` property, defaults to `false`
- **`DataTableBuilder<TModel>.WrapText(field, wrap)`** (C#) — new fluent builder method to enable text wrapping on a column
- **`DataColumn.wrapText`** (TypeScript) — new optional boolean on the `DataColumn` interface
- **`createTextCell(cellValue, editable, align, wrapText?)`** — added optional `wrapText` parameter
- **`createDateCell(cellValue, columnType, editable, align, wrapText?)`** — added optional `wrapText` parameter

## Files Modified

- **Backend:**
  - `src/Ivy/Widgets/DataTables/DataTableColumn.cs` — added `WrapText` property
  - `src/Ivy/Views/DataTables/DataTableBuilder.cs` — added `WrapText()` fluent method

- **Frontend:**
  - `src/frontend/src/widgets/dataTables/types/types.ts` — added `wrapText` to `DataColumn` interface
  - `src/frontend/src/widgets/dataTables/DataTableDefaults.ts` — added `wrapText: false` default
  - `src/frontend/src/widgets/dataTables/utils/cellContent.ts` — pass `allowWrapping` to text and date cells
  - `src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx` — compute `effectiveRowHeight` based on wrapping columns

- **Tests:**
  - `src/frontend/src/widgets/dataTables/utils/cellContent.test.ts` — 8 new test cases for wrapText behavior

## Commits

- `64017fb2a` — Text wrap in DataTable cells