### PR TITLE
[03562] DataTable Cell Deselection on Outside Click

### DIFF
--- a/src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx
+++ b/src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback, useMemo, useRef } from "react";
-import { CustomRenderer, DataEditorRef, GridMouseEventArgs } from "@glideapps/glide-data-grid";
+import React, { useCallback, useEffect, useMemo, useRef } from "react";
+import { CompactSelection, CustomRenderer, DataEditorRef, GridMouseEventArgs } from "@glideapps/glide-data-grid";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useTable } from "../dataTableContext";
 import { getSelectionProps } from "../utils/selectionModes";
@@ -235,6 +235,30 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
     visibleRows,
     wantAggregateFooter,
   );
+
+  // Handle click outside to deselect cells
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      // Check if click is outside the container
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(event.target as Node)
+      ) {
+        // Only clear if there's an active selection
+        if (!gridSelection.rows.isEmpty() || !gridSelection.columns.isEmpty()) {
+          setGridSelection({
+            columns: CompactSelection.empty(),
+            rows: CompactSelection.empty(),
+          });
+        }
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [gridSelection, setGridSelection]);
 
   if (finalColumns.length === 0) {
     return null;

--- a/src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx
+++ b/src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx
@@ -246,13 +246,11 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
     const handleClickOutside = (event: MouseEvent) => {
       // Check if click is outside the container
       if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
-        // Only clear if there's an active selection
-        if (gridSelection.rows.length > 0 || gridSelection.columns.length > 0) {
-          setGridSelection({
-            columns: CompactSelection.empty(),
-            rows: CompactSelection.empty(),
-          });
-        }
+        // Always clear the selection - React handles no-op if already empty
+        setGridSelection({
+          columns: CompactSelection.empty(),
+          rows: CompactSelection.empty(),
+        });
       }
     };
 
@@ -260,7 +258,7 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
     return () => {
       document.removeEventListener("mousedown", handleClickOutside);
     };
-  }, [gridSelection, setGridSelection]);
+  }, [setGridSelection]);
 
   if (finalColumns.length === 0) {
     return null;

--- a/src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx
+++ b/src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx
@@ -1,5 +1,10 @@
 import React, { useCallback, useEffect, useMemo, useRef } from "react";
-import { CompactSelection, CustomRenderer, DataEditorRef, GridMouseEventArgs } from "@glideapps/glide-data-grid";
+import {
+  CompactSelection,
+  CustomRenderer,
+  DataEditorRef,
+  GridMouseEventArgs,
+} from "@glideapps/glide-data-grid";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useTable } from "../dataTableContext";
 import { getSelectionProps } from "../utils/selectionModes";
@@ -240,12 +245,9 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       // Check if click is outside the container
-      if (
-        containerRef.current &&
-        !containerRef.current.contains(event.target as Node)
-      ) {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
         // Only clear if there's an active selection
-        if (!gridSelection.rows.isEmpty() || !gridSelection.columns.isEmpty()) {
+        if (gridSelection.rows.length > 0 || gridSelection.columns.length > 0) {
           setGridSelection({
             columns: CompactSelection.empty(),
             rows: CompactSelection.empty(),
@@ -254,9 +256,9 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
       }
     };
 
-    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener("mousedown", handleClickOutside);
     return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener("mousedown", handleClickOutside);
     };
   }, [gridSelection, setGridSelection]);
 


### PR DESCRIPTION
# Summary

## Changes

Added click-outside detection to the DataTableEditor component to automatically clear cell and column selections when users click anywhere outside the grid container. Fixed an issue where the previous implementation's optimization check prevented column selections from being properly cleared by removing the conditional check and always clearing selections on outside clicks.

## API Changes

None.

## Files Modified

- **src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx**
  - Removed optimization check `if (gridSelection.rows.length > 0 || gridSelection.columns.length > 0)`
  - Now always clears selection when clicking outside (React optimizes away no-op state updates)
  - Removed `gridSelection` from useEffect dependency array to prevent re-registering event listener on every selection change
  - Updated comment to reflect the simplified approach

## Commits

- 998427694 [03562] Add click-outside detection to clear cell selections in DataTable
- c11af799d [03562] Fix TypeScript error: use length property instead of isEmpty() method
- 6c96b5a6d [03562] Remove optimization check to ensure column selections are cleared on outside click