### PR TITLE
[00010] Sheet from right has gaps between screen edges and scroll bars

### DIFF
--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -91,6 +91,7 @@
     "react-icons": "5.5.0",
     "react-markdown": "10.1.0",
     "react-resizable-panels": "3.0.6",
+    "react-responsive-carousel": "^3.2.23",
     "react-syntax-highlighter": "16.1.0",
     "rehype-katex": "7.0.1",
     "rehype-raw": "7.0.0",

--- a/src/frontend/src/widgets/sheet/SheetWidget.tsx
+++ b/src/frontend/src/widgets/sheet/SheetWidget.tsx
@@ -278,7 +278,10 @@ export const SheetWidget: React.FC<SheetWidgetProps> = ({
             {description || "Sheet content"}
           </SheetDescription>
         </SheetHeader>
-        <div className="flex-1 pb-4 pt-1 pl-4 pr-4 mt-4 overflow-y-auto">{slots.Content}</div>
+        <div className={cn(
+          "flex-1 pb-4 pt-1 pl-4 mt-4 overflow-y-auto",
+          normalizedSide === "right" ? "pr-0" : "pr-4"
+        )}>{slots.Content}</div>
       </SheetContent>
     </Sheet>
   );

--- a/src/frontend/src/widgets/sheet/SheetWidget.tsx
+++ b/src/frontend/src/widgets/sheet/SheetWidget.tsx
@@ -278,10 +278,14 @@ export const SheetWidget: React.FC<SheetWidgetProps> = ({
             {description || "Sheet content"}
           </SheetDescription>
         </SheetHeader>
-        <div className={cn(
-          "flex-1 pb-4 pt-1 pl-4 mt-4 overflow-y-auto",
-          normalizedSide === "right" ? "pr-0" : "pr-4"
-        )}>{slots.Content}</div>
+        <div
+          className={cn(
+            "flex-1 pb-4 pt-1 pl-4 mt-4 overflow-y-auto",
+            normalizedSide === "right" ? "pr-0" : "pr-4",
+          )}
+        >
+          {slots.Content}
+        </div>
       </SheetContent>
     </Sheet>
   );


### PR DESCRIPTION
# Summary

## Changes

Modified the SheetWidget content container to conditionally remove right padding when the sheet is positioned on the right side. This allows the browser's vertical scrollbar to render flush against the panel edge, eliminating the visual gap. Also added missing `react-responsive-carousel` dependency discovered during build verification.

## API Changes

None.

## Files Modified

- **src/frontend/src/widgets/sheet/SheetWidget.tsx** — Updated content div className to use `pr-0` for right-side sheets and `pr-4` for other sides
- **src/frontend/package.json** — Added missing `react-responsive-carousel` dependency

---

## Commits

- c5ebb2bd5 [00010] Remove right padding from right-side sheet content for flush scrollbar
- ba7873e91 [00010] Format SheetWidget.tsx
- 01e41075d [00010] Add missing react-responsive-carousel dependency