### PR TITLE
[00007] Add connected account UI abstractions to Framework

### DIFF
--- a/src/Ivy.Test/Auth/ConnectedAccountButtonTests.cs
+++ b/src/Ivy.Test/Auth/ConnectedAccountButtonTests.cs
@@ -1,0 +1,122 @@
+using Ivy.Core.Server;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Ivy.Test.Auth;
+
+public class ConnectedAccountButtonTests
+{
+    [Theory]
+    [InlineData("github", "Github")]
+    [InlineData("google", "Google")]
+    [InlineData("discord", "Discord")]
+    [InlineData("myProvider", "MyProvider")]
+    public void FormatProviderName_CapitalizesFirstLetter(string input, string expected)
+    {
+        Assert.Equal(expected, ConnectedAccountButton.FormatProviderName(input));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void FormatProviderName_HandlesEmptyOrNull(string? input)
+    {
+        Assert.Equal(input ?? "", ConnectedAccountButton.FormatProviderName(input ?? ""));
+    }
+
+    [Theory]
+    [InlineData(OAuthProviders.GitHub, Icons.Github)]
+    [InlineData(OAuthProviders.Google, Icons.Google)]
+    [InlineData(OAuthProviders.Microsoft, Icons.Microsoft)]
+    [InlineData(OAuthProviders.Discord, Icons.Discord)]
+    [InlineData(OAuthProviders.Apple, Icons.Apple)]
+    [InlineData(OAuthProviders.Twitch, Icons.Twitch)]
+    [InlineData(OAuthProviders.Twitter, Icons.XTwitter)]
+    [InlineData(OAuthProviders.Figma, Icons.Figma)]
+    [InlineData(OAuthProviders.Notion, Icons.Notion)]
+    public void GetProviderIcon_ReturnsCorrectIcon(string provider, Icons expected)
+    {
+        Assert.Equal(expected, ConnectedAccountButton.GetProviderIcon(provider));
+    }
+
+    [Fact]
+    public void GetProviderIcon_ReturnsFallbackForUnknownProvider()
+    {
+        Assert.Equal(Icons.Link, ConnectedAccountButton.GetProviderIcon("unknown-provider"));
+    }
+
+    [Fact]
+    public void AccountConnected_EventFiresOnService()
+    {
+        var authSession = new AuthSession(authToken: null);
+        var sessionStore = new AppSessionStore();
+        var service = new ConnectedAccountsService(
+            authSession, CreateEmptyServiceProvider(), null!, sessionStore);
+
+        string? connectedProvider = null;
+        service.AccountConnected += p => connectedProvider = p;
+
+        var githubSession = new AuthSession(authToken: new AuthToken("token"));
+        authSession.AddConnectedAccount("github", githubSession);
+
+        Assert.Equal("github", connectedProvider);
+    }
+
+    [Fact]
+    public void AccountDisconnected_EventFiresOnService()
+    {
+        var authSession = new AuthSession(authToken: null);
+        var githubSession = new AuthSession(authToken: new AuthToken("token"));
+        authSession.AddConnectedAccount("github", githubSession);
+
+        var sessionStore = new AppSessionStore();
+        var service = new ConnectedAccountsService(
+            authSession, CreateEmptyServiceProvider(), null!, sessionStore);
+
+        string? disconnectedProvider = null;
+        service.AccountDisconnected += p => disconnectedProvider = p;
+
+        authSession.RemoveConnectedAccount("github");
+
+        Assert.Equal("github", disconnectedProvider);
+    }
+
+    [Fact]
+    public void EventTracking_IgnoresOtherProviders()
+    {
+        var authSession = new AuthSession(authToken: null);
+        var sessionStore = new AppSessionStore();
+        var service = new ConnectedAccountsService(
+            authSession, CreateEmptyServiceProvider(), null!, sessionStore);
+
+        string? connectedProvider = null;
+        service.AccountConnected += p => connectedProvider = p;
+
+        var googleSession = new AuthSession(authToken: new AuthToken("token"));
+        authSession.AddConnectedAccount("google", googleSession);
+
+        Assert.Equal("google", connectedProvider);
+        Assert.Null(service.GetAccountSession("github"));
+    }
+
+    [Fact]
+    public void IsConnected_DetectedViaAuthToken()
+    {
+        var authSession = new AuthSession(authToken: null);
+        var sessionStore = new AppSessionStore();
+        var service = new ConnectedAccountsService(
+            authSession, CreateEmptyServiceProvider(), null!, sessionStore);
+
+        Assert.Null(service.GetAccountSession("github")?.AuthToken);
+
+        var githubSession = new AuthSession(authToken: new AuthToken("token"));
+        authSession.AddConnectedAccount("github", githubSession);
+
+        Assert.NotNull(service.GetAccountSession("github")?.AuthToken);
+    }
+
+    private static IServiceProvider CreateEmptyServiceProvider()
+    {
+        var services = new ServiceCollection();
+        return services.BuildServiceProvider();
+    }
+}

--- a/src/Ivy/Auth/ConnectedAccountButton.cs
+++ b/src/Ivy/Auth/ConnectedAccountButton.cs
@@ -1,0 +1,75 @@
+using System.Reactive.Disposables;
+using Ivy.Core.Auth;
+
+// ReSharper disable once CheckNamespace
+namespace Ivy;
+
+/// <summary>
+/// A reusable button for connecting or disconnecting a third-party account provider.
+/// When not connected, renders a "Connect [Provider]" button that initiates the OAuth flow.
+/// When connected, renders a "Disconnect" button.
+/// Automatically tracks connection state via <see cref="IConnectedAccountsService"/> events.
+/// </summary>
+public class ConnectedAccountButton(string provider, string? displayName = null, Icons? icon = null) : ViewBase
+{
+    public override object? Build()
+    {
+        var appContext = UseService<AppContext>();
+        var loginRegistry = UseService<IOAuthLoginRegistry>();
+        var connectedAccounts = UseService<IConnectedAccountsService>();
+
+        var isConnected = UseState(() => connectedAccounts.GetAccountSession(provider)?.AuthToken != null);
+
+        UseEffect(() =>
+        {
+            connectedAccounts.AccountConnected += OnConnected;
+            connectedAccounts.AccountDisconnected += OnDisconnected;
+            return Disposable.Create(() =>
+            {
+                connectedAccounts.AccountConnected -= OnConnected;
+                connectedAccounts.AccountDisconnected -= OnDisconnected;
+            });
+
+            void OnConnected(string p) { if (p == provider) isConnected.Set(true); }
+            void OnDisconnected(string p) { if (p == provider) isConnected.Set(false); }
+        }, [EffectTrigger.OnMount()]);
+
+        var name = displayName ?? FormatProviderName(provider);
+        var resolvedIcon = icon ?? GetProviderIcon(provider);
+
+        if (isConnected.Value)
+        {
+            return new Button($"Disconnect {name}", async () =>
+            {
+                await connectedAccounts.DisconnectAccountAsync(provider);
+            }, variant: ButtonVariant.Destructive)
+                .Icon(resolvedIcon);
+        }
+
+        var loginId = UseState(() => loginRegistry.RegisterPending(appContext.ConnectionId, provider, provider));
+        var connectUrl = $"{appContext.BaseUrl.TrimEnd('/')}/ivy/auth/oauth-login?loginId={Uri.EscapeDataString(loginId.Value)}";
+
+        return new Button($"Connect {name}")
+            .Icon(resolvedIcon)
+            .Variant(ButtonVariant.Outline)
+            .Url(connectUrl)
+            .OpenInNewTab();
+    }
+
+    internal static string FormatProviderName(string provider) =>
+        string.IsNullOrEmpty(provider) ? provider : char.ToUpper(provider[0]) + provider[1..];
+
+    internal static Icons GetProviderIcon(string provider) => provider switch
+    {
+        OAuthProviders.GitHub => Icons.Github,
+        OAuthProviders.Google => Icons.Google,
+        OAuthProviders.Microsoft => Icons.Microsoft,
+        OAuthProviders.Discord => Icons.Discord,
+        OAuthProviders.Apple => Icons.Apple,
+        OAuthProviders.Twitch => Icons.Twitch,
+        OAuthProviders.Twitter => Icons.XTwitter,
+        OAuthProviders.Figma => Icons.Figma,
+        OAuthProviders.Notion => Icons.Notion,
+        _ => Icons.Link,
+    };
+}

--- a/src/auth/examples/BasicAuthExample/MainApp.cs
+++ b/src/auth/examples/BasicAuthExample/MainApp.cs
@@ -1,7 +1,5 @@
-using System.Reactive.Disposables;
 using Ivy;
 using Ivy.Auth.Examples.Shared;
-using Ivy.Core.Auth;
 
 namespace BasicAuthExample;
 
@@ -41,78 +39,31 @@ public class MainApp : ViewBase
             ).Gap(20).AlignContent(Align.Center),
 
             // Connected Accounts section
