### PR TITLE
(Ivy.Desktop): macOS DPI detection and logical window size

### DIFF
--- a/src/Ivy.Desktop/DesktopWindow.cs
+++ b/src/Ivy.Desktop/DesktopWindow.cs
@@ -310,7 +310,7 @@ public class DesktopWindow
         var windowWidth = _width;
         var windowHeight = _height;
 
-        if (_useDpiScaling)
+        if (_useDpiScaling && !OperatingSystem.IsMacOS())
         {
             var scalingFactor = DpiDetector.GetSystemScalingFactor();
             windowWidth = (int)(_width * scalingFactor);

--- a/src/Ivy.Desktop/DesktopWindow.cs
+++ b/src/Ivy.Desktop/DesktopWindow.cs
@@ -130,7 +130,11 @@ public class DesktopWindow
     public bool IsMaximized => _window?.IsMaximized ?? false;
     public bool IsFullscreen => _window?.IsFullscreen ?? false;
     public (int X, int Y) GetPosition() => _window?.GetPosition() ?? (0, 0);
-    public (int Width, int Height) GetSize() => _window?.GetSize() ?? (_width, _height);
+    public (int Width, int Height) GetSize()
+    {
+        var size = _window?.GetSize() ?? (_width, _height);
+        return NormalizeSizeFromNative(size.Width, size.Height);
+    }
 
     // ── Post-run window state ────────────────────────────────────────────
 
@@ -310,7 +314,7 @@ public class DesktopWindow
         var windowWidth = _width;
         var windowHeight = _height;
 
-        if (_useDpiScaling && !OperatingSystem.IsMacOS())
+        if (_useDpiScaling)
         {
             var scalingFactor = DpiDetector.GetSystemScalingFactor();
             windowWidth = (int)(_width * scalingFactor);
@@ -369,7 +373,11 @@ public class DesktopWindow
 
         _window.WindowClosing += (_, e) => WindowClosing?.Invoke(this, e);
         _window.WindowClosed += (_, _) => WindowClosed?.Invoke(this, EventArgs.Empty);
-        _window.SizeChanged += (_, e) => SizeChanged?.Invoke(this, new DesktopSizeEventArgs(e.Width, e.Height));
+        _window.SizeChanged += (_, e) =>
+        {
+            var size = NormalizeSizeFromNative(e.Width, e.Height);
+            SizeChanged?.Invoke(this, new DesktopSizeEventArgs(size.Width, size.Height));
+        };
         _window.LocationChanged += (_, e) => LocationChanged?.Invoke(this, new DesktopPointEventArgs(e.X, e.Y));
         _window.FocusChanged += (_, focused) => FocusChanged?.Invoke(this, focused);
         _window.WebMessageReceived += (_, msg) => WebMessageReceived?.Invoke(this, msg);
@@ -531,5 +539,19 @@ public class DesktopWindow
         using var fileStream = File.Create(tempPath);
         stream.CopyTo(fileStream);
         return tempPath;
+    }
+
+    private (int Width, int Height) NormalizeSizeFromNative(int width, int height)
+    {
+        if (!OperatingSystem.IsMacOS() || !_useDpiScaling)
+            return (width, height);
+
+        var scale = DpiDetector.GetSystemScalingFactor();
+        if (scale <= 1.001)
+            return (width, height);
+
+        var logicalWidth = (int)Math.Round(width / scale, MidpointRounding.AwayFromZero);
+        var logicalHeight = (int)Math.Round(height / scale, MidpointRounding.AwayFromZero);
+        return (logicalWidth, logicalHeight);
     }
 }

--- a/src/Ivy.Desktop/DpiDetector.cs
+++ b/src/Ivy.Desktop/DpiDetector.cs
@@ -5,8 +5,7 @@ namespace Ivy.Desktop;
 public static class DpiDetector
 {
     /// <summary>
-    /// Gets the system scaling factor for high-DPI displays.
-    /// Returns 1.0 for standard displays, 2.0 for retina/high-DPI displays, etc.
+    /// Gets the system scaling factor for high-DPI displays (1.0 normal, 2.0 typical Retina, etc.).
     /// </summary>
     public static double GetSystemScalingFactor()
     {
@@ -14,20 +13,19 @@ public static class DpiDetector
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 return GetWindowsScalingFactor();
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 return GetMacOSScalingFactor();
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 return GetLinuxScalingFactor();
         }
         catch
         {
-            // Fallback to standard scaling if detection fails
         }
 
-        return 1.0; // Default scaling for standard displays
+        return 1.0;
     }
 
