### PR TITLE
Add WireframeCallout widget and migrate wireframe widgets to Colors enum

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/02_Layouts/11_CanvasLayout.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/02_Layouts/11_CanvasLayout.md
@@ -52,11 +52,11 @@ Layout.Canvas().Width(Size.Full()).Height(Size.Px(200))
 
 ```csharp demo
 Layout.Canvas().Width(Size.Full()).Height(Size.Px(300))
-    | new WireframeNote("Step 1: User signs up", WireframeNoteColor.Yellow)
+    | new WireframeNote("Step 1: User signs up", Colors.Yellow)
         .CanvasLeft(Size.Px(20)).CanvasTop(Size.Px(20))
-    | new WireframeNote("Step 2: Verify email", WireframeNoteColor.Blue)
+    | new WireframeNote("Step 2: Verify email", Colors.Blue)
         .CanvasLeft(Size.Px(200)).CanvasTop(Size.Px(80))
-    | new WireframeNote("Step 3: Dashboard", WireframeNoteColor.Green)
+    | new WireframeNote("Step 3: Dashboard", Colors.Green)
         .CanvasLeft(Size.Px(380)).CanvasTop(Size.Px(30))
 ```
 
@@ -71,9 +71,9 @@ Layout.Canvas()
     .Background(Colors.Neutral)
     .Padding(new Thickness(8))
     | new Badge("Whiteboard").Outline().CanvasLeft(Size.Px(20)).CanvasTop(Size.Px(20))
-    | new WireframeNote("Idea 1", WireframeNoteColor.Yellow)
+    | new WireframeNote("Idea 1", Colors.Yellow)
         .CanvasLeft(Size.Px(20)).CanvasTop(Size.Px(60))
-    | new WireframeNote("Idea 2", WireframeNoteColor.Pink)
+    | new WireframeNote("Idea 2", Colors.Pink)
         .CanvasLeft(Size.Px(200)).CanvasTop(Size.Px(60))
 ```
 

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/08_Wireframe/01_WireframeNote.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/08_Wireframe/01_WireframeNote.md
@@ -31,11 +31,11 @@ Six color variants are available to categorize and distinguish notes:
 ```csharp demo
 Layout.Horizontal().Gap(4)
     | new WireframeNote("Yellow (default)")
-    | new WireframeNote("Blue note", WireframeNoteColor.Blue)
-    | new WireframeNote("Green note", WireframeNoteColor.Green)
-    | new WireframeNote("Pink note", WireframeNoteColor.Pink)
-    | new WireframeNote("Orange note", WireframeNoteColor.Orange)
-    | new WireframeNote("Purple note", WireframeNoteColor.Purple)
+    | new WireframeNote("Blue note", Colors.Blue)
+    | new WireframeNote("Green note", Colors.Green)
+    | new WireframeNote("Pink note", Colors.Pink)
+    | new WireframeNote("Orange note", Colors.Orange)
+    | new WireframeNote("Purple note", Colors.Purple)
 ```
 
 | Color    | Typical Use                    |
@@ -54,8 +54,8 @@ Use newlines in the text string to create multi-line notes:
 ```csharp demo
 Layout.Horizontal().Gap(4)
     | new WireframeNote("Step 1:\nUser signs up")
-    | new WireframeNote("Step 2:\nVerify email", WireframeNoteColor.Blue)
-    | new WireframeNote("Step 3:\nOnboarding flow", WireframeNoteColor.Green)
+    | new WireframeNote("Step 2:\nVerify email", Colors.Blue)
+    | new WireframeNote("Step 3:\nOnboarding flow", Colors.Green)
 ```
 
 ## Sizing
@@ -74,13 +74,13 @@ Combine with `CanvasLayout` for free-form placement:
 
 ```csharp demo
 Layout.Canvas().Width(Size.Full()).Height(Size.Px(300))
