### PR TITLE
Add ivyml docs command and improve enum error messages

### DIFF
--- a/src/Ivy.XamlBuilder/XamlBuilder.cs
+++ b/src/Ivy.XamlBuilder/XamlBuilder.cs
@@ -268,7 +268,15 @@ public class XamlBuilder
             return double.Parse(value, CultureInfo.InvariantCulture);
 
         if (targetType.IsEnum)
-            return Enum.Parse(targetType, value, ignoreCase: true);
+        {
+            if (!Enum.TryParse(targetType, value, ignoreCase: true, out var enumResult))
+            {
+                var valid = string.Join(", ", Enum.GetNames(targetType));
+                throw new InvalidOperationException(
+                    $"Invalid value '{value}' for {targetType.Name}. Valid values: {valid}");
+            }
+            return enumResult!;
+        }
 
         if (targetType == typeof(Size))
             return ParseSize(value);

--- a/src/ivyml/Ivy.IvyML.Console/DocsCommand.cs
+++ b/src/ivyml/Ivy.IvyML.Console/DocsCommand.cs
@@ -1,0 +1,29 @@
+using System.ComponentModel;
+using Ivy.IvyML;
+using Spectre.Console.Cli;
+
+namespace Ivy.IvyML.Console;
+
+public sealed class DocsCommand : Command<DocsCommand.Settings>
+{
+    public sealed class Settings : CommandSettings
+    {
+        [CommandArgument(0, "[widget]")]
+        [Description("Widget name to show detailed props for.")]
+        public string? Widget { get; init; }
+    }
+
+    protected override int Execute(CommandContext context, Settings settings, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(settings.Widget))
+        {
+            System.Console.WriteLine(DocsProvider.GetDocsOutput());
+        }
+        else
+        {
+            System.Console.WriteLine(DocsProvider.GetWidgetDocs(settings.Widget));
+        }
+
+        return 0;
+    }
+}

--- a/src/ivyml/Ivy.IvyML.Console/Program.cs
+++ b/src/ivyml/Ivy.IvyML.Console/Program.cs
@@ -7,6 +7,8 @@ app.Configure(config =>
 {
     config.AddCommand<DrawCommand>("draw")
         .WithDescription("Render IvyML to a screenshot image.");
+    config.AddCommand<DocsCommand>("docs")
+        .WithDescription("Show IvyML documentation and widget reference.");
 });
 
 return await app.RunAsync(args);

--- a/src/ivyml/Ivy.IvyML/Docs/IVYML.md
+++ b/src/ivyml/Ivy.IvyML/Docs/IVYML.md
@@ -1,0 +1,84 @@
+# IvyML
+
+IvyML is an XML-based markup language for describing Ivy widget trees. It maps directly to Ivy's widget system -- each XML element is a widget, each attribute is a prop.
+
+## Syntax
+
+```xml
+<WidgetName PropName="value" AnotherProp="value">
+  <ChildWidget Prop="value" />
+</WidgetName>
+```
+
+- Element names are widget type names (case-insensitive).
+- Attributes map to properties marked with `[Prop]` on the widget.
+- Child elements become the widget's children.
+- Property elements use dot notation: `<Card.Padding>10,10,10,10</Card.Padding>`
+
+## Value Types
+
+| Type      | Example values                                        |
+|-----------|-------------------------------------------------------|
+| string    | `"Hello"`                                             |
+| bool      | `true`, `false`                                       |
+| int       | `42`                                                  |
+| float     | `3.14`                                                |
+| enum      | `Primary`, `Success`, `H1` (case-insensitive)         |
+| Size      | `Full`, `Fit`, `Auto`, `Half`, `200px`, `50%`, `4rem` |
+| Thickness | `10` or `10,20` or `10,20,10,20`                      |
+
+## CLI Usage
+
+```
+ivyml draw -i <IVYML> [-o <PATH>] [-w <WIDTH>] [-h <HEIGHT>]
+```
+
+| Option          | Description                         | Default |
+|-----------------|-------------------------------------|---------|
+| `-i`, `--input` | IvyML markup string (required)      |         |
+| `-o`, `--output`| Output file path (png, jpg, webp)   | temp    |
+| `-w`, `--width` | Viewport width in pixels            | 300     |
+| `-h`, `--height`| Viewport height in pixels           | 200     |
+
+If `-o` is omitted, the screenshot is saved to a temp file and the path is printed to stdout.
+
+```
+ivyml docs
+```
+
+Print this guide and a list of all available widgets.
+
+```
+ivyml docs <widget>
+```
+
+Print all props and events for a specific widget.
+
+## Examples
+
+Simple text:
+```xml
+<TextBlock Content="Hello World" Variant="H1" />
+```
+
+Button:
+```xml
+<Button Title="Submit" Variant="Primary" />
+```
+
+Card with content:
+```xml
+<Card>
+  <TextBlock Content="Card body" />
+</Card>
+```
+
+Badge:
+```xml
+<Badge Title="New" Variant="Success" />
+```
+
+Progress bar:
+```xml
+<Progress Value="75" />
+```

