### PR TITLE
[00005] Delete connected account cookies on main auth logout

### DIFF
--- a/src/Ivy.Test/Auth/ConnectedAccountLifecycleTests.cs
+++ b/src/Ivy.Test/Auth/ConnectedAccountLifecycleTests.cs
@@ -3,21 +3,20 @@ namespace Ivy.Test.Auth;
 public class ConnectedAccountLifecycleTests
 {
     [Fact]
-    public void ConnectedAccounts_PersistThroughMainAuthLogout()
+    public void ConnectedAccounts_ClearedOnMainAuthLogout()
     {
         var session = new AuthSession(authToken: new AuthToken("main-token"));
         var githubSession = new AuthSession(authToken: new AuthToken("github-token"));
         session.AddConnectedAccount("github", githubSession);
         session.AddBrokeredSession("google", new AuthTokenHandlerSession(authToken: new AuthToken("google-brokered")));
 
-        // Simulate logout: clear main token and brokered sessions
+        // Simulate logout: clear main token, brokered sessions, and connected accounts
         session.AuthToken = null;
         session.ClearBrokeredSessions();
+        session.ClearConnectedAccounts();
 
-        // Connected accounts should persist
-        Assert.Single(session.ConnectedAccounts);
-        Assert.True(session.ConnectedAccounts.ContainsKey("github"));
-        Assert.Equal("github-token", session.ConnectedAccounts["github"].AuthToken?.AccessToken);
+        // Connected accounts should be cleared
+        Assert.Empty(session.ConnectedAccounts);
 
         // Brokered sessions should be cleared
         Assert.Empty(session.BrokeredSessions);

--- a/src/Ivy/Auth/AuthService.cs
+++ b/src/Ivy/Auth/AuthService.cs
@@ -79,8 +79,9 @@ public class AuthService : AuthTokenHandlerService, IAuthService
 
     public async Task LogoutAsync(CancellationToken cancellationToken)
     {
-        // Capture OAuth providers before clearing so we can delete their cookies
-        var providersToDelete = _authSession.BrokeredSessions.Keys.ToList();
+        // Capture providers before clearing so we can delete their cookies
+        var brokeredProvidersToDelete = _authSession.BrokeredSessions.Keys.ToList();
+        var connectedProvidersToDelete = _authSession.ConnectedAccounts.Keys.ToList();
 
         if (!string.IsNullOrWhiteSpace(_authSession.AuthToken?.AccessToken))
         {
@@ -90,10 +91,13 @@ public class AuthService : AuthTokenHandlerService, IAuthService
 
         _authSession.AuthToken = null;
         _authSession.ClearBrokeredSessions();
-        // NOTE: Do NOT clear connected accounts - they persist independently of main auth
+        _authSession.ClearConnectedAccounts();
 
-        // Pass the captured providers to delete their cookies
-        var cookieJarId = _sessionStore.RegisterAuthSessionCookies(_authSession, providersToDelete);
+        // Pass both provider lists to delete their cookies
+        var cookieJarId = _sessionStore.RegisterAuthSessionCookies(
+            _authSession,
+            brokeredProvidersToDelete,
+            connectedProvidersToDelete);
         _client.SetAuthCookies(cookieJarId, reloadPage: true, triggerMachineReload: null);
     }
 


### PR DESCRIPTION
# Summary

## Changes

Modified the authentication logout flow to delete connected account cookies when logging out of the main auth provider. Previously, connected account cookies persisted independently of the main auth session; now they are cleared and their cookies deleted on main logout.

## API Changes

**AuthService:**
- Modified `LogoutAsync()` method to capture connected account providers before clearing and pass them to cookie deletion

**No breaking changes** - the method signature remains the same; this is purely a behavior change.

## Files Modified

**Authentication:**
- `src/Ivy/Auth/AuthService.cs` - Updated logout to clear connected accounts and delete their cookies
- `src/Ivy.Test/Auth/ConnectedAccountLifecycleTests.cs` - Updated test from `ConnectedAccounts_PersistThroughMainAuthLogout` to `ConnectedAccounts_ClearedOnMainAuthLogout` to verify new behavior

---

## Commits

- e4c33864b [00005] Delete connected account cookies on main auth logout