-    | new WireframeNote("Login page", WireframeNoteColor.Yellow)
+    | new WireframeNote("Login page", Colors.Yellow)
         .CanvasLeft(Size.Px(20)).CanvasTop(Size.Px(20))
-    | new WireframeNote("Auth service", WireframeNoteColor.Blue)
+    | new WireframeNote("Auth service", Colors.Blue)
         .CanvasLeft(Size.Px(200)).CanvasTop(Size.Px(100))
-    | new WireframeNote("Dashboard", WireframeNoteColor.Green)
+    | new WireframeNote("Dashboard", Colors.Green)
         .CanvasLeft(Size.Px(380)).CanvasTop(Size.Px(30))
-    | new WireframeNote("Error handling", WireframeNoteColor.Pink)
+    | new WireframeNote("Error handling", Colors.Pink)
         .CanvasLeft(Size.Px(200)).CanvasTop(Size.Px(220))
 ```
 
@@ -95,14 +95,14 @@ Layout.Vertical().Gap(4)
         | (Layout.Vertical().Gap(3).Width(Size.Units(40))
             | Text.Strong("To Do")
             | new WireframeNote("Design login page").Width(Size.Full())
-            | new WireframeNote("Write API docs", WireframeNoteColor.Orange).Width(Size.Full()))
+            | new WireframeNote("Write API docs", Colors.Orange).Width(Size.Full()))
         | (Layout.Vertical().Gap(3).Width(Size.Units(40))
             | Text.Strong("In Progress")
-            | new WireframeNote("Build widgets", WireframeNoteColor.Blue).Width(Size.Full()))
+            | new WireframeNote("Build widgets", Colors.Blue).Width(Size.Full()))
         | (Layout.Vertical().Gap(3).Width(Size.Units(40))
             | Text.Strong("Done")
-            | new WireframeNote("DB schema", WireframeNoteColor.Green).Width(Size.Full())
-            | new WireframeNote("Scaffolding", WireframeNoteColor.Green).Width(Size.Full())))
+            | new WireframeNote("DB schema", Colors.Green).Width(Size.Full())
+            | new WireframeNote("Scaffolding", Colors.Green).Width(Size.Full())))
 ```
 
 <WidgetDocs Type="Ivy.WireframeNote" ExtensionTypes="Ivy.WireframeNoteExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Wireframe/WireframeNote.cs"/>

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/08_Wireframe/02_WireframeCallout.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/08_Wireframe/02_WireframeCallout.md
@@ -1,0 +1,85 @@
+---
+searchHints:
+- wireframe
+- callout
+- annotation
+- number
+- circle
+- marker
+- balsamiq
+---
+
+# WireframeCallout
+
+<Ingress>
+A hand-drawn numbered circle widget for annotations, step markers, and low-fidelity callouts with a Balsamiq-style aesthetic.
+</Ingress>
+
+The `WireframeCallout` widget renders as a wobbly hand-drawn circle with a bold centered label. It is designed for numbering steps, annotating diagrams, and adding visual markers to wireframe sketches.
+
+## Basic Usage
+
+```csharp demo
+new WireframeCallout("1")
+```
+
+## Colors
+
+Use colors to categorize callouts by meaning:
+
+```csharp demo
+Layout.Horizontal().Gap(4)
+    | new WireframeCallout("1")
+    | new WireframeCallout("2", Colors.Blue)
+    | new WireframeCallout("3", Colors.Green)
+    | new WireframeCallout("!", Colors.Pink)
+    | new WireframeCallout("?", Colors.Orange)
+    | new WireframeCallout("A", Colors.Purple)
+```
+
+| Color    | Typical Use                    |
+|----------|--------------------------------|
+| Yellow   | General annotations            |
+| Blue     | In-progress steps, questions   |
+| Green    | Completed steps, approvals     |
+| Pink     | Warnings, errors, blockers     |
+| Orange   | Deferred items, follow-ups     |
+| Purple   | Design decisions, references   |
+
+## On a Canvas
+
+Combine with `CanvasLayout` for annotated wireframe diagrams:
+
+```csharp demo
+Layout.Canvas().Width(Size.Full()).Height(Size.Px(200))
+    | new WireframeCallout("1", Colors.Blue)
+        .CanvasLeft(Size.Px(20)).CanvasTop(Size.Px(20))
+    | new WireframeCallout("2", Colors.Blue)
+        .CanvasLeft(Size.Px(80)).CanvasTop(Size.Px(80))
+    | new WireframeCallout("3", Colors.Green)
+        .CanvasLeft(Size.Px(140)).CanvasTop(Size.Px(30))
+    | new WireframeCallout("!", Colors.Pink)
+        .CanvasLeft(Size.Px(200)).CanvasTop(Size.Px(100))
+```
+
+## With Wireframe Notes
+
+Pair callouts with sticky notes for annotated flow diagrams:
+
+```csharp demo
+Layout.Canvas().Width(Size.Full()).Height(Size.Px(300))
+    | new WireframeCallout("1", Colors.Blue)
+        .CanvasLeft(Size.Px(20)).CanvasTop(Size.Px(20))
+    | new WireframeNote("User signs up", Colors.Yellow)
+        .CanvasLeft(Size.Px(60)).CanvasTop(Size.Px(10))
+    | new WireframeCallout("2", Colors.Blue)
+        .CanvasLeft(Size.Px(20)).CanvasTop(Size.Px(100))
+    | new WireframeNote("Verify email", Colors.Blue)
+        .CanvasLeft(Size.Px(60)).CanvasTop(Size.Px(90))
+    | new WireframeCallout("3", Colors.Green)
+        .CanvasLeft(Size.Px(20)).CanvasTop(Size.Px(180))
+    | new WireframeNote("Dashboard", Colors.Green)
+        .CanvasLeft(Size.Px(60)).CanvasTop(Size.Px(170))
+```
+
+<WidgetDocs Type="Ivy.WireframeCallout" ExtensionTypes="Ivy.WireframeCalloutExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Wireframe/WireframeCallout.cs"/>

