### PR TITLE
Add CanvasLayout and WireframeNote widgets with docs and samples

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/02_Layouts/11_CanvasLayout.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/02_Layouts/11_CanvasLayout.md
@@ -1,0 +1,80 @@
+---
+searchHints:
+- canvas
+- absolute
+- position
+- freeform
+- wireframe
+- coordinates
+- placement
+---
+
+# CanvasLayout
+
+<Ingress>
+Position child widgets at absolute coordinates for free-form layouts, wireframe sketches, and precise visual placement.
+</Ingress>
+
+The `CanvasLayout` widget positions its children using absolute coordinates via the `CanvasLeft` and `CanvasTop` attached properties. Unlike flow-based layouts, children are placed at exact positions relative to the canvas origin (top-left corner).
+
+## Basic Usage
+
+Place widgets at specific pixel coordinates:
+
+```csharp demo
+Layout.Canvas().Width(Size.Full()).Height(Size.Px(200))
+    | new Badge("Top Left").CanvasLeft(Size.Px(10)).CanvasTop(Size.Px(10))
+    | new Badge("Center").Info().CanvasLeft(Size.Px(150)).CanvasTop(Size.Px(80))
+    | new Badge("Bottom Right").Success().CanvasLeft(Size.Px(300)).CanvasTop(Size.Px(150))
+```
+
+## Attached Properties
+
+`CanvasLeft` and `CanvasTop` are attached properties -- they are set on **child** widgets, not on the layout itself. Any widget placed inside a `CanvasLayout` can use them.
+
+| Prop         | Type | Description                         |
+|--------------|------|-------------------------------------|
+| `CanvasLeft` | Size | Horizontal offset from left edge    |
+| `CanvasTop`  | Size | Vertical offset from top edge       |
+
+Both accept any `Size` value: pixels (`Size.Px(100)`), units (`Size.Units(20)`), percentages (`Size.Fraction(0.5)`), etc.
+
+```csharp demo
+Layout.Canvas().Width(Size.Full()).Height(Size.Px(200))
+    | new Badge("Pixels").Primary().CanvasLeft(Size.Px(20)).CanvasTop(Size.Px(20))
+    | new Badge("Units").Info().CanvasLeft(Size.Units(60)).CanvasTop(Size.Px(80))
+    | new Badge("50%").Success().CanvasLeft(Size.Fraction(0.5f)).CanvasTop(Size.Px(40))
+```
+
+## With Wireframe Notes
+
+`CanvasLayout` pairs naturally with `WireframeNote` for sketching and brainstorming:
+
+```csharp demo
+Layout.Canvas().Width(Size.Full()).Height(Size.Px(300))
+    | new WireframeNote("Step 1: User signs up", WireframeNoteColor.Yellow)
+        .CanvasLeft(Size.Px(20)).CanvasTop(Size.Px(20))
+    | new WireframeNote("Step 2: Verify email", WireframeNoteColor.Blue)
+        .CanvasLeft(Size.Px(200)).CanvasTop(Size.Px(80))
+    | new WireframeNote("Step 3: Dashboard", WireframeNoteColor.Green)
+        .CanvasLeft(Size.Px(380)).CanvasTop(Size.Px(30))
+```
+
+## Background and Padding
+
+Use `Background` and `Padding` to style the canvas container:
+
+```csharp demo
+Layout.Canvas()
+    .Width(Size.Full())
+    .Height(Size.Px(200))
+    .Background(Colors.Neutral)
+    .Padding(new Thickness(8))
+    | new Badge("Whiteboard").Outline().CanvasLeft(Size.Px(20)).CanvasTop(Size.Px(20))
+    | new WireframeNote("Idea 1", WireframeNoteColor.Yellow)
+        .CanvasLeft(Size.Px(20)).CanvasTop(Size.Px(60))
+    | new WireframeNote("Idea 2", WireframeNoteColor.Pink)
+        .CanvasLeft(Size.Px(200)).CanvasTop(Size.Px(60))
+```
+
+<WidgetDocs Type="Ivy.CanvasLayout" ExtensionTypes="Ivy.CanvasExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Layouts/CanvasLayout.cs"/>

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/08_Wireframe/01_WireframeNote.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/08_Wireframe/01_WireframeNote.md
@@ -1,0 +1,108 @@
+---
+searchHints:
+- wireframe
+- sticky
+- note
+- sketch
+- prototype
+- balsamiq
+- brainstorm
+- postit
+---
+
+# WireframeNote
+
+<Ingress>
+A hand-drawn sticky note widget for wireframing, brainstorming, and low-fidelity prototyping with a Balsamiq-style aesthetic.
+</Ingress>
+
+The `WireframeNote` widget renders as a sticky note with a folded corner, drop shadow, slight rotation, and hand-drawn font. It is designed for sketching ideas, annotating layouts, and building low-fidelity prototypes.
+
+## Basic Usage
+
+```csharp demo
+new WireframeNote("Remember to add validation")
+```
+
+## Colors
+
+Six color variants are available to categorize and distinguish notes:
+
+```csharp demo
+Layout.Horizontal().Gap(4)
+    | new WireframeNote("Yellow (default)")
+    | new WireframeNote("Blue note", WireframeNoteColor.Blue)
+    | new WireframeNote("Green note", WireframeNoteColor.Green)
+    | new WireframeNote("Pink note", WireframeNoteColor.Pink)
+    | new WireframeNote("Orange note", WireframeNoteColor.Orange)
+    | new WireframeNote("Purple note", WireframeNoteColor.Purple)
+```
+
+| Color    | Typical Use                    |
+|----------|--------------------------------|
+| Yellow   | General notes, ideas           |
+| Blue     | In-progress items, questions   |
+| Green    | Completed items, approvals     |
+| Pink     | Bugs, blockers, warnings       |
+| Orange   | Deferred items, follow-ups     |
+| Purple   | Design decisions, references   |
+
+## Multi-line Text
+
+Use newlines in the text string to create multi-line notes:
+
+```csharp demo
+Layout.Horizontal().Gap(4)
+    | new WireframeNote("Step 1:\nUser signs up")
+    | new WireframeNote("Step 2:\nVerify email", WireframeNoteColor.Blue)
+    | new WireframeNote("Step 3:\nOnboarding flow", WireframeNoteColor.Green)
+```
+
+## Sizing
+
+Control the note dimensions with `Width` and `Height`:
+
+```csharp demo
+Layout.Horizontal().Gap(4)
+    | new WireframeNote("Small").Width(Size.Px(120))
+    | new WireframeNote("Full width note").Width(Size.Full())
+```
+
+## On a Canvas
+
+Combine with `CanvasLayout` for free-form placement:
+
+```csharp demo
+Layout.Canvas().Width(Size.Full()).Height(Size.Px(300))
+    | new WireframeNote("Login page", WireframeNoteColor.Yellow)
+        .CanvasLeft(Size.Px(20)).CanvasTop(Size.Px(20))
+    | new WireframeNote("Auth service", WireframeNoteColor.Blue)
+        .CanvasLeft(Size.Px(200)).CanvasTop(Size.Px(100))
+    | new WireframeNote("Dashboard", WireframeNoteColor.Green)
+        .CanvasLeft(Size.Px(380)).CanvasTop(Size.Px(30))
+    | new WireframeNote("Error handling", WireframeNoteColor.Pink)
+        .CanvasLeft(Size.Px(200)).CanvasTop(Size.Px(220))
+```
+
+## Project Board
+
+Use with `StackLayout` for structured kanban-style boards:
+
+```csharp demo
+Layout.Vertical().Gap(4)
+    | Text.H3("Sprint Board")
+    | (Layout.Horizontal().Gap(4)
+        | (Layout.Vertical().Gap(3).Width(Size.Units(40))
+            | Text.Strong("To Do")
+            | new WireframeNote("Design login page").Width(Size.Full())
+            | new WireframeNote("Write API docs", WireframeNoteColor.Orange).Width(Size.Full()))
+        | (Layout.Vertical().Gap(3).Width(Size.Units(40))
+            | Text.Strong("In Progress")
+            | new WireframeNote("Build widgets", WireframeNoteColor.Blue).Width(Size.Full()))
+        | (Layout.Vertical().Gap(3).Width(Size.Units(40))
+            | Text.Strong("Done")
+            | new WireframeNote("DB schema", WireframeNoteColor.Green).Width(Size.Full())
+            | new WireframeNote("Scaffolding", WireframeNoteColor.Green).Width(Size.Full())))
+```
+
+<WidgetDocs Type="Ivy.WireframeNote" ExtensionTypes="Ivy.WireframeNoteExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Wireframe/WireframeNote.cs"/>

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/08_Wireframe/_Index.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/08_Wireframe/_Index.md
@@ -1,0 +1,3 @@
+---
+icon: PenTool
+---

