### PR TITLE
Fix CodeInput white background and red fill in invalid state

### DIFF
--- a/src/frontend/src/widgets/inputs/code/CodeInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/code/CodeInputWidget.tsx
@@ -226,12 +226,12 @@ export const CodeInputWidget: React.FC<CodeInputWidgetProps> = ({
           editable={!disabled}
           autoFocus={autoFocus}
           data-gramm="false"
+          theme="none"
           className={cn(
-            "h-full",
-            "[&_.cm-theme-light]:overflow-hidden [&_.cm-theme-light]:bg-transparent",
+            "h-full overflow-hidden",
             "border border-input shadow-sm rounded-field",
             "dark:bg-white/5 dark:border-white/10",
-            invalid && inputStyles.invalid,
+            invalid && inputStyles.invalidInput,
             disabled && "opacity-50 cursor-not-allowed",
           )}
           height="100%"


### PR DESCRIPTION
## Summary
- Pass `theme="none"` to `@uiw/react-codemirror` so its default light theme no longer injects `.cm-editor { background-color: #fff }` (the dynamically generated `.ͼ49` selector) which painted white over the rounded corners. The custom Ivy theme (`createIvyCodeTheme`) already sets `transparent`.
- Switch invalid styling from `inputStyles.invalid` (which sets `bg-destructive`) to `inputStyles.invalidInput` (border only). The red fill was previously masked by the white CodeMirror bg and only became visible after removing it.
- Move `overflow-hidden` from the outer wrapper onto the CodeMirror element itself, where `rounded-field` lives, so any internal background gets clipped to the rounded corners.

## Test plan
- [ ] Open the Plan Template code input in Ivy Tendril Setup — corners should no longer show white overflow.
- [ ] Trigger an invalid state on a CodeInput — only the border should turn red, the editor bg stays transparent.
- [ ] Verify dark mode still renders the existing `dark:bg-white/5` tint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)