### PR TITLE
(sheet): fix scrollbar visibility

### DIFF
--- a/src/frontend/src/widgets/sheet/SheetWidget.tsx
+++ b/src/frontend/src/widgets/sheet/SheetWidget.tsx
@@ -278,7 +278,9 @@ export const SheetWidget: React.FC<SheetWidgetProps> = ({
             {description || "Sheet content"}
           </SheetDescription>
         </SheetHeader>
-        <div className="flex-1 pb-4 pt-1 pl-4 pr-4 mt-4 overflow-y-auto">{slots.Content}</div>
+        <div className="flex-1 mt-4 overflow-y-auto min-h-0">
+          <div className="h-full min-h-0 pb-4 pt-1 pl-4 pr-4">{slots.Content}</div>
+        </div>
       </SheetContent>
     </Sheet>
   );


### PR DESCRIPTION
Issue:

<img width="392" height="419" alt="Screenshot 2026-04-27 at 23 58 49" src="https://github.com/user-attachments/assets/6a219cff-68c0-447d-8e03-b9a0d7f57825" />

Fixes sheet scrollbar edge alignment by separating the scroll container from the padded content wrapper in SheetWidget.

Fixed:

https://github.com/user-attachments/assets/78ea34c0-d3f2-4e82-ab3a-83aa2a0b9a8c