--- a/src/Ivy.Samples.Shared/Apps/Widgets/Layouts/CanvasLayoutApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Layouts/CanvasLayoutApp.cs
@@ -1,0 +1,37 @@
+
+namespace Ivy.Samples.Shared.Apps.Widgets.Layouts;
+
+[App(icon: Icons.Move, group: ["Widgets", "Layouts"], searchHints: ["canvas", "absolute", "position", "freeform", "wireframe", "coordinates"])]
+public class CanvasLayoutApp : SampleBase
+{
+    protected override object? BuildSample()
+    {
+        var basic = Layout.Canvas()
+            .Width(Size.Full()).Height(Size.Px(200))
+            | new Badge("Top Left").CanvasLeft(Size.Px(10)).CanvasTop(Size.Px(10))
+            | new Badge("Center").Info().CanvasLeft(Size.Px(200)).CanvasTop(Size.Px(80))
+            | new Badge("Bottom Right").Success().CanvasLeft(Size.Px(350)).CanvasTop(Size.Px(150));
+
+        var wireframe = Layout.Canvas()
+            .Width(Size.Full()).Height(Size.Px(350))
+            | new WireframeNote("User clicks Login", WireframeNoteColor.Yellow)
+                .CanvasLeft(Size.Px(20)).CanvasTop(Size.Px(10))
+            | new WireframeNote("Validate credentials\nagainst OAuth", WireframeNoteColor.Blue)
+                .CanvasLeft(Size.Px(200)).CanvasTop(Size.Px(70))
+            | new WireframeNote("Token exchange\n+ session create", WireframeNoteColor.Green)
+                .CanvasLeft(Size.Px(380)).CanvasTop(Size.Px(20))
+            | new WireframeNote("Redirect to\ndashboard", WireframeNoteColor.Purple)
+                .CanvasLeft(Size.Px(380)).CanvasTop(Size.Px(170))
+            | new WireframeNote("Show error toast", WireframeNoteColor.Pink)
+                .CanvasLeft(Size.Px(200)).CanvasTop(Size.Px(230))
+            | new WireframeNote("Retry?", WireframeNoteColor.Orange)
+                .CanvasLeft(Size.Px(20)).CanvasTop(Size.Px(250));
+
+        return Layout.Vertical()
+            | Text.H1("Canvas Layout")
+            | Text.H2("Basic Positioning")
+            | basic
+            | Text.H2("Wireframe Sketch")
+            | wireframe;
+    }
+}

