### PR TITLE
[00075] Remove cm-editor white background in CodeInput widget

### DIFF
--- a/src/frontend/src/widgets/inputs/code/CodeInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/code/CodeInputWidget.tsx
@@ -228,7 +228,7 @@ export const CodeInputWidget: React.FC<CodeInputWidgetProps> = ({
           data-gramm="false"
           className={cn(
             "h-full",
-            "[&_.cm-theme-light]:overflow-hidden",
+            "[&_.cm-theme-light]:overflow-hidden [&_.cm-theme-light]:bg-transparent",
             "border border-input shadow-sm rounded-field",
             "dark:bg-white/5 dark:border-white/10",
             invalid && inputStyles.invalid,


### PR DESCRIPTION
## Summary

The CodeInput widget's CodeMirror editor had a `.cm-theme-light` class applying a white background, causing visible corner overflow against rounded container borders. Added `bg-transparent` to the cm-theme-light selector to remove the white background and let the container's own background show through.

## Commits

- `32b7838` [00075] Remove cm-editor white background in CodeInput widget