--- a/src/ivyml/Ivy.IvyML/DocsProvider.cs
+++ b/src/ivyml/Ivy.IvyML/DocsProvider.cs
@@ -1,0 +1,37 @@
+using System.Reflection;
+using System.Text;
+
+namespace Ivy.IvyML;
+
+public static class DocsProvider
+{
+    public static string GetGuide()
+    {
+        using var stream = Assembly.GetExecutingAssembly()
+            .GetManifestResourceStream("Ivy.IvyML.Docs.IVYML.md");
+        if (stream is null)
+            return "Documentation not found.";
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
+
+    public static string GetDocsOutput()
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine(GetGuide());
+        sb.AppendLine();
+        sb.AppendLine("## Available Widgets");
+        sb.AppendLine();
+        foreach (var name in WidgetCatalog.ListNames())
+            sb.AppendLine(name);
+        return sb.ToString().TrimEnd();
+    }
+
+    public static string GetWidgetDocs(string widgetName)
+    {
+        var widget = WidgetCatalog.Get(widgetName);
+        if (widget is null)
+            return $"Unknown widget: {widgetName}";
+        return WidgetCatalog.FormatWidgetDetail(widget);
+    }
+}

--- a/src/ivyml/Ivy.IvyML/Ivy.IvyML.csproj
+++ b/src/ivyml/Ivy.IvyML/Ivy.IvyML.csproj
@@ -12,6 +12,10 @@
     <PackageReference Include="SkiaSharp" Version="3.119.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <EmbeddedResource Include="Docs\IVYML.md" LogicalName="Ivy.IvyML.Docs.IVYML.md" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(IvyPackageVersion)' != ''">
     <PackageReference Include="Ivy" Version="$(IvyPackageVersion)" />
     <PackageReference Include="Ivy.XamlBuilder" Version="$(IvyPackageVersion)" />