-            new ConnectedGitHubSection(connectedAccounts)
+            Layout.Vertical(
+                Text.H3("Connected Accounts"),
+                new ConnectedAccountButton(OAuthProviders.GitHub),
+                new ConnectedAccountTestSection(connectedAccounts)
+            ).Gap(10)
 
         ).Gap(40).Padding(50).AlignContent(Align.Center).Height(Size.Full());
     }
 }
 
-public class ConnectedGitHubSection : ViewBase
+public class ConnectedAccountTestSection : ViewBase
 {
     private readonly IConnectedAccountsService _connectedAccounts;
 
-    public ConnectedGitHubSection(IConnectedAccountsService connectedAccounts)
+    public ConnectedAccountTestSection(IConnectedAccountsService connectedAccounts)
     {
         _connectedAccounts = connectedAccounts;
     }
 
     public override object? Build()
     {
-        var appContext = UseService<Ivy.AppContext>();
-        var loginRegistry = UseService<IOAuthLoginRegistry>();
-        var connected = UseState(() => _connectedAccounts.GetAccountSession(OAuthProviders.GitHub)?.AuthToken != null);
-
-        UseEffect(() =>
-        {
-            _connectedAccounts.AccountConnected += OnConnected;
-            _connectedAccounts.AccountDisconnected += OnDisconnected;
-            return Disposable.Create(() =>
-            {
-                _connectedAccounts.AccountConnected -= OnConnected;
-                _connectedAccounts.AccountDisconnected -= OnDisconnected;
-            });
-
-            void OnConnected(string provider) { if (provider == OAuthProviders.GitHub) connected.Set(true); }
-            void OnDisconnected(string provider) { if (provider == OAuthProviders.GitHub) connected.Set(false); }
-        }, [EffectTrigger.OnMount()]);
-
         var gitHubSession = _connectedAccounts.GetAccountSession(OAuthProviders.GitHub);
-        var isConnected = gitHubSession?.AuthToken != null;
+        if (gitHubSession?.AuthToken == null)
+            return null;
 
-        if (!isConnected)
-        {
-            return Layout.Vertical(
-                Text.H3("Connected Accounts"),
-                new Button("Connect GitHub")
-                    .Icon(Icons.Github)
-                    .Variant(ButtonVariant.Outline)
-                    .Url(BuildConnectUrl(appContext, loginRegistry, OAuthProviders.GitHub))
-                    .OpenInNewTab()
-            ).Gap(10);
-        }
-
-        return Layout.Vertical(
-            Text.H3("Connected Accounts"),
-            Layout.Horizontal(
-                Text.P("GitHub").Bold(),
-                new Badge("Connected").Variant(BadgeVariant.Success),
-                new Button("Disconnect", async () =>
-                {
-                    await _connectedAccounts.DisconnectAccountAsync(OAuthProviders.GitHub);
-                }, variant: ButtonVariant.Destructive)
-            ).Gap(10).AlignContent(Align.Center),
-            new OAuthProviderTestView(OAuthProviders.GitHub, gitHubSession!)
-        ).Gap(10);
-    }
-
-    private static string BuildConnectUrl(Ivy.AppContext appContext, IOAuthLoginRegistry loginRegistry, string provider)
-    {
-        var loginId = loginRegistry.RegisterPending(
-            appContext.ConnectionId,
-            provider,
-            provider
-        );
-
-        return $"{appContext.BaseUrl.TrimEnd('/')}/ivy/auth/oauth-login?loginId={Uri.EscapeDataString(loginId)}";
+        return new OAuthProviderTestView(OAuthProviders.GitHub, gitHubSession);
     }
 }


