### PR TITLE
[Auth]: Enhance password handling and validation in forms

### DIFF
--- a/src/Ivy/Auth/DefaultAuthApp.cs
+++ b/src/Ivy/Auth/DefaultAuthApp.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using System.Reflection;
 using Ivy.Core.Auth;
 
@@ -58,7 +59,7 @@ public class DefaultAuthApp : ViewBase
 
 public class PasswordEmailFlowView(IState<string?> errorMessage) : ViewBase
 {
-    private record LoginFormModel(string User, string Password);
+    private record LoginFormModel(string User, [property: MinLength(0)] string Password);
 
     public override object Build()
     {
@@ -104,7 +105,7 @@ public class PasswordEmailFlowView(IState<string?> errorMessage) : ViewBase
             .Label(m => m.User, "User")
             .Label(m => m.Password, "Password")
             .Builder(m => m.User, state => state.ToTextInput())
-            .Builder(m => m.Password, state => state.ToPasswordInput())
+            .Builder(m => m.Password, state => state.ToPasswordInput().MinLength(0))
             .SubmitStrategy(FormSubmitStrategy.OnSubmit)
             .SubmitTitle("Login")
             .OnSubmit(async model => await HandleLoginAsync(model));

--- a/src/Ivy/Views/Forms/FormHelpers.cs
+++ b/src/Ivy/Views/Forms/FormHelpers.cs
@@ -14,13 +14,15 @@ public static class FormHelpers
         return IsNonNullableString(propertyInfo);
     }
 
-    public static List<Func<object?, (bool, string)>> GetValidators(PropertyInfo propertyInfo)
+    public static List<Func<object?, (bool, string)>> GetValidators(PropertyInfo propertyInfo, Func<ValidationAttribute, bool>? skipAttribute = null)
     {
         var validators = new List<Func<object?, (bool, string)>>();
         var attributes = propertyInfo.GetCustomAttributes<ValidationAttribute>();
 
         foreach (var attr in attributes)
         {
+            if (skipAttribute != null && skipAttribute(attr)) continue;
+
             var capturedAttr = attr; // Capture for closure
 
             if (TryCreateCollectionValidator(attr, propertyInfo.PropertyType, out var collectionValidator))
@@ -54,13 +56,15 @@ public static class FormHelpers
         return validators;
     }
 
-    public static List<Func<object?, (bool, string)>> GetValidators(FieldInfo fieldInfo)
+    public static List<Func<object?, (bool, string)>> GetValidators(FieldInfo fieldInfo, Func<ValidationAttribute, bool>? skipAttribute = null)
     {
         var validators = new List<Func<object?, (bool, string)>>();
         var attributes = fieldInfo.GetCustomAttributes<ValidationAttribute>();
 
         foreach (var attr in attributes)
         {
+            if (skipAttribute != null && skipAttribute(attr)) continue;
+
             var capturedAttr = attr; // Capture for closure
 
             if (TryCreateCollectionValidator(attr, fieldInfo.FieldType, out var collectionValidator))
@@ -290,6 +294,52 @@ public static class FormHelpers
         if (lengthAttr is { MaximumLength: > 0 })
         {
             return lengthAttr.MaximumLength;
+        }
+
+        return null;
+    }
+
+    public static int? GetMinLength(PropertyInfo propertyInfo)
+    {
+        var minLengthAttr = propertyInfo.GetCustomAttribute<MinLengthAttribute>();
+        if (minLengthAttr is { Length: >= 0 })
+        {
+            return minLengthAttr.Length;
+        }
+
+        var stringLengthAttr = propertyInfo.GetCustomAttribute<StringLengthAttribute>();
+        if (stringLengthAttr is { MinimumLength: > 0 })
+        {
+            return stringLengthAttr.MinimumLength;
+        }
+
+        var lengthAttr = propertyInfo.GetCustomAttribute<LengthAttribute>();
+        if (lengthAttr is { MinimumLength: >= 0 })
+        {
+            return lengthAttr.MinimumLength;
+        }
+
+        return null;
+    }
+
+    public static int? GetMinLength(FieldInfo fieldInfo)
+    {
+        var minLengthAttr = fieldInfo.GetCustomAttribute<MinLengthAttribute>();
+        if (minLengthAttr is { Length: >= 0 })
+        {
+            return minLengthAttr.Length;
+        }
+
+        var stringLengthAttr = fieldInfo.GetCustomAttribute<StringLengthAttribute>();
+        if (stringLengthAttr is { MinimumLength: > 0 })
+        {
+            return stringLengthAttr.MinimumLength;
+        }
+
+        var lengthAttr = fieldInfo.GetCustomAttribute<LengthAttribute>();
+        if (lengthAttr is { MinimumLength: >= 0 })
+        {
+            return lengthAttr.MinimumLength;
         }
 
         return null;

--- a/src/Ivy/Views/Forms/FormScaffolder.cs
+++ b/src/Ivy/Views/Forms/FormScaffolder.cs
@@ -135,6 +135,10 @@ internal static class FormScaffolder
             return (state) =>
             {
                 var input = ApplyMaxLength(state.ToPasswordInput(), field);
+                if (field.GetMinLength() is { } minLength)
+                {
+                    input = input.MinLength(minLength);
+                }
                 if (field.IsNullable && !field.Required) input.Nullable = true;
                 return input;
             };
@@ -293,13 +297,18 @@ internal static class FormScaffolder
             validators.Add(e => (ValidationHelper.IsValidRequired(e), "Required field"));
         }
 
+        // Password: skip duplicate [MinLength] from DA — scaffolded password validator covers it.
+        Func<ValidationAttribute, bool>? skipAttribute = field.IsPassword()
+            ? attr => attr is MinLengthAttribute
+            : null;
+
         if (field.PropertyInfo != null)
         {
-            validators.AddRange(FormHelpers.GetValidators(field.PropertyInfo));
+            validators.AddRange(FormHelpers.GetValidators(field.PropertyInfo, skipAttribute));
         }
         else if (field.FieldInfo != null)
         {
-            validators.AddRange(FormHelpers.GetValidators(field.FieldInfo));
+            validators.AddRange(FormHelpers.GetValidators(field.FieldInfo, skipAttribute));
         }
 
         if (field.IsEmail())
@@ -309,7 +318,7 @@ internal static class FormScaffolder
         if (field.IsUrl())
             validators.Add(Validators.CreateUrlValidator(field.Name));
         if (field.IsPassword())
-            validators.Add(Validators.CreatePasswordValidator(field.Name));
+            validators.Add(Validators.CreatePasswordValidator(field.Name, field.GetMinLength() ?? Validators.DefaultPasswordMinLength));
 
         return validators;
     }
@@ -342,6 +351,7 @@ internal static class FormScaffolder
         public FormHelpers.DisplayInfo GetDisplayInfo() => PropertyInfo != null ? FormHelpers.GetDisplayInfo(PropertyInfo) : FormHelpers.GetDisplayInfo(FieldInfo!);
         public FormHelpers.RangeInfo GetRangeInfo() => PropertyInfo != null ? FormHelpers.GetRangeInfo(PropertyInfo) : FormHelpers.GetRangeInfo(FieldInfo!);
         public int? GetMaxLength() => PropertyInfo != null ? FormHelpers.GetMaxLength(PropertyInfo) : FormHelpers.GetMaxLength(FieldInfo!);
+        public int? GetMinLength() => PropertyInfo != null ? FormHelpers.GetMinLength(PropertyInfo) : FormHelpers.GetMinLength(FieldInfo!);
         public object[]? GetAllowedValues() => PropertyInfo != null ? FormHelpers.GetAllowedValues(PropertyInfo) : FormHelpers.GetAllowedValues(FieldInfo!);
 
         public bool IsEmail() =>

--- a/src/Ivy/Views/Forms/Validators.cs
+++ b/src/Ivy/Views/Forms/Validators.cs
@@ -9,8 +9,11 @@ namespace Ivy;
 /// </summary>
 public static class Validators
 {
+    /// <summary>Default min password length when the model/widget does not specify one.</summary>
+    public const int DefaultPasswordMinLength = 8;
+
     /// <summary>Returns (true, null) if valid, (false, errorMessage) if invalid. Empty/whitespace is treated as valid (required handled separately).</summary>
-    public static (bool isValid, string? errorMessage) ValidateForVariant(object? value, TextInputVariant variant, int passwordMinLength = 8)
+    public static (bool isValid, string? errorMessage) ValidateForVariant(object? value, TextInputVariant variant, int passwordMinLength = DefaultPasswordMinLength)
     {
         if (value is not string s || string.IsNullOrWhiteSpace(s))
             return (true, null);
@@ -39,9 +42,10 @@ public static class Validators
         }
     }
 
-    private static string? ValidatePassword(object? value, int minLength = 8)
+    private static string? ValidatePassword(object? value, int minLength = DefaultPasswordMinLength)
     {
         if (value is not string s || string.IsNullOrWhiteSpace(s)) return null;
+        if (minLength <= 0) return null;
         return s.Length >= minLength ? null : $"Password must be at least {minLength} characters";
     }
 
@@ -71,16 +75,16 @@ public static class Validators
     public static Func<object?, (bool, string)> CreateUrlValidator(string fieldName) =>
         v => { var (ok, err) = ValidateForVariant(v, TextInputVariant.Url); return (ok, err ?? ""); };
 
-    public static Func<object?, (bool, string)> CreatePasswordValidator(string fieldName, int minLength = 8) =>
+    public static Func<object?, (bool, string)> CreatePasswordValidator(string fieldName, int minLength = DefaultPasswordMinLength) =>
         v => { var (ok, err) = ValidateForVariant(v, TextInputVariant.Password, minLength); return (ok, err ?? ""); };
 
-    public static Func<object?, (bool, string)>? ForVariant(TextInputVariant variant, string fieldName) =>
+    public static Func<object?, (bool, string)>? ForVariant(TextInputVariant variant, string fieldName, int? passwordMinLength = null) =>
         variant switch
         {
             TextInputVariant.Email => CreateEmailValidator(fieldName),
             TextInputVariant.Tel => CreateTelValidator(fieldName),
             TextInputVariant.Url => CreateUrlValidator(fieldName),
-            TextInputVariant.Password => CreatePasswordValidator(fieldName),
+            TextInputVariant.Password => CreatePasswordValidator(fieldName, passwordMinLength ?? DefaultPasswordMinLength),
             _ => null
         };
 
@@ -92,7 +96,11 @@ public static class Validators
             .ToList();
         if (input is IAnyTextInput textInput)
         {
-            var v = ForVariant(textInput.Variant, label ?? "");
+            // Password: use widget MinLength if set, else default.
+            int? passwordMin = textInput.Variant == TextInputVariant.Password
+                ? (input as TextInputBase)?.MinLength
+                : null;
+            var v = ForVariant(textInput.Variant, label ?? "", passwordMin);
             if (v != null)
                 list.Add(v);
         }

--- a/src/Ivy/Widgets/Inputs/TextInput.cs
+++ b/src/Ivy/Widgets/Inputs/TextInput.cs
@@ -152,6 +152,7 @@ public static class TextInputExtensions
     internal static readonly Type ValidationOwner = typeof(TextInputExtensions);
     internal const string AttachedValidationState = "ValidationState";
     internal const string AttachedValidatedVariant = "ValidatedVariant";
+    internal const string AttachedMinLength = "MinLength";
 
     private static bool VariantHasBuiltInValidation(TextInputVariant variant) =>
         variant is TextInputVariant.Email or TextInputVariant.Tel or TextInputVariant.Url or TextInputVariant.Password;
@@ -164,10 +165,18 @@ public static class TextInputExtensions
 
         var invalidState = context.UseState(default(string?), true);
         var blurOnceState = context.UseState(false, true);
+        // Closure reads MinLength from attached props (updated by .MinLength() on record clones).
+        var widgetForAttached = widget;
         context.UseEffect(() =>
         {
             if (!blurOnceState.Value) return;
-            var (_, err) = Validators.ValidateForVariant(state.As<object>().Value, variant);
+            int? passwordMin = variant == TextInputVariant.Password
+                ? widgetForAttached.GetAttachedValue(ValidationOwner, AttachedMinLength) as int?
+                : null;
+            var (_, err) = Validators.ValidateForVariant(
+                state.As<object>().Value,
+                variant,
+                passwordMin ?? Validators.DefaultPasswordMinLength);
             invalidState.Set(string.IsNullOrEmpty(err) ? "" : err);
         }, state, blurOnceState);
 
@@ -265,7 +274,13 @@ public static class TextInputExtensions
 
     public static TextInputBase MaxLength(this TextInputBase widget, int maxLength) => widget with { MaxLength = maxLength };
 
-    public static TextInputBase MinLength(this TextInputBase widget, int minLength) => widget with { MinLength = minLength };
+    public static TextInputBase MinLength(this TextInputBase widget, int minLength)
+    {
+        var w = widget with { MinLength = minLength };
+        // So on-blur validation (wired before chaining) sees the same MinLength.
+        w.SetAttachedValue(ValidationOwner, AttachedMinLength, minLength);
+        return w;
+    }
 
     public static TextInputBase Pattern(this TextInputBase widget, string pattern) => widget with { Pattern = pattern };
 


### PR DESCRIPTION
## Summary

Password fields in scaffolded forms now respect `[MinLength]`, `[StringLength]`, and `[Length]` instead of always enforcing a hardcoded minimum. The default remains **8 characters** when nothing is specified. Login (`DefaultAuthApp`) no longer blocks short passwords that already match the auth provider (e.g. Basic Auth hashes from the CLI).

## Motivation

Users could create short passwords via tooling (e.g. `ivy auth add`), but the email/password login form always required at least 8 characters before the request reached the provider. That mismatch blocked valid credentials.

## Changes

- **Login form** — `LoginFormModel.Password` uses `[MinLength(0)]` and `ToPasswordInput().MinLength(0)` so only **required** is enforced; length policy stays with the auth backend.
- **FormHelpers** — optional `skipAttribute` filter on `GetValidators`; new `GetMinLength` helpers for property/field (reads `MinLength`, `StringLength`, `Length`).
- **FormScaffolder** — password widgets get `.MinLength(...)` from model metadata when present; skips duplicate `[MinLength]` DataAnnotations for password fields (single password validator + message); `CreatePasswordValidator` receives `GetMinLength() ?? DefaultPasswordMinLength`.
- **Validators** — `DefaultPasswordMinLength = 8`; `minLength <= 0` skips length check; `GetEffectiveValidators` uses `TextInputBase.MinLength` for password variant when set; `ForVariant` accepts optional password min override.
- **TextInput** — mirrors `MinLength` into attached metadata so on-blur validation sees values set after `ToPasswordInput()` (record `with` / chaining).


https://github.com/user-attachments/assets/d16b1dd6-0906-491e-bc45-434e35ae2a50