--- a/src/Ivy.Samples.Shared/Apps/Widgets/Wireframe/WireframeNoteApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Wireframe/WireframeNoteApp.cs
@@ -1,0 +1,44 @@
+
+namespace Ivy.Samples.Shared.Apps.Widgets.Wireframe;
+
+[App(icon: Icons.StickyNote, group: ["Widgets", "Wireframe"], searchHints: ["wireframe", "sticky", "note", "sketch", "prototype", "balsamiq", "brainstorm", "postit"])]
+public class WireframeNoteApp : SampleBase
+{
+    protected override object? BuildSample()
+    {
+        var colors = Layout.Horizontal().Gap(4)
+            | new WireframeNote("Yellow (default)")
+            | new WireframeNote("Blue", WireframeNoteColor.Blue)
+            | new WireframeNote("Green", WireframeNoteColor.Green)
+            | new WireframeNote("Pink", WireframeNoteColor.Pink)
+            | new WireframeNote("Orange", WireframeNoteColor.Orange)
+            | new WireframeNote("Purple", WireframeNoteColor.Purple);
+
+        var multiline = Layout.Horizontal().Gap(4)
+            | new WireframeNote("Step 1:\nUser signs up")
+            | new WireframeNote("Step 2:\nVerify email", WireframeNoteColor.Blue)
+            | new WireframeNote("Step 3:\nOnboarding", WireframeNoteColor.Green);
+
+        var board = Layout.Horizontal().Gap(4)
+            | (Layout.Vertical().Gap(3).Width(Size.Units(40))
+                | Text.Strong("To Do")
+                | new WireframeNote("Design login page").Width(Size.Full())
+                | new WireframeNote("Write API docs", WireframeNoteColor.Orange).Width(Size.Full()))
+            | (Layout.Vertical().Gap(3).Width(Size.Units(40))
+                | Text.Strong("In Progress")
+                | new WireframeNote("Build widgets", WireframeNoteColor.Blue).Width(Size.Full()))
+            | (Layout.Vertical().Gap(3).Width(Size.Units(40))
+                | Text.Strong("Done")
+                | new WireframeNote("DB schema", WireframeNoteColor.Green).Width(Size.Full())
+                | new WireframeNote("Scaffolding", WireframeNoteColor.Green).Width(Size.Full()));
+
+        return Layout.Vertical()
+            | Text.H1("Wireframe Note")
+            | Text.H2("Colors")
+            | colors
+            | Text.H2("Multi-line")
+            | multiline
+            | Text.H2("Project Board")
+            | board;
+    }
+}

