### PR TITLE
[00006] Add basic validation of URLs received in AuthController

### DIFF
--- a/src/Ivy.Test/Auth/AuthControllerTests.cs
+++ b/src/Ivy.Test/Auth/AuthControllerTests.cs
@@ -1,0 +1,221 @@
+using Ivy.Core.Auth;
+using Ivy.Core.Server;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Ivy.Test.Auth;
+
+public class AuthControllerTests
+{
+    private class FakeAuthService : IAuthService
+    {
+        private readonly Uri _redirectUri;
+
+        public FakeAuthService(Uri redirectUri)
+        {
+            _redirectUri = redirectUri;
+        }
+
+        public IAuthSession GetAuthSession() => new AuthSession(authToken: null);
+
+        public List<AuthOption> GetAuthOptions() =>
+            [new AuthOption { Id = "test-option", DisplayName = "Test" }];
+
+        public Task<Uri> GetOAuthUriAsync(AuthOption option, string callback, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(_redirectUri);
+        }
+
+        public Task<LoginResult> HandleOAuthCallbackAsync(IAuthSession authSession, HttpRequest request)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<LogoutResult> LogoutAsync(IAuthSession authSession)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    private class FakeConnectedAccountsService : IConnectedAccountsService
+    {
+        private readonly Uri _redirectUri;
+
+        public FakeConnectedAccountsService(Uri redirectUri)
+        {
+            _redirectUri = redirectUri;
+        }
+
+        public Task<Uri> ConnectAccountAsync(string provider, string callback, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(_redirectUri);
+        }
+
+        public Task DisconnectAccountAsync(string provider, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IAuthSession? GetAccountSession(string provider)
+        {
+            throw new NotImplementedException();
+        }
+
+        public List<string> GetAvailableProviders()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<LoginResult> HandleConnectCallbackAsync(string provider, HttpRequest request, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    private static (AuthController controller, AppSessionStore sessionStore, string connectionId) SetupController(Uri redirectUri, bool useConnectedAccounts = false)
+    {
+        var controller = new AuthController();
+        var sessionStore = new AppSessionStore();
+        var connectionId = "test-connection";
+
+        var services = new ServiceCollection();
+        if (useConnectedAccounts)
+        {
+            services.AddSingleton<IConnectedAccountsService>(new FakeConnectedAccountsService(redirectUri));
+        }
+        else
+        {
+            services.AddSingleton<IAuthService>(new FakeAuthService(redirectUri));
+        }
+
+        var serviceProvider = services.BuildServiceProvider();
+        var appSession = new AppSession(connectionId, serviceProvider, "", null, null);
+        sessionStore.Sessions[connectionId] = appSession;
+
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                Request =
+                {
+                    Scheme = "https",
+                    Host = new HostString("localhost:5000")
+                }
+            }
+        };
+
+        return (controller, sessionStore, connectionId);
+    }
+
+    [Fact]
+    public async Task OAuthLogin_WithHttpsRedirect_AllowsRedirect()
+    {
+        // Arrange
+        var httpsUri = new Uri("https://oauth.example.com/authorize");
+        var (controller, sessionStore, connectionId) = SetupController(httpsUri);
+
+        var loginRegistry = new OAuthLoginRegistry();
+        var loginId = loginRegistry.RegisterPending(connectionId, "test-option", null);
+
+        var callbackRegistry = new OAuthCallbackRegistry();
+        var serverArgs = new ServerArgs { BasePath = null };
+        var logger = NullLogger<AuthController>.Instance;
+
+        // Act
+        var result = await controller.OAuthLogin(loginId, loginRegistry, callbackRegistry, sessionStore, serverArgs, logger);
+
+        // Assert
+        var redirectResult = Assert.IsType<RedirectResult>(result);
+        Assert.Equal("https://oauth.example.com/authorize", redirectResult.Url);
+    }
+
+    [Fact]
+    public async Task OAuthLogin_WithRelativeRedirect_AllowsRedirect()
+    {
+        // Arrange
+        var relativeUri = new Uri("/oauth/callback", UriKind.Relative);
+        var (controller, sessionStore, connectionId) = SetupController(relativeUri);
+
+        var loginRegistry = new OAuthLoginRegistry();
+        var loginId = loginRegistry.RegisterPending(connectionId, "test-option", null);
+
+        var callbackRegistry = new OAuthCallbackRegistry();
+        var serverArgs = new ServerArgs { BasePath = null };
+        var logger = NullLogger<AuthController>.Instance;
+
+        // Act
+        var result = await controller.OAuthLogin(loginId, loginRegistry, callbackRegistry, sessionStore, serverArgs, logger);
+
+        // Assert
+        var redirectResult = Assert.IsType<RedirectResult>(result);
+        Assert.Equal("/oauth/callback", redirectResult.Url);
+    }
+
+    [Fact]
+    public async Task OAuthLogin_WithHttpRedirect_RejectsRedirect()
+    {
+        // Arrange
+        var httpUri = new Uri("http://malicious.example.com/phishing");
+        var (controller, sessionStore, connectionId) = SetupController(httpUri);
+
+        var loginRegistry = new OAuthLoginRegistry();
+        var loginId = loginRegistry.RegisterPending(connectionId, "test-option", null);
+
+        var callbackRegistry = new OAuthCallbackRegistry();
+        var serverArgs = new ServerArgs { BasePath = null };
+        var logger = NullLogger<AuthController>.Instance;
+
+        // Act
+        var result = await controller.OAuthLogin(loginId, loginRegistry, callbackRegistry, sessionStore, serverArgs, logger);
+
+        // Assert
+        var badRequestResult = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Equal("Invalid OAuth redirect URL", badRequestResult.Value);
+    }
+
+    [Fact]
+    public async Task OAuthLogin_ConnectedAccount_WithHttpsRedirect_AllowsRedirect()
+    {
+        // Arrange
+        var httpsUri = new Uri("https://oauth.example.com/authorize");
+        var (controller, sessionStore, connectionId) = SetupController(httpsUri, useConnectedAccounts: true);
+
+        var loginRegistry = new OAuthLoginRegistry();
+        var loginId = loginRegistry.RegisterPending(connectionId, null, "github");
+
+        var callbackRegistry = new OAuthCallbackRegistry();
+        var serverArgs = new ServerArgs { BasePath = null };
+        var logger = NullLogger<AuthController>.Instance;
+
+        // Act
+        var result = await controller.OAuthLogin(loginId, loginRegistry, callbackRegistry, sessionStore, serverArgs, logger);
+
+        // Assert
+        var redirectResult = Assert.IsType<RedirectResult>(result);
+        Assert.Equal("https://oauth.example.com/authorize", redirectResult.Url);
+    }
+
+    [Fact]
+    public async Task OAuthLogin_ConnectedAccount_WithHttpRedirect_RejectsRedirect()
+    {
+        // Arrange
+        var httpUri = new Uri("http://malicious.example.com/phishing");
+        var (controller, sessionStore, connectionId) = SetupController(httpUri, useConnectedAccounts: true);
+
+        var loginRegistry = new OAuthLoginRegistry();
+        var loginId = loginRegistry.RegisterPending(connectionId, null, "github");
+
+        var callbackRegistry = new OAuthCallbackRegistry();
+        var serverArgs = new ServerArgs { BasePath = null };
+        var logger = NullLogger<AuthController>.Instance;
+
+        // Act
+        var result = await controller.OAuthLogin(loginId, loginRegistry, callbackRegistry, sessionStore, serverArgs, logger);
+
+        // Assert
+        var badRequestResult = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Equal("Invalid OAuth redirect URL", badRequestResult.Value);
+    }
+}

--- a/src/Ivy.Test/Auth/AuthControllerTests.cs
+++ b/src/Ivy.Test/Auth/AuthControllerTests.cs
@@ -1,3 +1,5 @@
+using Ivy.Core;
+using Ivy.Core.Apps;
 using Ivy.Core.Auth;
 using Ivy.Core.Server;
 using Microsoft.AspNetCore.Http;
@@ -20,22 +22,79 @@ public class AuthControllerTests
 
         public IAuthSession GetAuthSession() => new AuthSession(authToken: null);
 
-        public List<AuthOption> GetAuthOptions() =>
-            [new AuthOption { Id = "test-option", DisplayName = "Test" }];
+        public AuthOption[] GetAuthOptions() =>
+            [new AuthOption(AuthFlow.OAuth, Id: "test-option")];
 
-        public Task<Uri> GetOAuthUriAsync(AuthOption option, string callback, CancellationToken cancellationToken)
+        public Task<Uri> GetOAuthUriAsync(AuthOption option, WebhookEndpoint callback, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(_redirectUri);
         }
 
-        public Task<LoginResult> HandleOAuthCallbackAsync(IAuthSession authSession, HttpRequest request)
+        public Task<AuthToken?> HandleOAuthCallbackAsync(HttpRequest request, CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();
         }
 
-        public Task<LogoutResult> LogoutAsync(IAuthSession authSession)
+        public Task LogoutAsync(CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();
+        }
+
+        public Task<LoginResult> LoginAsync(string email, string password, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<BrokeredSessionsResult> GetBrokeredSessionsAsync(bool skipCache = false, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        void IAuthService.SetAuthCookies(bool reloadPage, bool? triggerMachineReload, bool triggerMachineAuthSync)
+        {
+        }
+
+        public Task<AuthToken?> RefreshAccessTokenAsync(CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<bool> ValidateAccessTokenAsync(CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<UserInfo?> GetUserInfoAsync(CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<TokenLifetime?> GetAccessTokenLifetimeAsync(CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public AuthToken? GetCurrentToken()
+        {
+            throw new NotImplementedException();
+        }
+
+        public string? GetCurrentSessionData()
+        {
+            throw new NotImplementedException();
+        }
+
+        public IAuthTokenHandlerSession GetAuthTokenHandlerSession()
+        {
+            throw new NotImplementedException();
+        }
+
+        void IAuthTokenHandlerService.SetAuthTokenCookies(bool reloadPage, bool? triggerMachineReload)
+        {
+        }
+
+        void IAuthTokenHandlerService.SetAuthSessionDataCookies(bool reloadPage, bool? triggerMachineReload)
+        {
         }
     }
 
@@ -48,12 +107,12 @@ public class AuthControllerTests
             _redirectUri = redirectUri;
         }
 
-        public Task<Uri> ConnectAccountAsync(string provider, string callback, CancellationToken cancellationToken)
+        public Task<Uri> ConnectAccountAsync(string provider, WebhookEndpoint callback, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(_redirectUri);
         }
 
-        public Task DisconnectAccountAsync(string provider, CancellationToken cancellationToken)
+        public Task DisconnectAccountAsync(string provider, CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();
         }
@@ -63,15 +122,20 @@ public class AuthControllerTests
             throw new NotImplementedException();
         }
 
-        public List<string> GetAvailableProviders()
+        public string[] GetAvailableProviders()
         {
             throw new NotImplementedException();
         }
 
-        public Task<LoginResult> HandleConnectCallbackAsync(string provider, HttpRequest request, CancellationToken cancellationToken)
+        public Task<AuthToken?> HandleConnectCallbackAsync(string provider, HttpRequest request, CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();
         }
+
+#pragma warning disable CS0067 // Event is never used
+        public event Action<string>? AccountConnected;
+        public event Action<string>? AccountDisconnected;
+#pragma warning restore CS0067
     }
 
     private static (AuthController controller, AppSessionStore sessionStore, string connectionId) SetupController(Uri redirectUri, bool useConnectedAccounts = false)
@@ -91,7 +155,19 @@ public class AuthControllerTests
         }
 
         var serviceProvider = services.BuildServiceProvider();
-        var appSession = new AppSession(connectionId, serviceProvider, "", null, null);
+        var appSession = new AppSession
+        {
+            ConnectionId = connectionId,
+            AppId = "",
+            MachineId = "",
+            ParentId = null,
+            WidgetTree = null!,
+            AppDescriptor = null!,
+            App = null!,
+            ContentBuilder = null!,
+            AppServices = serviceProvider,
+            LastInteraction = DateTime.UtcNow
+        };
         sessionStore.Sessions[connectionId] = appSession;
 
         controller.ControllerContext = new ControllerContext
@@ -117,7 +193,7 @@ public class AuthControllerTests
         var (controller, sessionStore, connectionId) = SetupController(httpsUri);
 
         var loginRegistry = new OAuthLoginRegistry();
-        var loginId = loginRegistry.RegisterPending(connectionId, "test-option", null);
+        var loginId = loginRegistry.RegisterPending(connectionId, "test-option");
 
         var callbackRegistry = new OAuthCallbackRegistry();
         var serverArgs = new ServerArgs { BasePath = null };
@@ -139,7 +215,7 @@ public class AuthControllerTests
         var (controller, sessionStore, connectionId) = SetupController(relativeUri);
 
         var loginRegistry = new OAuthLoginRegistry();
-        var loginId = loginRegistry.RegisterPending(connectionId, "test-option", null);
+        var loginId = loginRegistry.RegisterPending(connectionId, "test-option");
 
         var callbackRegistry = new OAuthCallbackRegistry();
         var serverArgs = new ServerArgs { BasePath = null };
@@ -161,7 +237,7 @@ public class AuthControllerTests
         var (controller, sessionStore, connectionId) = SetupController(httpUri);
 
         var loginRegistry = new OAuthLoginRegistry();
-        var loginId = loginRegistry.RegisterPending(connectionId, "test-option", null);
+        var loginId = loginRegistry.RegisterPending(connectionId, "test-option");
 
         var callbackRegistry = new OAuthCallbackRegistry();
         var serverArgs = new ServerArgs { BasePath = null };
@@ -183,7 +259,7 @@ public class AuthControllerTests
         var (controller, sessionStore, connectionId) = SetupController(httpsUri, useConnectedAccounts: true);
 
         var loginRegistry = new OAuthLoginRegistry();
-        var loginId = loginRegistry.RegisterPending(connectionId, null, "github");
+        var loginId = loginRegistry.RegisterPending(connectionId, "github", "github");
 
         var callbackRegistry = new OAuthCallbackRegistry();
         var serverArgs = new ServerArgs { BasePath = null };
@@ -205,7 +281,7 @@ public class AuthControllerTests
         var (controller, sessionStore, connectionId) = SetupController(httpUri, useConnectedAccounts: true);
 
         var loginRegistry = new OAuthLoginRegistry();
-        var loginId = loginRegistry.RegisterPending(connectionId, null, "github");
+        var loginId = loginRegistry.RegisterPending(connectionId, "github", "github");
 
         var callbackRegistry = new OAuthCallbackRegistry();
         var serverArgs = new ServerArgs { BasePath = null };

--- a/src/Ivy/Core/Auth/AuthController.cs
+++ b/src/Ivy/Core/Auth/AuthController.cs
@@ -15,6 +15,24 @@ public class AuthController() : Controller
 {
     internal static string SanitizeForLog(string? input) => input?.Replace("\n", "").Replace("\r", "") ?? string.Empty;
 
+    private static bool IsValidRedirectUri(Uri uri, ILogger logger)
+    {
+        // Allow relative URLs
+        if (!uri.IsAbsoluteUri)
+        {
+            return true;
+        }
+
+        // For absolute URLs: must use HTTPS
+        if (uri.Scheme != Uri.UriSchemeHttps)
+        {
+            logger.LogWarning("OAuth redirect rejected: non-HTTPS URL {Url}", SanitizeForLog(uri.ToString()));
+            return false;
+        }
+
+        return true;
+    }
+
     [Route("ivy/auth/oauth-login")]
     [HttpGet]
     public async Task<IActionResult> OAuthLogin(
@@ -82,6 +100,12 @@ public class AuthController() : Controller
             try
             {
                 var uri = await authService.GetOAuthUriAsync(option, callback, HttpContext.RequestAborted);
+
+                if (!IsValidRedirectUri(uri, logger))
+                {
+                    return BadRequest("Invalid OAuth redirect URL");
+                }
+
                 return Redirect(uri.ToString());
             }
             catch (Exception ex)
@@ -103,6 +127,12 @@ public class AuthController() : Controller
             try
             {
                 var uri = await connectedAccountsService.ConnectAccountAsync(provider, callback, HttpContext.RequestAborted);
+
+                if (!IsValidRedirectUri(uri, logger))
+                {
+                    return BadRequest("Invalid OAuth redirect URL");
+                }
+
                 return Redirect(uri.ToString());
             }
             catch (Exception ex)


### PR DESCRIPTION
# Summary

Note: this should resolve two of the three open code scanning alerts. These alerts originally appeared in #4254 before the last commit, which added `IOAuthLoginRegistry`. That change already made it impossible for the user to pass arbitrary parameters to `ivy/auth/oauth-login`. This PR just adds some additional protection against buggy auth provider implementations.

## Changes

Added URL validation to AuthController's OAuth redirect flows to prevent open redirect vulnerabilities. The implementation validates redirect URIs received from both `GetOAuthUriAsync` (main auth flow) and `ConnectAccountAsync` (connected accounts), ensuring they are either relative URLs or use HTTPS for absolute URLs.

## API Changes

- **AuthController.IsValidRedirectUri** (private static method) — validates redirect URIs, returns bool
  - Parameters: `Uri uri, ILogger logger`
  - Allows relative URLs and HTTPS absolute URLs
  - Logs warnings for rejected non-HTTPS URLs

## Files Modified

**Core changes:**
- `src/Ivy/Core/Auth/AuthController.cs` — added validation helper and applied it at both redirect points

## Commits

- 6ab3f67eb [00006] Add URL validation to AuthController OAuth redirects