### PR TITLE
[00049] Simplify chart hover tooltip styling

### DIFF
--- a/src/frontend/src/widgets/charts/AreaChartWidget.tsx
+++ b/src/frontend/src/widgets/charts/AreaChartWidget.tsx
@@ -193,6 +193,7 @@ const AreaChartWidget: React.FC<AreaChartWidgetProps> = ({
           fontSans: themeColors.fontSans,
           background: themeColors.background,
           mutedForeground: themeColors.mutedForeground,
+          card: themeColors.card,
         }),
         formatter: (params: any) => {
           const extractValue = (p: any) =>
@@ -227,6 +228,7 @@ const AreaChartWidget: React.FC<AreaChartWidgetProps> = ({
         isVertical,
         {
           mutedForeground: themeColors.mutedForeground,
+          card: themeColors.card,
           fontSans: themeColors.fontSans,
         },
         cartesianGrid,
@@ -241,6 +243,7 @@ const AreaChartWidget: React.FC<AreaChartWidgetProps> = ({
         undefined,
         {
           mutedForeground: themeColors.mutedForeground,
+          card: themeColors.card,
           fontSans: themeColors.fontSans,
         },
         cartesianGrid,

--- a/src/frontend/src/widgets/charts/BarChartWidget.tsx
+++ b/src/frontend/src/widgets/charts/BarChartWidget.tsx
@@ -218,6 +218,7 @@ const BarChartWidget: React.FC<BarChartWidgetProps> = ({
         isVertical,
         {
           mutedForeground: themeColors.mutedForeground,
+          card: themeColors.card,
           fontSans: themeColors.fontSans,
         },
         cartesianGrid,
@@ -232,6 +233,7 @@ const BarChartWidget: React.FC<BarChartWidgetProps> = ({
         categories,
         {
           mutedForeground: themeColors.mutedForeground,
+          card: themeColors.card,
           fontSans: themeColors.fontSans,
         },
         cartesianGrid,
@@ -247,6 +249,7 @@ const BarChartWidget: React.FC<BarChartWidgetProps> = ({
           fontSans: themeColors.fontSans,
           background: themeColors.background,
           mutedForeground: themeColors.mutedForeground,
+          card: themeColors.card,
         }),
         formatter: (params: any) => {
           const extractValue = (p: any) =>

--- a/src/frontend/src/widgets/charts/ChordChartWidget.tsx
+++ b/src/frontend/src/widgets/charts/ChordChartWidget.tsx
@@ -103,6 +103,7 @@ const ChordChartWidget: React.FC<ChordChartWidgetProps> = ({
           fontSans: themeColors.fontSans,
           background: themeColors.background,
           mutedForeground: themeColors.mutedForeground,
+          card: themeColors.card,
         }),
         trigger: "item",
       },

--- a/src/frontend/src/widgets/charts/FunnelChartWidget.tsx
+++ b/src/frontend/src/widgets/charts/FunnelChartWidget.tsx
@@ -175,6 +175,7 @@ const FunnelChartWidget: React.FC<FunnelChartWidgetProps> = ({
           fontSans: themeColors.fontSans,
           background: themeColors.background,
           mutedForeground: themeColors.mutedForeground,
+          card: themeColors.card,
         }),
         trigger: "item" as const,
         formatter: (params: { name: string; value: number; percent: number; marker: string }) => {

--- a/src/frontend/src/widgets/charts/LineChartWidget.tsx
+++ b/src/frontend/src/widgets/charts/LineChartWidget.tsx
@@ -83,6 +83,7 @@ const LineChartWidget: React.FC<LineChartWidgetProps> = ({
         isVertical,
         {
           mutedForeground: themeColors.mutedForeground,
+          card: themeColors.card,
           fontSans: themeColors.fontSans,
         },
         cartesianGrid,
@@ -97,6 +98,7 @@ const LineChartWidget: React.FC<LineChartWidgetProps> = ({
         undefined,
         {
           mutedForeground: themeColors.mutedForeground,
+          card: themeColors.card,
           fontSans: themeColors.fontSans,
         },
         cartesianGrid,
@@ -107,6 +109,7 @@ const LineChartWidget: React.FC<LineChartWidgetProps> = ({
           fontSans: themeColors.fontSans,
           background: themeColors.background,
           mutedForeground: themeColors.mutedForeground,
+          card: themeColors.card,
         }),
         formatter: (params: any) => {
           const extractValue = (p: any) =>

--- a/src/frontend/src/widgets/charts/PieChartWidget.tsx
+++ b/src/frontend/src/widgets/charts/PieChartWidget.tsx
@@ -165,6 +165,7 @@ const PieChartWidget: React.FC<PieChartWidgetProps> = ({
           fontSans: themeColors.fontSans,
           background: themeColors.background,
           mutedForeground: themeColors.mutedForeground,
+          card: themeColors.card,
         }),
         trigger: "item",
         formatter: (params: { name: string; value: number; percent: number; marker: string }) => {

--- a/src/frontend/src/widgets/charts/RadarChartWidget.tsx
+++ b/src/frontend/src/widgets/charts/RadarChartWidget.tsx
@@ -193,6 +193,7 @@ const RadarChartWidget: React.FC<RadarChartWidgetProps> = ({
           fontSans: themeColors.fontSans,
           background: themeColors.background,
           mutedForeground: themeColors.mutedForeground,
+          card: themeColors.card,
         }),
         trigger: "item",
       },

--- a/src/frontend/src/widgets/charts/SankeyChartWidget.tsx
+++ b/src/frontend/src/widgets/charts/SankeyChartWidget.tsx
@@ -62,6 +62,7 @@ const SankeyChartWidget: React.FC<SankeyChartWidgetProps> = ({
           fontSans: themeColors.fontSans,
           background: themeColors.background,
           mutedForeground: themeColors.mutedForeground,
+          card: themeColors.card,
         }),
         trigger: "item",
         formatter: (params: any) => {

--- a/src/frontend/src/widgets/charts/ScatterChartWidget.tsx
+++ b/src/frontend/src/widgets/charts/ScatterChartWidget.tsx
@@ -373,12 +373,12 @@ const ScatterChartWidget: React.FC<ScatterChartWidgetProps> = ({
       grid: generateEChartGrid(cartesianGrid, !!toolbox && toolbox.enabled !== false, yAxis, xAxis),
       xAxis: generateScatterXAxis(xAxis, {
         mutedForeground: themeColors.mutedForeground,
-          card: themeColors.card,
+        card: themeColors.card,
         fontSans: themeColors.fontSans,
       }),
       yAxis: generateScatterYAxis(yAxis, {
         mutedForeground: themeColors.mutedForeground,
-          card: themeColors.card,
+        card: themeColors.card,
         fontSans: themeColors.fontSans,
       }),
       tooltip: {

--- a/src/frontend/src/widgets/charts/ScatterChartWidget.tsx
+++ b/src/frontend/src/widgets/charts/ScatterChartWidget.tsx
@@ -373,10 +373,12 @@ const ScatterChartWidget: React.FC<ScatterChartWidgetProps> = ({
       grid: generateEChartGrid(cartesianGrid, !!toolbox && toolbox.enabled !== false, yAxis, xAxis),
       xAxis: generateScatterXAxis(xAxis, {
         mutedForeground: themeColors.mutedForeground,
+          card: themeColors.card,
         fontSans: themeColors.fontSans,
       }),
       yAxis: generateScatterYAxis(yAxis, {
         mutedForeground: themeColors.mutedForeground,
+          card: themeColors.card,
         fontSans: themeColors.fontSans,
       }),
       tooltip: {
@@ -385,6 +387,7 @@ const ScatterChartWidget: React.FC<ScatterChartWidgetProps> = ({
           fontSans: themeColors.fontSans,
           background: themeColors.background,
           mutedForeground: themeColors.mutedForeground,
+          card: themeColors.card,
         }),
         formatter: (params: any) => {
           const xValue = formatTooltipValue(params.value[0], tooltip);

--- a/src/frontend/src/widgets/charts/sharedUtils.ts
+++ b/src/frontend/src/widgets/charts/sharedUtils.ts
@@ -720,7 +720,8 @@ export const generateTooltip = (
     textStyle: generateTextStyle(themeColors?.foreground, themeColors?.fontSans),
     backgroundColor: themeColors?.card || themeColors?.background || "rgba(255, 255, 255, 0.9)",
     borderWidth: 0,
-    extraCssText: "min-width: 180px; box-shadow: 0 4px 6px -1px rgba(0,0,0,.1), 0 2px 4px -2px rgba(0,0,0,.1);",
+    extraCssText:
+      "min-width: 180px; box-shadow: 0 4px 6px -1px rgba(0,0,0,.1), 0 2px 4px -2px rgba(0,0,0,.1);",
   };
 };
 

--- a/src/frontend/src/widgets/charts/sharedUtils.ts
+++ b/src/frontend/src/widgets/charts/sharedUtils.ts
@@ -679,6 +679,7 @@ export const generateTooltip = (
     fontSans: string;
     background: string;
     mutedForeground?: string;
+    card?: string;
   },
   valueFormat?: {
     formatter?: string | null;
@@ -717,9 +718,9 @@ export const generateTooltip = (
         ),
     }),
     textStyle: generateTextStyle(themeColors?.foreground, themeColors?.fontSans),
-    backgroundColor: themeColors?.background || "rgba(255, 255, 255, 0.9)",
-    borderColor: themeColors?.foreground || "#000",
-    borderWidth: 1,
+    backgroundColor: themeColors?.card || themeColors?.background || "rgba(255, 255, 255, 0.9)",
+    borderWidth: 0,
+    extraCssText: "min-width: 180px; box-shadow: 0 4px 6px -1px rgba(0,0,0,.1), 0 2px 4px -2px rgba(0,0,0,.1);",
   };
 };
 

--- a/src/frontend/src/widgets/charts/styles/theme.ts
+++ b/src/frontend/src/widgets/charts/styles/theme.ts
@@ -8,6 +8,7 @@ export interface ChartThemeColors {
   mutedForeground: string;
   fontSans: string;
   background: string;
+  card: string;
 }
 
 /**
@@ -39,6 +40,7 @@ export const getChartThemeColors = (colors: ThemeColors, isDark: boolean): Chart
     mutedForeground: colors.mutedForeground || (isDark ? "#a1a1aa" : "#666666"),
     fontSans: getFontSans(),
     background: colors.background || (isDark ? "#000000" : "#ffffff"),
+    card: colors.card || (isDark ? "#1a1a1a" : "#ffffff"),
   };
 };
 


### PR DESCRIPTION
# Summary

## Changes

Simplified chart hover tooltip styling to match the framework's Tooltip UI component. Removed borders, applied card background color instead of background, added minimum width and subtle shadow for improved visual consistency and readability.

## API Changes

**Modified type:**
- `ChartThemeColors` interface - added optional `card: string` property
- `generateTooltip` function signature - added optional `card?: string` to themeColors parameter

**Behavior changes:**
- Chart tooltips now use `--card` CSS variable background instead of `--background`
- Tooltip borders are no longer rendered (borderWidth: 0)
- Tooltips now have min-width: 180px and a subtle box-shadow

## Files Modified

**Core implementations:**
- `src/frontend/src/widgets/charts/styles/theme.ts` - Added card property to theme colors
- `src/frontend/src/widgets/charts/sharedUtils.ts` - Updated generateTooltip with new styling

**Chart widgets updated:**
- `src/frontend/src/widgets/charts/BarChartWidget.tsx`
- `src/frontend/src/widgets/charts/LineChartWidget.tsx`
- `src/frontend/src/widgets/charts/AreaChartWidget.tsx`
- `src/frontend/src/widgets/charts/PieChartWidget.tsx`
- `src/frontend/src/widgets/charts/ScatterChartWidget.tsx`
- `src/frontend/src/widgets/charts/RadarChartWidget.tsx`
- `src/frontend/src/widgets/charts/FunnelChartWidget.tsx`
- `src/frontend/src/widgets/charts/SankeyChartWidget.tsx`
- `src/frontend/src/widgets/charts/ChordChartWidget.tsx`

## Commits

- `151c568a2` - [00049] Simplify chart hover tooltip styling
- `1ee2cc7b4` - [00049] Fix formatting from frontend linter