### PR TITLE
[iPad]: Enable tooltip on finger tap (not only Pencil hover)

### DIFF
--- a/src/frontend/src/components/ui/tooltip.tsx
+++ b/src/frontend/src/components/ui/tooltip.tsx
@@ -10,9 +10,65 @@ const TooltipProvider = ({
   <TooltipPrimitive.Provider delayDuration={delayDuration} {...props} />
 );
 
-const Tooltip = TooltipPrimitive.Root;
+type TooltipControl = {
+  open: boolean;
+  setOpen: (next: boolean) => void;
+};
 
-const TooltipTrigger = TooltipPrimitive.Trigger;
+const TooltipContext = React.createContext<TooltipControl | null>(null);
+
+/**
+ * Radix Tooltip is hover/focus driven, so coarse pointers (finger / stylus tap)
+ * never see it on iPad/iPhone. Wrap Root with a small controlled-state shim and
+ * let the Trigger toggle it on touch / pen pointerdown without affecting mouse.
+ */
+const Tooltip = ({
+  open: openProp,
+  defaultOpen,
+  onOpenChange,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Root>) => {
+  const [internalOpen, setInternalOpen] = React.useState(defaultOpen ?? false);
+  const isControlled = openProp !== undefined;
+  const open = isControlled ? openProp : internalOpen;
+
+  const setOpen = React.useCallback(
+    (next: boolean) => {
+      if (!isControlled) {
+        setInternalOpen(next);
+      }
+      onOpenChange?.(next);
+    },
+    [isControlled, onOpenChange],
+  );
+
+  return (
+    <TooltipContext.Provider value={{ open, setOpen }}>
+      <TooltipPrimitive.Root open={open} onOpenChange={setOpen} {...props} />
+    </TooltipContext.Provider>
+  );
+};
+
+const TooltipTrigger = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Trigger>
+>((props, ref) => {
+  const ctx = React.useContext(TooltipContext);
+  return (
+    <TooltipPrimitive.Trigger
+      ref={ref}
+      {...props}
+      onPointerDown={(e) => {
+        props.onPointerDown?.(e);
+        if (!ctx) return;
+        if (e.pointerType === "touch" || e.pointerType === "pen") {
+          ctx.setOpen(!ctx.open);
+        }
+      }}
+    />
+  );
+});
+TooltipTrigger.displayName = TooltipPrimitive.Trigger.displayName;
 
 const hasNoSpaces = (str: string): boolean => {
   const trimmed = str.trim();


### PR DESCRIPTION
## Summary

Wraps Radix `Tooltip` root with controlled/uncontrolled state and toggles the tooltip on **touch** and **pen** `pointerdown`, while keeping default **mouse** behavior (hover / focus).

## What changed

- **Shim around `TooltipPrimitive.Root`** supporting:
  - **Controlled:** `open`, `onOpenChange`
  - **Uncontrolled:** `defaultOpen`
- **`TooltipContext`** exposing `open` / `setOpen` for the trigger.
- **`TooltipTrigger`** on `pointerdown`: if `pointerType` is `touch` or `pen`, visibility toggles; **mouse** is unchanged (Radix hover/focus).

## Why

Radix Tooltip is hover/focus-driven, so on **coarse pointers** (finger, stylus) tooltips often never show on iPad/iPhone. The extra touch/pen toggle fixes that without changing desktop UX.

https://github.com/user-attachments/assets/b2e4f498-fffd-41f4-b48b-3be326c567d4

