### PR TITLE
Add ivyml CLI tool for rendering IvyML markup to screenshots

### DIFF
--- a/src/Ivy-Framework.slnx
+++ b/src/Ivy-Framework.slnx
@@ -45,6 +45,11 @@
   <Project Path="Ivy.XamlBuilder.Test/Ivy.XamlBuilder.Test.csproj" />
   <Project Path="Ivy.XamlBuilder/Ivy.XamlBuilder.csproj" />
   <Project Path="Ivy/Ivy.csproj" />
+  <Folder Name="/ivyml/">
+    <Project Path="ivyml/Ivy.IvyML/Ivy.IvyML.csproj" />
+    <Project Path="ivyml/Ivy.IvyML.Console/Ivy.IvyML.Console.csproj" />
+    <Project Path="ivyml/Ivy.IvyML.Test/Ivy.IvyML.Test.csproj" />
+  </Folder>
   <Project Path="Ivy.Agent.EfQuery/Ivy.Agent.EfQuery.csproj" />
   <Project Path="Ivy.Agent.EfQuery.Test/Ivy.Agent.EfQuery.Test.csproj" />
 </Solution>

--- a/src/Ivy/Ivy.csproj
+++ b/src/Ivy/Ivy.csproj
@@ -82,6 +82,7 @@
     <InternalsVisibleTo Include="Ivy.XamlBuilder" />
     <InternalsVisibleTo Include="Ivy.XamlBuilder.Test" />
     <InternalsVisibleTo Include="Ivy.Integration.Tests" />
+    <InternalsVisibleTo Include="Ivy.IvyML" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Ivy/Properties/AssemblyInfo.cs
+++ b/src/Ivy/Properties/AssemblyInfo.cs
@@ -8,5 +8,6 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Ivy.XamlBuilder.Test")]
 [assembly: InternalsVisibleTo("Ivy.Tendril")]
 [assembly: InternalsVisibleTo("Ivy.Agent.Test.Studio")]
+[assembly: InternalsVisibleTo("Ivy.IvyML")]
 // [assembly: InternalsVisibleTo("Ivy.Docs.Shared")]
 // [assembly: InternalsVisibleTo("Ivy.Samples.Shared")]

--- a/src/ivyml/Ivy.IvyML.Console/DrawCommand.cs
+++ b/src/ivyml/Ivy.IvyML.Console/DrawCommand.cs
@@ -1,0 +1,72 @@
+using System.ComponentModel;
+using Ivy.IvyML;
+using Spectre.Console.Cli;
+
+namespace Ivy.IvyML.Console;
+
+public sealed class DrawCommand : AsyncCommand<DrawCommand.Settings>
+{
+    private static readonly string[] SupportedExtensions = [".png", ".jpg", ".jpeg", ".webp"];
+
+    public sealed class Settings : CommandSettings
+    {
+        [CommandOption("-w|--width")]
+        [Description("Viewport width in pixels.")]
+        [DefaultValue(300)]
+        public int Width { get; init; }
+
+        [CommandOption("-h|--height")]
+        [Description("Viewport height in pixels.")]
+        [DefaultValue(200)]
+        public int Height { get; init; }
+
+        [CommandOption("-o|--output <PATH>")]
+        [Description("Output file path. Supported formats: png, jpg, webp. If omitted a temp file is used.")]
+        public string? OutputPath { get; init; }
+
+        [CommandOption("-i|--input <IVYML>")]
+        [Description("IvyML markup string.")]
+        public required string IvyML { get; init; }
+    }
+
+    protected override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(settings.IvyML))
+        {
+            System.Console.Error.WriteLine("Error: IvyML input (-i) is required.");
+            return 1;
+        }
+
+        if (settings.Width <= 0 || settings.Height <= 0)
+        {
+            System.Console.Error.WriteLine("Error: Width and height must be positive integers.");
+            return 1;
+        }
+
+        var outputPath = settings.OutputPath;
+        if (string.IsNullOrWhiteSpace(outputPath))
+        {
+            outputPath = Path.Combine(Path.GetTempPath(), $"ivyml_{Guid.NewGuid():N}.png");
+        }
+
+        var ext = Path.GetExtension(outputPath).ToLowerInvariant();
+        if (!SupportedExtensions.Contains(ext))
+        {
+            System.Console.Error.WriteLine($"Error: Unsupported format '{ext}'. Supported: {string.Join(", ", SupportedExtensions)}");
+            return 1;
+        }
+
+        var service = new IvyScreenshotService();
+        var options = new ScreenshotOptions(settings.Width, settings.Height, outputPath);
+        var result = await service.CaptureAsync(settings.IvyML, options, ct);
+
+        if (result.Success)
+        {
+            System.Console.WriteLine(result.OutputPath);
+            return 0;
+        }
+
+        System.Console.Error.WriteLine($"Error: {result.ErrorMessage}");
+        return 1;
+    }
+}