--- a/src/Ivy.XamlBuilder/XamlBuilder.cs
+++ b/src/Ivy.XamlBuilder/XamlBuilder.cs
@@ -9,6 +9,7 @@ namespace Ivy;
 public class XamlBuilder
 {
     private readonly Dictionary<string, Type> _typeMap;
+    private readonly Dictionary<string, (Type ParentType, Type ValueType)> _attachedProps;
 
     public XamlBuilder(params Assembly[] assemblies)
     {
@@ -17,20 +18,38 @@ public class XamlBuilder
             : [typeof(AbstractWidget).Assembly];
 
         _typeMap = new Dictionary<string, Type>(StringComparer.OrdinalIgnoreCase);
+        _attachedProps = new Dictionary<string, (Type, Type)>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var assembly in assembliesToScan)
         {
             foreach (var type in assembly.GetTypes())
             {
-                if (type.IsAbstract || type.IsGenericTypeDefinition || type.IsEnum ||
+                if (type.IsGenericTypeDefinition || type.IsEnum ||
                     type.IsInterface || type.IsNested)
                     continue;
 
-                if (!HasUsableConstructor(type))
-                    continue;
+                if (!type.IsAbstract && HasUsableConstructor(type))
+                    _typeMap[type.Name] = type;
 
-                _typeMap[type.Name] = type;
+                if (typeof(AbstractWidget).IsAssignableFrom(type))
+                    ScanAttachedProps(type);
             }
+        }
+    }
+
+    private void ScanAttachedProps(Type parentType)
+    {
+        foreach (var prop in parentType.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            var attr = prop.GetCustomAttribute<PropAttribute>();
+            if (attr?.AttachedName == null) continue;
+
+            var arrayElementType = prop.PropertyType.IsArray
+                ? prop.PropertyType.GetElementType()!
+                : prop.PropertyType;
+            var valueType = Nullable.GetUnderlyingType(arrayElementType) ?? arrayElementType;
+
+            _attachedProps[attr.AttachedName] = (parentType, valueType);
         }
     }
 
@@ -180,12 +199,22 @@ public class XamlBuilder
                 }
             }
 
