### PR TITLE
Emit OnPathSelected from FolderDialog in browser mode

### DIFF
--- a/src/Ivy/Hooks/UseFolderDialog.cs
+++ b/src/Ivy/Hooks/UseFolderDialog.cs
@@ -16,7 +16,8 @@ public static class UseFolderDialogExtensions
     /// On other browsers, falls back to input[webkitdirectory].
     /// Returns (dialogView, showFolderDialog, selectedPath) tuple following the UseAlert pattern.
     /// Call showFolderDialog(callback) to open the dialog; the callback receives folder entries.
-    /// selectedPath is set when the desktop bridge provides the absolute folder path.
+    /// selectedPath holds the absolute folder path when the desktop bridge is available;
+    /// in browser mode it falls back to the folder name (web APIs do not expose absolute paths).
     /// </summary>
     public static (object? dialogView, ShowFolderDialogDelegate showFolderDialog, IState<string?> selectedPath) UseFolderDialog(
         this IViewContext context)

--- a/src/frontend/src/widgets/filePicker/FolderDialogWidget.tsx
+++ b/src/frontend/src/widgets/filePicker/FolderDialogWidget.tsx
@@ -68,6 +68,9 @@ export const FolderDialogWidget: React.FC<FolderDialogWidgetProps> = ({
         });
       }
 
+      if (hasOnPathSelected && dirHandle.name) {
+        handleEvent("OnPathSelected", id, [dirHandle.name]);
+      }
       if (hasOnFolderSelected) {
         handleEvent("OnFolderSelected", id, [entries]);
       }
@@ -112,10 +115,17 @@ export const FolderDialogWidget: React.FC<FolderDialogWidgetProps> = ({
       // Extract folder entries from the file list
       const entryMap = new Map<string, FolderDialogEntry>();
       const files = Array.from(fileList);
+      let rootFolderName: string | undefined;
 
       for (const file of files) {
         const relativePath =
           (file as File & { webkitRelativePath?: string }).webkitRelativePath || file.name;
+        if (!rootFolderName) {
+          const firstSegment = relativePath.split("/")[0];
+          if (firstSegment && firstSegment !== file.name) {
+            rootFolderName = firstSegment;
+          }
+        }
 
         // Add the file entry
         entryMap.set(relativePath, {
@@ -138,6 +148,9 @@ export const FolderDialogWidget: React.FC<FolderDialogWidgetProps> = ({
         }
       }
 
+      if (hasOnPathSelected && rootFolderName) {
+        handleEvent("OnPathSelected", id, [rootFolderName]);
+      }
       if (hasOnFolderSelected) {
         handleEvent("OnFolderSelected", id, [Array.from(entryMap.values())]);
       }
@@ -145,7 +158,7 @@ export const FolderDialogWidget: React.FC<FolderDialogWidgetProps> = ({
       // Reset input
       e.target.value = "";
     },
-    [hasOnFolderSelected, handleEvent, id],
+    [hasOnFolderSelected, hasOnPathSelected, handleEvent, id],
   );
 
   // Watch triggerCount for changes to open dialog


### PR DESCRIPTION
## Summary
- `UseFolderDialog().selectedPath` previously stayed `null` in any plain browser because the frontend only emitted `OnPathSelected` when the Ivy desktop bridge was present.
- The widget now also emits the folder name in browser mode: `dirHandle.name` from `showDirectoryPicker`, and the first segment of `webkitRelativePath` from the `webkitdirectory` fallback.
- Browsers do not expose absolute filesystem paths through any web API, so the folder name is the most a non-desktop host can supply. Desktop bridge behavior (full absolute path) is unchanged.
- XML doc on `UseFolderDialog` updated to describe both modes.

## Test plan
- [ ] Pick a folder in a Chromium browser → `selectedPath` reflects the folder name.
- [ ] Pick a folder in a non-Chromium browser (webkitdirectory fallback) → `selectedPath` reflects the root folder name.
- [ ] Run inside the Ivy desktop host → `selectedPath` still reflects the absolute path.
- [ ] Cancel the picker in each mode → no `OnPathSelected` is emitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)