### PR TITLE
[00101] Fix auto-scroll in job output sheet to pause when user scrolls up

### DIFF
--- a/src/widgets/Ivy.Widgets.ClaudeJsonRenderer/frontend/package.json
+++ b/src/widgets/Ivy.Widgets.ClaudeJsonRenderer/frontend/package.json
@@ -28,6 +28,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3"
   },
+  "packageManager": "pnpm@10.33.0",
   "pnpm": {
     "overrides": {
       "jiti": "^2.0.0",
@@ -36,6 +37,5 @@
       "vite": "npm:@voidzero-dev/vite-plus-core@0.1.18",
       "vitest": "npm:@voidzero-dev/vite-plus-test@0.1.18"
     }
-  },
-  "packageManager": "pnpm@10.33.0"
+  }
 }

--- a/src/widgets/Ivy.Widgets.ClaudeJsonRenderer/frontend/src/ClaudeJsonRenderer.tsx
+++ b/src/widgets/Ivy.Widgets.ClaudeJsonRenderer/frontend/src/ClaudeJsonRenderer.tsx
@@ -29,10 +29,11 @@ function buildToolResultMap(events: ClaudeEvent[]): Map<string, string> {
     const blocks = event.message?.content ?? [];
     for (const block of blocks) {
       if (block.type === "tool_result" && block.tool_use_id) {
-        const text = contentToString(block.content)
-          || contentToString(toolResult?.stdout)
-          || contentToString(toolResult?.content)
-          || "";
+        const text =
+          contentToString(block.content) ||
+          contentToString(toolResult?.stdout) ||
+          contentToString(toolResult?.content) ||
+          "";
         map.set(block.tool_use_id, text);
       }
     }
@@ -72,7 +73,15 @@ function parseEvents(jsonStream: string | undefined): ClaudeEvent[] {
   return events;
 }
 
-function ToolUseCard({ name, input, result }: { name: string; input: Record<string, unknown>; result?: string }) {
+function ToolUseCard({
+  name,
+  input,
+  result,
+}: {
+  name: string;
+  input: Record<string, unknown>;
+  result?: string;
+}) {
   const [open, setOpen] = useState(false);
 
   let displayContent: string;
@@ -89,9 +98,8 @@ function ToolUseCard({ name, input, result }: { name: string; input: Record<stri
     displayContent = JSON.stringify(input, null, 2);
   }
 
-  const resultPreview = result != null
-    ? (result.length > 120 ? result.slice(0, 120) + "..." : result)
-    : null;
+  const resultPreview =
+    result != null ? (result.length > 120 ? result.slice(0, 120) + "..." : result) : null;
 
   return (
     <div className="tool-card my-2">
@@ -101,18 +109,20 @@ function ToolUseCard({ name, input, result }: { name: string; input: Record<stri
         {resultPreview != null && (
           <span className="font-mono truncate opacity-60 ml-2">{resultPreview}</span>
         )}
-        {result == null && (
-          <span className="opacity-40 ml-2">running...</span>
-        )}
+        {result == null && <span className="opacity-40 ml-2">running...</span>}
       </div>
       {open && (
         <div className="tool-card-body">
           <div className="opacity-50 text-[0.875rem] mb-1">Input</div>
-          <pre><code>{displayContent}</code></pre>
+          <pre>
+            <code>{displayContent}</code>
+          </pre>
           {result != null && (
             <>
               <div className="opacity-50 text-[0.875rem] mb-1 mt-3">Output</div>
-              <pre><code>{result}</code></pre>
+              <pre>
+                <code>{result}</code>
+              </pre>
             </>
           )}
         </div>
@@ -126,16 +136,16 @@ function ResultSummary({ event }: { event: ResultEvent }) {
   return (
     <div className={`result-card my-3 ${isError ? "error" : ""}`}>
       <div className="flex items-center gap-2 mb-2">
-        <span className="font-semibold text-[0.875rem]">
-          {isError ? "Error" : "Completed"}
-        </span>
+        <span className="font-semibold text-[0.875rem]">{isError ? "Error" : "Completed"}</span>
         <span className="text-[0.875rem] opacity-60">
           {event.num_turns} turn{event.num_turns !== 1 ? "s" : ""}
         </span>
       </div>
       {event.result && (
         <div className="claude-renderer mb-2">
-          <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>{event.result}</Markdown>
+          <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
+            {event.result}
+          </Markdown>
         </div>
       )}
       <div className="flex flex-wrap gap-4 text-[0.875rem] opacity-70">
@@ -143,7 +153,8 @@ function ResultSummary({ event }: { event: ResultEvent }) {
         <span>Duration: {(event.duration_ms / 1000).toFixed(1)}s</span>
         {event.usage && (
           <span>
-            Tokens: {(event.usage.input_tokens ?? 0).toLocaleString()} in / {(event.usage.output_tokens ?? 0).toLocaleString()} out
+            Tokens: {(event.usage.input_tokens ?? 0).toLocaleString()} in /{" "}
+            {(event.usage.output_tokens ?? 0).toLocaleString()} out
           </span>
         )}
       </div>
@@ -169,7 +180,9 @@ function AssistantMessage({
         if (block.type === "text" && block.text) {
           return (
             <div key={i} className="claude-renderer">
-              <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>{block.text}</Markdown>
+              <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
+                {block.text}
+              </Markdown>
             </div>
           );
         }

--- a/src/widgets/Ivy.Widgets.ClaudeJsonRenderer/frontend/src/ClaudeJsonRenderer.tsx
+++ b/src/widgets/Ivy.Widgets.ClaudeJsonRenderer/frontend/src/ClaudeJsonRenderer.tsx
@@ -1,10 +1,11 @@
-import React, { useMemo, useEffect, useRef, useState, useCallback } from "react";
+import React, { useMemo, useEffect, useState, useCallback } from "react";
 import Markdown from "react-markdown";
 import rehypeHighlight from "rehype-highlight";
 import remarkGfm from "remark-gfm";
 import "./claude-json-renderer.css";
 import type { EventHandler, ClaudeEvent, ContentBlock, AssistantEvent, ResultEvent } from "./types";
 import { getWidth, getHeight } from "./styles";
+import { useAutoScroll } from "./use-auto-scroll";
 
 function contentToString(content: unknown): string {
   if (typeof content === "string") return content;
@@ -204,7 +205,6 @@ export const ClaudeJsonRenderer: React.FC<ClaudeJsonRendererProps> = ({
   showSystemEvents = false,
   resetToken = 0,
 }) => {
-  const containerRef = useRef<HTMLDivElement>(null);
   const [streamedLines, setStreamedLines] = useState<string[]>([]);
 
   useEffect(() => {
@@ -233,6 +233,12 @@ export const ClaudeJsonRenderer: React.FC<ClaudeJsonRendererProps> = ({
   const parsedEvents = useMemo(() => parseEvents(combinedStream), [combinedStream]);
   const toolResults = useMemo(() => buildToolResultMap(parsedEvents), [parsedEvents]);
 
+  const { scrollRef, disableAutoScroll } = useAutoScroll({
+    content: parsedEvents,
+    enabled: autoScroll,
+    smooth: false,
+  });
+
   const handleComplete = useCallback(
     (resultJson: string) => {
       if (enabledEvents.includes("OnComplete")) {
@@ -249,12 +255,6 @@ export const ClaudeJsonRenderer: React.FC<ClaudeJsonRendererProps> = ({
     }
   }, [parsedEvents, handleComplete]);
 
-  useEffect(() => {
-    if (autoScroll && containerRef.current) {
-      containerRef.current.scrollTop = containerRef.current.scrollHeight;
-    }
-  }, [parsedEvents, autoScroll]);
-
   const style: React.CSSProperties = {
     ...getWidth(width),
     ...getHeight(height),
@@ -266,7 +266,13 @@ export const ClaudeJsonRenderer: React.FC<ClaudeJsonRendererProps> = ({
   }
 
   return (
-    <div ref={containerRef} style={style} className="claude-renderer p-4">
+    <div
+      ref={scrollRef}
+      style={style}
+      className="claude-renderer p-4"
+      onWheel={autoScroll ? disableAutoScroll : undefined}
+      onTouchMove={autoScroll ? disableAutoScroll : undefined}
+    >
       {parsedEvents.map((event, index) => {
         if (event.type === "system") {
           if (!showSystemEvents) return null;

--- a/src/widgets/Ivy.Widgets.ClaudeJsonRenderer/frontend/src/claude-json-renderer.css
+++ b/src/widgets/Ivy.Widgets.ClaudeJsonRenderer/frontend/src/claude-json-renderer.css
@@ -67,10 +67,18 @@
   line-height: 1.375;
 }
 
-.claude-renderer h1 { font-size: 0.875rem; }
-.claude-renderer h2 { font-size: 0.875rem; }
-.claude-renderer h3 { font-size: 0.875rem; }
-.claude-renderer h4 { font-size: 0.875rem; }
+.claude-renderer h1 {
+  font-size: 0.875rem;
+}
+.claude-renderer h2 {
+  font-size: 0.875rem;
+}
+.claude-renderer h3 {
+  font-size: 0.875rem;
+}
+.claude-renderer h4 {
+  font-size: 0.875rem;
+}
 
 .claude-renderer blockquote {
   margin: 0.5rem 0;

--- a/src/widgets/Ivy.Widgets.ClaudeJsonRenderer/frontend/src/use-auto-scroll.ts
+++ b/src/widgets/Ivy.Widgets.ClaudeJsonRenderer/frontend/src/use-auto-scroll.ts
@@ -1,0 +1,142 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface ScrollState {
+  isAtBottom: boolean;
+  autoScrollEnabled: boolean;
+}
+
+interface UseAutoScrollOptions {
+  offset?: number;
+  smooth?: boolean;
+  content?: unknown;
+  enabled?: boolean;
+}
+
+export function useAutoScroll(options: UseAutoScrollOptions = {}) {
+  const { offset = 20, smooth = false, content, enabled = true } = options;
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const lastContentHeight = useRef(0);
+  const userHasScrolled = useRef(false);
+  const prevEnabledRef = useRef(enabled);
+
+  const [scrollState, setScrollState] = useState<ScrollState>({
+    isAtBottom: true,
+    autoScrollEnabled: true,
+  });
+
+  const checkIsAtBottom = useCallback(
+    (element: HTMLElement) => {
+      const { scrollTop, scrollHeight, clientHeight } = element;
+      const distanceToBottom = Math.abs(scrollHeight - scrollTop - clientHeight);
+      return distanceToBottom <= offset;
+    },
+    [offset],
+  );
+
+  const scrollToBottom = useCallback(
+    (instant?: boolean) => {
+      if (!scrollRef.current) return;
+
+      const targetScrollTop = scrollRef.current.scrollHeight - scrollRef.current.clientHeight;
+
+      if (instant) {
+        scrollRef.current.scrollTop = targetScrollTop;
+      } else {
+        scrollRef.current.scrollTo({
+          top: targetScrollTop,
+          behavior: smooth ? "smooth" : "auto",
+        });
+      }
+
+      setScrollState({
+        isAtBottom: true,
+        autoScrollEnabled: true,
+      });
+      userHasScrolled.current = false;
+    },
+    [smooth],
+  );
+
+  const handleScroll = useCallback(() => {
+    if (!scrollRef.current) return;
+
+    const atBottom = checkIsAtBottom(scrollRef.current);
+
+    setScrollState((prev) => ({
+      isAtBottom: atBottom,
+      autoScrollEnabled: atBottom ? true : prev.autoScrollEnabled,
+    }));
+  }, [checkIsAtBottom]);
+
+  useEffect(() => {
+    const element = scrollRef.current;
+    if (!element) return;
+
+    element.addEventListener("scroll", handleScroll, { passive: true });
+    return () => element.removeEventListener("scroll", handleScroll);
+  }, [handleScroll]);
+
+  useEffect(() => {
+    const scrollElement = scrollRef.current;
+    if (!scrollElement) return;
+
+    const currentHeight = scrollElement.scrollHeight;
+    const hasNewContent = currentHeight !== lastContentHeight.current;
+
+    if (hasNewContent) {
+      if (enabled && scrollState.autoScrollEnabled) {
+        requestAnimationFrame(() => {
+          scrollToBottom(lastContentHeight.current === 0);
+        });
+      }
+      lastContentHeight.current = currentHeight;
+    }
+  }, [content, scrollState.autoScrollEnabled, scrollToBottom, enabled]);
+
+  useEffect(() => {
+    const element = scrollRef.current;
+    if (!element) return;
+
+    const resizeObserver = new ResizeObserver(() => {
+      if (enabled && scrollState.autoScrollEnabled) {
+        scrollToBottom(true);
+      }
+    });
+
+    resizeObserver.observe(element);
+
+    const contentChild = element.firstElementChild;
+    if (contentChild) {
+      resizeObserver.observe(contentChild);
+    }
+
+    return () => resizeObserver.disconnect();
+  }, [scrollState.autoScrollEnabled, scrollToBottom, enabled]);
+
+  useEffect(() => {
+    if (enabled && !prevEnabledRef.current) {
+      requestAnimationFrame(() => scrollToBottom(true));
+    }
+    prevEnabledRef.current = enabled;
+  }, [enabled, scrollToBottom]);
+
+  const disableAutoScroll = useCallback(() => {
+    const atBottom = scrollRef.current ? checkIsAtBottom(scrollRef.current) : false;
+
+    if (!atBottom) {
+      userHasScrolled.current = true;
+      setScrollState((prev) => ({
+        ...prev,
+        autoScrollEnabled: false,
+      }));
+    }
+  }, [checkIsAtBottom]);
+
+  return {
+    scrollRef,
+    isAtBottom: scrollState.isAtBottom,
+    autoScrollEnabled: scrollState.autoScrollEnabled,
+    scrollToBottom: () => scrollToBottom(false),
+    disableAutoScroll,
+  };
+}

--- a/src/widgets/Ivy.Widgets.ClaudeJsonRenderer/frontend/vite.config.ts
+++ b/src/widgets/Ivy.Widgets.ClaudeJsonRenderer/frontend/vite.config.ts
@@ -8,9 +8,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 export default defineConfig({
-  plugins: [
-    react(),
-  ],
+  plugins: [react()],
   define: {
     "process.env.NODE_ENV": JSON.stringify("production"),
   },


### PR DESCRIPTION
## Summary

Replaced the naive auto-scroll implementation in ClaudeJsonRenderer with the framework's existing `useAutoScroll` hook. The old implementation unconditionally forced `scrollTop = scrollHeight` on every content update, making it impossible to read earlier output during streaming. The new implementation pauses auto-scroll when the user scrolls up and re-enables it when they scroll back to the bottom.

Since the ClaudeJsonRenderer is an isolated widget package that cannot import from the core frontend, a local copy of the `use-auto-scroll.ts` hook was created in the widget's `src/` directory.

## API Changes

None.

## Files Modified

- **src/widgets/Ivy.Widgets.ClaudeJsonRenderer/frontend/src/ClaudeJsonRenderer.tsx** — Replaced naive auto-scroll `useEffect` with `useAutoScroll` hook, added `onWheel`/`onTouchMove` handlers for scroll detection
- **src/widgets/Ivy.Widgets.ClaudeJsonRenderer/frontend/src/use-auto-scroll.ts** — New file: local copy of the framework's `useAutoScroll` hook

## Commits

- cf1cbffcb [00101] Replace naive auto-scroll with useAutoScroll hook in ClaudeJsonRenderer
- 34bb5b363 [00101] Fix formatting in ClaudeJsonRenderer widget

Closes https://github.com/Ivy-Interactive/Ivy-Tendril/issues/381