### PR DESCRIPTION
# Summary

## Changes

Added `ConnectedAccountButton`, a reusable ViewBase component that encapsulates OAuth URL building, connection state tracking, and connect/disconnect button rendering for third-party account providers. Updated BasicAuthExample to use the new abstraction, removing the manual `ConnectedGitHubSection` class and its duplicated URL building and event subscription logic. Per reviewer feedback, `ConnectedAccountSection` was intentionally omitted as too opinionated for the framework.

## API Changes

- New class: `ConnectedAccountButton(string provider, string? displayName = null, Icons? icon = null) : ViewBase` in `Ivy` namespace
  - Renders "Connect [Provider]" button (with OAuth URL) when not connected
  - Renders "Disconnect [Provider]" button when connected
  - Auto-tracks connection state via `IConnectedAccountsService.AccountConnected`/`AccountDisconnected` events
  - Auto-resolves provider icons for known providers (GitHub, Google, Microsoft, Discord, Apple, Twitch, Twitter, Figma, Notion)
- Removed: `ConnectedGitHubSection` class from BasicAuthExample (replaced by `ConnectedAccountButton`)
- Removed: `BuildConnectUrl` helper from BasicAuthExample (internalized in `ConnectedAccountButton`)

## Files Modified

- **New:** `src/Ivy/Auth/ConnectedAccountButton.cs` - Reusable connected account button component
- **New:** `src/Ivy.Test/Auth/ConnectedAccountButtonTests.cs` - Unit tests for helper methods and event tracking
- **Modified:** `src/auth/examples/BasicAuthExample/MainApp.cs` - Simplified to use `ConnectedAccountButton`

## Commits

- 4c50b46b5 [00007] Add ConnectedAccountButton abstraction for connected account UI