--- a/src/Ivy.Samples.Shared/Apps/Widgets/Layouts/CanvasLayoutApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Layouts/CanvasLayoutApp.cs
@@ -14,17 +14,17 @@ public class CanvasLayoutApp : SampleBase
 
         var wireframe = Layout.Canvas()
             .Width(Size.Full()).Height(Size.Px(350))
-            | new WireframeNote("User clicks Login", WireframeNoteColor.Yellow)
+            | new WireframeNote("User clicks Login", Colors.Yellow)
                 .CanvasLeft(Size.Px(20)).CanvasTop(Size.Px(10))
-            | new WireframeNote("Validate credentials\nagainst OAuth", WireframeNoteColor.Blue)
+            | new WireframeNote("Validate credentials\nagainst OAuth", Colors.Blue)
                 .CanvasLeft(Size.Px(200)).CanvasTop(Size.Px(70))
-            | new WireframeNote("Token exchange\n+ session create", WireframeNoteColor.Green)
+            | new WireframeNote("Token exchange\n+ session create", Colors.Green)
                 .CanvasLeft(Size.Px(380)).CanvasTop(Size.Px(20))
-            | new WireframeNote("Redirect to\ndashboard", WireframeNoteColor.Purple)
+            | new WireframeNote("Redirect to\ndashboard", Colors.Purple)
                 .CanvasLeft(Size.Px(380)).CanvasTop(Size.Px(170))
-            | new WireframeNote("Show error toast", WireframeNoteColor.Pink)
+            | new WireframeNote("Show error toast", Colors.Pink)
                 .CanvasLeft(Size.Px(200)).CanvasTop(Size.Px(230))
-            | new WireframeNote("Retry?", WireframeNoteColor.Orange)
+            | new WireframeNote("Retry?", Colors.Orange)
                 .CanvasLeft(Size.Px(20)).CanvasTop(Size.Px(250));
 
         return Layout.Vertical()