--- a/src/ivyml/Ivy.IvyML.Console/Ivy.IvyML.Console.csproj
+++ b/src/ivyml/Ivy.IvyML.Console/Ivy.IvyML.Console.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AssemblyName>ivyml</AssemblyName>
+    <RootNamespace>Ivy.IvyML.Console</RootNamespace>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>ivyml</ToolCommandName>
+    <PackageId>Ivy.IvyML.Tool</PackageId>
+    <Description>CLI tool for rendering IvyML widgets as screenshots</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Spectre.Console.Cli" Version="0.55.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Ivy.IvyML/Ivy.IvyML.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/ivyml/Ivy.IvyML.Console/Program.cs
+++ b/src/ivyml/Ivy.IvyML.Console/Program.cs
@@ -1,0 +1,12 @@
+using Ivy.IvyML.Console;
+using Spectre.Console.Cli;
+
+var app = new CommandApp();
+
+app.Configure(config =>
+{
+    config.AddCommand<DrawCommand>("draw")
+        .WithDescription("Render IvyML to a screenshot image.");
+});
+
+return await app.RunAsync(args);

--- a/src/ivyml/Ivy.IvyML.Test/Ivy.IvyML.Test.csproj
+++ b/src/ivyml/Ivy.IvyML.Test/Ivy.IvyML.Test.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Ivy.IvyML/Ivy.IvyML.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/ivyml/Ivy.IvyML.Test/XamlValidatorTests.cs
+++ b/src/ivyml/Ivy.IvyML.Test/XamlValidatorTests.cs
@@ -1,0 +1,55 @@
+using Ivy.IvyML;
+
+namespace Ivy.IvyML.Test;
+
+public class IvyMLValidatorTests
+{
+    [Fact]
+    public void ValidIvyML_ReturnsSuccess()
+    {
+        var result = IvyMLValidator.Validate("<TextBlock Content=\"Hello\" />");
+        Assert.True(result.IsValid);
+        Assert.NotNull(result.Widget);
+        Assert.Null(result.ErrorMessage);
+    }
+
+    [Fact]
+    public void MalformedMarkup_ReturnsFailure()
+    {
+        var result = IvyMLValidator.Validate("<TextBlock Content=\"Hello\"");
+        Assert.False(result.IsValid);
+        Assert.Null(result.Widget);
+        Assert.Contains("Malformed markup", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void UnknownElement_ReturnsFailure()
+    {
+        var result = IvyMLValidator.Validate("<NonExistentWidget />");
+        Assert.False(result.IsValid);
+        Assert.Null(result.Widget);
+        Assert.NotNull(result.ErrorMessage);
+    }
+
+    [Fact]
+    public void UnknownProperty_ReturnsFailure()
+    {
+        var result = IvyMLValidator.Validate("<TextBlock FakeProperty=\"value\" />");
+        Assert.False(result.IsValid);
+        Assert.Null(result.Widget);
+        Assert.NotNull(result.ErrorMessage);
+    }
+
+    [Fact]
+    public void NestedWidgets_ReturnsSuccess()
+    {
+        var ivyml = """
+            <Card>
+                <TextBlock Content="Hello" />
+            </Card>
+            """;
+        var result = IvyMLValidator.Validate(ivyml);
+        Assert.True(result.IsValid);
+        Assert.NotNull(result.Widget);
+    }
+}

--- a/src/ivyml/Ivy.IvyML/Ivy.IvyML.csproj
+++ b/src/ivyml/Ivy.IvyML/Ivy.IvyML.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Ivy.IvyML</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Playwright" Version="1.52.0" />
+    <PackageReference Include="SkiaSharp" Version="3.119.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(IvyPackageVersion)' != ''">
+    <PackageReference Include="Ivy" Version="$(IvyPackageVersion)" />
+    <PackageReference Include="Ivy.XamlBuilder" Version="$(IvyPackageVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(IvyPackageVersion)' == ''">
+    <ProjectReference Include="../../Ivy/Ivy.csproj" />
+    <ProjectReference Include="../../Ivy.XamlBuilder/Ivy.XamlBuilder.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/ivyml/Ivy.IvyML/IvyScreenshotService.cs
+++ b/src/ivyml/Ivy.IvyML/IvyScreenshotService.cs
@@ -1,0 +1,108 @@
+using Ivy.Core.Apps;
+using Ivy.Core.Server;
+using Microsoft.Playwright;
+using SkiaSharp;
+
+namespace Ivy.IvyML;
+
+public class IvyScreenshotService
+{
+    private static readonly Dictionary<string, SKEncodedImageFormat> FormatMap = new(StringComparer.OrdinalIgnoreCase)
+    {
+        [".png"] = SKEncodedImageFormat.Png,
+        [".jpg"] = SKEncodedImageFormat.Jpeg,
+        [".jpeg"] = SKEncodedImageFormat.Jpeg,
+        [".webp"] = SKEncodedImageFormat.Webp,
+    };
+
+    public static bool IsSupportedFormat(string ext) => FormatMap.ContainsKey(ext);
+
+    public async Task<ScreenshotResult> CaptureAsync(
+        string ivyml,
+        ScreenshotOptions options,
+        CancellationToken ct = default)
+    {
+        var validation = IvyMLValidator.Validate(ivyml);
+        if (!validation.IsValid)
+            return ScreenshotResult.Failed(validation.ErrorMessage!);
+
+        var ext = Path.GetExtension(options.OutputPath).ToLowerInvariant();
+        if (!FormatMap.TryGetValue(ext, out var skFormat))
+            return ScreenshotResult.Failed($"Unsupported format '{ext}'. Supported: png, jpg, webp.");
+
+        var widget = validation.Widget!;
+        var sessionStore = new AppSessionStore();
+        var server = new Server(new ServerArgs
+        {
+            Port = 0,
+            Silent = true,
+            Host = "127.0.0.1"
+        });
+        server.AddApp(new AppDescriptor
+        {
+            Id = AppIds.Default,
+            Title = "IvyML Preview",
+            ViewFunc = _ => widget,
+            Group = [],
+            IsVisible = true
+        });
+
+        var app = server.BuildWebApplication(sessionStore);
+        if (app is null)
+            return ScreenshotResult.Failed("Failed to build the Ivy application.");
+
+        await app.StartAsync(ct);
+        var baseUrl = app.Urls.First();
+
+        try
+        {
+            using var playwright = await Playwright.CreateAsync();
+            await using var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+            {
+                Headless = true
+            });
+
+            var page = await browser.NewPageAsync(new BrowserNewPageOptions
+            {
+                ViewportSize = new ViewportSize
+                {
+                    Width = options.Width,
+                    Height = options.Height
+                }
+            });
+
+            await page.GotoAsync(baseUrl, new PageGotoOptions
+            {
+                WaitUntil = WaitUntilState.NetworkIdle
+            });
+
+            var fullPath = Path.GetFullPath(options.OutputPath);
+            var dir = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrEmpty(dir))
+                Directory.CreateDirectory(dir);
+
+            var pngBytes = await page.ScreenshotAsync(new PageScreenshotOptions
+            {
+                Type = ScreenshotType.Png,
+                FullPage = false
+            });
+
+            using var bitmap = SKBitmap.Decode(pngBytes);
+            await using var fs = File.Create(fullPath);
+            using var wrapperStream = new SKManagedWStream(fs);
+            bitmap.Encode(wrapperStream, skFormat, 90);
+
+            return ScreenshotResult.Succeeded(fullPath);
+        }
+        catch (PlaywrightException ex)
+        {
+            return ScreenshotResult.Failed($"Browser error: {ex.Message}");
+        }
+        finally
+        {
+            await app.StopAsync(ct);
+            await app.DisposeAsync();
+            sessionStore.Dispose();
+        }
+    }
+}

