### PR TITLE
Add ImageBaseUrl prop to SidebarNews for CORS proxy support

### DIFF
--- a/src/Ivy/Widgets/Internal/SidebarNews.cs
+++ b/src/Ivy/Widgets/Internal/SidebarNews.cs
@@ -5,12 +5,14 @@ namespace Ivy.Widgets.Internal;
 /// </summary>
 public record SidebarNews : WidgetBase<SidebarNews>
 {
-    public SidebarNews(string feedUrl)
+    public SidebarNews(string feedUrl, string? imageBaseUrl = null)
     {
         FeedUrl = feedUrl;
+        ImageBaseUrl = imageBaseUrl;
     }
 
     internal SidebarNews() { }
 
     [Prop] public string? FeedUrl { get; set; }
+    [Prop] public string? ImageBaseUrl { get; set; }
 }

--- a/src/frontend/src/widgets/internal/SidebarNewsWidget.tsx
+++ b/src/frontend/src/widgets/internal/SidebarNewsWidget.tsx
@@ -7,6 +7,7 @@ import { Card } from "@/components/ui/card";
 
 export interface SidebarNewsWidgetProps {
   feedUrl: string;
+  imageBaseUrl?: string;
 }
 
 function baseUrlFromFeed(feedUrl: string): string {
@@ -27,7 +28,7 @@ const fetchNewsData = async (feedUrl: string): Promise<NewsArticle[]> => {
   return [];
 };
 
-const SidebarNewsWidget = ({ feedUrl }: SidebarNewsWidgetProps) => {
+const SidebarNewsWidget = ({ feedUrl, imageBaseUrl }: SidebarNewsWidgetProps) => {
   // const [removeBranding, setRemoveBranding] = useState(true); // TODO: Branding check commented out - can be re-enabled in the future
   const [articles, setArticles] = useState<NewsArticle[] | null>(null);
 
@@ -43,7 +44,7 @@ const SidebarNewsWidget = ({ feedUrl }: SidebarNewsWidgetProps) => {
 
   if (!articles || articles.length === 0) return null;
 
-  return <News articles={articles} imageBaseUrl={baseUrlFromFeed(feedUrl)} />;
+  return <News articles={articles} imageBaseUrl={imageBaseUrl ?? baseUrlFromFeed(feedUrl)} />;
 };
 
 export default SidebarNewsWidget;


### PR DESCRIPTION
## Summary
- Add optional `ImageBaseUrl` prop to `SidebarNews` widget (C# and TSX)
- When provided, uses it for image URLs instead of deriving from feedUrl
- Needed when feedUrl is a local proxy endpoint and images live on a CDN