-            var prop = FindProperty(target, attrName)
-                ?? throw new InvalidOperationException(
+            var prop = FindProperty(target, attrName);
+            if (prop != null)
+            {
+                var value = ConvertValue(attr.Value, prop.PropertyType);
+                SetProperty(target, prop, value);
+            }
+            else if (target is AbstractWidget widget && _attachedProps.TryGetValue(attrName, out var attached))
+            {
+                var value = ConvertValue(attr.Value, attached.ValueType);
+                widget.SetAttachedValue(attached.ParentType, attrName, value);
+            }
+            else
+            {
+                throw new InvalidOperationException(
                     $"Unknown property '{attrName}' on {target.GetType().Name}.");
-
-            var value = ConvertValue(attr.Value, prop.PropertyType);
-            SetProperty(target, prop, value);
+            }
         }
 
         if (responsiveAttrs != null)

--- a/src/Ivy/Core/WidgetSerializer.cs
+++ b/src/Ivy/Core/WidgetSerializer.cs
@@ -236,8 +236,8 @@ public static class WidgetSerializer
     {
         if (attribute.IsAttached)
         {
-            if (!property.PropertyType.IsArray || !property.PropertyType.GetElementType()!.IsGenericType)
-                throw new InvalidOperationException("Attached properties must be arrays of nullable types.");
+            if (!property.PropertyType.IsArray)
+                throw new InvalidOperationException("Attached properties must be arrays.");
 
             var children = widget.Children;
             var attachedValues = new object?[children.Length];

--- a/src/Ivy/Views/Layout.cs
+++ b/src/Ivy/Views/Layout.cs
@@ -49,6 +49,11 @@ public static class Layout
         return new GridView(Flatten(elements));
     }
 
+    public static CanvasLayout Canvas(params IEnumerable<object?> elements)
+    {
+        return new CanvasLayout(Flatten(elements));
+    }
+
     public static Spacer Spacer()
     {
         return new Spacer();

--- a/src/Ivy/Widgets/Layouts/CanvasLayout.cs
+++ b/src/Ivy/Widgets/Layouts/CanvasLayout.cs
@@ -1,0 +1,48 @@
+// ReSharper disable once CheckNamespace
+namespace Ivy;
+
+/// <summary>
+/// A layout that positions children absolutely using CanvasLeft and CanvasTop attached properties.
+/// </summary>
+public record CanvasLayout : WidgetBase<CanvasLayout>
+{
+    public CanvasLayout(params object[] children) : base(children) { }
+
+    internal CanvasLayout() { }
+
+    [Prop] public Thickness Padding { get; set; } = new(0);
+
+    [Prop] public Colors? Background { get; set; }
+
+    [Prop(attached: nameof(CanvasExtensions.CanvasLeft))] public Size?[] ChildLeft { get; set; } = null!;
+
+    [Prop(attached: nameof(CanvasExtensions.CanvasTop))] public Size?[] ChildTop { get; set; } = null!;
+}
+
+public static class CanvasLayoutExtensions
+{
+    public static CanvasLayout Background(this CanvasLayout canvas, Colors color)
+        => canvas with { Background = color };
+
+    public static CanvasLayout Padding(this CanvasLayout canvas, Thickness padding)
+        => canvas with { Padding = padding };
+
+    public static CanvasLayout Padding(this CanvasLayout canvas, int uniform)
+        => canvas with { Padding = new Thickness(uniform) };
+}
+
+public static class CanvasExtensions
+{
+    public static WidgetBase<T> CanvasLeft<T>(this WidgetBase<T> child, Size left) where T : WidgetBase<T>
+    {
+        child.SetAttachedValue(typeof(CanvasLayout), nameof(CanvasLeft), left);
+        return child;
+    }
+
+    public static WidgetBase<T> CanvasTop<T>(this WidgetBase<T> child, Size top) where T : WidgetBase<T>
+    {
+        child.SetAttachedValue(typeof(CanvasLayout), nameof(CanvasTop), top);
+        return child;
+    }
+
+}

--- a/src/frontend/src/widgets/layouts/CanvasLayoutWidget.tsx
+++ b/src/frontend/src/widgets/layouts/CanvasLayoutWidget.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { getColor, getHeight, getPadding, getWidth } from "@/lib/styles";
+
+const EMPTY_ARRAY: never[] = [];
+
+interface CanvasLayoutWidgetProps {
+  children: React.ReactNode[];
+  padding?: string;
+  width?: string;
+  height?: string;
+  background?: string;
+  childLeft?: (string | undefined)[];
+  childTop?: (string | undefined)[];
+}
+
+function sizeToCss(size?: string): string | undefined {
+  if (!size) return undefined;
+  const [sizeType, value] = size.split(":");
+  switch (sizeType.toLowerCase()) {
+    case "units":
+      return `${parseFloat(value) * 0.25}rem`;
+    case "px":
+      return `${value}px`;
+    case "rem":
+      return `${value}rem`;
+    case "fraction":
+      return `${parseFloat(value) * 100}%`;
+    case "full":
+      return "100%";
+    default:
+      return undefined;
+  }
+}
+
+export const CanvasLayoutWidget: React.FC<CanvasLayoutWidgetProps> = ({
+  children,
+  padding,
+  width,
+  height,
+  background,
+  childLeft = EMPTY_ARRAY,
+  childTop = EMPTY_ARRAY,
+}) => {
+  const containerStyles: React.CSSProperties = {
+    position: "relative",
+    ...getPadding(padding),
+    ...getWidth(width),
+    ...getHeight(height),
+    ...getColor(background, "backgroundColor", "background"),
+  };
+
+  return (
+    <div style={containerStyles}>
+      {React.Children.map(children, (child, index) => {
+        const left = sizeToCss(childLeft[index]);
+        const top = sizeToCss(childTop[index]);
+
+        const positionStyles: React.CSSProperties = {
+          position: "absolute",
+          left,
+          top,
+        };
+
+        return <div style={positionStyles}>{child}</div>;
+      })}
+    </div>
+  );
+};
+
+export default CanvasLayoutWidget;

--- a/src/frontend/src/widgets/widgetMap.ts
+++ b/src/frontend/src/widgets/widgetMap.ts
@@ -36,6 +36,7 @@ import {
   ResizablePanelWidget,
 } from "@/widgets/layouts/ResizablePanelGroupWidget";
 import { FloatingPanelWidget } from "@/widgets/layouts/FloatingPanelWidget";
+import { CanvasLayoutWidget } from "@/widgets/layouts/CanvasLayoutWidget";
 import { ListItemWidget } from "@/widgets/lists";
 import { TreeWidget } from "@/widgets/tree";
 import { TextBlockWidget } from "@/widgets/primitives/TextBlockWidget";
@@ -179,6 +180,7 @@ export const widgetMap = {
   "Ivy.ResizablePanelGroup": ResizablePanelGroupWidget,
   "Ivy.ResizablePanel": ResizablePanelWidget,
   "Ivy.FloatingPanel": FloatingPanelWidget,
+  "Ivy.CanvasLayout": CanvasLayoutWidget,
 
   // Inputs
   "Ivy.Field": FieldWidget,

--- a/src/ivyml/Ivy.IvyML/Docs/IVYML.md
+++ b/src/ivyml/Ivy.IvyML/Docs/IVYML.md
@@ -158,6 +158,59 @@ Use `Color="Red"`, not `Color="Red500"`. Available values: Black, White, Slate, 
 - Use `<Separator />` between major sections to create visual hierarchy and prevent content from blending together.
 - Prefer semantic variants (`Primary`, `Success`, `Muted`) over raw colors when available on a widget.
 
+## Attached Properties
+
+Some layout widgets define properties that are set on **child** elements rather than the layout itself. These are called attached properties. In IvyML, use them as attributes on any child widget inside that layout.
+
+```xml
+<CanvasLayout Width="Full" Height="300px">
+  <TextBlock Content="Hello" CanvasLeft="50px" CanvasTop="20px" />
+</CanvasLayout>
+```
+
+Attached props are resolved automatically -- the child doesn't need to know about them.
+
+## Wireframe Widgets
+
+Wireframe widgets have a hand-drawn, Balsamiq-style appearance for sketching and prototyping.
+
+### WireframeNote
+
+A sticky note with a folded corner, drop shadow, and hand-drawn font.
+
+```xml
+<WireframeNote Text="Remember this" />
+<WireframeNote Text="Urgent item" Color="Pink" />
+```
+
+| Prop    | Type              | Default  | Values                                         |
+|---------|-------------------|----------|-------------------------------------------------|
+| `Text`  | string            |          | The note content. Use `&#10;` for line breaks.  |
+| `Color` | WireframeNoteColor| Yellow   | Yellow, Blue, Green, Pink, Orange, Purple       |
+
+### CanvasLayout
+
+A free-form layout that positions children at absolute coordinates using attached properties.
+
+```xml
+<CanvasLayout Width="Full" Height="400px">
+  <WireframeNote Text="Top left" CanvasLeft="20px" CanvasTop="20px" />
+  <WireframeNote Text="Center" CanvasLeft="200px" CanvasTop="150px" />
+</CanvasLayout>
+```
+
+| Prop         | Type      | Description                |
+|--------------|-----------|----------------------------|
+| `Padding`    | Thickness | Inner padding              |
+| `Background` | Colors    | Background color           |
+
+**Attached props** (set on children):
+
+| Prop         | Type | Description                         |
+|--------------|------|-------------------------------------|
+| `CanvasLeft` | Size | Horizontal offset from left edge    |
+| `CanvasTop`  | Size | Vertical offset from top edge       |
+
 ## Examples
 
 Simple text:
@@ -185,4 +238,14 @@ Badge:
 Progress bar:
 ```xml
 <Progress Value="75" />
+```
+
+Wireframe sketch:
+```xml
+<CanvasLayout Width="Full" Height="400px">
+  <WireframeNote Text="Step 1: User signs up" Color="Yellow" CanvasLeft="30px" CanvasTop="20px" />
+  <WireframeNote Text="Step 2: Verify email" Color="Blue" CanvasLeft="220px" CanvasTop="100px" />
+  <WireframeNote Text="Step 3: Onboarding" Color="Green" CanvasLeft="410px" CanvasTop="40px" />
+  <TextBlock Content="Signup Flow" Variant="H3" CanvasLeft="180px" CanvasTop="300px" />
+</CanvasLayout>
 ```


### PR DESCRIPTION
- CanvasLayout: absolute positioning layout with CanvasLeft/CanvasTop attached props (Size type)
- WireframeNote: Balsamiq-style sticky note with 6 color variants and folded corner
- XamlBuilder: support for attached properties in IvyML markup
- WidgetSerializer: relax attached prop type guard to support reference-type arrays
- Layout.Canvas() factory method and fluent extensions
- Docs in Ivy.Docs.Shared (Layouts + new Wireframe category)
- Sample apps in Ivy.Samples.Shared
- IvyML docs updated with attached properties, wireframe widgets, and CanvasLayout sections
