### PR TITLE
IvyML: add debug overlay, responsive breakpoints, file input, and expanded docs

### DIFF
--- a/src/Ivy.XamlBuilder.Test/XamlBuilderTests.cs
+++ b/src/Ivy.XamlBuilder.Test/XamlBuilderTests.cs
@@ -393,6 +393,65 @@ public class XamlBuilderTests
         Assert.Single(chart.XAxis);
     }
 
+    // --- Responsive breakpoint syntax ---
+
+    [Fact]
+    public void Build_Responsive_SingleBreakpoint()
+    {
+        var widget = _builder.Build("<Badge Width.Mobile=\"Half\" />");
+        var badge = Assert.IsType<Badge>(widget);
+        Assert.NotNull(badge.Width);
+        Assert.Equal(Size.Half(), badge.Width!.Mobile);
+    }
+
+    [Fact]
+    public void Build_Responsive_DefaultAndBreakpoint()
+    {
+        var widget = _builder.Build("<Badge Width=\"Full\" Width.Mobile=\"Half\" />");
+        var badge = Assert.IsType<Badge>(widget);
+        Assert.NotNull(badge.Width);
+        Assert.Equal(Size.Full(), badge.Width!.Default);
+        Assert.Equal(Size.Half(), badge.Width!.Mobile);
+    }
+
+    [Fact]
+    public void Build_Responsive_MultipleBreakpoints()
+    {
+        var widget = _builder.Build("<Badge Width=\"Full\" Width.Mobile=\"200px\" Width.Tablet=\"Half\" Width.Desktop=\"80%\" />");
+        var badge = Assert.IsType<Badge>(widget);
+        Assert.NotNull(badge.Width);
+        Assert.Equal(Size.Full(), badge.Width!.Default);
+        Assert.Equal(Size.Px(200), badge.Width!.Mobile);
+        Assert.Equal(Size.Half(), badge.Width!.Tablet);
+        Assert.Equal(Size.Fraction(0.8f), badge.Width!.Desktop);
+    }
+
+    [Fact]
+    public void Build_Responsive_BreakpointOnly_NoDefault()
+    {
+        var widget = _builder.Build("<Badge Width.Desktop=\"Full\" />");
+        var badge = Assert.IsType<Badge>(widget);
+        Assert.NotNull(badge.Width);
+        Assert.Null(badge.Width!.Default);
+        Assert.Equal(Size.Full(), badge.Width!.Desktop);
+    }
+
+    [Fact]
+    public void Build_Responsive_CaseInsensitiveBreakpoint()
+    {
+        var widget = _builder.Build("<Badge Width.mobile=\"Half\" />");
+        var badge = Assert.IsType<Badge>(widget);
+        Assert.NotNull(badge.Width);
+        Assert.Equal(Size.Half(), badge.Width!.Mobile);
+    }
+
+    [Fact]
+    public void Build_Responsive_NonResponsiveProp_Throws()
+    {
+        Assert.Throws<InvalidOperationException>(
+            () => _builder.Build("<Badge Title.Mobile=\"Hello\" />"));
+    }
+
     // --- Error cases ---
 
     [Fact]

--- a/src/Ivy.XamlBuilder/XamlBuilder.cs
+++ b/src/Ivy.XamlBuilder/XamlBuilder.cs
@@ -157,16 +157,78 @@ public class XamlBuilder
         return obj;
     }
 
