### PR TITLE
[00055] Add overflow hidden to cm-theme-light in code input widget

### DIFF
--- a/src/frontend/src/widgets/inputs/code/CodeInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/code/CodeInputWidget.tsx
@@ -228,6 +228,7 @@ export const CodeInputWidget: React.FC<CodeInputWidgetProps> = ({
           data-gramm="false"
           className={cn(
             "h-full",
+            "[&_.cm-theme-light]:overflow-hidden",
             "border border-input shadow-sm rounded-field",
             "dark:bg-white/5 dark:border-white/10",
             invalid && inputStyles.invalid,


### PR DESCRIPTION
In the code input widget, the `cm-theme-light` element needs `overflow: hidden` to prevent the `cm-editor` background color from overflowing its container.

### Commits
- `a7dec8599` — [00055] Add overflow hidden to cm-theme-light in code input widget