--- a/src/Ivy.Samples.Shared/Apps/Widgets/Wireframe/WireframeCalloutApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Wireframe/WireframeCalloutApp.cs
@@ -1,0 +1,39 @@
+
+namespace Ivy.Samples.Shared.Apps.Widgets.Wireframe;
+
+[App(icon: Icons.Circle, group: ["Widgets", "Wireframe"], searchHints: ["wireframe", "callout", "annotation", "number", "circle", "marker", "balsamiq"])]
+public class WireframeCalloutApp : SampleBase
+{
+    protected override object? BuildSample()
+    {
+        var colors = Layout.Horizontal().Gap(4)
+            | new WireframeCallout("1")
+            | new WireframeCallout("2", Colors.Blue)
+            | new WireframeCallout("3", Colors.Green)
+            | new WireframeCallout("!", Colors.Pink)
+            | new WireframeCallout("?", Colors.Orange)
+            | new WireframeCallout("A", Colors.Purple);
+
+        var annotated = Layout.Canvas()
+            .Width(Size.Full()).Height(Size.Px(300))
+            | new WireframeCallout("1", Colors.Blue)
+                .CanvasLeft(Size.Px(20)).CanvasTop(Size.Px(20))
+            | new WireframeNote("User signs up", Colors.Yellow)
+                .CanvasLeft(Size.Px(60)).CanvasTop(Size.Px(10))
+            | new WireframeCallout("2", Colors.Blue)
+                .CanvasLeft(Size.Px(20)).CanvasTop(Size.Px(100))
+            | new WireframeNote("Verify email", Colors.Blue)
+                .CanvasLeft(Size.Px(60)).CanvasTop(Size.Px(90))
+            | new WireframeCallout("3", Colors.Green)
+                .CanvasLeft(Size.Px(20)).CanvasTop(Size.Px(180))
+            | new WireframeNote("Dashboard", Colors.Green)
+                .CanvasLeft(Size.Px(60)).CanvasTop(Size.Px(170));
+
+        return Layout.Vertical()
+            | Text.H1("Wireframe Callout")
+            | Text.H2("Colors")
+            | colors
+            | Text.H2("Annotated Flow")
+            | annotated;
+    }
+}

--- a/src/Ivy.Samples.Shared/Apps/Widgets/Wireframe/WireframeNoteApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Wireframe/WireframeNoteApp.cs
@@ -8,29 +8,29 @@ public class WireframeNoteApp : SampleBase
     {
         var colors = Layout.Horizontal().Gap(4)
             | new WireframeNote("Yellow (default)")
-            | new WireframeNote("Blue", WireframeNoteColor.Blue)
-            | new WireframeNote("Green", WireframeNoteColor.Green)
-            | new WireframeNote("Pink", WireframeNoteColor.Pink)
-            | new WireframeNote("Orange", WireframeNoteColor.Orange)
-            | new WireframeNote("Purple", WireframeNoteColor.Purple);
+            | new WireframeNote("Blue", Colors.Blue)
+            | new WireframeNote("Green", Colors.Green)
+            | new WireframeNote("Pink", Colors.Pink)
+            | new WireframeNote("Orange", Colors.Orange)
+            | new WireframeNote("Purple", Colors.Purple);
 
         var multiline = Layout.Horizontal().Gap(4)
             | new WireframeNote("Step 1:\nUser signs up")
-            | new WireframeNote("Step 2:\nVerify email", WireframeNoteColor.Blue)
-            | new WireframeNote("Step 3:\nOnboarding", WireframeNoteColor.Green);
+            | new WireframeNote("Step 2:\nVerify email", Colors.Blue)
+            | new WireframeNote("Step 3:\nOnboarding", Colors.Green);
 
         var board = Layout.Horizontal().Gap(4)
             | (Layout.Vertical().Gap(3).Width(Size.Units(40))
                 | Text.Strong("To Do")
                 | new WireframeNote("Design login page").Width(Size.Full())
-                | new WireframeNote("Write API docs", WireframeNoteColor.Orange).Width(Size.Full()))
+                | new WireframeNote("Write API docs", Colors.Orange).Width(Size.Full()))
             | (Layout.Vertical().Gap(3).Width(Size.Units(40))
                 | Text.Strong("In Progress")
-                | new WireframeNote("Build widgets", WireframeNoteColor.Blue).Width(Size.Full()))
+                | new WireframeNote("Build widgets", Colors.Blue).Width(Size.Full()))
             | (Layout.Vertical().Gap(3).Width(Size.Units(40))
                 | Text.Strong("Done")
-                | new WireframeNote("DB schema", WireframeNoteColor.Green).Width(Size.Full())
-                | new WireframeNote("Scaffolding", WireframeNoteColor.Green).Width(Size.Full()));
+                | new WireframeNote("DB schema", Colors.Green).Width(Size.Full())
+                | new WireframeNote("Scaffolding", Colors.Green).Width(Size.Full()));
 
         return Layout.Vertical()
             | Text.H1("Wireframe Note")

