### PR TITLE
[00069] Add keyboard shortcut to toggle Chrome sidebar and tooltip on toggle button

### DIFF
--- a/src/frontend/src/widgets/layouts/sidebar/SidebarLayoutWidget.tsx
+++ b/src/frontend/src/widgets/layouts/sidebar/SidebarLayoutWidget.tsx
@@ -3,9 +3,11 @@ import React, { useState, useEffect, useCallback, useMemo, useRef, useReducer } 
 import Icon from "@/components/Icon";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { ChevronRight, PanelLeftClose, PanelLeftOpen } from "lucide-react";
 import { MenuItem, WidgetEventHandlerType } from "@/types/widgets";
 import { useFocusable } from "@/hooks/use-focus-management";
+import { useShortcut } from "@/lib/useShortcut";
 import { sidebarMenuRef } from "./sidebar-refs";
 import { useEventHandler } from "@/components/event-handler";
 import { cn, getAppId } from "@/lib/utils";
@@ -192,6 +194,14 @@ export const SidebarLayoutWidget: React.FC<SidebarLayoutWidgetProps> = ({
     dispatchSidebar({ isManuallyToggled: true });
   }, [dispatchSidebar]);
 
+  // Register keyboard shortcut for toggling sidebar (Ctrl+B)
+  useShortcut(
+    "sidebar-layout-toggle",
+    "CTRL+B",
+    handleManualToggle,
+    { skipInInputs: true, disabled: !mainAppSidebar }
+  );
+
   // Auto-collapse/expand based on width (only for main app sidebar)
   useEffect(() => {
     if (!mainAppSidebar) return;
@@ -287,18 +297,27 @@ export const SidebarLayoutWidget: React.FC<SidebarLayoutWidgetProps> = ({
       >
         {/* Toggle Button - Only show for main app sidebar */}
         {showToggleButton && mainAppSidebar && (
-          <button
-            onClick={handleManualToggle}
-            className="absolute top-0 left-1 z-50 p-2 rounded-selector bg-background hover:bg-muted hover:text-accent-foreground cursor-pointer"
-            style={{ marginTop: "3px" }}
-            aria-label={isSidebarOpen ? "Close sidebar" : "Open sidebar"}
-          >
-            {isSidebarOpen ? (
-              <PanelLeftClose className="h-4 w-4" />
-            ) : (
-              <PanelLeftOpen className="h-4 w-4" />
-            )}
-          </button>
+          <TooltipProvider delayDuration={300}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={handleManualToggle}
+                  className="absolute top-0 left-1 z-50 p-2 rounded-selector bg-background hover:bg-muted hover:text-accent-foreground cursor-pointer"
+                  style={{ marginTop: "3px" }}
+                  aria-label={isSidebarOpen ? "Close sidebar" : "Open sidebar"}
+                >
+                  {isSidebarOpen ? (
+                    <PanelLeftClose className="h-4 w-4" />
+                  ) : (
+                    <PanelLeftOpen className="h-4 w-4" />
+                  )}
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="right">
+                Toggle sidebar (Ctrl+B)
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
         )}
         {slots?.MainContent}
       </div>

--- a/src/frontend/src/widgets/layouts/sidebar/SidebarLayoutWidget.tsx
+++ b/src/frontend/src/widgets/layouts/sidebar/SidebarLayoutWidget.tsx
@@ -195,12 +195,10 @@ export const SidebarLayoutWidget: React.FC<SidebarLayoutWidgetProps> = ({
   }, [dispatchSidebar]);
 
   // Register keyboard shortcut for toggling sidebar (Ctrl+B)
-  useShortcut(
-    "sidebar-layout-toggle",
-    "CTRL+B",
-    handleManualToggle,
-    { skipInInputs: true, disabled: !mainAppSidebar }
-  );
+  useShortcut("sidebar-layout-toggle", "CTRL+B", handleManualToggle, {
+    skipInInputs: true,
+    disabled: !mainAppSidebar,
+  });
 
   // Auto-collapse/expand based on width (only for main app sidebar)
   useEffect(() => {
@@ -313,9 +311,7 @@ export const SidebarLayoutWidget: React.FC<SidebarLayoutWidgetProps> = ({
                   )}
                 </button>
               </TooltipTrigger>
-              <TooltipContent side="right">
-                Toggle sidebar (Ctrl+B)
-              </TooltipContent>
+              <TooltipContent side="right">Toggle sidebar (Ctrl+B)</TooltipContent>
             </Tooltip>
           </TooltipProvider>
         )}


### PR DESCRIPTION
## Summary

Added keyboard shortcut (Ctrl+B) and hover tooltip to the Chrome sidebar toggle button in SidebarLayoutWidget. The Ctrl+B shortcut is wired into the existing shortcut infrastructure and only registers when the sidebar is the main app sidebar. The tooltip displays "Toggle sidebar (Ctrl+B)" on hover with a 300ms delay.

## API Changes

None.

## Files Modified

- `src/frontend/src/widgets/layouts/sidebar/SidebarLayoutWidget.tsx` — Added `useShortcut` hook import and registration, added tooltip component wrapping the toggle button

## Commits

- `4d1b798f0`
- `3807a4287`