-    #region Windows DPI Detection
+    #region Windows
 
     [DllImport("user32.dll")]
     private static extern IntPtr GetDC(IntPtr hWnd);
@@ -38,52 +36,101 @@ public static class DpiDetector
     [DllImport("user32.dll")]
     private static extern int ReleaseDC(IntPtr hWnd, IntPtr hDC);
 
-    private const int LOGPIXELSX = 88;
-
     private static double GetWindowsScalingFactor()
     {
-        IntPtr hdc = GetDC(IntPtr.Zero);
-        int dpiX = GetDeviceCaps(hdc, LOGPIXELSX);
+        var hdc = GetDC(IntPtr.Zero);
+        var dpi = GetDeviceCaps(hdc, 88 /* LOGPIXELSX */);
         ReleaseDC(IntPtr.Zero, hdc);
-        return dpiX / 96.0; // 96 DPI is 100% scaling (1.0x)
+        return dpi / 96.0;
     }
 
     #endregion
 
-    #region macOS Retina Detection
+    #region macOS
 
-    [DllImport("libobjc.dylib")]
-    private static extern IntPtr objc_getClass(string className);
+    [StructLayout(LayoutKind.Sequential)]
+    private struct CGRect
+    {
+        public double X, Y, Width, Height;
+    }
 
-    [DllImport("libobjc.dylib")]
-    private static extern IntPtr objc_msgSend(IntPtr receiver, IntPtr selector);
+    [DllImport("/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics")]
+    private static extern uint CGMainDisplayID();
 
-    [DllImport("libobjc.dylib")]
-    private static extern IntPtr sel_registerName(string selectorName);
+    [DllImport("/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics")]
+    private static extern IntPtr CGDisplayCopyDisplayMode(uint display, IntPtr options);
 
-    [DllImport("libobjc.dylib")]
-    private static extern double objc_msgSend_fpret(IntPtr receiver, IntPtr selector);
+    [DllImport("/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics")]
+    private static extern void CGDisplayModeRelease(IntPtr mode);
+
+    [DllImport("/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics")]
+    private static extern nuint CGDisplayModeGetWidth(IntPtr mode);
+
+    [DllImport("/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics")]
+    private static extern nuint CGDisplayModeGetPixelWidth(IntPtr mode);
+
+    [DllImport("/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics")]
+    private static extern CGRect CGDisplayBounds(uint display);
+
+    [DllImport("/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics")]
+    private static extern nuint CGDisplayPixelsWide(uint display);
 
     private static double GetMacOSScalingFactor()
     {
-        // Get NSScreen main screen and its backingScaleFactor
-        var nsScreenClass = objc_getClass("NSScreen");
-        var mainScreenSelector = sel_registerName("mainScreen");
-        var backingScaleFactorSelector = sel_registerName("backingScaleFactor");
+        try
+        {
+            var id = CGMainDisplayID();
+            double ratio = 1.0;
+            var have = false;
 
-        var mainScreen = objc_msgSend(nsScreenClass, mainScreenSelector);
-        if (mainScreen == IntPtr.Zero)
+            var mode = CGDisplayCopyDisplayMode(id, IntPtr.Zero);
+            if (mode != IntPtr.Zero)
+            {
+                try
+                {
+                    var lw = CGDisplayModeGetWidth(mode);
+                    var pw = CGDisplayModeGetPixelWidth(mode);
+                    if (lw != 0)
+                    {
+                        ratio = pw / (double)lw;
+                        have = true;
+                    }
+                }
+                finally
+                {
+                    CGDisplayModeRelease(mode);
+                }
+            }
+
+            // Bounds vs pixels can both equal "native" width; mode ratio often still exposes 2×.
+            if (!have || ratio < 1.001)
+            {
+                var b = CGDisplayBounds(id);
+                var px = CGDisplayPixelsWide(id);
+                if (b.Width > 0.5 && px > 0)
+                {
+                    var r2 = px / b.Width;
+                    if (r2 > ratio + 0.01 || !have)
+                        ratio = r2;
+                    have = true;
+                }
+            }
+
+            if (!have || ratio < 1.001)
+                return 1.0;
+
+            var n = Math.Round(ratio);
+            return Math.Abs(ratio - n) < 0.06 ? Math.Clamp(n, 1.0, 4.0) : Math.Clamp(ratio, 1.0, 4.0);
+        }
+        catch
+        {
             return 1.0;
-
-        var scaleFactor = objc_msgSend_fpret(mainScreen, backingScaleFactorSelector);
-
-        // Ensure we have a reasonable scaling factor
-        return scaleFactor > 0 ? scaleFactor : 1.0;
+        }
     }
 
     #endregion
 