--- a/src/Ivy/Widgets/Wireframe/WireframeCallout.cs
+++ b/src/Ivy/Widgets/Wireframe/WireframeCallout.cs
@@ -1,0 +1,31 @@
+// ReSharper disable once CheckNamespace
+namespace Ivy;
+
+public record WireframeCallout : WidgetBase<WireframeCallout>
+{
+    public WireframeCallout(string? label = null, Colors color = Colors.Yellow)
+    {
+        Label = label;
+        Color = color;
+    }
+
+    internal WireframeCallout() { }
+
+    [Prop] public string? Label { get; set; }
+
+    [Prop] public Colors Color { get; set; } = Colors.Yellow;
+
+    public static WireframeCallout operator |(WireframeCallout widget, object child)
+    {
+        throw new NotSupportedException("WireframeCallout does not support children. Use the Label property.");
+    }
+}
+
+public static class WireframeCalloutExtensions
+{
+    public static WireframeCallout Label(this WireframeCallout callout, string label)
+        => callout with { Label = label };
+
+    public static WireframeCallout Color(this WireframeCallout callout, Colors color)
+        => callout with { Color = color };
+}

--- a/src/Ivy/Widgets/Wireframe/WireframeNote.cs
+++ b/src/Ivy/Widgets/Wireframe/WireframeNote.cs
@@ -1,19 +1,9 @@
 // ReSharper disable once CheckNamespace
 namespace Ivy;
 
