### PR TITLE
[00004] Fix MadeWithIvy touch event support for mobile devices

### DIFF
--- a/src/frontend/src/components/MadeWithIvy.tsx
+++ b/src/frontend/src/components/MadeWithIvy.tsx
@@ -47,8 +47,8 @@ export default function MadeWithIvy() {
   return (
     <div
       className="fixed bottom-0 right-0 z-100 overflow-hidden rounded-tl-full "
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
+      onPointerEnter={() => setIsHovered(true)}
+      onPointerLeave={() => setIsHovered(false)}
     >
       <div
         className={`


### PR DESCRIPTION
## Problem

The `MadeWithIvy` component only uses `onMouseEnter` and `onMouseLeave` events to control the hover state. These mouse events do not fire for touch-based input methods like Apple Pencil or finger touches on mobile devices.

This causes the "Made with Ivy" / "Star on GitHub" prompt to be undismissable on mobile devices - users can tap to open it but cannot dismiss it by moving their touch away.

**Issue reported:** [GitHub Issue #4281](https://github.com/Ivy-Interactive/Ivy-Framework/issues/4281)

## Solution

Replace mouse-only events with pointer events that work across all input methods (mouse, touch, stylus):

1. Replace `onMouseEnter` with `onPointerEnter`
2. Replace `onMouseLeave` with `onPointerLeave`

Pointer events are supported by all modern browsers and handle mouse, touch, and stylus input uniformly. This is the recommended approach for building responsive UI components that work across devices.

## Commits

- 32af585d0 [00004] Replace mouse events with pointer events for touch support