--- a/src/ivyml/Ivy.IvyML/ScreenshotResult.cs
+++ b/src/ivyml/Ivy.IvyML/ScreenshotResult.cs
@@ -1,0 +1,9 @@
+namespace Ivy.IvyML;
+
+public record ScreenshotOptions(int Width, int Height, string OutputPath);
+
+public record ScreenshotResult(bool Success, string? OutputPath, string? ErrorMessage)
+{
+    public static ScreenshotResult Succeeded(string outputPath) => new(true, outputPath, null);
+    public static ScreenshotResult Failed(string error) => new(false, null, error);
+}

--- a/src/ivyml/Ivy.IvyML/XamlValidator.cs
+++ b/src/ivyml/Ivy.IvyML/XamlValidator.cs
@@ -1,0 +1,35 @@
+using System.Xml;
+using Ivy.Core;
+
+namespace Ivy.IvyML;
+
+public record IvyMLValidationResult(bool IsValid, AbstractWidget? Widget, string? ErrorMessage)
+{
+    public static IvyMLValidationResult Success(AbstractWidget widget) => new(true, widget, null);
+    public static IvyMLValidationResult Failure(string error) => new(false, null, error);
+}
+
+public static class IvyMLValidator
+{
+    public static IvyMLValidationResult Validate(string ivyml)
+    {
+        try
+        {
+            var builder = new XamlBuilder();
+            var widget = builder.Build(ivyml);
+            return IvyMLValidationResult.Success(widget);
+        }
+        catch (XmlException ex)
+        {
+            return IvyMLValidationResult.Failure($"Malformed markup: {ex.Message}");
+        }
+        catch (InvalidOperationException ex)
+        {
+            return IvyMLValidationResult.Failure(ex.Message);
+        }
+        catch (Exception ex)
+        {
+            return IvyMLValidationResult.Failure($"Unexpected error: {ex.Message}");
+        }
+    }
+}


### PR DESCRIPTION
Introduces three new projects under src/ivyml/:
- Ivy.IvyML: shared library with IvyML validation (via XamlBuilder) and
  screenshot capture (headless Ivy server + Playwright + SkiaSharp)
- Ivy.IvyML.Console: dotnet tool "ivyml" with draw command
  (supports png, jpg, webp output formats)
- Ivy.IvyML.Test: xunit tests for IvyML validation