+    private static readonly HashSet<string> Breakpoints = new(StringComparer.OrdinalIgnoreCase)
+        { "Mobile", "Tablet", "Desktop", "Wide" };
+
     private void SetAttributes(object target, XElement element)
     {
+        List<(string propName, string breakpoint, string value)>? responsiveAttrs = null;
+
         foreach (var attr in element.Attributes())
         {
-            var prop = FindProperty(target, attr.Name.LocalName)
+            var attrName = attr.Name.LocalName;
+            var dotIndex = attrName.IndexOf('.');
+
+            if (dotIndex > 0 && dotIndex < attrName.Length - 1)
+            {
+                var suffix = attrName[(dotIndex + 1)..];
+                if (Breakpoints.Contains(suffix))
+                {
+                    responsiveAttrs ??= [];
+                    responsiveAttrs.Add((attrName[..dotIndex], suffix, attr.Value));
+                    continue;
+                }
+            }
+
+            var prop = FindProperty(target, attrName)
                 ?? throw new InvalidOperationException(
-                    $"Unknown property '{attr.Name.LocalName}' on {target.GetType().Name}.");
+                    $"Unknown property '{attrName}' on {target.GetType().Name}.");
 
             var value = ConvertValue(attr.Value, prop.PropertyType);
             SetProperty(target, prop, value);
+        }
+
+        if (responsiveAttrs != null)
+            SetResponsiveBreakpoints(target, responsiveAttrs);
+    }
+
+    private void SetResponsiveBreakpoints(object target,
+        List<(string propName, string breakpoint, string value)> attrs)
+    {
+        foreach (var (propName, breakpoint, attrValue) in attrs)
+        {
+            var prop = FindProperty(target, propName)
+                ?? throw new InvalidOperationException(
+                    $"Unknown property '{propName}' on {target.GetType().Name}.");
+
+            var propType = prop.PropertyType;
+            var underlyingType = Nullable.GetUnderlyingType(propType) ?? propType;
+
+            if (!underlyingType.IsGenericType ||
+                underlyingType.GetGenericTypeDefinition() != typeof(Responsive<>))
+                throw new InvalidOperationException(
+                    $"Property '{propName}' on {target.GetType().Name} does not support responsive breakpoints.");
+
+            var innerType = underlyingType.GetGenericArguments()[0];
+            var innerValue = ConvertValue(attrValue, innerType);
+
+            var existing = prop.GetValue(target);
+            if (existing == null)
+            {
+                existing = Activator.CreateInstance(underlyingType)!;
+                SetProperty(target, prop, existing);
+            }
+
+            var bpName = Breakpoints.First(b => string.Equals(b, breakpoint, StringComparison.OrdinalIgnoreCase));
+            var bpField = underlyingType.GetField(
+                $"<{bpName}>k__BackingField",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+
+            if (bpField == null)
+                throw new InvalidOperationException(
+                    $"Unknown breakpoint '{breakpoint}' on Responsive<{innerType.Name}>.");
+
+            bpField.SetValue(existing, innerValue);
         }
     }
 

--- a/src/Ivy/Abstractions/SlotAttribute.cs
+++ b/src/Ivy/Abstractions/SlotAttribute.cs
@@ -1,0 +1,8 @@
+// Resharper disable once CheckNamespace
+namespace Ivy;
+
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+public class SlotAttribute(string name) : Attribute
+{
+    public string Name { get; } = name;
+}

--- a/src/Ivy/Widgets/Card.cs
+++ b/src/Ivy/Widgets/Card.cs
@@ -6,6 +6,9 @@ namespace Ivy;
 /// <summary>
 /// A flexible container with a border and shadow for grouping related content.
 /// </summary>
+[Slot("Content")]
+[Slot("Header")]
+[Slot("Footer")]
 public record Card : WidgetBase<Card>
 {
     public Card(object? content = null, object? footer = null, object? header = null) : base(

--- a/src/Ivy/Widgets/DropDownMenu.cs
+++ b/src/Ivy/Widgets/DropDownMenu.cs
@@ -9,6 +9,8 @@ namespace Ivy;
 /// A menu that appears when an element is clicked.
 /// </summary>
 [ChildType(typeof(MenuItem))]
+[Slot("Trigger")]
+[Slot("Header")]
 public record DropDownMenu : WidgetBase<DropDownMenu>
 {
     public enum SideOptions

--- a/src/Ivy/Widgets/Expandable.cs
+++ b/src/Ivy/Widgets/Expandable.cs
@@ -4,6 +4,8 @@ namespace Ivy;
 /// <summary>
 /// A widget that can expand or collapse its content.
 /// </summary>
+[Slot("Header")]
+[Slot("Content")]
 public record Expandable : WidgetBase<Expandable>
 {
     public Expandable(object header, object content) : base([new Slot("Header", header), new Slot("Content", content)])

--- a/src/Ivy/Widgets/Inputs/BoolInput.cs
+++ b/src/Ivy/Widgets/Inputs/BoolInput.cs
@@ -26,6 +26,8 @@ public interface IAnyBoolInput : IAnyInput
     public bool Loading { get; set; }
 }
 
+[Slot("Prefix")]
+[Slot("Suffix")]
 public abstract record BoolInputBase : WidgetBase<BoolInputBase>, IAnyBoolInput
 {
     [Prop] public bool Disabled { get; set; }

--- a/src/Ivy/Widgets/Inputs/CodeInput.cs
+++ b/src/Ivy/Widgets/Inputs/CodeInput.cs
@@ -16,6 +16,8 @@ public interface IAnyCodeInput : IAnyInput
     public CodeInputVariant Variant { get; set; }
 }
 
+[Slot("Prefix")]
+[Slot("Suffix")]
 public abstract record CodeInputBase : WidgetBase<CodeInputBase>, IAnyCodeInput
 {
     [Prop] public bool Disabled { get; set; }

--- a/src/Ivy/Widgets/Inputs/ColorInput.cs
+++ b/src/Ivy/Widgets/Inputs/ColorInput.cs
@@ -20,6 +20,8 @@ public interface IAnyColorInput : IAnyInput
     public ColorInputVariant Variant { get; set; }
 }
 
+[Slot("Prefix")]
+[Slot("Suffix")]
 public abstract record ColorInputBase : WidgetBase<ColorInputBase>, IAnyColorInput
 {
     [Prop] public bool Disabled { get; set; }

--- a/src/Ivy/Widgets/Inputs/DateRangeInput.cs
+++ b/src/Ivy/Widgets/Inputs/DateRangeInput.cs
@@ -11,6 +11,8 @@ public interface IAnyDateRangeInput : IAnyInput
     public string? Format { get; set; }
 }
 
+[Slot("Prefix")]
+[Slot("Suffix")]
 public abstract record DateRangeInputBase : WidgetBase<DateRangeInputBase>, IAnyDateRangeInput
 {
     [Prop] public string? Placeholder { get; set; }

--- a/src/Ivy/Widgets/Inputs/DateTimeInput.cs
+++ b/src/Ivy/Widgets/Inputs/DateTimeInput.cs
@@ -23,6 +23,8 @@ public interface IAnyDateTimeInput : IAnyInput
     public string? Format { get; set; }
 }
 
+[Slot("Prefix")]
+[Slot("Suffix")]
 public abstract record DateTimeInputBase : WidgetBase<DateTimeInputBase>, IAnyDateTimeInput
 {
     [Prop] public DateTimeInputVariant Variant { get; set; } = DateTimeInputVariant.Date;

--- a/src/Ivy/Widgets/Inputs/FeedbackInput.cs
+++ b/src/Ivy/Widgets/Inputs/FeedbackInput.cs
@@ -19,6 +19,8 @@ public interface IAnyFeedbackInput : IAnyInput
     public FeedbackInputVariant Variant { get; set; }
 }
 
+[Slot("Prefix")]
+[Slot("Suffix")]
 public abstract record FeedbackInputBase : WidgetBase<FeedbackInputBase>, IAnyFeedbackInput
 {
     [Prop] public bool Disabled { get; set; }

--- a/src/Ivy/Widgets/Inputs/IconInput.cs
+++ b/src/Ivy/Widgets/Inputs/IconInput.cs
@@ -9,6 +9,8 @@ namespace Ivy;
 /// <summary>
 /// An input field for selecting an icon from the Ivy icon set (Lucide icons).
 /// </summary>
+[Slot("Prefix")]
+[Slot("Suffix")]
 public abstract record IconInputBase : WidgetBase<IconInputBase>, IAnyInput
 {
     [Prop] public bool Disabled { get; set; }

--- a/src/Ivy/Widgets/Inputs/NumberInput.cs
+++ b/src/Ivy/Widgets/Inputs/NumberInput.cs
@@ -43,6 +43,8 @@ public interface IAnyNumberInput : IAnyInput
     public string? TargetType { get; set; }
 }
 
+[Slot("Prefix")]
+[Slot("Suffix")]
 public abstract record NumberInputBase : WidgetBase<NumberInputBase>, IAnyNumberInput
 {
     [Prop] public bool Disabled { get; set; }

--- a/src/Ivy/Widgets/Inputs/NumberRangeInput.cs
+++ b/src/Ivy/Widgets/Inputs/NumberRangeInput.cs
@@ -23,6 +23,8 @@ public interface IAnyNumberRangeInput : IAnyInput
     public string? TargetType { get; set; }
 }
 
+[Slot("Prefix")]
+[Slot("Suffix")]
 public abstract record NumberRangeInputBase : WidgetBase<NumberRangeInputBase>, IAnyNumberRangeInput
 {
     [Prop] public bool Disabled { get; set; }

--- a/src/Ivy/Widgets/Inputs/SelectInput.cs
+++ b/src/Ivy/Widgets/Inputs/SelectInput.cs
@@ -27,6 +27,8 @@ public interface IAnySelectInput : IAnyInput
     public SelectInputVariant Variant { get; set; }
 }
 
+[Slot("Prefix")]
+[Slot("Suffix")]
 public abstract record SelectInputBase : WidgetBase<SelectInputBase>, IAnySelectInput
 {
     [Prop] public bool Disabled { get; set; }

--- a/src/Ivy/Widgets/Inputs/TextInput.cs
+++ b/src/Ivy/Widgets/Inputs/TextInput.cs
@@ -30,6 +30,8 @@ public interface IAnyTextInput : IAnyInput
     public TextInputVariant Variant { get; set; }
 }
 
+[Slot("Prefix")]
+[Slot("Suffix")]
 public abstract record TextInputBase : WidgetBase<TextInputBase>, IAnyTextInput
 {
     [Prop] public bool Disabled { get; set; }

--- a/src/Ivy/Widgets/Layouts/FooterLayout.cs
+++ b/src/Ivy/Widgets/Layouts/FooterLayout.cs
@@ -4,6 +4,8 @@ namespace Ivy;
 /// <summary>
 /// A layout container for footer content, typically pinned to the bottom.
 /// </summary>
+[Slot("Footer")]
+[Slot("Content")]
 public record FooterLayout : WidgetBase<FooterLayout>
 {
     public FooterLayout(object footer, object content) : base([new Slot("Footer", footer), new Slot("Content", content)])

--- a/src/Ivy/Widgets/Layouts/HeaderLayout.cs
+++ b/src/Ivy/Widgets/Layouts/HeaderLayout.cs
@@ -4,6 +4,8 @@ namespace Ivy;
 /// <summary>
 /// A standard header layout with branding and navigation areas.
 /// </summary>
+[Slot("Header")]
+[Slot("Content")]
 public record HeaderLayout : WidgetBase<HeaderLayout>
 {
     public HeaderLayout(object header, object content) : base([new Slot("Header", header), new Slot("Content", content)])

--- a/src/Ivy/Widgets/Layouts/SidebarLayout.cs
+++ b/src/Ivy/Widgets/Layouts/SidebarLayout.cs
@@ -7,6 +7,10 @@ namespace Ivy;
 /// <summary>
 /// A common application layout with a collapsible sidebar and main content area.
 /// </summary>
+[Slot("MainContent")]
+[Slot("SidebarContent")]
+[Slot("SidebarHeader")]
+[Slot("SidebarFooter")]
 public record SidebarLayout : WidgetBase<SidebarLayout>
 {
     public static Size DefaultWidth => Size.Rem(16);

--- a/src/Ivy/Widgets/Sheet.cs
+++ b/src/Ivy/Widgets/Sheet.cs
@@ -15,6 +15,7 @@ public enum SheetSide
 /// <summary>
 /// A side-aligned modal panel for editing or displaying distinct sub-tasks.
 /// </summary>
+[Slot("Content")]
 public record Sheet : WidgetBase<Sheet>
 {
     public static Size DefaultWidth => Size.Rem(24);

--- a/src/Ivy/Widgets/Tooltip.cs
+++ b/src/Ivy/Widgets/Tooltip.cs
@@ -6,6 +6,8 @@ namespace Ivy;
 /// <summary>
 /// A brief informational message that appears when hovering over an element.
 /// </summary>
+[Slot("Trigger")]
+[Slot("Content")]
 public record Tooltip : WidgetBase<Tooltip>
 {
     public Tooltip(object trigger, object content) : base([new Slot("Trigger", trigger), new Slot("Content", content)])

--- a/src/ivyml/Ivy.IvyML.Console/DrawCommand.cs
+++ b/src/ivyml/Ivy.IvyML.Console/DrawCommand.cs
@@ -26,14 +26,45 @@ public sealed class DrawCommand : AsyncCommand<DrawCommand.Settings>
 
         [CommandOption("-i|--input <IVYML>")]
         [Description("IvyML markup string.")]
-        public required string IvyML { get; init; }
+        public string? IvyML { get; init; }
+
+        [CommandOption("-f|--file <PATH>")]
+        [Description("Path to an IvyML file.")]
+        public string? FilePath { get; init; }
+
+        [CommandOption("-d|--debug")]
+        [Description("Draw debug overlays showing widget bounds, sizes, and padding.")]
+        [DefaultValue(false)]
+        public bool Debug { get; init; }
     }
 
     protected override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken ct)
     {
-        if (string.IsNullOrWhiteSpace(settings.IvyML))
+        if (!string.IsNullOrWhiteSpace(settings.IvyML) && !string.IsNullOrWhiteSpace(settings.FilePath))
         {
-            System.Console.Error.WriteLine("Error: IvyML input (-i) is required.");
+            System.Console.Error.WriteLine("Error: Specify either -i or -f, not both.");
+            return 1;
+        }
+
+        string? ivyml = null;
+
+        if (!string.IsNullOrWhiteSpace(settings.FilePath))
+        {
+            if (!File.Exists(settings.FilePath))
+            {
+                System.Console.Error.WriteLine($"Error: File not found: {settings.FilePath}");
+                return 1;
+            }
+            ivyml = await File.ReadAllTextAsync(settings.FilePath, ct);
+        }
+        else
+        {
+            ivyml = settings.IvyML;
+        }
+
+        if (string.IsNullOrWhiteSpace(ivyml))
+        {
+            System.Console.Error.WriteLine("Error: Provide IvyML markup via -i or -f.");
             return 1;
         }
 
@@ -57,8 +88,8 @@ public sealed class DrawCommand : AsyncCommand<DrawCommand.Settings>
         }
 
         var service = new IvyScreenshotService();
-        var options = new ScreenshotOptions(settings.Width, settings.Height, outputPath);
-        var result = await service.CaptureAsync(settings.IvyML, options, ct);
+        var options = new ScreenshotOptions(settings.Width, settings.Height, outputPath, settings.Debug);
+        var result = await service.CaptureAsync(ivyml, options, ct);
 
         if (result.Success)
         {

--- a/src/ivyml/Ivy.IvyML/DebugOverlay.js
+++ b/src/ivyml/Ivy.IvyML/DebugOverlay.js
@@ -1,0 +1,233 @@
+(() => {
+  const DEPTH_COLORS = [
+    [239, 68, 68],   // red
+    [59, 130, 246],   // blue
+    [34, 197, 94],    // green
+    [168, 85, 247],   // purple
+    [249, 115, 22],   // orange
+    [6, 182, 212],    // cyan
+    [236, 72, 153],   // pink
+    [234, 179, 8],    // yellow
+  ];
+
+  const PADDING_ALPHA = 0.12;
+  const BORDER_ALPHA = 0.7;
+  const ZERO_SIZE_COLOR = 'rgba(239, 68, 68, 0.9)';
+  const LABEL_BG = 'rgba(0, 0, 0, 0.75)';
+  const LABEL_COLOR = '#fff';
+  const FONT = '10px monospace';
+
+  const container = document.createElement('div');
+  container.id = 'ivyml-debug-overlay';
+  Object.assign(container.style, {
+    position: 'fixed',
+    top: '0',
+    left: '0',
+    width: '100vw',
+    height: '100vh',
+    pointerEvents: 'none',
+    zIndex: '999999',
+  });
+  document.body.appendChild(container);
+
+  function getDepth(el) {
+    let depth = 0;
+    let parent = el.parentElement;
+    while (parent) {
+      if (parent.tagName && parent.tagName.toLowerCase() === 'ivy-widget') depth++;
+      parent = parent.parentElement;
+    }
+    return depth;
+  }
+
+  function formatType(type) {
+    return (type || '').replace(/^Ivy\./, '');
+  }
+
+  const widgets = document.querySelectorAll('ivy-widget');
+
+  widgets.forEach(el => {
+    const depth = getDepth(el);
+    const color = DEPTH_COLORS[depth % DEPTH_COLORS.length];
+    const type = formatType(el.getAttribute('type'));
+    const testId = el.querySelector('[data-testid]')?.getAttribute('data-testid');
+    const label = testId || type;
+
+    const children = el.children;
+    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+    for (let i = 0; i < children.length; i++) {
+      const tag = children[i].tagName?.toLowerCase();
+      if (tag === 'div' && children[i].id === 'ivyml-debug-overlay') continue;
+      const rect = children[i].getBoundingClientRect();
+      if (rect.width === 0 && rect.height === 0) continue;
+      minX = Math.min(minX, rect.left);
+      minY = Math.min(minY, rect.top);
+      maxX = Math.max(maxX, rect.right);
+      maxY = Math.max(maxY, rect.bottom);
+    }
+
+    const isZero = minX === Infinity;
+    const bounds = isZero
+      ? el.getBoundingClientRect()
+      : new DOMRect(minX, minY, maxX - minX, maxY - minY);
+
+    const w = Math.round(bounds.width);
+    const h = Math.round(bounds.height);
+
+    if (isZero || (w === 0 && h === 0)) {
+      const marker = document.createElement('div');
+      Object.assign(marker.style, {
+        position: 'fixed',
+        top: `${bounds.top - 6}px`,
+        left: `${bounds.left - 6}px`,
+        width: '12px',
+        height: '12px',
+        zIndex: '999999',
+      });
+
+      const cross = document.createElement('div');
+      Object.assign(cross.style, {
+        position: 'absolute',
+        top: '0',
+        left: '0',
+        width: '12px',
+        height: '12px',
+        fontSize: '12px',
+        lineHeight: '12px',
+        textAlign: 'center',
+        color: ZERO_SIZE_COLOR,
+        fontWeight: 'bold',
+        fontFamily: 'monospace',
+      });
+      cross.textContent = '✖';
+      marker.appendChild(cross);
+
+      const zeroLabel = document.createElement('div');
+      Object.assign(zeroLabel.style, {
+        position: 'absolute',
+        top: '-2px',
+        left: '14px',
+        background: 'rgba(239, 68, 68, 0.9)',
+        color: LABEL_COLOR,
+        font: FONT,
+        padding: '1px 4px',
+        borderRadius: '2px',
+        whiteSpace: 'nowrap',
+      });
+      zeroLabel.textContent = `${label} 0×0`;
+      marker.appendChild(zeroLabel);
+
+      container.appendChild(marker);
+      return;
+    }
+
+    // Padding visualization
+    const cs = window.getComputedStyle(el.children[0] || el);
+    const pt = parseFloat(cs.paddingTop) || 0;
+    const pr = parseFloat(cs.paddingRight) || 0;
+    const pb = parseFloat(cs.paddingBottom) || 0;
+    const pl = parseFloat(cs.paddingLeft) || 0;
+    const hasPadding = pt > 0 || pr > 0 || pb > 0 || pl > 0;
+
+    if (hasPadding) {
+      const padColor = `rgba(${color[0]}, ${color[1]}, ${color[2]}, ${PADDING_ALPHA})`;
+
+      // Top padding
+      if (pt > 0) {
+        const pad = document.createElement('div');
+        Object.assign(pad.style, {
+          position: 'fixed',
+          top: `${bounds.top}px`,
+          left: `${bounds.left}px`,
+          width: `${w}px`,
+          height: `${Math.min(pt, h)}px`,
+          background: padColor,
+        });
+        container.appendChild(pad);
+      }
+      // Bottom padding
+      if (pb > 0) {
+        const pad = document.createElement('div');
+        Object.assign(pad.style, {
+          position: 'fixed',
+          top: `${bounds.bottom - Math.min(pb, h)}px`,
+          left: `${bounds.left}px`,
+          width: `${w}px`,
+          height: `${Math.min(pb, h)}px`,
+          background: padColor,
+        });
+        container.appendChild(pad);
+      }
+      // Left padding
+      if (pl > 0) {
+        const innerTop = bounds.top + Math.min(pt, h);
+        const innerH = h - Math.min(pt, h) - Math.min(pb, h);
+        if (innerH > 0) {
+          const pad = document.createElement('div');
+          Object.assign(pad.style, {
+            position: 'fixed',
+            top: `${innerTop}px`,
+            left: `${bounds.left}px`,
+            width: `${Math.min(pl, w)}px`,
+            height: `${innerH}px`,
+            background: padColor,
+          });
+          container.appendChild(pad);
+        }
+      }
+      // Right padding
+      if (pr > 0) {
+        const innerTop = bounds.top + Math.min(pt, h);
+        const innerH = h - Math.min(pt, h) - Math.min(pb, h);
+        if (innerH > 0) {
+          const pad = document.createElement('div');
+          Object.assign(pad.style, {
+            position: 'fixed',
+            top: `${innerTop}px`,
+            left: `${bounds.right - Math.min(pr, w)}px`,
+            width: `${Math.min(pr, w)}px`,
+            height: `${innerH}px`,
+            background: padColor,
+          });
+          container.appendChild(pad);
+        }
+      }
+    }
+
+    // Bounding box border
+    const box = document.createElement('div');
+    Object.assign(box.style, {
+      position: 'fixed',
+      top: `${bounds.top}px`,
+      left: `${bounds.left}px`,
+      width: `${w}px`,
+      height: `${h}px`,
+      border: `1px solid rgba(${color[0]}, ${color[1]}, ${color[2]}, ${BORDER_ALPHA})`,
+      boxSizing: 'border-box',
+    });
+    container.appendChild(box);
+
+    // Size + type label (skip for tiny widgets)
+    if (w >= 40 && h >= 16) {
+      const labelTop = bounds.top >= 14 ? bounds.top - 14 : bounds.top;
+      const sizeLabel = document.createElement('div');
+      Object.assign(sizeLabel.style, {
+        position: 'fixed',
+        top: `${labelTop}px`,
+        left: `${bounds.left}px`,
+        background: `rgba(${color[0]}, ${color[1]}, ${color[2]}, 0.85)`,
+        color: LABEL_COLOR,
+        font: FONT,
+        padding: '1px 4px',
+        borderRadius: '2px',
+        whiteSpace: 'nowrap',
+        lineHeight: '12px',
+        maxWidth: `${w}px`,
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+      });
+      sizeLabel.textContent = `${label} ${w}×${h}`;
+      container.appendChild(sizeLabel);
+    }
+  });
+})();

--- a/src/ivyml/Ivy.IvyML/Docs/IVYML.md
+++ b/src/ivyml/Ivy.IvyML/Docs/IVYML.md
@@ -27,20 +27,87 @@ IvyML is an XML-based markup language for describing Ivy widget trees. It maps d
 | Size      | `Full`, `Fit`, `Auto`, `Half`, `200px`, `50%`, `4rem` |
 | Thickness | `10` or `10,20` or `10,20,10,20`                      |
 
+### Size
+
+Size values control width and height of widgets. All keyword values are case-insensitive.
+
+| Format     | Example  | Description                                 |
+|------------|----------|---------------------------------------------|
+| keyword    | `Full`   | Fill available space                         |
+| keyword    | `Fit`    | Shrink to fit content                        |
+| keyword    | `Auto`   | Automatic sizing                             |
+| keyword    | `Half`   | 50% of available space                       |
+| keyword    | `Screen` | Full viewport size                           |
+| pixels     | `200px`  | Fixed size in pixels                         |
+| percentage | `50%`    | Fraction of available space                  |
+| rem        | `4rem`   | Size in rem units                            |
+| unitless   | `10`     | Plain number interpreted as unit-less value  |
+
+### Thickness
+
+Thickness values are used for `Padding`, `Margin`, and `BorderThickness`. Values are comma-separated integers.
+
+| Format          | Example       | Description                                                           |
+|-----------------|---------------|-----------------------------------------------------------------------|
+| 1 value         | `10`          | Uniform -- all four sides                                             |
+| 2 values        | `10,20`       | `horizontal,vertical` -- Left=Right=10, Top=Bottom=20                 |
+| 4 values        | `10,20,10,20` | `left,top,right,bottom`                                               |
+
+### Responsive Breakpoints
+
+Props that support responsive values (like `Width`, `Height`, `Padding`) can be set per breakpoint using the `Prop.Breakpoint` attribute syntax. The base attribute sets the default value; breakpoint-suffixed attributes override it at specific screen widths.
+
+| Breakpoint | Min width |
+|------------|-----------|
+| `Mobile`   | 640px     |
+| `Tablet`   | 768px     |
+| `Desktop`  | 1024px    |
+| `Wide`     | 1280px    |
+
+```xml
+<StackLayout Width="Full" Width.Mobile="300px" Width.Desktop="80%" />
+```
+
+You can combine a default with any number of breakpoints:
+
+```xml
+<Badge Width="Full" Width.Mobile="200px" Width.Tablet="Half" Width.Desktop="80%" />
+```
+
+Or use breakpoints without a default:
+
+```xml
+<Badge Width.Desktop="Full" />
+```
+
+Breakpoint names are case-insensitive (`Width.mobile` and `Width.Mobile` are equivalent).
+
 ## CLI Usage
 
 ```
-ivyml draw -i <IVYML> [-o <PATH>] [-w <WIDTH>] [-h <HEIGHT>]
+ivyml draw -i <IVYML> [-o <PATH>] [-w <WIDTH>] [-h <HEIGHT>] [--debug]
+ivyml draw -f <FILE>  [-o <PATH>] [-w <WIDTH>] [-h <HEIGHT>] [--debug]
 ```
 
-| Option          | Description                         | Default |
-|-----------------|-------------------------------------|---------|
-| `-i`, `--input` | IvyML markup string (required)      |         |
-| `-o`, `--output`| Output file path (png, jpg, webp)   | temp    |
-| `-w`, `--width` | Viewport width in pixels            | 300     |
-| `-h`, `--height`| Viewport height in pixels           | 200     |
+| Option          | Description                                          | Default |
+|-----------------|------------------------------------------------------|---------|
+| `-i`, `--input` | IvyML markup string                                  |         |
+| `-f`, `--file`  | Path to an IvyML file                                |         |
+| `-o`, `--output`| Output file path (png, jpg, webp)                    | temp    |
+| `-w`, `--width` | Viewport width in pixels                             | 300     |
+| `-h`, `--height`| Viewport height in pixels                            | 200     |
+| `-d`, `--debug` | Draw debug overlays showing layout bounds and sizes  | false   |
 
-If `-o` is omitted, the screenshot is saved to a temp file and the path is printed to stdout.
+Provide markup via `-i` (inline string) or `-f` (file path), but not both. If `-o` is omitted, the screenshot is saved to a temp file and the path is printed to stdout.
+
+### Debug Mode
+
+`--debug` annotates the output image with layout diagnostics:
+
+- **Bounding boxes** around every widget, color-coded by nesting depth (red → blue → green → purple → ...).
+- **Size labels** at each widget showing its type and resolved dimensions (e.g. `StackLayout 468x727`).
+- **Padding regions** shaded as translucent fills between widget edge and content area.
+- **Zero-size markers** -- any widget that resolved to 0x0 pixels gets a red ✖ with a label, making collapsed or invisible widgets immediately obvious.
 
 ```
 ivyml docs
@@ -53,6 +120,43 @@ ivyml docs <widget>
 ```
 
 Print all props and events for a specific widget.
+
+## Spacing Scale
+
+Integer values for `RowGap`, `ColumnGap`, `Padding`, and `Margin` follow the Tailwind CSS spacing scale: each unit is 0.25rem.
+
+| Value | Size     |
+|-------|----------|
+| `1`   | 0.25rem  |
+| `2`   | 0.5rem   |
+| `4`   | 1rem     |
+| `8`   | 2rem     |
+| `16`  | 4rem     |
+
+Layout widgets (`StackLayout`, `GridLayout`) default to a gap of 4 (1rem). Do not add `RowGap="4"` or `ColumnGap="4"` -- it is the default.
+
+Padding is rarely needed. Layouts have appropriate padding by default. Only add `Padding` when you need extra inner spacing for a specific reason.
+
+## Size vs Density
+
+`Width` and `Height` control the dimensions of a widget. `Density` controls the visual density -- it adjusts text size, internal padding, and overall compactness. They are independent.
+
+| Prop      | What it controls                  | Values                              |
+|-----------|-----------------------------------|-------------------------------------|
+| `Width`   | Horizontal dimension              | Size (`Full`, `200px`, `50%`, ...)  |
+| `Height`  | Vertical dimension                | Size (`Full`, `200px`, `50%`, ...)  |
+| `Density` | Visual compactness (text, padding)| `Small`, `Medium`, `Large`          |
+
+## Colors
+
+The `Colors` enum is flat -- there are no shade levels.
+
+Use `Color="Red"`, not `Color="Red500"`. Available values: Black, White, Slate, Gray, Zinc, Neutral, Stone, Red, Orange, Amber, Yellow, Lime, Green, Emerald, Teal, Cyan, Sky, Blue, Indigo, Violet, Purple, Fuchsia, Pink, Rose, Primary, Secondary, Destructive, Success, Warning, Info, Muted, IvyGreen.
+
+## Design Tips
+
+- Use `<Separator />` between major sections to create visual hierarchy and prevent content from blending together.
+- Prefer semantic variants (`Primary`, `Success`, `Muted`) over raw colors when available on a widget.
 
 ## Examples
 

--- a/src/ivyml/Ivy.IvyML/Ivy.IvyML.csproj
+++ b/src/ivyml/Ivy.IvyML/Ivy.IvyML.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <EmbeddedResource Include="Docs\IVYML.md" LogicalName="Ivy.IvyML.Docs.IVYML.md" />
+    <EmbeddedResource Include="DebugOverlay.js" LogicalName="Ivy.IvyML.DebugOverlay.js" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(IvyPackageVersion)' != ''">

--- a/src/ivyml/Ivy.IvyML/IvyScreenshotService.cs
+++ b/src/ivyml/Ivy.IvyML/IvyScreenshotService.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Ivy.Core.Apps;
 using Ivy.Core.Server;
 using Microsoft.Playwright;
@@ -14,6 +15,15 @@ public class IvyScreenshotService
         [".jpeg"] = SKEncodedImageFormat.Jpeg,
         [".webp"] = SKEncodedImageFormat.Webp,
     };
+
+    private static readonly Lazy<string> DebugOverlayScript = new(() =>
+    {
+        using var stream = Assembly.GetExecutingAssembly()
+            .GetManifestResourceStream("Ivy.IvyML.DebugOverlay.js");
+        if (stream is null) return "";
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    });
 
     public static bool IsSupportedFormat(string ext) => FormatMap.ContainsKey(ext);
 
@@ -75,6 +85,11 @@ public class IvyScreenshotService
             {
                 WaitUntil = WaitUntilState.NetworkIdle
             });
+
+            if (options.Debug)
+            {
+                await page.EvaluateAsync(DebugOverlayScript.Value);
+            }
 
             var fullPath = Path.GetFullPath(options.OutputPath);
             var dir = Path.GetDirectoryName(fullPath);

--- a/src/ivyml/Ivy.IvyML/ScreenshotResult.cs
+++ b/src/ivyml/Ivy.IvyML/ScreenshotResult.cs
@@ -1,6 +1,6 @@
 namespace Ivy.IvyML;
 
-public record ScreenshotOptions(int Width, int Height, string OutputPath);
+public record ScreenshotOptions(int Width, int Height, string OutputPath, bool Debug = false);
 
 public record ScreenshotResult(bool Success, string? OutputPath, string? ErrorMessage)
 {

--- a/src/ivyml/Ivy.IvyML/WidgetCatalog.cs
+++ b/src/ivyml/Ivy.IvyML/WidgetCatalog.cs
@@ -8,7 +8,9 @@ public record WidgetPropInfo(string Name, string Type, bool IsNullable, string? 
 
 public record WidgetEventInfo(string Name);
 
-public record WidgetInfo(string Name, WidgetPropInfo[] Props, WidgetEventInfo[] Events);
+public record WidgetSlotInfo(string Name);
+
+public record WidgetInfo(string Name, WidgetPropInfo[] Props, WidgetEventInfo[] Events, WidgetSlotInfo[] Slots);
 
 public static class WidgetCatalog
 {
@@ -39,8 +41,9 @@ public static class WidgetCatalog
 
             var props = GetProps(type);
             var events = GetEvents(type);
+            var slots = GetSlots(type);
 
-            if (props.Length == 0 && events.Length == 0)
+            if (props.Length == 0 && events.Length == 0 && slots.Length == 0)
                 continue;
 
             var name = type.Name;
@@ -50,7 +53,7 @@ public static class WidgetCatalog
             if (catalog.ContainsKey(name))
                 continue;
 
-            catalog[name] = new WidgetInfo(name, props, events);
+            catalog[name] = new WidgetInfo(name, props, events, slots);
         }
 
         return catalog;
@@ -116,6 +119,11 @@ public static class WidgetCatalog
             .Select(p => new WidgetEventInfo(p.Name))
             .ToArray();
 
+    private static WidgetSlotInfo[] GetSlots(Type type) =>
+        type.GetCustomAttributes<SlotAttribute>()
+            .Select(a => new WidgetSlotInfo(a.Name))
+            .ToArray();
+
     private static string FormatTypeName(Type type)
     {
         if (type == typeof(string)) return "string";
@@ -177,9 +185,18 @@ public static class WidgetCatalog
             }
         }
 
-        if (widget.Events.Length > 0)
+        if (widget.Slots.Length > 0)
         {
             if (widget.Props.Length > 0)
+                sb.AppendLine();
+            sb.AppendLine("Slots:");
+            foreach (var slot in widget.Slots)
+                sb.AppendLine($"  {slot.Name}");
+        }
+
+        if (widget.Events.Length > 0)
+        {
+            if (widget.Props.Length > 0 || widget.Slots.Length > 0)
                 sb.AppendLine();
             sb.AppendLine("Events:");
             foreach (var evt in widget.Events)


### PR DESCRIPTION
- Add --debug flag that draws bounding boxes, size labels, padding regions,
  and zero-size markers on the rendered output for layout debugging
- Add responsive breakpoint attribute syntax (Width.Mobile="X") to XamlBuilder
  with tests for single/multiple breakpoints and error cases
- Add -f/--file flag to read markup from a file instead of inline string
- Expand IVYML.md docs with Size, Thickness, Responsive Breakpoints,
  Spacing Scale, Size vs Density, Colors, and Design Tips sections
- Add SlotAttribute and slot discovery to WidgetCatalog