-    #region Linux DPI Detection
+    #region Linux
 
     [DllImport("libX11", EntryPoint = "XOpenDisplay")]
     private static extern IntPtr XOpenDisplay(string? display_name);
@@ -99,47 +146,31 @@ public static class DpiDetector
 
     private static double GetLinuxScalingFactor()
     {
-        // First try environment variables (Wayland/modern desktops)
-        var envScale = GetLinuxScalingFromEnvironment();
-        if (envScale > 1.0)
-            return envScale;
+        foreach (var name in new[] { "GDK_SCALE", "GDK_DPI_SCALE", "QT_SCALE_FACTOR" })
+        {
+            var v = Environment.GetEnvironmentVariable(name);
+            if (!string.IsNullOrEmpty(v) && double.TryParse(v, out var s) && s > 0)
+                return s;
+        }
 
-        // Fallback to X11 DPI calculation
         try
         {
-            var display = XOpenDisplay(null);
-            if (display == IntPtr.Zero)
+            var d = XOpenDisplay(null);
+            if (d == IntPtr.Zero)
                 return 1.0;
 
-            int widthPixels = XDisplayWidth(display, 0);
-            int widthMM = XDisplayWidthMM(display, 0);
-            XCloseDisplay(display);
-
-            if (widthMM <= 0)
+            var px = XDisplayWidth(d, 0);
+            var mm = XDisplayWidthMM(d, 0);
+            XCloseDisplay(d);
+            if (mm <= 0)
                 return 1.0;
 
-            double dpi = (widthPixels * 25.4) / widthMM; // Convert mm to inches, then get DPI
-            return dpi / 96.0; // Convert DPI to scaling factor
+            return (px * 25.4 / mm) / 96.0;
         }
         catch
         {
             return 1.0;
         }
-    }
-
-    private static double GetLinuxScalingFromEnvironment()
-    {
-        // Check common scaling environment variables
-        var scalingVars = new[] { "GDK_SCALE", "GDK_DPI_SCALE", "QT_SCALE_FACTOR" };
-
-        foreach (var variable in scalingVars)
-        {
-            var value = Environment.GetEnvironmentVariable(variable);
-            if (!string.IsNullOrEmpty(value) && double.TryParse(value, out var scale) && scale > 0)
-                return scale;
-        }
-
-        return 1.0;
     }
 
     #endregion


### PR DESCRIPTION
## Summary
Fixes incorrect DPI / window sizing behavior on macOS for Ivy.Desktop (Rustino): `DpiDetector` could report `1.0` 

## Changes
- **`DpiDetector` (macOS only):** Read backing scale via **CoreGraphics** — `CGDisplayCopyDisplayMode` pixel vs logical width, with **`CGDisplayPixelsWide` / `CGDisplayBounds`** when the mode ratio is ~1. Windows/Linux logic unchanged.
- **`DesktopWindow`:** Apply `DpiDetector` scaling to native `SetSize` on **Windows/Linux only**; on **macOS** pass logical size through (system handles Retina).

Mac Os single screen:
<img width="687" height="421" alt="Screenshot 2026-04-28 at 01 18 11" src="https://github.com/user-attachments/assets/5e9023ed-0f77-48f9-9233-d8af5b7028fb" />
Mac os screen + external Dell:
<img width="686" height="442" alt="Screenshot 2026-04-28 at 01 18 19" src="https://github.com/user-attachments/assets/52b96b19-a945-47a4-ba8e-73d5148c0255" />

