### PR TITLE
[00064] Fix Size.Px not setting maxWidth in table cells

### DIFF
--- a/src/frontend/src/lib/styles.ts
+++ b/src/frontend/src/lib/styles.ts
@@ -25,9 +25,9 @@ const _getWantedWidth = (width?: string): React.CSSProperties => {
     case "units":
       return { width: `${remValue}rem`, maxWidth: `${remValue}rem` };
     case "px":
-      return { width: `${value}px` };
+      return { width: `${value}px`, maxWidth: `${value}px` };
     case "rem":
-      return { width: `${value}rem` };
+      return { width: `${value}rem`, maxWidth: `${value}rem` };
     case "fraction":
       return {
         width: `${parseFloat(value) * 100}%`,


### PR DESCRIPTION
## Changes

Fixed table cell column width handling in `styles.ts` by adding `maxWidth` property to the `px` and `rem` size cases in the `_getWantedWidth` function. This ensures inline `maxWidth` overrides the Tailwind `max-w-0` class applied to truncated cells, allowing columns sized with `Size.Px()` or `Size.Rem()` to render at their intended width instead of collapsing to minimum content width.

## API Changes

None.

## Files Modified

- `src/frontend/src/lib/styles.ts` — Added `maxWidth` property to `px` and `rem` cases in `_getWantedWidth` function

## Commits

- 2e7a294f97a5a7ad2fcff8560a4aae316570a32d