### PR TITLE
[00066] BoolInput Checkbox and Switch subtle hover animation

### DIFF
--- a/src/frontend/src/components/ui/checkbox.tsx
+++ b/src/frontend/src/components/ui/checkbox.tsx
@@ -62,7 +62,7 @@ const Checkbox = React.forwardRef<
       }
     };
 
-    const baseClass = `peer ${getSizeClasses(density)} shrink-0 rounded-checkbox border border-border shadow focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring cursor-pointer disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground data-[state=checked]:border-primary dark:border-white/10`;
+    const baseClass = `peer ${getSizeClasses(density)} shrink-0 rounded-checkbox border border-border shadow transition-colors hover:bg-accent/50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring cursor-pointer disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground data-[state=checked]:border-primary data-[state=checked]:hover:bg-primary/90 dark:border-white/10`;
     const finalClass = className?.includes("bg-red-50")
       ? baseClass.replace("data-[state=checked]:bg-primary", "")
       : baseClass;

--- a/src/frontend/src/components/ui/input/switch-variant.ts
+++ b/src/frontend/src/components/ui/input/switch-variant.ts
@@ -1,7 +1,7 @@
 import { cva } from "class-variance-authority";
 
 export const switchVariant = cva(
-  "peer inline-flex shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+  "peer inline-flex shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors hover:data-[state=unchecked]:bg-input/80 hover:data-[state=checked]:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
   {
     variants: {
       density: {


### PR DESCRIPTION
## Changes

Added subtle hover animations to Checkbox and Switch BoolInput variants, following the established pattern used in other interactive elements (TreeItem, Expandable, table rows). Both components now use `transition-colors` with opacity-based hover backgrounds that work in both checked and unchecked states.

## API Changes

None.

## Files Modified

- `src/frontend/src/components/ui/checkbox.tsx` — Added `transition-colors hover:bg-accent/50` for unchecked state and `data-[state=checked]:hover:bg-primary/90` for checked state
- `src/frontend/src/components/ui/input/switch-variant.ts` — Added `hover:data-[state=unchecked]:bg-input/80` and `hover:data-[state=checked]:bg-primary/90` to track variants

## Commits

- 5bdfeab1833a9855d4d842c7f6364ece9cc6eea9