--- a/src/ivyml/Ivy.IvyML/WidgetCatalog.cs
+++ b/src/ivyml/Ivy.IvyML/WidgetCatalog.cs
@@ -1,0 +1,191 @@
+using System.Reflection;
+using System.Text;
+using Ivy.Core;
+
+namespace Ivy.IvyML;
+
+public record WidgetPropInfo(string Name, string Type, bool IsNullable, string? DefaultValue, string[]? EnumValues);
+
+public record WidgetEventInfo(string Name);
+
+public record WidgetInfo(string Name, WidgetPropInfo[] Props, WidgetEventInfo[] Events);
+
+public static class WidgetCatalog
+{
+    private static readonly Lazy<Dictionary<string, WidgetInfo>> Widgets = new(BuildCatalog);
+
+    public static IReadOnlyDictionary<string, WidgetInfo> All => Widgets.Value;
+
+    public static WidgetInfo? Get(string name) =>
+        Widgets.Value.GetValueOrDefault(name) ??
+        Widgets.Value.FirstOrDefault(kv => kv.Key.Equals(name, StringComparison.OrdinalIgnoreCase)).Value;
+
+    public static string[] ListNames() =>
+        Widgets.Value.Keys.Order().ToArray();
+
+    private static Dictionary<string, WidgetInfo> BuildCatalog()
+    {
+        var catalog = new Dictionary<string, WidgetInfo>(StringComparer.OrdinalIgnoreCase);
+        var assembly = typeof(AbstractWidget).Assembly;
+
+        foreach (var type in assembly.GetTypes())
+        {
+            if (type.IsGenericTypeDefinition || type.IsEnum ||
+                type.IsInterface || type.IsNested)
+                continue;
+
+            if (!typeof(AbstractWidget).IsAssignableFrom(type))
+                continue;
+
+            var props = GetProps(type);
+            var events = GetEvents(type);
+
+            if (props.Length == 0 && events.Length == 0)
+                continue;
+
+            var name = type.Name;
+            if (type.IsAbstract && name.EndsWith("Base"))
+                name = name[..^4];
+
+            if (catalog.ContainsKey(name))
+                continue;
+
+            catalog[name] = new WidgetInfo(name, props, events);
+        }
+
+        return catalog;
+    }
+
+    private static WidgetPropInfo[] GetProps(Type type)
+    {
+        object? defaultInstance = null;
+        if (!type.IsAbstract)
+        {
+            var ctor = type.GetConstructor(
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+                null, Type.EmptyTypes, null);
+            if (ctor != null)
+            {
+                try { defaultInstance = ctor.Invoke(null); }
+                catch { /* ignore */ }
+            }
+        }
+
+        return type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.GetCustomAttribute<PropAttribute>() != null)
+            .Where(p => p.GetCustomAttribute<PropAttribute>()!.AttachedName == null)
+            .Select(p => BuildPropInfo(p, defaultInstance))
+            .ToArray();
+    }
+
+    private static WidgetPropInfo BuildPropInfo(PropertyInfo prop, object? defaultInstance)
+    {
+        var propType = prop.PropertyType;
+        var underlying = Nullable.GetUnderlyingType(propType);
+        var isNullable = underlying != null;
+        var effectiveType = underlying ?? propType;
+
+        if (effectiveType.IsGenericType && effectiveType.GetGenericTypeDefinition() == typeof(Responsive<>))
+            effectiveType = effectiveType.GetGenericArguments()[0];
+
+        string? defaultValue = null;
+        if (defaultInstance != null)
+        {
+            try
+            {
+                var val = prop.GetValue(defaultInstance);
+                if (val != null)
+                    defaultValue = FormatDefault(val, effectiveType);
+            }
+            catch { /* ignore */ }
+        }
+
+        string[]? enumValues = null;
+        var enumType = effectiveType;
+        if (Nullable.GetUnderlyingType(enumType) is { } innerEnum)
+            enumType = innerEnum;
+        if (enumType.IsEnum)
+            enumValues = Enum.GetNames(enumType);
+
+        return new WidgetPropInfo(prop.Name, FormatTypeName(effectiveType), isNullable, defaultValue, enumValues);
+    }
+
+    private static WidgetEventInfo[] GetEvents(Type type) =>
+        type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.GetCustomAttribute<EventAttribute>() != null)
+            .Select(p => new WidgetEventInfo(p.Name))
+            .ToArray();
+
+    private static string FormatTypeName(Type type)
+    {
+        if (type == typeof(string)) return "string";
+        if (type == typeof(bool)) return "bool";
+        if (type == typeof(int)) return "int";
+        if (type == typeof(float)) return "float";
+        if (type == typeof(double)) return "double";
+        if (type == typeof(char)) return "char";
+        if (type == typeof(Size)) return "Size";
+        if (type == typeof(Thickness)) return "Thickness";
+        if (type.IsEnum) return type.Name;
+        if (type.IsArray) return FormatTypeName(type.GetElementType()!) + "[]";
+        if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Responsive<>))
+            return FormatTypeName(type.GetGenericArguments()[0]);
+        if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>))
+            return FormatTypeName(Nullable.GetUnderlyingType(type)!);
+        if (type.IsGenericType)
+            return type.Name.Split('`')[0];
+        return type.Name;
+    }
+
+    private static string? FormatDefault(object value, Type type)
+    {
+        if (type.IsEnum) return value.ToString();
+        if (value is bool b) return b ? "true" : "false";
+        if (value is string s) return s.Length > 0 ? $"\"{s}\"" : null;
+        if (value is char c) return $"'{c}'";
+        if (value is int i) return i != 0 ? i.ToString() : null;
+        if (value is float f) return f != 0 ? f.ToString() : null;
+        if (value is double d) return d != 0 ? d.ToString() : null;
+        return null;
+    }
+
+    public static string FormatWidgetList()
+    {
+        var sb = new StringBuilder();
+        foreach (var name in ListNames())
+            sb.AppendLine(name);
+        return sb.ToString().TrimEnd();
+    }
+
+    public static string FormatWidgetDetail(WidgetInfo widget)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine(widget.Name);
+        sb.AppendLine();
+
+        if (widget.Props.Length > 0)
+        {
+            sb.AppendLine("Props:");
+            foreach (var prop in widget.Props)
+            {
+                var def = prop.DefaultValue != null ? $" = {prop.DefaultValue}" : "";
+                var nullable = prop.IsNullable ? "?" : "";
+                sb.Append($"  {prop.Name} : {prop.Type}{nullable}{def}");
+                if (prop.EnumValues is { Length: > 0 })
+                    sb.Append($" [{string.Join(", ", prop.EnumValues)}]");
+                sb.AppendLine();
+            }
+        }
+
+        if (widget.Events.Length > 0)
+        {
+            if (widget.Props.Length > 0)
+                sb.AppendLine();
+            sb.AppendLine("Events:");
+            foreach (var evt in widget.Events)
+                sb.AppendLine($"  {evt.Name}");
+        }
+
+        return sb.ToString().TrimEnd();
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ivyml docs` command that outputs the IvyML guide and lists all available widgets
- Add `ivyml docs <widget>` that shows detailed props with types, defaults, and valid enum values
- Include abstract base input widgets (SelectInput, TextInput, etc.) in the widget catalog by stripping the "Base" suffix
- Improve XamlBuilder enum parsing to suggest valid values on invalid input

## Test plan
- [x] All 5 existing IvyML unit tests pass
- [x] `ivyml docs` lists all widgets
- [x] `ivyml docs Button` shows props with enum values
- [x] `ivyml docs SelectInput` now appears (was previously missing)
- [x] Invalid enum values produce helpful error messages