-public enum WireframeNoteColor
-{
-    Yellow,
-    Blue,
-    Green,
-    Pink,
-    Orange,
-    Purple
-}
-
 public record WireframeNote : WidgetBase<WireframeNote>
 {
-    public WireframeNote(string? text = null, WireframeNoteColor color = WireframeNoteColor.Yellow)
+    public WireframeNote(string? text = null, Colors color = Colors.Yellow)
     {
         Text = text;
         Color = color;
@@ -23,7 +13,7 @@ public record WireframeNote : WidgetBase<WireframeNote>
 
     [Prop] public string? Text { get; set; }
 
-    [Prop] public WireframeNoteColor Color { get; set; } = WireframeNoteColor.Yellow;
+    [Prop] public Colors Color { get; set; } = Colors.Yellow;
 
     public static WireframeNote operator |(WireframeNote widget, object child)
     {
@@ -36,6 +26,6 @@ public static class WireframeNoteExtensions
     public static WireframeNote Text(this WireframeNote note, string text)
         => note with { Text = text };
 
-    public static WireframeNote Color(this WireframeNote note, WireframeNoteColor color)
+    public static WireframeNote Color(this WireframeNote note, Colors color)
         => note with { Color = color };
 }

--- a/src/frontend/src/widgets/widgetMap.ts
+++ b/src/frontend/src/widgets/widgetMap.ts
@@ -57,6 +57,7 @@ import { AvatarWidget } from "@/widgets/primitives/AvatarWidget";
 import { IvyLogoWidget } from "@/widgets/primitives/IvyLogoWidget";
 import { SpacerWidget } from "@/widgets/primitives/SpacerWidget";
 import { WireframeNoteWidget } from "@/widgets/wireframe/WireframeNoteWidget";
+import { WireframeCalloutWidget } from "@/widgets/wireframe/WireframeCalloutWidget";
 import { LoadingWidget } from "@/widgets/primitives/LoadingWidget";
 import { AppHostWidget } from "@/widgets/primitives/AppHostWidget";
 import { AutoScrollWidget } from "@/widgets/primitives/AutoScrollWidget";
@@ -303,6 +304,7 @@ export const widgetMap = {
 
   // Wireframe
   "Ivy.WireframeNote": WireframeNoteWidget,
+  "Ivy.WireframeCallout": WireframeCalloutWidget,
 
   // Effects
   "Ivy.Confetti": lazyWithRetry(() => import("@/widgets/effects/ConfettiWidget")),

--- a/src/frontend/src/widgets/wireframe/WireframeCalloutWidget.tsx
+++ b/src/frontend/src/widgets/wireframe/WireframeCalloutWidget.tsx
@@ -1,0 +1,54 @@
+import { getWireframePalette } from "./wireframeColors";
+import React from "react";
+
+interface WireframeCalloutWidgetProps {
+  id: string;
+  label?: string;
+  color?: string;
+}
+
+export const WireframeCalloutWidget: React.FC<WireframeCalloutWidgetProps> = ({ label, color }) => {
+  const palette = getWireframePalette(color);
+  const size = 44;
+
+  return (
+    <div
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        width: size,
+        height: size,
+        filter: `drop-shadow(2px 3px 4px ${palette.shadow})`,
+      }}
+    >
+      <svg width={size} height={size} viewBox="0 0 44 44" style={{ position: "absolute" }}>
+        <path
+          d={`M 22 2
+              C 30 1, 40 6, 42 14
+              C 44 22, 42 32, 36 38
+              C 30 44, 18 44, 10 38
+              C 3 32, 1 22, 3 14
+              C 6 6, 14 1, 22 2 Z`}
+          fill={palette.bg}
+          stroke={palette.border}
+          strokeWidth="2"
+          strokeLinejoin="round"
+        />
+      </svg>
+      <span
+        style={{
+          position: "relative",
+          color: palette.text,
+          fontFamily: "'Comic Sans MS', 'Segoe Print', 'Bradley Hand', cursive",
+          fontSize: "16px",
+          fontWeight: 700,
+          lineHeight: 1,
+          userSelect: "none",
+        }}
+      >
+        {label}
+      </span>
+    </div>
+  );
+};

--- a/src/frontend/src/widgets/wireframe/WireframeNoteWidget.tsx
+++ b/src/frontend/src/widgets/wireframe/WireframeNoteWidget.tsx
@@ -1,32 +1,24 @@
 import { getHeight, getWidth } from "@/lib/styles";
+import { getWireframePalette } from "./wireframeColors";
 import React from "react";
 
 interface WireframeNoteWidgetProps {
   id: string;
   text?: string;
-  color?: "Yellow" | "Blue" | "Green" | "Pink" | "Orange" | "Purple";
+  color?: string;
   width?: string;
   height?: string;
 }
-
-const NOTE_COLORS = {
-  Yellow: { bg: "#f5d949", fold: "#d4b82e", shadow: "rgba(180,150,30,0.25)", text: "#3a3000" },
-  Blue: { bg: "#87ceeb", fold: "#6ab0d0", shadow: "rgba(80,140,180,0.25)", text: "#1a2e40" },
-  Green: { bg: "#90d890", fold: "#70b870", shadow: "rgba(80,160,80,0.25)", text: "#1a3a1a" },
-  Pink: { bg: "#f5a0c0", fold: "#d880a0", shadow: "rgba(180,80,120,0.25)", text: "#3a1020" },
-  Orange: { bg: "#f5b870", fold: "#d89850", shadow: "rgba(180,130,50,0.25)", text: "#3a2000" },
-  Purple: { bg: "#c8a8e8", fold: "#a888c8", shadow: "rgba(140,100,180,0.25)", text: "#2a1040" },
-};
 
 const FOLD_SIZE = 24;
 
 export const WireframeNoteWidget: React.FC<WireframeNoteWidgetProps> = ({
   text,
-  color = "Yellow",
+  color,
   width,
   height,
 }) => {
-  const palette = NOTE_COLORS[color] || NOTE_COLORS.Yellow;
+  const palette = getWireframePalette(color);
 
   const style: React.CSSProperties = {
     ...getWidth(width),
@@ -51,7 +43,6 @@ export const WireframeNoteWidget: React.FC<WireframeNoteWidgetProps> = ({
         preserveAspectRatio="none"
         viewBox="0 0 200 200"
       >
-        {/* Main note body with slightly wobbly edges */}
         <path
           d={`M 2 1
               Q 100 -1, 176 1.5
@@ -65,10 +56,9 @@ export const WireframeNoteWidget: React.FC<WireframeNoteWidgetProps> = ({
           strokeWidth="1.2"
           strokeOpacity="0.18"
         />
-        {/* Folded corner triangle */}
         <path
           d={`M 176 1.5 L 176 ${FOLD_SIZE} L 200 ${FOLD_SIZE} Z`}
-          fill={palette.fold}
+          fill={palette.border}
           stroke={palette.text}
           strokeWidth="0.8"
           strokeOpacity="0.15"

--- a/src/frontend/src/widgets/wireframe/wireframeColors.ts
+++ b/src/frontend/src/widgets/wireframe/wireframeColors.ts
@@ -1,0 +1,40 @@
+export interface WireframePalette {
+  bg: string;
+  border: string;
+  shadow: string;
+  text: string;
+}
+
+const WIREFRAME_COLORS: Record<string, WireframePalette> = {
+  Yellow: { bg: "#f5d949", border: "#d4b82e", shadow: "rgba(180,150,30,0.25)", text: "#3a3000" },
+  Blue: { bg: "#87ceeb", border: "#5a9aba", shadow: "rgba(80,140,180,0.25)", text: "#1a2e40" },
+  Green: { bg: "#90d890", border: "#60a860", shadow: "rgba(80,160,80,0.25)", text: "#1a3a1a" },
+  Pink: { bg: "#f5a0c0", border: "#c87898", shadow: "rgba(180,80,120,0.25)", text: "#3a1020" },
+  Orange: { bg: "#f5b870", border: "#c89048", shadow: "rgba(180,130,50,0.25)", text: "#3a2000" },
+  Purple: { bg: "#c8a8e8", border: "#9878b8", shadow: "rgba(140,100,180,0.25)", text: "#2a1040" },
+  Red: { bg: "#f5a0a0", border: "#c87070", shadow: "rgba(180,80,80,0.25)", text: "#3a1010" },
+  Amber: { bg: "#f5d080", border: "#c8a850", shadow: "rgba(180,150,50,0.25)", text: "#3a2800" },
+  Lime: { bg: "#c8e878", border: "#a0c050", shadow: "rgba(120,180,50,0.25)", text: "#283a10" },
+  Emerald: { bg: "#80d8b0", border: "#58b088", shadow: "rgba(60,160,120,0.25)", text: "#103028" },
+  Teal: { bg: "#80d0d0", border: "#58a8a8", shadow: "rgba(60,150,150,0.25)", text: "#102a2a" },
+  Cyan: { bg: "#80d8e8", border: "#58b0c0", shadow: "rgba(60,150,180,0.25)", text: "#102830" },
+  Sky: { bg: "#90c8f0", border: "#68a0c8", shadow: "rgba(60,130,180,0.25)", text: "#102040" },
+  Indigo: { bg: "#a0a8e8", border: "#7880c0", shadow: "rgba(80,80,160,0.25)", text: "#1a1840" },
+  Violet: { bg: "#b8a0e8", border: "#9078c0", shadow: "rgba(100,80,160,0.25)", text: "#201040" },
+  Fuchsia: { bg: "#e0a0e0", border: "#b878b8", shadow: "rgba(160,80,160,0.25)", text: "#301030" },
+  Rose: { bg: "#f5a0b0", border: "#c87888", shadow: "rgba(180,80,100,0.25)", text: "#3a1018" },
+  Slate: { bg: "#b0b8c8", border: "#8890a0", shadow: "rgba(100,110,130,0.25)", text: "#202830" },
+  Gray: { bg: "#c0c0c0", border: "#989898", shadow: "rgba(120,120,120,0.25)", text: "#282828" },
+  Zinc: { bg: "#b8b8b8", border: "#909090", shadow: "rgba(110,110,110,0.25)", text: "#282828" },
+  Neutral: { bg: "#c8c8c0", border: "#a0a098", shadow: "rgba(120,120,110,0.25)", text: "#282820" },
+  Stone: { bg: "#c8c0b8", border: "#a09888", shadow: "rgba(120,110,100,0.25)", text: "#282018" },
+  Black: { bg: "#505050", border: "#383838", shadow: "rgba(30,30,30,0.3)", text: "#e8e8e8" },
+  White: { bg: "#f8f8f0", border: "#d0d0c8", shadow: "rgba(150,150,140,0.2)", text: "#303028" },
+};
+
+const DEFAULT_PALETTE: WireframePalette = WIREFRAME_COLORS.Yellow;
+
+export function getWireframePalette(color?: string): WireframePalette {
+  if (!color) return DEFAULT_PALETTE;
+  return WIREFRAME_COLORS[color] || DEFAULT_PALETTE;
+}

--- a/src/ivyml/Ivy.IvyML/Docs/IVYML.md
+++ b/src/ivyml/Ivy.IvyML/Docs/IVYML.md
@@ -186,7 +186,21 @@ A sticky note with a folded corner, drop shadow, and hand-drawn font.
 | Prop    | Type              | Default  | Values                                         |
 |---------|-------------------|----------|-------------------------------------------------|
 | `Text`  | string            |          | The note content. Use `&#10;` for line breaks.  |
-| `Color` | WireframeNoteColor| Yellow   | Yellow, Blue, Green, Pink, Orange, Purple       |
+| `Color` | Colors            | Yellow   | Any color from the Colors enum                  |
+
+### WireframeCallout
+
+A hand-drawn numbered circle for annotations and step markers.
+
+```xml
+<WireframeCallout Label="1" />
+<WireframeCallout Label="!" Color="Pink" />
+```
+
+| Prop    | Type              | Default  | Values                                         |
+|---------|-------------------|----------|-------------------------------------------------|
+| `Label` | string            |          | Short text shown inside the circle.             |
+| `Color` | Colors            | Yellow   | Any color from the Colors enum                  |
 
 ### CanvasLayout
 


### PR DESCRIPTION
- Add WireframeCallout: hand-drawn numbered circle for annotations and step markers
- Replace custom WireframeNoteColor enum with standard Ivy Colors enum on both wireframe widgets
- Add shared wireframeColors.ts palette mapping all Ivy Colors to hand-drawn hex values
- Add docs and sample apps for WireframeCallout in Ivy.Docs.Shared and Ivy.Samples.Shared
- Update WireframeNote docs/samples to reflect Colors enum change
- Update IVYML.md with WireframeCallout section
