### PR TITLE
feat: port 21 Ivy agent workflows into Claude Code skills

### DIFF
--- a/src/skills/ConvertingWorkflowsToSkills.md
+++ b/src/skills/ConvertingWorkflowsToSkills.md
@@ -1,0 +1,139 @@
+# Converting Workflows to Skills: Lessons Learned
+
+Notes from porting three Ivy Agent workflows (Dashboard, CRUD, AdHoc) from C# state machines into Claude Code skills, combined with official best practices from the [Agent Skills standard](https://agentskills.io/specification) and [Claude Code docs](https://code.claude.com/docs/en/skills.md).
+
+---
+
+## What Went Well
+
+### The plan/review/implement loop translates cleanly
+Each workflow had the same three-state core: generate a plan, let the user approve or revise, then implement. This mapped 1:1 to numbered steps in markdown. The state machine transitions (AgenticTransition, StateTransition, WorkflowTransition) became prose instructions -- simpler and easier to maintain than the C# class hierarchy.
+
+### Reference files as concrete examples beat abstract rules
+The workflows already embedded reference .cs files as learning material for the LLM. Keeping that pattern (a `references/` folder with real, compilable code) works better than describing patterns in prose. The LLM can read `OrderListBlade.cs` and generalize from it; a paragraph explaining "use UseQuery with tags" is less reliable.
+
+### One source of truth via CopyReferences.ps1
+The reference files are copies of canonical code in `Ivy.Internals.Workflows.References`. A copy script with namespace rewriting avoids drift between the actual framework examples and what the skills teach. Any future change to the reference code propagates with a single script run.
+
+---
+
+## What We Should Improve
+
+### 1. Add YAML frontmatter
+
+All three skills currently start with a plain `# heading`. The [Agent Skills spec](https://agentskills.io/specification) requires frontmatter with at least `name` and `description`. Claude Code uses these fields for skill discovery and activation.
+
+**Current:**
+```markdown
+# ivy-create-dashboard
+
+Create a Dashboard app with metrics, charts, and KPIs for an Ivy project.
+```
+
+**Should be:**
+```yaml
+---
+name: ivy-create-dashboard
+description: >
+  Create a Dashboard app with metrics, charts, and KPIs for an Ivy project.
+  Use when the user asks for a dashboard, analytics page, KPI view, or
+  data visualization app. Handles metric cards, line/bar/pie/area charts,
+  date range filtering, and grid layouts.
+---
+```
+
+Key frontmatter fields to consider for each skill:
+- `name` -- required, lowercase + hyphens, max 64 chars
+- `description` -- required, max 1024 chars; front-load intent and trigger keywords
+- `allowed-tools` -- pre-approve `Bash(dotnet:*)`, `Read`, `Write`, `Grep`, `Glob` so the workflow runs without per-tool confirmation
+- `effort: high` -- these are multi-file generation tasks that benefit from deeper reasoning
+- `disable-model-invocation: true` -- consider this if the skills should only run when explicitly invoked, not auto-triggered by Claude
+
+### 2. Write descriptions for activation, not just humans
+
+The description field is how Claude decides whether to load the skill. It should include trigger keywords and implicit contexts:
+
+```yaml
+description: >
+  Create a CRUD app with list, detail, create, and edit views for Ivy.
+  Use when the user mentions CRUD, master-detail, data management,
+  entity management, or wants to build views for database tables.
+  Handles blades, dialogs, sheets, foreign key lookups, search,
+  pagination, and parent-child relationships.
+```
+
+### 3. Explicitly reference files from SKILL.md
+
+The current skills say things like "Read the reference documents" without linking to specific files. Claude discovers files automatically, but explicit paths reduce ambiguity and ensure the right files are read:
+
+```markdown
+Read these reference files before implementing:
+- [references/DashboardApp.cs](references/DashboardApp.cs) -- app structure, HeaderLayout, grid
+- [references/TotalSalesMetricView.cs](references/TotalSalesMetricView.cs) -- MetricView pattern
+- [references/SalesByDayLineChartView.cs](references/SalesByDayLineChartView.cs) -- chart pattern
+- [references/AGENTS.md](references/AGENTS.md) -- Ivy framework API reference
+```
+
+### 4. Keep SKILL.md under 500 lines
+
+`ivy-create-crud` is 305 lines, which is fine. But as skills grow, move detailed subsections (e.g., the "Critical Code Generation Rules" pitfalls lists) into separate reference files. The SKILL.md should contain the workflow and high-level rules; edge cases and anti-patterns belong in `references/pitfalls.md` or similar.
+
+Target: SKILL.md body under 300 lines, reference files for depth.
+
+### 5. Use `$ARGUMENTS` for entity/feature names
+
+The skills could accept the user's description as an argument:
+
+```yaml
+---
+name: ivy-create-crud
+argument-hint: "[entity description or spec]"
+---
+
+Create CRUD views for: $ARGUMENTS
+```
+
+This lets users invoke `/ivy-create-crud Orders with OrderLines` directly instead of the skill having to ask.
+
+### 6. Consider `context: fork` for isolation
+
+These skills generate multiple files and have multi-step workflows. Running in a forked context (`context: fork`) would isolate the generation work from the main conversation, keeping the user's context clean:
+
+```yaml
+---
+context: fork
+---
+```
+
+Trade-off: forked skills return a single summary, so the user loses step-by-step visibility. This matters during the plan/review loop. For now, keep the default (inline) execution until we have a way to pause for user approval in forked context.
+
+---
+
+## Structural Lessons
+
+### Workflow state machines are over-engineered for LLM tasks
+The C# workflows used `AgenticTransition`, `UseExternalWidget`, and queue-based entity processing. These exist to handle the stateful, multi-turn nature of LLM conversations in a server framework. Claude Code already manages conversation state. The markdown skill just says "do step 1, then step 2" and the LLM follows.
+
+### Prompt templates collapse into inline instructions
+The original workflows had separate `.md` prompt files (`PlanDashboard.md`, `Implement.md`) that were loaded and interpolated with `{{variables}}`. In a skill, these become inline sections under each step heading. No template engine needed.
+
+### The "entity queue" pattern from CRUD is just a list
+The CRUD workflow had an explicit `EntityQueue` state variable and `NextEntityTransition` to process entities one by one. In the skill, this is just: "Implement each entity from the plan, one at a time. For each entity, create the App, ListBlade, DetailsBlade, CreateDialog, and EditSheet."
+
+### Type alias stripping was the hardest rewrite
+The reference code used `using Exa = Ivy.Internals.Workflows.References.Connections.IvyAgentExamples;` to avoid namespace collisions. The copy script had to strip these aliases and replace `Exa.` prefixes. Lesson: keep reference code clean of internal aliases; use the namespaces the skill consumers will actually see.
+
+---
+
+## Checklist for Future Skill Conversions
+
+When converting another workflow to a skill:
+
+1. **Extract the state graph** -- identify the states and transitions. Map each state to a step in the skill.
+2. **Collapse prompt templates** -- inline the prompt content under each step heading. Remove template variables; use plain instructions.
+3. **Copy reference files** -- add entries to `CopyReferences.ps1`. Verify namespace rewriting handles any new patterns.
+4. **Add frontmatter** -- `name`, `description` (with trigger keywords), `allowed-tools`, `effort`.
+5. **Link references explicitly** -- list each reference file with a markdown link and one-line description.
+6. **Test the description** -- mentally run 10 queries through it: would Claude pick this skill for "build me a dashboard"? For "add a login page"? Get both true positives and true negatives right.
+7. **Keep SKILL.md lean** -- workflow steps and key rules in the SKILL.md, detailed examples and edge cases in `references/`.
+8. **Verify the script** -- run `CopyReferences.ps1` and confirm all files copy with 0 failures.

--- a/src/skills/CopyReferences.ps1
+++ b/src/skills/CopyReferences.ps1
@@ -1,0 +1,211 @@
+<#
+.SYNOPSIS
+    Copies reference files from Ivy.Internals.Workflows.References into the skill folders,
+    rewriting namespaces so they serve as clean templates.
+
+.DESCRIPTION
+    The canonical source of truth for all reference code lives in:
+      - Ivy\Ivy.Internals.Workflows.References\  (shared .cs examples)
+      - Ivy\Ivy.Internals\Workflows\Apps\CreateApp\AdHoc\References\  (AdHoc-specific .md)
+      - Ivy-Framework\AGENTS.md  (framework documentation)
+      - Ivy\Ivy.Internals\Workflows\Connections\GenerateDbConnection\  (DB generation references)
+
+    This script copies those files into src/skills/*/references/ and rewrites the
+    original namespaces to generic "MyProject" namespaces so they work as templates.
+
+.NOTES
+    Run from the Ivy-Framework repo root, or pass -RefsRoot / -SkillsRoot explicitly.
+#>
+param(
+    [string]$RefsRoot      = (Join-Path $PSScriptRoot '..\..\..\Ivy\Ivy.Internals.Workflows.References'),
+    [string]$AdHocRoot     = (Join-Path $PSScriptRoot '..\..\..\Ivy\Ivy.Internals\Workflows\Apps\CreateApp\AdHoc\References'),
+    [string]$GenDbRoot     = (Join-Path $PSScriptRoot '..\..\..\Ivy\Ivy.Internals\Workflows\Connections\GenerateDbConnection'),
+    [string]$FrameworkRoot = (Join-Path $PSScriptRoot '..\..'),
+    [string]$SkillsRoot    = $PSScriptRoot
+)
+
+$RefsRoot      = (Resolve-Path $RefsRoot).Path
+$AdHocRoot     = (Resolve-Path $AdHocRoot).Path
+$GenDbRoot     = (Resolve-Path $GenDbRoot).Path
+$FrameworkRoot = (Resolve-Path $FrameworkRoot).Path
+$SkillsRoot    = (Resolve-Path $SkillsRoot).Path
+
+# ── Namespace replacements applied to every copied .cs file ──────────────────
+$NamespaceReplacements = @(
+    @{ From = 'Ivy.Internals.Workflows.References.Apps.Dashboard';              To = 'MyProject.Apps.Dashboard' }
+    @{ From = 'Ivy.Internals.Workflows.References.Apps.Products';               To = 'MyProject.Apps.Products' }
+    @{ From = 'Ivy.Internals.Workflows.References.Apps.Orders';                 To = 'MyProject.Apps.Orders' }
+    @{ From = 'Ivy.Internals.Workflows.References.Apps';                        To = 'MyProject.Apps' }
+    @{ From = 'Ivy.Internals.Workflows.References.Connections.IvyAgentExamples'; To = 'MyProject.Connections.MyDb' }
+    @{ From = 'Ivy.Internals.Workflows.References.Connections.OpenAI';          To = 'MyProject.Connections.OpenAI' }
+)
+
+# ── Using-alias lines to strip (they reference internal type aliases) ────────
+$AliasLinesToStrip = @(
+    'using Exa = Ivy.Internals.Workflows.References.Connections.IvyAgentExamples;'
+)
+
+# ── Copy manifest ────────────────────────────────────────────────────────────
+# Each entry: Source (relative to $RefsRoot or absolute), Destination (relative to $SkillsRoot)
+$Copies = @(
+    # ── ivy-create-dashboard ─────────────────────────────────────────────────
+    @{ Src = 'Apps\DashboardApp.cs';                                  Dst = 'ivy-create-dashboard\references\DashboardApp.cs' }
+    @{ Src = 'Apps\Dashboard\TotalSalesMetricView.cs';                Dst = 'ivy-create-dashboard\references\TotalSalesMetricView.cs' }
+    @{ Src = 'Apps\Dashboard\OrdersMetricView.cs';                    Dst = 'ivy-create-dashboard\references\OrdersMetricView.cs' }
+    @{ Src = 'Apps\Dashboard\CustomerRetentionRateMetricView.cs';     Dst = 'ivy-create-dashboard\references\CustomerRetentionRateMetricView.cs' }
+    @{ Src = 'Apps\Dashboard\SalesByDayLineChartView.cs';             Dst = 'ivy-create-dashboard\references\SalesByDayLineChartView.cs' }
+    @{ Src = 'Apps\Dashboard\OrdersByChannelPieChartView.cs';         Dst = 'ivy-create-dashboard\references\OrdersByChannelPieChartView.cs' }
+    @{ Src = 'Apps\Dashboard\SalesByCategoryBarChartView.cs';         Dst = 'ivy-create-dashboard\references\SalesByCategoryBarChartView.cs' }
+    @{ Src = 'Apps\Dashboard\SalesByStoreTypeAreaChartView.cs';       Dst = 'ivy-create-dashboard\references\SalesByStoreTypeAreaChartView.cs' }
+
+    # ── ivy-create-crud ──────────────────────────────────────────────────────
+    @{ Src = 'Apps\ProductsApp.cs';                                   Dst = 'ivy-create-crud\references\ProductsApp.cs' }
+    @{ Src = 'Apps\OrdersApp.cs';                                     Dst = 'ivy-create-crud\references\OrdersApp.cs' }
+    @{ Src = 'Apps\Products\ProductListBlade.cs';                     Dst = 'ivy-create-crud\references\ProductListBlade.cs' }
+    @{ Src = 'Apps\Products\ProductDetailsBlade.cs';                  Dst = 'ivy-create-crud\references\ProductDetailsBlade.cs' }
+    @{ Src = 'Apps\Products\ProductCreateDialog.cs';                  Dst = 'ivy-create-crud\references\ProductCreateDialog.cs' }
+    @{ Src = 'Apps\Products\ProductEditSheet.cs';                     Dst = 'ivy-create-crud\references\ProductEditSheet.cs' }
+    @{ Src = 'Apps\Orders\OrderListBlade.cs';                         Dst = 'ivy-create-crud\references\OrderListBlade.cs' }
+    @{ Src = 'Apps\Orders\OrderDetailsBlade.cs';                      Dst = 'ivy-create-crud\references\OrderDetailsBlade.cs' }
+    @{ Src = 'Apps\Orders\OrderCreateDialog.cs';                      Dst = 'ivy-create-crud\references\OrderCreateDialog.cs' }
+    @{ Src = 'Apps\Orders\OrderEditSheet.cs';                         Dst = 'ivy-create-crud\references\OrderEditSheet.cs' }
+    @{ Src = 'Apps\Orders\OrderLinesBlade.cs';                        Dst = 'ivy-create-crud\references\OrderLinesBlade.cs' }
+    @{ Src = 'Apps\Orders\OrderLineCreateDialog.cs';                  Dst = 'ivy-create-crud\references\OrderLineCreateDialog.cs' }
+    @{ Src = 'Apps\Orders\OrderLineEditSheet.cs';                     Dst = 'ivy-create-crud\references\OrderLineEditSheet.cs' }
+
+    # ── ivy-create-app ───────────────────────────────────────────────────────
+    @{ Src = 'Apps\ChatApp.cs';                                       Dst = 'ivy-create-app\references\ChatApp.cs' }
+    @{ Src = 'Connections\OpenAI\OpenAIConnection.cs';                Dst = 'ivy-create-app\references\OpenAIConnection.cs' }
+)
+
+# AdHoc-specific references (source is $AdHocRoot, not $RefsRoot)
+$AdHocCopies = @(
+    @{ Src = 'DesignGuidelines.md'; Dst = 'ivy-create-app\references\DesignGuidelines.md' }
+)
+
+# GenerateDbConnection references (source is $GenDbRoot)
+$GenDbCopies = @(
+    @{ Src = 'GenerateAndReviewDbml\References\DbmlGeneratePrompt.md';              Dst = 'ivy-generate-db-connection\references\DbmlGeneratePrompt.md' }
+    @{ Src = 'GenerateCodeAndMigrate\References\DbmlToDataContextPrompt.md';        Dst = 'ivy-generate-db-connection\references\DbmlToDataContextPrompt.md' }
+    @{ Src = 'GenerateCodeAndMigrate\References\DbmlToDataContext-Sqlite.md';       Dst = 'ivy-generate-db-connection\references\DbmlToDataContext-Sqlite.md' }
+    @{ Src = 'GenerateCodeAndMigrate\References\DbmlToDataContext-Postgres.md';     Dst = 'ivy-generate-db-connection\references\DbmlToDataContext-Postgres.md' }
+    @{ Src = 'GenerateCodeAndMigrate\References\DbmlToDataContext-SqlServer.md';    Dst = 'ivy-generate-db-connection\references\DbmlToDataContext-SqlServer.md' }
+    @{ Src = 'GenerateCodeAndMigrate\References\DbmlToDataContext-MySql.md';        Dst = 'ivy-generate-db-connection\references\DbmlToDataContext-MySql.md' }
+    @{ Src = 'GenerateCodeAndMigrate\CreateSeeder\References\DataSeederPrompt.md';  Dst = 'ivy-generate-db-connection\references\DataSeederPrompt.md' }
+    @{ Src = 'GenerateCodeAndMigrate\CreateSeeder\References\DataSeeder-Sqlite.md'; Dst = 'ivy-generate-db-connection\references\DataSeeder-Sqlite.md' }
+    @{ Src = 'GenerateCodeAndMigrate\CreateSeeder\References\DataSeeder-Postgres.md'; Dst = 'ivy-generate-db-connection\references\DataSeeder-Postgres.md' }
+    @{ Src = 'GenerateCodeAndMigrate\CreateSeeder\References\DataSeeder-SqlServer.md'; Dst = 'ivy-generate-db-connection\references\DataSeeder-SqlServer.md' }
+    @{ Src = 'GenerateCodeAndMigrate\CreateSeeder\References\DataSeeder-MySql.md';  Dst = 'ivy-generate-db-connection\references\DataSeeder-MySql.md' }
+)
+
+# Framework-level files (source is $FrameworkRoot) — copied into each skill's references
+$FrameworkCopies = @(
+    @{ Src = 'AGENTS.md'; Dst = 'ivy-create-dashboard\references\AGENTS.md' }
+    @{ Src = 'AGENTS.md'; Dst = 'ivy-create-crud\references\AGENTS.md' }
+    @{ Src = 'AGENTS.md'; Dst = 'ivy-create-app\references\AGENTS.md' }
+)
+
+function Copy-WithRewrite {
+    param(
+        [string]$SourcePath,
+        [string]$DestPath
+    )
+
+    if (-not (Test-Path $SourcePath)) {
+        Write-Warning "Source not found: $SourcePath"
+        return $false
+    }
+
+    $destDir = Split-Path $DestPath -Parent
+    if (-not (Test-Path $destDir)) {
+        New-Item -ItemType Directory -Path $destDir -Force | Out-Null
+    }
+
+    $content = Get-Content $SourcePath -Raw -Encoding UTF8
+
+    if ($SourcePath -match '\.cs$') {
+        foreach ($alias in $AliasLinesToStrip) {
+            $content = $content -replace [regex]::Escape($alias), ''
+        }
+
+        # Replace Exa.Line with Line (from the stripped alias)
+        $content = $content -replace '\bExa\.', ''
+
+        foreach ($r in $NamespaceReplacements) {
+            $content = $content -replace [regex]::Escape($r.From), $r.To
+        }
+
+        # Replace IvyAgentExamplesContextFactory with MyDbContextFactory
+        $content = $content -replace 'IvyAgentExamplesContextFactory', 'MyDbContextFactory'
+    }
+
+    # Normalize line endings and trim trailing blank lines
+    $content = $content -replace "`r`n", "`n"
+    $content = $content.TrimEnd("`n", " ") + "`n"
+
+    Set-Content -Path $DestPath -Value $content -NoNewline -Encoding UTF8
+    return $true
+}
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+Write-Host "Copying reference files..." -ForegroundColor Cyan
+Write-Host "  Source (shared):    $RefsRoot"
+Write-Host "  Source (adhoc):     $AdHocRoot"
+Write-Host "  Source (gendb):     $GenDbRoot"
+Write-Host "  Source (framework): $FrameworkRoot"
+Write-Host "  Destination:        $SkillsRoot"
+Write-Host ""
+
+$copied = 0
+$failed = 0
+
+foreach ($entry in $Copies) {
+    $src = Join-Path $RefsRoot  $entry.Src
+    $dst = Join-Path $SkillsRoot $entry.Dst
+
+    if (Copy-WithRewrite -SourcePath $src -DestPath $dst) {
+        Write-Host "  OK  $($entry.Dst)" -ForegroundColor Green
+        $copied++
+    } else {
+        $failed++
+    }
+}
+
+foreach ($entry in $AdHocCopies) {
+    $src = Join-Path $AdHocRoot  $entry.Src
+    $dst = Join-Path $SkillsRoot $entry.Dst
+
+    if (Copy-WithRewrite -SourcePath $src -DestPath $dst) {
+        Write-Host "  OK  $($entry.Dst)" -ForegroundColor Green
+        $copied++
+    } else {
+        $failed++
+    }
+}
+
+foreach ($entry in $GenDbCopies) {
+    $src = Join-Path $GenDbRoot   $entry.Src
+    $dst = Join-Path $SkillsRoot  $entry.Dst
+
+    if (Copy-WithRewrite -SourcePath $src -DestPath $dst) {
+        Write-Host "  OK  $($entry.Dst)" -ForegroundColor Green
+        $copied++
+    } else {
+        $failed++
+    }
+}
+
+foreach ($entry in $FrameworkCopies) {
+    $src = Join-Path $FrameworkRoot $entry.Src
+    $dst = Join-Path $SkillsRoot   $entry.Dst
+
+    if (Copy-WithRewrite -SourcePath $src -DestPath $dst) {
+        Write-Host "  OK  $($entry.Dst)" -ForegroundColor Green
+        $copied++
+    } else {
+        $failed++
+    }
+}
+
+Write-Host ""
+Write-Host "Done. Copied $copied file(s), $failed failure(s)." -ForegroundColor Cyan

--- a/src/skills/ivy-convert-airtable/SKILL.md
+++ b/src/skills/ivy-convert-airtable/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: ivy-convert-airtable
+description: >
+  Convert an Airtable base to an Ivy project. Use when the user wants to migrate
+  from Airtable, convert an Airtable base, import Airtable data, or build an Ivy
+  app from an Airtable base. Requires Base ID and Personal Access Token (PAT).
+  Uses the ivy-inspector-airtable CLI tool to inspect and extract base metadata.
+allowed-tools: Bash(ivy-inspector-airtable:*) Bash(dotnet:*) Bash(git:*) Bash(test:*) Bash(mkdir:*) Read Write Edit Glob Grep
+effort: high
+argument-hint: "[Airtable Base ID]"
+---
+
+# ivy-convert-airtable
+
+Convert an Airtable base to an Ivy project.
+
+## Step 1: Gather Credentials
+
+You need an Airtable Base ID (e.g. `appXXXXXXXXXXXXXX`) and a Personal Access Token (PAT). Check if these were provided as arguments via `$ARGUMENTS`. If not, ask the user to provide them.
+
+## Step 2: Research the Airtable Base
+
+Use the `ivy-inspector-airtable` CLI tool to inspect the content of the Airtable base. This tool is already installed.
+
+1. Run `ivy-inspector-airtable docs` to see all available commands and options.
+2. Authentication: Pass `--pat <token>` before the command when using ivy-inspector-airtable.
+3. Inspect the base using the Base ID and PAT. Issue multiple Bash commands in parallel to gather information as fast as possible.
+
+Your goal is to answer these questions:
+- What is the overall structure of the base?
+- What tables exist and what are their purposes?
+- What is the schema for each table (fields, types, relationships)?
+- What views exist for each table and what filtering/sorting do they apply?
+- Which tables represent **manageable data** (records the user would create, edit, delete -- e.g. contacts, orders, activities) vs **reference/lookup data** (static lists, configuration, categories)?
+- What are the relationships between tables (linked records)?
+- What field types are used and how should they map to database types?
+- Any design/layout hints for how we can build a web-based application based on this base?
+
+## Step 3: Present the Conversion Plan
+
+Given the research output, present the user with a plan using the following structure:
+
+```markdown
+# Airtable to Ivy Conversion Plan
+
+**Base ID:** [Base ID]
+
+## Create Database
+
+**Connection Name:** MyCompanyBase
+**Namespace:** MyCompanyBase.Connections.MyCompanyBase
+
+The base contains the following tables that should be converted to tables in a database:
+
+### Table:Customers
+
+**Airtable Table:** Customers
+**Airtable Table ID:** tblXXXXXXXXXXXXXX
+**Columns:**
+- name: Name
+  type: string
+  nullable: false
+  airtableType: singleLineText
+  normalization: Trim(Value)
+- name: Email
+  type: string
+  nullable: true
+  airtableType: email
+  normalization: Lowercase(Trim(Value))
+- name: Status
+  type: Enum
+  nullable: false
+  values: Active, Inactive, Pending
+  airtableType: singleSelect
+  normalization: <None>
+- name: Tags
+  type: string[]
+  nullable: true
+  airtableType: multipleSelects
+  normalization: <None>
+- name: AccountManager
+  type: ForeignKey(Users)
+  nullable: true
+  airtableType: linkedRecord
+  linkedTable: Users
+  normalization: <None>
+- ...
+
+### Table:Orders
+
+**Airtable Table:** Orders
+**Airtable Table ID:** tblYYYYYYYYYYYYYY
+**Columns:**
+- name: OrderNumber
+  type: string
+  nullable: false
+  airtableType: number/formula
+  normalization: <None>
+- name: Customer
+  type: ForeignKey(Customers)
+  nullable: false
+  airtableType: linkedRecord
+  linkedTable: Customers
+  normalization: <None>
+- name: OrderDate
+  type: DateTime
+  nullable: false
+  airtableType: date
+  normalization: <None>
+- name: Total
+  type: decimal
+  nullable: false
+  airtableType: currency
+  normalization: <None>
+- name: Attachments
+  type: string[]
+  nullable: true
+  airtableType: multipleAttachments
+  normalization: Store URLs or download to blob storage
+- ...
+
+## Apps
+
+For each app, assign a **Type:**
+- `CRUD` -- When the app is backed by a database table containing entity records that users would create, edit, and delete (e.g. contacts, orders, activities, deals). CRUD apps should include: DataTable with Add button in header, Sheet/Dialog for create/edit forms with validation, delete via row action with confirmation dialog.
+- `Dashboard` -- For summary, analytics, or reporting views.
+- `Ad-hoc` -- For utility or custom apps that don't fit the above categories.
+
+Default to `CRUD` for any app backed by a database table with entity data. Only use read-only views when the user explicitly requests it or the data is reference/lookup data.
+
+### App:Customers
+
+**File:** /Apps/CustomersApp.cs
+**Icon:** User
+**Table:** Customers
+**Type:** CRUD
+**Description:**
+Full CRUD management for customer records: DataTable with Add button, Sheet for create/edit forms with validation, delete via row action with confirmation. Include filters for Status and search by Name/Email.
+
+Airtable Views to consider:
+- "All Customers" (default view)
+- "Active Only" (filtered by Status = Active)
+- "Recently Added" (sorted by Created Time desc)
+
+### App:Orders
+
+**File:** /Apps/OrdersApp.cs
+**Icon:** ShoppingCart
+**Table:** Orders
+**Type:** CRUD
+**Description:**
+Full CRUD management for order records: DataTable with Add button, Sheet for create/edit forms with validation, delete via row action with confirmation. Include Customer lookup/selector, date pickers, and currency formatting.
+
+Airtable Views to consider:
+- "All Orders" (default view)
+- "Pending Orders" (filtered by Status)
+- "By Customer" (grouped by Customer)
+
+### App:Dashboard
+
+**File:** /Apps/DashboardApp.cs
+**Icon:** Dashboard
+**Type:** Dashboard
+**Description:**
+Overview dashboard showing key metrics: total customers, active customers, total orders, revenue charts. Use BarChart, LineChart, and Stat widgets.
+
+## Migration Notes
+
+- **Attachments**: Airtable attachment URLs are temporary. Use the `export` command to download attachments locally before migration, or implement a migration script to upload them to blob storage.
+- **Linked Records**: Airtable's linkedRecord fields should become foreign keys. Ensure referential integrity is maintained.
+- **Formula Fields**: Airtable formulas should be evaluated and either converted to computed properties in C# or stored as static values during migration.
+- **Rollup/Lookup Fields**: Convert to SQL views, computed properties, or aggregate queries.
+- **Collaborator Fields**: Map to User table foreign keys if implementing user management.
+
+## Other Notes
+
+- Preserve view configurations (filters, sorts, groupings) as default UI states
+- Consider implementing view presets that match Airtable views
+- Migrate attachment files using `ivy-inspector-airtable export` command
+- Test data migration with a subset before full migration
+```
+
+## Step 4: Implementation
+
+Implement the plan approved by the user in the previous step.

--- a/src/skills/ivy-convert-excel/SKILL.md
+++ b/src/skills/ivy-convert-excel/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: ivy-convert-excel
+description: >
+  Convert an Excel (.xlsx) document to an Ivy project. Use when the user wants to
+  migrate from Excel, convert a spreadsheet, import Excel data, or build an Ivy
+  app from an .xlsx file. Uses the ivy-inspector-excel CLI tool to inspect and
+  extract data from Excel files.
+allowed-tools: Bash(ivy-inspector-excel:*) Bash(dotnet:*) Bash(git:*) Bash(test:*) Bash(realpath:*) Bash(cygpath:*) Bash(mkdir:*) Read Write Edit Glob Grep
+effort: high
+argument-hint: "[path to .xlsx file]"
+---
+
+# ivy-convert-excel
+
+Convert an Excel (.xlsx) document to an Ivy project.
+
+## Step 1: Locate the Excel File
+
+You need a path to a `.xlsx` file. Check if a path was provided as arguments via `$ARGUMENTS`. If not, ask the user to provide one.
+
+1. Verify the file exists using `test -f "<path>"`.
+2. Convert the path to an absolute path using `realpath "<path>"` (or `cygpath -w` on Windows if needed). Use this absolute path in all subsequent commands.
+
+## Step 2: Research the Excel File
+
+Use the `ivy-inspector-excel` CLI tool to inspect the content of the Excel file. This tool is already installed.
+
+1. Run `ivy-inspector-excel docs` to see all available commands and options.
+2. Inspect the xlsx file using ivy-inspector-excel. Issue multiple Bash commands in parallel to gather information as fast as possible.
+
+Your goal is to answer these questions:
+- What is the overall structure?
+- Any design/layout hints for how we can build a web-based application based on this document?
+- What terminology is used? What are the entities?
+- What is the underlying logic of the sheet? What formulas are used?
+- What are the relationships between the different sheets (if there are multiple sheets)?
+- What tables or ranges are suitable to convert to tables in a relational database (if any)?
+- Which entities represent **manageable data** (records the user would create, edit, delete -- e.g. contacts, orders, activities) vs **reference/lookup data** (static lists, configuration, categories)?
+
+3. After inspecting the Excel file and identifying all data ranges suitable for conversion, extract the data:
+   - Create the output directory: `mkdir -p .ivy/data`
+   - For each identified table/range, extract the data to a CSV file:
+     ```
+     ivy-inspector-excel extract "<path-to-xlsx>" "<sheet-name>" "<range>" "<absolute-path-to/.ivy/data/table-name.csv>"
+     ```
+   - Use lowercase, hyphenated filenames matching the entity name (e.g. `customers.csv`, `order-items.csv`)
+   - Include the list of extracted CSV files and their source sheet/range in your analysis
+
+## Step 3: Present the Conversion Plan
+
+Given the research output, present the user with a plan using the following structure:
+
+```markdown
+# Excel to Ivy Conversion Plan
+
+**File:** [path to xlsx file]
+
+## Create Database
+
+**Connection Name:** MyCompanyCrm
+**Namespace:** MyCompanyCrm.Connections.MyCompanyCrm
+
+The document contains the following entities that should be converted to tables in a database:
+
+### Table:Customers
+
+**Sheet:** Sheet1
+**Range:** A1:D90
+**Columns:**
+- name: name
+  type: string
+  nullable: false
+  normalization: Trim(UpperCase(Value))
+- name: Age
+  type: int
+  nullable: false
+  default: 0
+  normalisation: <None>
+- name: Gender
+  type: Enum
+  nullable: false
+  values: Male, Female, Other
+  normalization: The source file has some misspelled values 'Femal' these should be mapped to "Female"
+- ...
+
+### Table:Orders
+
+## Apps
+
+For each app, assign a **Type:**
+- `CRUD` -- When the app is backed by a database table containing entity records that users would create, edit, and delete (e.g. contacts, orders, activities, deals). CRUD apps should include: DataTable with Add button in header, Sheet/Dialog for create/edit forms with validation, delete via row action with confirmation dialog.
+- `Dashboard` -- For summary, analytics, or reporting views.
+- `Ad-hoc` -- For utility or custom apps that don't fit the above categories.
+
+Default to `CRUD` for any app backed by a database table with entity data. Only use read-only views when the user explicitly requests it or the data is reference/lookup data.
+
+### App:Customers
+
+**File:** /Apps/CustomersApp.cs
+**Icon:** User
+**Table:** Customers
+**Type:** CRUD
+**Description:**
+Full CRUD management for customer records: DataTable with Add button, Sheet for create/edit forms with validation, delete via row action with confirmation.
+
+### App:Dashboard
+
+**File:** /Apps/DashboardApp.cs
+**Icon:** Dashboard
+**Type:** Dashboard
+**Description:**
+...
+
+### App:Quote
+
+**File:** /Apps/QuoteApp.cs
+**Icon:** Numbers
+**Type:** CRUD
+**Description:**
+Full CRUD management for quote records: DataTable with Add button, Sheet for create/edit forms with validation, delete via row action with confirmation.
+
+## Other Notes
+
+...
+
+```
+
+## Step 4: Implementation
+
+Implement the plan approved by the user in the previous step.

--- a/src/skills/ivy-convert-lovable/SKILL.md
+++ b/src/skills/ivy-convert-lovable/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: ivy-convert-lovable
+description: >
+  Convert a Lovable (lovable.dev) application to an Ivy project. Use when the user
+  wants to migrate from Lovable, convert a Lovable app, or build an Ivy app from a
+  Lovable project. Lovable generates React+Vite+TypeScript apps with Supabase backends.
+  Handles GitHub URLs and local paths.
+allowed-tools: Bash(dotnet:*) Bash(git:*) Bash(test:*) Bash(mkdir:*) Read Write Edit Glob Grep
+effort: high
+argument-hint: "[GitHub URL or local path]"
+---
+
+# ivy-convert-lovable
+
+Convert a Lovable (lovable.dev) application to an Ivy project. Lovable generates React+Vite+TypeScript apps with Supabase backends.
+
+## Reference Files
+
+There are 31 reference files containing React/shadcn to Ivy component mappings located at:
+`D:\Repos\_Ivy\Ivy\Ivy.Internals\Workflows\Conversion\Lovable\References\`
+
+Read these reference files before implementing the conversion to understand how to map Lovable/React features to Ivy features.
+
+## Step 1: Locate the Lovable Project
+
+You need a path to a cloned Lovable GitHub repository or a GitHub URL. Check if a value was provided via `$ARGUMENTS`. If not, ask the user to provide one.
+
+- If it is a **GitHub URL** (starts with `https://github.com/`): Clone it to `.ivy/source/<repo-name>/` using `git clone <url> .ivy/source/<repo-name>/` and use that as the path going forward.
+- If it is a **local path**: Use it directly.
+- Verify the path exists with `test -d "<path>"` and is a valid project with `test -f "<path>/package.json"`.
+
+## Step 2: Verify it is a Lovable Project
+
+Check for these identifying markers:
+- `package.json` with Vite+React+TypeScript setup (often `"name": "vite_react_shadcn_ts"`)
+- `src/integrations/supabase/client.ts` (auto-generated Supabase client)
+- `src/integrations/supabase/types.ts` (auto-generated DB types)
+- `supabase/config.toml` (Supabase project config)
+- `components.json` (shadcn/ui config)
+- `public/lovable-uploads/` directory (Lovable-specific assets)
+
+If none of these markers are present, report that this does not appear to be a Lovable project and suggest verifying the path.
+
+## Step 3: Research -- Extract Database Schema
+
+Read these files in priority order:
+1. `src/integrations/supabase/types.ts` -- The most complete source. Contains a typed `Database` object with `Tables`, `Views`, `Functions`, `Enums` for each schema. Each table has `Row`, `Insert`, `Update` types with all columns and their TypeScript types.
+2. `supabase/migrations/*.sql` -- Authoritative SQL schema history. Migration filenames follow pattern `YYYYMMDDHHMMSS_<description>.sql`. Parse for `CREATE TABLE`, `ALTER TABLE`, `CREATE TYPE`, `CREATE POLICY`, `CREATE FUNCTION`, `CREATE TRIGGER`, `CREATE INDEX`.
+3. `supabase/config.toml` -- Contains `project_id` and edge function declarations with `verify_jwt` settings.
+
+For each table, document: name, columns with types, nullable status, defaults, primary keys, foreign keys, and any enums.
+
+## Step 4: Research -- Extract Edge Functions
+
+Read `supabase/functions/*/index.ts` for each edge function:
+- Functions are Deno/TypeScript using `serve()` from `https://deno.land/std@0.168.0/http/server.ts`
+- Access env vars via `Deno.env.get("SECRET_NAME")`
+- Common patterns: CORS handling, JWT verification, external API calls (Stripe, OpenAI, ElevenLabs, Resend)
+- Edge function declarations in `supabase/config.toml` under `[functions.<name>]` with `verify_jwt` settings
+- For each function, document: name, purpose, HTTP methods, auth requirements, external API dependencies, env vars needed
+
+## Step 5: Research -- Extract Frontend Structure
+
+Read these files to understand the app structure:
+1. `src/App.tsx` -- Route definitions mapping paths to page components
+2. `src/pages/*.tsx` -- Each file is a route/page
+3. `src/hooks/*.ts(x)` -- Custom React hooks, often for Supabase data fetching
+4. `src/components/**/*.tsx` -- Feature-organized components (skip `src/components/ui/*.tsx` -- those are shadcn/ui primitives that map to Ivy widgets)
+5. `src/lib/*.ts`, `src/utils/*.ts` -- Utility functions
+6. `src/types/*.ts` -- Custom type definitions (if present)
+
+## Step 6: Research -- Identify Data Sources and Connections
+
+- Supabase tables from types.ts -> Convert to Ivy database Connection
+- External APIs called from edge functions -> Note for manual setup
+- Auth patterns (Supabase Auth) -> Map to Ivy auth patterns
+- Supabase Realtime subscriptions -> Note for Ivy real-time handling
+- Supabase Storage usage -> Note for Ivy file storage
+
+## Step 7: Research -- Map Pages to Ivy Apps
+
+- Each meaningful page becomes an Ivy App
+- Landing/marketing pages may be skipped or simplified
+- Auth pages are handled by Ivy's built-in auth
+- CRUD pages -> DataTable + Sheet/Dialog pattern
+- Dashboard pages -> Chart widgets + KPI cards
+- Form pages -> Form widgets
+
+## Step 8: Present the Conversion Plan
+
+Given the research output, present the user with a plan using the following structure:
+
+```markdown
+# Lovable to Ivy Conversion Plan
+
+**Source:** [path to Lovable project]
+
+## Database
+
+**Connection Name:** <derived from project>
+**Namespace:** <ProjectName>.Connections.<ConnectionName>
+
+The Supabase schema contains the following tables that should be converted to a database:
+
+### Table:<TableName>
+
+**Columns:**
+- name: <column>
+  type: <CSharp type>
+  nullable: <bool>
+  default: <default value if any>
+
+### Table:<TableName2>
+
+...
+
+## Edge Functions -> Backend Logic
+
+### Function:<FunctionName>
+
+**Purpose:** <description>
+**External APIs:** <list>
+**Env Vars:** <list>
+**Conversion:** <how to handle in Ivy - server action, scheduled job, webhook handler, etc.>
+
+## Apps
+
+For each app, assign a **Type:**
+- `CRUD` -- When the app is backed by a database table containing entity records that users would create, edit, and delete (e.g. contacts, orders, activities, deals). CRUD apps should include: DataTable with Add button in header, Sheet/Dialog for create/edit forms with validation, delete via row action with confirmation dialog.
+- `Dashboard` -- For summary, analytics, or reporting views.
+- `Ad-hoc` -- For utility or custom apps that don't fit the above categories.
+
+Default to `CRUD` for any app backed by a database table with entity data. Only use read-only views when the user explicitly requests it or the data is reference/lookup data.
+
+### App:<AppName>
+
+**File:** /Apps/<AppName>App.cs
+**Icon:** <icon>
+**Type:** CRUD | Dashboard | Ad-hoc
+**Source Page:** src/pages/<Page>.tsx
+**Description:** <what it does and how to convert>
+
+### App:<AppName2>
+
+...
+
+## Auth
+
+<auth pattern used in Lovable (Supabase Auth) and how to map to Ivy auth>
+
+## Other Notes
+
+<anything that can't be automatically converted, external API dependencies, env vars needed, etc.>
+```
+
+## Step 9: Implementation
+
+Identify if there are any connections (db, auth, api) that should be set up using the appropriate connection skill (e.g., `/ivy-create-db-connection` for databases, `/ivy-create-auth-connection` for auth, `/ivy-create-any-connection` for APIs).
+
+Given the conversion plan from the previous step, implement the conversion of the Lovable application to an Ivy application. Use the conversion plan and the reference files as guides to map Lovable/React features to Ivy features.
+
+The conversion guide should include:
+1. **Database schema** -- All tables with columns, types mapped to C#, relationships
+2. **Edge functions** -- Purpose, external dependencies, how to handle in Ivy
+3. **Apps** -- Each page mapped to an Ivy App with type (CRUD/Dashboard/Ad-hoc), widgets needed, and data sources
+4. **Auth** -- How Supabase Auth maps to Ivy auth
+5. **Component mapping** -- Which React/shadcn components are used and their Ivy equivalents
+6. **Hooks and state** -- How React hooks and state management map to Ivy patterns

--- a/src/skills/ivy-convert-odoo/SKILL.md
+++ b/src/skills/ivy-convert-odoo/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: ivy-convert-odoo
+description: >
+  Convert an Odoo application or module to an Ivy project. Use when the user wants to
+  migrate from Odoo, convert an Odoo module, or build an Ivy app from Odoo Python/XML
+  source files. Handles Python files and folders containing Odoo modules.
+allowed-tools: Bash(dotnet:*) Bash(git:*) Bash(test:*) Bash(mkdir:*) Read Write Edit Glob Grep
+effort: high
+argument-hint: "[path to Odoo module]"
+---
+
+# ivy-convert-odoo
+
+Convert an Odoo application or module to an Ivy project.
+
+## Reference Files
+
+There are 60 reference files containing Odoo to Ivy component mappings located at:
+`D:\Repos\_Ivy\Ivy\Ivy.Internals\Workflows\Conversion\Odoo\References\`
+
+Read these reference files before implementing the conversion to understand how to map Odoo features to Ivy features.
+
+## Step 1: Locate the Odoo Module
+
+You need a path to a Python file or a folder containing the Odoo application/module. Check if a path was provided via `$ARGUMENTS`. If not, ask the user to provide one.
+
+Verify the path exists with `test -f "<path>"` or `test -d "<path>"`.
+
+## Step 2: Research the Odoo Application
+
+Read all the `.py` and `.xml` files and build a mental model of:
+- Odoo models (fields.Char, fields.Many2one, fields.Selection, etc.)
+- View types used (form, list/tree, kanban, calendar, graph, pivot, search, activity, etc.)
+- Field widgets and OWL components
+- Actions (ir.actions.act_window, server actions, automated actions)
+- Business logic (compute methods, onchange, constraints, workflows)
+- Security rules (ir.model.access.csv, record rules)
+- Reports (QWeb templates)
+- Menu structure and navigation
+
+### 2a: Classify Each View
+
+For each view identified, classify it:
+- **CRUD**: Standard create/read/update/delete for a model (list + form)
+- **Dashboard**: Reporting, charts, KPIs (pivot, graph, calendar)
+- **Workflow**: Multi-step process with state transitions
+- **Read-only**: Information display only, no editing
+
+This determines the Ivy pattern to use.
+
+### 2b: Document Security Model
+
+Identify security and access control:
+- Access rights from `ir.model.access.csv`
+- Record rules (row-level security)
+- `@check_access_rights` decorators
+- User groups and permissions
+- Document who can view/edit each model
+
+### 2c: Map Computed Fields
+
+For each model, identify:
+- Fields with `@api.depends` decorators (computed fields)
+- Fields with `@api.onchange` handlers (dynamic updates)
+- `_compute_*` methods and their logic
+- Dependency chains between fields
+- Document the computation logic for each
+
+### 2d: Map Menu and Navigation
+
+Document the application structure:
+- Extract menu hierarchy from `ir.ui.menu`
+- Map actions from `ir.actions.act_window`
+- Identify navigation flow between views
+- Note sidebar, top menu, breadcrumbs
+
+## Step 3: Detect Odoo Connection
+
+Before converting, check if an Odoo connection is configured:
+
+1. Look for connection files in the project's connections directory
+2. Check if connection type is "odoo"
+3. Verify connection details (host, database, username)
+4. If missing, prompt the user to configure a connection using the appropriate connection skill (e.g., `/ivy-create-db-connection` for databases, `/ivy-create-auth-connection` for auth, `/ivy-create-any-connection` for APIs)
+5. Test connection before proceeding
+
+## Step 4: Present the Conversion Plan
+
+Write a summarized conversion guide that maps the Odoo features used in the application to Ivy features. The conversion guide should be structured in a way that makes it easy to follow when implementing the conversion. Use markdown formatting to make it clear and organized -- but be concise and token efficient.
+
+Present the plan to the user for approval before proceeding.
+
+## Step 5: Implementation
+
+Identify if there are any additional connections (db, auth, api) that should be set up using the appropriate connection skill (e.g., `/ivy-create-db-connection` for databases, `/ivy-create-auth-connection` for auth, `/ivy-create-any-connection` for APIs).
+
+Given the conversion guide from the previous step, implement the conversion of the Odoo application to an Ivy application. Use the conversion guide and the reference files to map Odoo features to Ivy features.
+
+## Step 6: Validation
+
+After generating Ivy code, validate the conversion:
+
+1. All Odoo views have corresponding Ivy pages
+2. All models have Ivy data classes
+3. All form fields have Ivy input widgets
+4. Security rules are documented (even if not implemented)
+5. Computed fields have UseQuery or UseEffect equivalents
+6. Menu structure maps to Ivy routing
+
+Generate a validation report listing:
+- Successfully converted views
+- Views with workarounds/limitations
+- Missing or incomplete conversions

--- a/src/skills/ivy-convert-reflex/SKILL.md
+++ b/src/skills/ivy-convert-reflex/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: ivy-convert-reflex
+description: >
+  Convert a Reflex (Python) application to an Ivy project. Use when the user wants to
+  migrate from Reflex, convert a Reflex app, or build an Ivy app from Reflex Python
+  source files. Handles .py files, folders, and GitHub URLs.
+allowed-tools: Bash(dotnet:*) Bash(git:*) Bash(test:*) Bash(mkdir:*) Read Write Edit Glob Grep
+effort: high
+argument-hint: "[path or GitHub URL]"
+---
+
+# ivy-convert-reflex
+
+Convert a Reflex application to an Ivy project.
+
+## Reference Files
+
+There are 94 reference files containing Reflex to Ivy component mappings located at:
+`D:\Repos\_Ivy\Ivy\Ivy.Internals\Workflows\Conversion\Reflex\References\`
+
+Read these reference files before implementing the conversion to understand how to map Reflex features to Ivy features.
+
+## Step 1: Locate the Reflex Application
+
+You need a path to a `.py` file, a folder, or a GitHub URL containing the Reflex application. Check if a value was provided via `$ARGUMENTS`. If not, ask the user to provide one.
+
+- If it is a **GitHub URL** (starts with `https://github.com/`): Clone it to `.ivy/source/<repo-name>/` using `git clone <url> .ivy/source/<repo-name>/` and use that as the path going forward.
+- If it is a **local path**: Use it directly.
+- Verify the path exists with `test -f "<path>"` or `test -d "<path>"`.
+
+## Step 2: Research the Reflex Application
+
+Read all the `.py` files and build a mental model of all Reflex features used in the application (`rx.*` components, state classes, event handlers, etc.).
+
+Use the reference files listed above to learn how to map Reflex features to Ivy features.
+
+Gather enough information to produce a complete conversion guide before proceeding to the next step.
+
+## Step 3: Write the Conversion Guide
+
+Write a summarized conversion guide that maps the Reflex features used in the application to Ivy features. The conversion guide should be structured in a way that makes it easy to follow when implementing the conversion. Use markdown formatting to make it clear and organized -- but be concise and token efficient.
+
+Present the plan to the user for approval before proceeding.
+
+## Step 4: Implementation
+
+Identify if there are any connections (db, auth, api) that should be set up using the appropriate connection skill (e.g., `/ivy-create-db-connection` for databases, `/ivy-create-auth-connection` for auth, `/ivy-create-any-connection` for APIs).
+
+Given the conversion guide from the previous step, implement the conversion of the Reflex application to an Ivy application. Use the conversion guide and the reference files to map Reflex features to Ivy features.

--- a/src/skills/ivy-convert-retool/SKILL.md
+++ b/src/skills/ivy-convert-retool/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: ivy-convert-retool
+description: >
+  Convert a Retool application to an Ivy project. Use when the user wants to migrate
+  from Retool, convert a Retool app, or build an Ivy app from an exported Retool
+  project (.zip file). Uses the ivy-inspector-retool CLI tool to inspect exported
+  Retool projects.
+allowed-tools: Bash(ivy-inspector-retool:*) Bash(dotnet:*) Bash(git:*) Bash(test:*) Bash(mkdir:*) Read Write Edit Glob Grep
+effort: high
+argument-hint: "[path to .zip file]"
+---
+
+# ivy-convert-retool
+
+Convert an exported Retool project to an Ivy project.
+
+## Reference Files
+
+There are 134 reference files containing Retool to Ivy component mappings located at:
+`D:\Repos\_Ivy\Ivy\Ivy.Internals\Workflows\Conversion\Retool\References\`
+
+Read these reference files before implementing the conversion to understand how to map Retool features to Ivy features.
+
+## Step 1: Locate the Retool Export
+
+You need a path to a `.zip` file containing an exported Retool project. Check if a path was provided via `$ARGUMENTS`. If not, ask the user to provide one.
+
+Verify the file exists using `test -f "<path>"`.
+
+## Step 2: Research the Retool Application
+
+Use the `ivy-inspector-retool` CLI tool to inspect the content of the zip file. This tool is already installed.
+
+1. Run `ivy-inspector-retool docs` to see all available commands and options.
+2. Use ivy-inspector-retool to inspect the zip file. Issue multiple Bash commands in parallel to gather information as fast as possible.
+
+Your goal is to analyze the application built in Retool and compile a detailed report so that it can be converted to an Ivy application. Answer these questions:
+
+- What are the data sources used in the Retool application? For each data source, what type is it (e.g. REST API, SQL database, GraphQL, etc), what are the endpoints or tables used, and what queries are made?
+- What are the pages in the Retool application? What are their names and purposes? A page in Retool will be converted to an App in Ivy.
+- What are the modals (dialogs) and drawers (sheets)?
+
+## Step 3: Present the Conversion Plan
+
+Given the research output, present the user with a plan using the following structure:
+
+For each app, assign a **Type:**
+- `CRUD` -- When the app is backed by a database table containing entity records that users would create, edit, delete
+- `Dashboard` -- For summary, analytics, or reporting views
+- `Ad-hoc` -- For utility or custom apps that don't fit the above categories
+
+```markdown
+# Retool to Ivy Conversion Plan
+
+**File:** [path to zip file]
+
+## Data Sources
+
+### DataSource:MyRestApi
+
+**Type:** REST API
+**Base URL:** https://api.example.com/v1
+**Authentication:** Bearer token
+**Endpoints:**
+- GET /customers -- list all customers
+- GET /customers/:id -- get customer by ID
+- POST /customers -- create customer
+- ...
+
+### DataSource:MyDatabase
+
+**Type:** SQL (PostgreSQL)
+**Tables:** customers, orders, products
+**Key Queries:**
+- SELECT * FROM customers WHERE active = true
+- ...
+
+## Pages
+
+### Page:Customers -> App:Customers
+
+**File:** /Apps/CustomersApp.cs
+**Type:** CRUD
+**Icon:** User
+**Data Source:** MyRestApi (GET /customers, POST /customers)
+**Description:**
+Lists all customers with search and filtering. Allows creating and editing customer records.
+
+### Page:Dashboard -> App:Dashboard
+
+**File:** /Apps/DashboardApp.cs
+**Type:** Dashboard
+**Icon:** Dashboard
+**Data Source:** MyDatabase (aggregation queries)
+**Description:**
+Summary view showing key metrics and charts.
+
+### Page:ImportTool -> App:ImportTool
+
+**File:** /Apps/ImportToolApp.cs
+**Type:** Ad-hoc
+**Icon:** Upload
+**Description:**
+Utility page for importing CSV data into the system.
+
+## Modals and Drawers
+
+### Modal:EditCustomer
+
+**Triggered from:** Customers page
+**Purpose:** Edit form for a single customer record
+
+### Drawer:CustomerDetails
+
+**Triggered from:** Customers page
+**Purpose:** Side panel showing full customer details
+
+## Connection Configuration
+
+**Connection Name:** MyCompany
+**Namespace:** MyCompany.Connections.MyCompany
+**Secrets:**
+- MyCompany:ApiKey
+- MyCompany:BaseUrl
+
+## Other Notes
+
+...
+
+```
+
+## Step 4: Implementation
+
+Implement the plan approved by the user in the previous step.

--- a/src/skills/ivy-convert-streamlit/SKILL.md
+++ b/src/skills/ivy-convert-streamlit/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: ivy-convert-streamlit
+description: >
+  Convert a Streamlit (Python) application to an Ivy project. Use when the user wants to
+  migrate from Streamlit, convert a Streamlit app, or build an Ivy app from Streamlit
+  Python source files. Handles .py files, folders, and GitHub URLs.
+allowed-tools: Bash(dotnet:*) Bash(git:*) Bash(test:*) Bash(mkdir:*) Read Write Edit Glob Grep
+effort: high
+argument-hint: "[path or GitHub URL]"
+---
+
+# ivy-convert-streamlit
+
+Convert a Streamlit application to an Ivy project.
+
+## Reference Files
+
+There are 105 reference files containing Streamlit to Ivy component mappings located at:
+`D:\Repos\_Ivy\Ivy\Ivy.Internals\Workflows\Conversion\Streamlit\References\`
+
+Read these reference files before implementing the conversion to understand how to map Streamlit features to Ivy features.
+
+## Step 1: Locate the Streamlit Application
+
+You need a path to a `.py` file, a folder, or a GitHub URL containing the Streamlit application. Check if a value was provided via `$ARGUMENTS`. If not, ask the user to provide one.
+
+- If it is a **GitHub URL** (starts with `https://github.com/`): Clone it to `.ivy/source/<repo-name>/` using `git clone <url> .ivy/source/<repo-name>/` and use that as the path going forward.
+- If it is a **local path**: Use it directly.
+- Verify the path exists with `test -f "<path>"` or `test -d "<path>"`.
+
+## Step 2: Research the Streamlit Application
+
+Read all the `.py` files and build a mental model of all Streamlit `st.*` features used in the application.
+
+Use the reference files listed above to learn how to map Streamlit features to Ivy features.
+
+Gather enough information to produce a complete conversion guide before proceeding to the next step.
+
+## Step 3: Write the Conversion Guide
+
+Write a summarized conversion guide that maps the Streamlit features used in the application to Ivy features. The conversion guide should be structured in a way that makes it easy to follow when implementing the conversion. Use markdown formatting to make it clear and organized -- but be concise and token efficient.
+
+Present the plan to the user for approval before proceeding.
+
+## Step 4: Implementation
+
+Identify if there are any connections (db, auth, api) that should be set up using the appropriate connection skill (e.g., `/ivy-create-db-connection` for databases, `/ivy-create-auth-connection` for auth, `/ivy-create-any-connection` for APIs).
+
+Given the conversion guide from the previous step, implement the conversion of the Streamlit application to an Ivy application. Use the conversion guide and the reference files to map Streamlit features to Ivy features.

--- a/src/skills/ivy-create-any-connection/SKILL.md
+++ b/src/skills/ivy-create-any-connection/SKILL.md
@@ -1,0 +1,663 @@
+---
+name: ivy-create-any-connection
+description: >
+  Create an ad-hoc API connection or service integration in an Ivy project. Supports
+  NuGet package, OpenAPI/Swagger with Refitter, REST API, and custom HTTP client
+  approaches. Use when the user wants to connect to an external API, add a service
+  integration, or create a typed client for a REST endpoint.
+allowed-tools: Bash(dotnet:*) Bash(refitter:*) Read Write Edit Glob Grep
+effort: high
+argument-hint: "[name or URL of the API/service to connect to]"
+---
+
+# ivy-create-any-connection
+
+Create a connection to an external API or service inside an existing Ivy project. This produces connection files under `Connections/[ConnectionName]/` -- it does NOT create a separate project or catalog entry. Only use this skill when the user wants to connect to an API or service that does not already have a pre-built reference connection in the Ivy catalog.
+
+## Step 1: Validate the Project
+
+1. Verify this is a valid Ivy project. Check for a `.csproj` file and `Program.cs` in the working directory. If this is not an Ivy project, tell the user and stop.
+
+2. **LLM endpoint detection:** If the user's request mentions an OpenAI-compatible LLM endpoint (URL contains `openai`, `litellm`, `chat/completions`, or `v1`; or keywords like "OpenAI-compatible", "LLM proxy", "chat completions"), do NOT create an ad-hoc connection. Instead, tell the user to use the **OpenAI** reference connection, which already supports custom endpoints via the `OpenAI:Endpoint` secret. Stop and suggest using the `/ivy-create-using-reference-connection` skill with "OpenAI" as the provider.
+
+## Step 2: Clarify the Target API
+
+3. Is it clear what API or service the connection is for? If not, ask the user to clarify. Ask for a link to the API documentation or the name of the service. Some services have multiple APIs (e.g. Stripe has payments, billing, customers). If so, clarify which API and reflect this in the connection name.
+
+4. Determine a name for the connection. This is usually the service name in PascalCase, like "Stripe" or "GitHub". Ask the user to confirm the name.
+
+5. Create the connection directory using the pattern `Connections/[ConnectionName]/` inside the user's project directory.
+
+Expected directory structure after this skill completes:
+
+```
+[UserProject]/
+├── [UserProject].csproj
+├── Program.cs
+├── Connections/
+│   └── [ConnectionName]/
+│       ├── [ConnectionName]Connection.cs
+│       ├── [ConnectionName]ConnectionTests.cs
+│       └── (OpenAPI only: ClientFactory, .refitter, Refresh.ps1, generated client)
+│       └── (Custom only: [ConnectionName]Client.cs)
+└── Apps/
+    └── [ConnectionName]App.cs
+```
+
+## Step 3: Choose an Approach
+
+6. Try to find a good NuGet package that implements the API.
+
+**GOOD indicators:**
+- Lots of downloads
+- Recently updated
+- Permissive license (MIT, Apache-2.0, BSD, ISC, etc.)
+- Good documentation
+- Official, created by the service itself
+
+**BAD indicators:**
+- Few downloads
+- Not updated in a long time
+- Restrictive license (GPL, etc.)
+- No documentation
+- Not official, created by a third party
+
+**Notes:**
+- For anything related to LLM model inference, prefer packages that provide an `IChatClient` adapter via `Microsoft.Extensions.AI`. It is fine to also register the provider-specific client (e.g. `AnthropicClient`) -- but always register `IChatClient` as well if possible, since it gives a unified chat interface across all LLM connections.
+
+Given these parameters, present the user a list of potential NuGets. The strategy for choosing the connection approach (in priority order):
+
+1. **NuGet package** -- if a good NuGet exists, proceed to the "NuGet Approach" section
+2. **OpenAPI/Swagger spec** -- if no good NuGet exists but the API has an official OpenAPI spec, use Refitter to generate a typed client. Proceed to the "OpenAPI / Refitter Approach" section
+3. **Custom client** -- as a last resort, if there is no NuGet and no OpenAPI spec, generate a custom HTTP client from the API documentation. Proceed to the "Custom HTTP Client Approach" section
+
+Consult with the user on which approach to take if not clear.
+
+---
+
+## NuGet Approach
+
+### Add the NuGet package
+
+7. Add the selected NuGet package(s) to the project using the dotnet CLI:
+
+```bash
+dotnet add package [PackageName]
+```
+
+### Create the Connection class
+
+8. Create `Connections/[ConnectionName]/[ConnectionName]Connection.cs` implementing `IConnection` and `IHaveSecrets`.
+
+The connection class must follow this pattern:
+
+```csharp
+using Ivy;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace [ProjectNamespace].Connections.[ConnectionName];
+
+public class [ConnectionName]Connection : IConnection, IHaveSecrets
+{
+    public string GetContext(string connectionPath) => """
+        # [ConnectionName] Connection
+
+        ## Getting the service
+
+        ```csharp
+        var client = UseService<[ServiceType]>();
+        ```
+
+        ## Common Usage
+
+        // Include 2-3 of the most common usage examples with code snippets
+        // Show how to call the most important methods
+        // Include information about response types and error handling
+        """;
+
+    public string GetNamespace() => typeof([ConnectionName]Connection).Namespace!;
+
+    public string GetName() => "[ConnectionName]";
+
+    public string GetConnectionType() => "Nuget:[PackageId]";
+
+    public ConnectionEntity[] GetEntities() =>
+    [
+        // List the main entities this API exposes
+        // e.g. new("Message", "Messages"),
+    ];
+
+    public void RegisterServices(Server server)
+    {
+        server.Services.AddSingleton(sp =>
+        {
+            var config = sp.GetRequiredService<IConfiguration>();
+            var apiKey = config["[ConnectionName]:ApiKey"] ?? "";
+            // Create and return the API client
+        });
+
+        // For LLM connections, also register IChatClient:
+        // server.Services.AddSingleton<IChatClient>(sp => { ... });
+    }
+
+    public async Task<(bool ok, string? message)> TestConnection(IConfiguration config)
+    {
+        try
+        {
+            var apiKey = config["[ConnectionName]:ApiKey"];
+            if (string.IsNullOrEmpty(apiKey))
+                return (false, "[ConnectionName]:ApiKey is not configured. Please set your API key in user secrets.");
+
+            // Create a client and call a lightweight read-only endpoint
+            return (true, "Connected successfully.");
+        }
+        catch (Exception ex)
+        {
+            return (false, $"Connection test failed: {ex.Message}");
+        }
+    }
+
+    public Secret[] GetSecrets() => [new Secret("[ConnectionName]:ApiKey")];
+    // If the user provided a value, use: new Secret("[ConnectionName]:ApiKey", "user-provided-value")
+}
+```
+
+- Some connections need multiple secrets. Use appropriate names.
+
+### Set up secrets
+
+9. Determine what secrets are needed to connect to the API. For example: API key, bearer token, client ID/secret, endpoint URL, etc. Ask the user what credentials the API requires if not clear from documentation.
+
+10. Initialize user secrets for the project (idempotent if already initialized):
+
+```bash
+dotnet user-secrets init
+```
+
+> **Note:** If the user provided specific credential values in their prompt (API keys, tokens, endpoints), set them as `Preset` values in `GetSecrets()`: `new Secret("Key", "user-provided-value")`. This ensures the connection works immediately without manual secret configuration.
+
+11. Make sure the connection class's `GetSecrets()` method returns all secret keys, and `RegisterServices()` reads them from `IConfiguration`.
+
+After completing the NuGet approach, proceed to the Verification section.
+
+---
+
+## OpenAPI / Refitter Approach
+
+No suitable NuGet package was found, but the API has an official OpenAPI/Swagger specification. Use **Refitter** to generate a strongly-typed C# client from the spec.
+
+### Find the OpenAPI spec
+
+7. Search for the official OpenAPI/Swagger spec URL for the API. Common locations:
+   - `https://api.example.com/openapi.json`
+   - `https://api.example.com/swagger.json`
+   - `https://api.example.com/v1/openapi.yaml`
+   - The API documentation site often links to it
+   - GitHub repositories may contain the spec file
+
+Validate that the URL returns a valid OpenAPI 2.0/3.0/3.1 spec (JSON or YAML). Ask the user to confirm the spec URL.
+
+### Determine authentication
+
+8. What authentication scheme does the API use?
+   - **Bearer token** (`Authorization: Bearer <token>`) -- most common for modern APIs
+   - **API key header** (e.g. `X-Api-Key: <key>`) -- common for simpler APIs
+
+Note the auth scheme type (`bearer` or `apikey`) and the header name (e.g. `Authorization` or `X-Api-Key`).
+
+### Set up secrets
+
+9. Initialize user secrets for the project (idempotent if already initialized):
+
+```bash
+dotnet user-secrets init
+```
+
+> **Note:** If the user provided specific credential values in their prompt (API keys, tokens, endpoints), set them as `Preset` values in `GetSecrets()`: `new Secret("Key", "user-provided-value")`. This ensures the connection works immediately without manual secret configuration.
+
+### Install Refitter and Refit
+
+10. Ensure the Refitter dotnet tool is installed globally:
+
+```bash
+dotnet tool install --global refitter
+```
+
+11. Add the Refit NuGet package to the project:
+
+```bash
+dotnet add package Refit
+```
+
+### Create the .refitter configuration
+
+12. Create the file `Connections/[ConnectionName]/[ConnectionName].refitter` with smart defaults:
+
+```json
+{
+    "openApiPath": "<OpenAPI spec URL>",
+    "namespace": "[ProjectNamespace].Connections.[ConnectionName]",
+    "outputFilename": "<absolute path to Connections/[ConnectionName]/[ConnectionName]Client.cs>",
+    "naming": {
+        "useOpenApiTitle": false,
+        "interfaceName": "[ConnectionName]Client"
+    },
+    "immutableRecords": false,
+    "operationNameGenerator": "SingleClientFromPathSegments",
+    "optionalParameters": true,
+    "addAutoGeneratedHeader": false,
+    "generateXmlDocCodeComments": false,
+    "generateStatusCodeComments": false,
+    "codeGeneratorSettings": {
+        "generateOptionalPropertiesAsNullable": true,
+        "generateNullableReferenceTypes": true
+    }
+}
+```
+
+Key settings explained:
+- `operationNameGenerator: "SingleClientFromPathSegments"` -- generates a single interface with method names derived from URL path segments instead of operationIds (cleaner names)
+- `optionalParameters: true` -- optional query params become C# optional parameters with defaults
+- `immutableRecords: false` -- generates mutable classes (safer for serialization)
+- `generateNullableReferenceTypes: true` -- respects nullable reference types
+- `interfaceName` -- omits the `I` prefix; Refitter adds it automatically, producing `I[ConnectionName]Client`
+
+### Generate the client
+
+13. Run refitter to generate the C# client from the OpenAPI spec:
+
+```bash
+refitter --settings-file "Connections/[ConnectionName]/[ConnectionName].refitter" --skip-validation --no-banner
+```
+
+This generates `[ConnectionName]Client.cs` containing the `I[ConnectionName]Client` Refit interface with all API methods.
+
+14. Verify the generated file exists and contains the expected interface. If generation fails, check that:
+   - The OpenAPI spec URL is accessible
+   - The spec is valid (the `--skip-validation` flag is already used)
+   - The output path is correct
+
+### Create Refresh.ps1
+
+15. Create `Connections/[ConnectionName]/Refresh.ps1` so the client can be regenerated when the API spec changes:
+
+```powershell
+# Regenerates the [ConnectionName] API client from the OpenAPI spec.
+# Run this script when the API spec has been updated.
+#
+# Prerequisites: dotnet tool install --global refitter
+
+$ErrorActionPreference = "Stop"
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$settingsFile = Join-Path $scriptDir "[ConnectionName].refitter"
+
+Write-Host "Regenerating [ConnectionName] client from OpenAPI spec..." -ForegroundColor Cyan
+refitter --settings-file $settingsFile --skip-validation --no-banner
+
+if ($LASTEXITCODE -eq 0) {
+    Write-Host "Client regenerated successfully." -ForegroundColor Green
+} else {
+    Write-Host "Refitter failed with exit code $LASTEXITCODE." -ForegroundColor Red
+    exit $LASTEXITCODE
+}
+```
+
+### Create the ClientFactory
+
+16. Create `Connections/[ConnectionName]/[ConnectionName]ClientFactory.cs`. This class reads credentials from configuration and creates an authenticated Refit client:
+
+```csharp
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Refit;
+
+namespace [ProjectNamespace].Connections.[ConnectionName];
+
+public static class [ConnectionName]ClientFactory
+{
+    private class [ConnectionName]AuthHandler : DelegatingHandler
+    {
+        private readonly string _token;
+        private readonly string _headerName;
+        private readonly bool _isBearer;
+
+        public [ConnectionName]AuthHandler(string token, string headerName, bool isBearer)
+        {
+            _token = token;
+            _headerName = headerName;
+            _isBearer = isBearer;
+            InnerHandler = new HttpClientHandler();
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (_isBearer)
+                request.Headers.Add(_headerName, $"Bearer {_token}");
+            else
+                request.Headers.Add(_headerName, _token);
+            return base.SendAsync(request, cancellationToken);
+        }
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase, allowIntegerValues: true) },
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        NumberHandling = JsonNumberHandling.AllowReadingFromString,
+    };
+
+    public static I[ConnectionName]Client CreateClient()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddEnvironmentVariables()
+            .AddUserSecrets(typeof([ConnectionName]ClientFactory).Assembly)
+            .Build();
+
+        var endpointUrl = configuration.GetValue<string>("[ConnectionName]:EndpointUrl")
+            ?? throw new Exception("[ConnectionName]:EndpointUrl is required");
+        var token = configuration.GetValue<string>("[ConnectionName]:BearerToken")  // or [ConnectionName]:ApiKey
+            ?? throw new Exception("[ConnectionName]:BearerToken is required");
+
+        return CreateClient(endpointUrl, token);
+    }
+
+    public static I[ConnectionName]Client CreateClient(string endpointUrl, string token)
+    {
+        return RestService.For<I[ConnectionName]Client>(endpointUrl, new RefitSettings
+        {
+            HttpMessageHandlerFactory = () => new [ConnectionName]AuthHandler(token, "Authorization", true),
+            // For API key auth: new [ConnectionName]AuthHandler(token, "X-Api-Key", false)
+            ContentSerializer = new SystemTextJsonContentSerializer(JsonOptions)
+        });
+    }
+}
+```
+
+### Create the Connection class
+
+17. Create `Connections/[ConnectionName]/[ConnectionName]Connection.cs` implementing `IConnection` and `IHaveSecrets`:
+
+```csharp
+using System.Reflection;
+using Ivy;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace [ProjectNamespace].Connections.[ConnectionName];
+
+public class [ConnectionName]Connection : IConnection, IHaveSecrets
+{
+    public string GetContext(string connectionPath)
+    {
+        var connectionFile = nameof([ConnectionName]Connection) + ".cs";
+        var clientFactoryFile = nameof([ConnectionName]ClientFactory) + ".cs";
+        var files = Directory.GetFiles(connectionPath, "*.*", SearchOption.TopDirectoryOnly)
+            .Where(f => !f.EndsWith(connectionFile) && !f.EndsWith(clientFactoryFile))
+            .Select(File.ReadAllText)
+            .ToArray();
+        return string.Join(Environment.NewLine, files);
+    }
+
+    public string GetNamespace() => typeof([ConnectionName]Connection).Namespace!;
+
+    public string GetName() => "[ConnectionName]";
+
+    public string GetConnectionType() => "OpenApi.Rest";
+
+    public ConnectionEntity[] GetEntities()
+    {
+        var clientType = typeof(I[ConnectionName]Client);
+        var methods = clientType.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+        return methods.Select(m => new ConnectionEntity(m.Name, m.Name)).ToArray();
+    }
+
+    public void RegisterServices(Server server)
+    {
+        server.Services.AddTransient<I[ConnectionName]Client>(_ => [ConnectionName]ClientFactory.CreateClient());
+    }
+
+    public Secret[] GetSecrets() =>
+    [
+        new Secret("[ConnectionName]:EndpointUrl"),
+        new Secret("[ConnectionName]:BearerToken"),  // or [ConnectionName]:ApiKey
+    ];
+
+    public async Task<(bool ok, string? message)> TestConnection(IConfiguration config)
+    {
+        try
+        {
+            var token = config["[ConnectionName]:BearerToken"];  // or [ConnectionName]:ApiKey
+            if (string.IsNullOrEmpty(token))
+                return (false, "[ConnectionName]:BearerToken is not configured. Please set your API token in user secrets.");
+
+            var client = [ConnectionName]ClientFactory.CreateClient();
+            // Call a lightweight read-only endpoint to verify connectivity
+            return (true, "Connected successfully.");
+        }
+        catch (Exception ex)
+        {
+            return (false, $"Connection test failed: {ex.Message}");
+        }
+    }
+}
+```
+
+After completing the OpenAPI approach, proceed to the Verification section.
+
+---
+
+## Custom HTTP Client Approach
+
+No suitable NuGet package was found and there is no official OpenAPI/Swagger specification available. As a last resort, generate a custom C# HTTP client based on the API documentation.
+
+### Research the API
+
+7. Find and read the official API documentation. Identify:
+   - Base URL and versioning scheme (e.g. `https://api.example.com/v1`)
+   - Authentication method (Bearer token, API key header, query parameter, etc.)
+   - The most important endpoints (focus on 5-10 core read-only endpoints first)
+   - Request/response formats (usually JSON)
+   - Rate limiting and pagination patterns
+   - Error response format
+
+8. Ask the user to confirm which endpoints are most important for their use case.
+
+### Set up secrets
+
+9. Determine what authentication the API requires. Note the auth type and header name.
+
+10. Initialize user secrets for the project (idempotent if already initialized):
+
+```bash
+dotnet user-secrets init
+```
+
+> **Note:** If the user provided specific credential values in their prompt (API keys, tokens, endpoints), set them as `Preset` values in `GetSecrets()`: `new Secret("Key", "user-provided-value")`. This ensures the connection works immediately without manual secret configuration.
+
+### Generate the custom client
+
+11. Create `Connections/[ConnectionName]/[ConnectionName]Client.cs` with a clean, typed HTTP client. Follow these guidelines:
+
+**Client structure:**
+
+```csharp
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace [ProjectNamespace].Connections.[ConnectionName];
+
+public interface I[ConnectionName]Client
+{
+    // One method per endpoint, grouped logically
+    Task<ListResponse<Item>> GetItemsAsync(int? page = null, int? pageSize = null, CancellationToken ct = default);
+    Task<Item> GetItemByIdAsync(string id, CancellationToken ct = default);
+    // ... more endpoints
+}
+
+public class [ConnectionName]Client : I[ConnectionName]Client
+{
+    private readonly HttpClient _http;
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    public [ConnectionName]Client(HttpClient http)
+    {
+        _http = http;
+    }
+
+    public async Task<ListResponse<Item>> GetItemsAsync(int? page = null, int? pageSize = null, CancellationToken ct = default)
+    {
+        var query = new List<string>();
+        if (page.HasValue) query.Add($"page={page}");
+        if (pageSize.HasValue) query.Add($"page_size={pageSize}");
+        var qs = query.Count > 0 ? "?" + string.Join("&", query) : "";
+
+        var response = await _http.GetAsync($"/items{qs}", ct);
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<ListResponse<Item>>(JsonOptions, ct))!;
+    }
+
+    // ... more endpoint implementations
+}
+```
+
+**Guidelines for a good custom client:**
+- Define an `I[ConnectionName]Client` interface so it can be mocked in tests and registered with DI
+- Use `System.Net.Http.Json` for JSON serialization (no external dependencies)
+- Use `System.Text.Json` with `CamelCase` naming policy and `WhenWritingNull` for clean payloads
+- Make all methods async with `CancellationToken` support
+- Use optional parameters for query string params (pagination, filters, sorting)
+- Create typed C# records/classes for request/response models -- match the API's JSON structure
+- Use `record` types for response models (immutable, concise)
+- Handle pagination patterns (offset/limit, cursor-based, page-based) consistently
+- Only implement read-only endpoints first; add write endpoints if specifically needed
+
+**Response model patterns:**
+
+```csharp
+// For paginated list responses
+public record ListResponse<T>(
+    [property: JsonPropertyName("data")] T[] Data,
+    [property: JsonPropertyName("total")] int Total,
+    [property: JsonPropertyName("has_more")] bool HasMore
+);
+
+// For individual resource models
+public record Item(
+    [property: JsonPropertyName("id")] string Id,
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("created_at")] DateTimeOffset CreatedAt
+);
+```
+
+### Create the Connection class
+
+12. Create `Connections/[ConnectionName]/[ConnectionName]Connection.cs` implementing `IConnection` and `IHaveSecrets`:
+
+```csharp
+using Ivy;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace [ProjectNamespace].Connections.[ConnectionName];
+
+public class [ConnectionName]Connection : IConnection, IHaveSecrets
+{
+    public string GetName() => "[ConnectionName]";
+    public string GetNamespace() => typeof([ConnectionName]Connection).Namespace!;
+    public string GetConnectionType() => "Custom";
+
+    public void RegisterServices(Server server)
+    {
+        server.Services.AddTransient<I[ConnectionName]Client>(sp =>
+        {
+            var config = sp.GetRequiredService<IConfiguration>();
+            var baseUrl = config["[ConnectionName]:BaseUrl"]
+                ?? throw new Exception("[ConnectionName]:BaseUrl is required");
+            var apiKey = config["[ConnectionName]:ApiKey"]
+                ?? throw new Exception("[ConnectionName]:ApiKey is required");
+
+            var http = new HttpClient
+            {
+                BaseAddress = new Uri(baseUrl)
+            };
+            http.DefaultRequestHeaders.Add("Authorization", $"Bearer {apiKey}");
+            // OR: http.DefaultRequestHeaders.Add("X-Api-Key", apiKey);
+
+            return new [ConnectionName]Client(http);
+        });
+    }
+
+    public Secret[] GetSecrets() =>
+    [
+        new Secret("[ConnectionName]:BaseUrl"),
+        new Secret("[ConnectionName]:ApiKey"),
+        // If the user provided values, use: new Secret("[ConnectionName]:ApiKey", "user-provided-value")
+    ];
+
+    public string GetContext(string connectionPath)
+    {
+        return """
+            ## [ConnectionName] API Client
+
+            Get the client:
+            ```csharp
+            var client = UseService<I[ConnectionName]Client>();
+            ```
+
+            // Include 2-3 of the most common usage examples
+            // Show how to call the most important methods
+            """;
+    }
+
+    public ConnectionEntity[] GetEntities() =>
+    [
+        // Fill based on API resources
+    ];
+
+    public async Task<(bool ok, string? message)> TestConnection(IConfiguration config)
+    {
+        try
+        {
+            var baseUrl = config["[ConnectionName]:BaseUrl"];
+            var apiKey = config["[ConnectionName]:ApiKey"];
+            if (string.IsNullOrEmpty(baseUrl) || string.IsNullOrEmpty(apiKey))
+                return (false, "[ConnectionName] secrets are not configured. Please set BaseUrl and ApiKey in user secrets.");
+
+            // Create a client and call a lightweight read-only endpoint
+            return (true, "Connected successfully.");
+        }
+        catch (Exception ex)
+        {
+            return (false, $"Connection test failed: {ex.Message}");
+        }
+    }
+}
+```
+
+After completing the Custom approach, proceed to the Verification section.
+
+---
+
+## Verification
+
+This section applies regardless of which approach was used above.
+
+18. Run `dotnet build` to verify everything compiles. Fix any errors.
+
+19. Test the connection by running `dotnet build` to verify compilation, then manually test by running the project with `dotnet run`. If the test fails, investigate and fix the issue. Common causes: missing or incorrect secrets, wrong API endpoint, network issues.
+
+20. If the project is in a git repository, create a commit with a descriptive message summarizing what was added. For example: "Add [ConnectionName] connection with [approach] client".
+
+21. Present a summary to the user:
+    - Connection name and approach used (NuGet / OpenAPI / Custom)
+    - Files created (list each file)
+    - Secrets configured (list each secret key, not the values)
+    - Demo apps created
+    - Next steps: how to use the connection in their Ivy apps via `UseService<T>()`

--- a/src/skills/ivy-create-app/SKILL.md
+++ b/src/skills/ivy-create-app/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: ivy-create-app
+description: >
+  Create a custom Ivy app with any combination of views. Use when the user asks for
+  an app that is not a standard dashboard or CRUD screen -- chat interfaces, tools,
+  custom layouts, SOAP/WSDL integrations, streaming UIs, wizards, or any bespoke
+  application. Handles layout composition, connections, streaming chat with IChatClient,
+  and custom view hierarchies.
+allowed-tools: Bash(dotnet:*) Read Write Edit Glob Grep
+effort: high
+argument-hint: "[description of the app to create]"
+---
+
+# ivy-create-app
+
+Create an ad hoc Ivy app with any combination of views.
+
+## Reference Files
+
+Read these before implementing:
+- [references/AGENTS.md](references/AGENTS.md) -- Ivy framework API reference (widgets, hooks, layouts, inputs, colors)
+- [references/ChatApp.cs](references/ChatApp.cs) -- streaming chat app with IChatClient, ImmutableArray messages
+- [references/OpenAIConnection.cs](references/OpenAIConnection.cs) -- IConnection implementation for external services
+- [references/DesignGuidelines.md](references/DesignGuidelines.md) -- layout patterns, spacing, UX interaction rules
+
+## Workflow
+
+This skill guides you through creating custom Ivy applications:
+
+1. **Plan** - Understand the user's request and design the app structure
+2. **Review** - Present the plan for user approval (accept / request changes / cancel)
+3. **Implement** - Generate all app files following reference patterns
+
+## Step 1: Plan the App
+
+If the app requires data from a database, use `ivy cli explain connections/{ConnectionName}` to get the connection schema first.
+
+If the user's prompt includes a `.wsdl` URL or mentions SOAP/WSDL, the app MUST use a SOAP connection (`IConnection`) rather than hardcoding HTTP calls. Any external service access must go through an `IConnection` implementation.
+
+### Analysis
+
+- Determine what views and components the app needs.
+- **Multiple entities = multiple apps.** If the request involves distinct data entities (e.g., Contacts, Deals, Activities), plan a **separate app for each entity** rather than combining them into tabs within a single app. A Dashboard app may reference data from multiple entities, but each entity's CRUD/management screen should be its own app.
+- **TabsLayout** is for showing different views or aspects of the **same** data (e.g., chart vs. table view, settings categories, wizard steps) -- not for combining unrelated entity screens.
+- Choose a Lucide icon for the app (PascalCase, e.g. `ShoppingBag`, `LayoutDashboard`, `FileText`, `Users`).
+
+### Plan Format
+
+```
+# Plan
+
+## Create App: [AppName]
+
+**Connection**: `[ConnectionName or "None"]`
+**App Attribute**: `[App(icon: Icons.[LucideIcon])]`
+**Note**: The `group` parameter defaults to `["Apps"]` at runtime. Only specify `group` explicitly when assigning the app to a different group (e.g., `group: ["Tools"]`, `group: ["Settings"]`).
+**Layout**: `[Blades / Dashboard / Custom]`
+**Chrome**: `[UseAppShell / UseDefaultApp]`
+**Files**: `Apps\[AppName]App.cs`
+**Namespace**: `{ProjectNamespace}.Apps`
+
+[Description of the app entry point and layout.]
+
+### Create View: [ViewName]
+
+**Files**: `Apps\[AppFolder]\[ViewName].cs`
+**Namespace**: `{ProjectNamespace}.Apps.[AppFolder]`
+
+[Description of what this view does, what data it shows, what interactions it supports.]
+```
+
+### Chrome Decision
+- If the app has **only one app class** and no multi-app navigation needs, set Chrome to `UseDefaultApp`. This skips the sidebar.
+- If the app has **multiple app classes** or the user explicitly wants sidebar navigation, set Chrome to `UseAppShell`.
+- Include a `### Update Program.cs` section at the end of the plan.
+
+### Data File Ordering
+If the plan includes files with large static datasets (lookup tables, seed data, icon/emoji lists, etc.):
+- These files should be created **last**, after all UI and logic files.
+- Prefer programmatic generation or embedded resources over inlined literals.
+
+Present the plan to the user and ask them to **Accept**, **Request Changes**, or **Cancel**.
+
+## Step 2: Handle Changes
+
+If the user requests changes, apply them to the plan and present the updated plan again.
+
+## Step 3: Implement
+
+Once approved, implement all app files.
+
+### Namespace Conventions
+- App files (`[AppName]App.cs`): `namespace {ProjectNamespace}.Apps;`
+- View files: `namespace {ProjectNamespace}.Apps.[AppFolder];`
+
+### Required Using Directives
+
+Every generated `.cs` file must include explicit `using` statements. Do NOT rely on global usings.
+
+**Connection usings (when using a database connection):**
+- `using {ProjectNamespace}.Connections.{ConnectionName};` -- for context factory
+- `using {ProjectNamespace}.Connections.{ConnectionName}.Models;` -- for entity classes (only if project uses a Models subfolder)
+- `using Microsoft.EntityFrameworkCore;` -- for LINQ extensions
+
+**Common Ivy usings by view type:**
+
+| View Type | Required Namespaces |
+|---|---|
+| All views | `Ivy`, `Ivy.Core.Hooks`, `Ivy.Hooks`, `Ivy.Shared`, `Ivy.Views` |
+| App entry point | + `Ivy.Apps` |
+| Blades | + `Ivy.Views.Blades` |
+| Details views | + `Ivy.Views.Builders` |
+| Forms (dialogs, sheets) | + `Ivy.Views.Forms`, `System.ComponentModel.DataAnnotations` |
+| Tables | + `Ivy.Views.Tables` |
+| Alerts/Callouts | + `Ivy.Views.Alerts` |
+| Async select inputs | + `Ivy.Widgets.Inputs` |
+| Charts | + `Ivy.Views.Charts` |
+| Metrics/Dashboard | + `Ivy.Views.Dashboards` |
+
+### App Entry Point
+
+Use `[App(icon: Icons.[Icon], group: ["Apps"])]` attribute. The icon and group are parameters **inside** the `[App(...)]` attribute -- they are NOT separate attributes.
+
+Common Hallucinations -- Do NOT Use:
+- **`[Icon("...")]`** -- NOT a valid Ivy attribute
+- **`[Group("...")]`** -- NOT a valid Ivy attribute
+- **`[Description("...")]`** -- NOT a valid Ivy attribute
+- All metadata belongs as named parameters on the single `[App(...)]` attribute
+
+### App Attribute - Group Parameter
+
+The `[App]` attribute's `group` parameter is nullable and has a runtime default value of `["Apps"]`.
+- Omit the `group` parameter when using the default "Apps" group
+- Explicitly specify `group` only for non-default groups
+- **CRITICAL**: When a specification explicitly defines a non-default `group` value, you MUST include it in the implementation
+
+### Program.cs Chrome Configuration
+- If `UseDefaultApp`: Open `Program.cs` and **remove** the `server.UseAppShell(...)` line entirely, then add `server.UseDefaultApp(typeof(AppClassName));`. Do NOT keep both.
+- If `UseAppShell`: Ensure `server.UseAppShell(new AppShellSettings().DefaultApp<AppClassName>().UseTabs(preventDuplicates: true));` is present.
+- Follow the approved plan exactly.
+
+### Critical Code Rules
+- Use modern C# features: file-scoped namespaces, primary constructors, collection expressions.
+- Write UI, logic, and app entry-point files **before** any data/seed files.
+- If a file will contain >50 static records, prefer programmatic generation or embedded JSON resources over inline C# arrays.
+
+### When NOT to Use Html Widget
+- Do NOT use the `Html` widget to build interactive canvases, drawing surfaces, or diagram editors. The `Html` widget renders static HTML -- it cannot handle click/drag events on individual elements within the HTML.
+- Simple HTML usage for display purposes is fine.
+- If the user needs interactive canvas, drawing, or diagram functionality, recommend using the `/ivy-create-external-widget` skill to create a React-based external widget instead.
+
+### Pattern Sources
+- Use ONLY the reference documents in the `references/` folder and `ivy docs` / `ivy ask` for API patterns and code examples.
+- Do NOT read existing app files in the project's `Apps/` directory for patterns.
+
+### After Implementation
+After writing all files, summarize what was created and verify the build succeeds.
+
+## Reference: Design Guidelines
+
+### Page Layout
+
+**Centered Max-Width (default):**
+```csharp
+return Layout.TopCenter()
+    | (Layout.Vertical().Width(Size.Full().Max(200)).Margin(10)
+        | content);
+```
+- Always use `Layout.TopCenter()` -- without it, content hugs left edge.
+
+**Full Center (rare):**
+```csharp
+return Layout.Center()
+    | (Layout.Vertical().Gap(2) | urlInput | submitButton);
+```
+Reserve for truly minimal UIs (login, empty state, single action).
+
+**Full-Width Panels (editor + preview):**
+```csharp
+return Layout.TopCenter()
+    | (Layout.Vertical().Width(Size.Full().Max(300)).Margin(10)
+        | Text.H1("Title")
+        | (Layout.Horizontal().Gap(6)
+            | (Layout.Vertical().Width(Size.Full()) | leftPanel)
+            | (Layout.Vertical().Width(Size.Full()) | rightPanel)));
+```
+
+### Visual Hierarchy & Spacing
+- Use `new Separator()` between major sections
+- Gap default is 4 -- do NOT add `.Gap(4)`
+- Padding is rarely needed
+
+### Inputs & Validation
+Use `.WithField().Label()` -- never call `.Label()` directly:
+```csharp
+nameState.ToTextInput().WithField().Label("Name");
+```
+
+### MetricView for KPIs
+```csharp
+new MetricView("Sales", Icons.DollarSign,
+    ctx => ctx.UseQuery("sales", () => Task.FromResult(new MetricRecord("$84.3K", 0.21, 0.21, "$400K"))))
+```
+
+### UX Interaction
+- **Toast after actions:** `client.Toast($"{item.Name} added!");`
+- **Confirm destructive actions:** Use `.WithConfirm()`
+- **Empty states:** Show guidance toward first action, not blank area

--- a/src/skills/ivy-create-app/references/AGENTS.md
+++ b/src/skills/ivy-create-app/references/AGENTS.md
@@ -1,0 +1,350 @@
+﻿# Introduction to the Ivy Framework for LLMs
+
+- Ivy is a declarative full-stack UI framework that allows developers to build user interfaces using a component-based approach very similar to React.
+- In Ivy, you only write one application in pure C# and we don't have a BE and FE distinction.
+- UI rendering is handled by Ivy.
+- When programming in Ivy you focus on building the logical structure of your application using a large set of pre-built widgets and views - you rarely need to specify any styling - Ivy just makes it look good by default.
+
+Terminology:
+
+- "Views" are the main building blocks of the UI, similar to React components.
+- "Hooks" are functions that allow views to manage state and side effects.
+- "Widgets" are the UI elements that make up the views. e.g., Button, TextBlock, StackPanel...
+- "Apps" are the top-level views that represent entire applications.
+
+A view is defined as a class that inherits from `ViewBase` and implements a `Build` method. The `Build` method returns either another view or a widget.
+
+> WARNING: There is NO `AppBase` class. ALL views and apps inherit from `ViewBase`.
+
+Widgets can have multiple children, but views can only return a single object (widget or view). To return multiple widgets from a view, you can use a `Fragment` use the Layout helpers. See below.
+
+public class MyView : ViewBase
+{
+  public override object? Build()
+  {
+    var count = UseState(0);
+    return Layout.Vertical()
+        | new Text($"Count: {count.Value}")
+        | new Button("Increment", () => count.Set(count.Value + 1));
+  }
+}
+
+The topmost view in an Ivy application is called an [App](https://docs.ivy.app/onboarding/concepts/apps.md) and is decorated with the `[App]` attribute. The attribute uses **named constructor parameters** (lowercase):
+
+[App(title: "Customers", icon: Icons.Rocket, group: new[] { "CRM" })]
+public class CustomersApp : ViewBase
+
+- `title` is optional — if omitted, it is derived from the class name (e.g. `CustomersApp` → "Customers").
+- `icon` uses the `Icons` enum — these are Lucide icons in PascalCase (e.g. `Icons.Link`, `Icons.Settings`, `Icons.Rocket`).
+- `group` groups the app in the navigation sidebar (e.g. `group: new[] { "Apps" }`).
+- There is no `chrome` parameter. Chrome is configured in `Program.cs` via `server.UseDefaultApp(typeof(MyApp))`. Always ensure `server.AddAppsFromAssembly()` is called before `UseDefaultApp` — without it, `[App]`-attributed classes are not registered and the server throws at runtime.
+- Use **lowercase** parameter names (`icon:`, `group:`), NOT PascalCase property names (`Icon =`, `Group =`) — PascalCase causes CS0655.
+
+An app is built into a tree of widgets. This is what's rendered to the screen.
+
+## Application Structure
+
+A typical Ivy project has this folder structure:
+
+MyProject/
+├── Program.cs                  # Entry point — configures and starts the Ivy server
+├── MyProject.csproj            # Project file
+├── Apps/                       # All app classes go here (convention)
+│   ├── DashboardApp.cs
+│   └── Settings/               # Subfolder namespaces become URL path segments
+│       └── UserProfileApp.cs   # → /settings/user-profile
+└── Connections/
+    └── MyDb/
+        ├── MyDbContext.cs
+        ├── MyDbContextFactory.cs
+        ├── MyDbConnection.cs
+        └── Product.cs          # Entity classes
+
+### Dependency Injection
+
+Register services in Program.cs, consume them in views with `UseService<T>()`:
+
+// Program.cs
+server.Services.AddSingleton<IMyService, MyService>();
+
+// In a view
+var myService = UseService<IMyService>();
+
+## Common Widgets
+
+[Button](https://docs.ivy.app/widgets/common/button.md)
+[Card](https://docs.ivy.app/widgets/common/card.md)
+[Badge](https://docs.ivy.app/widgets/common/badge.md)
+[Sheet](https://docs.ivy.app/widgets/advanced/sheet.md)
+[Progress](https://docs.ivy.app/widgets/common/progress.md)
+[Expandable](https://docs.ivy.app/widgets/common/expandable.md)
+[Tooltip](https://docs.ivy.app/widgets/common/tooltip.md)
+[DropDownMenu](https://docs.ivy.app/widgets/common/drop-down-menu.md)
+[Table](https://docs.ivy.app/widgets/common/table.md)
+[List](https://docs.ivy.app/widgets/common/list.md)
+[Details](https://docs.ivy.app/widgets/common/details.md)
+[Image](https://docs.ivy.app/widgets/primitives/image.md)
+[Avatar](https://docs.ivy.app/widgets/primitives/avatar.md)
+[Spacer](https://docs.ivy.app/widgets/primitives/spacer.md)
+[Callout](https://docs.ivy.app/widgets/primitives/callout.md)
+
+## Layouts
+
+- Use Layout.Vertical() or Layout.Horizontal() to create stack layouts.
+- Layout.Grid()
+— Layout.Wrap()
+- Add Children: Pipe child elements using the | operator to arrange them top-to-bottom (vertical) or left-to-right (horizontal).
+- Layouts can be customized with methods like .Gap(int number) to set spacing between children. Use .Left(), .Center(), or .Right() methods to control alignment.
+- The number in Gap(int number) works the same as in Tailwind CSS spacing scale (e.g., 1 = 0.25rem, 2 = 0.5rem, etc.).
+- Layouts have a default gap of 4 (1rem). Do NOT add `.Gap(4)` — it is the default and adds unnecessary noise. Only use `.Gap()` when you need a value other than 4.
+- `.Padding()` is rarely needed. Layouts and pages already have appropriate padding by default. Only add `.Padding()` when you need extra inner spacing for a specific design reason.
+
+// Basic Vertical Layout
+Layout.Vertical()
+    | new Badge("Top")
+    | new Badge("Middle")
+    | new Badge("Bottom");
+
+// Nested layouts with alignment
+Layout.Vertical().AlignContent(Align.Center)
+    | Text.Label("Header")
+    | (Layout.Horizontal()
+        | new Button("Previous")
+        | new Button("Next")); //NOTE: Parentheses are used to group the horizontal layout - THIS IS REQUIRED
+
+Grids:
+
+Layout.Grid()
+  .Columns(2)
+  .Rows(2)
+    | Text.Block("Cell 1")
+    | Text.Block("Cell 2")
+    ...
+
+Align values: TopLeft, TopCenter, TopRight, Left, Center, Right, BottomLeft, BottomCenter, BottomRight, Stretch
+
+[Layouts](https://docs.ivy.app/onboarding/concepts/layout.md)
+
+## Text
+
+The Text helper utility is used to create various semantic text elements.
+
+- Text.H1, Text.H2, : For headings.
+- Text.Lead: For prominent introductory text.
+- Text.P: For standard paragraphs.
+- Text.Block: For block-level content (e.g., list items).
+- Text.InlineCode: For displaying inline code snippets.
+- Test.Muted
+
+Styling Modifiers:
+.NoWrap():
+.Bold()
+.Italic()
+.StrikeThrough()
+.Color(Colors)
+
+Layout.Vertical()
+    | Text.H1("Getting Started")
+    | Text.P("This is a paragraph of text.").NoWrap()
+
+[Text](https://docs.ivy.app/widgets/primitives/text-block.md)
+
+## Colors
+
+Ivy.Colors enum has the following values:
+
+Black, White, Slate, Gray, Zinc, Neutral, Stone, Red, Orange, Amber, Yellow, Lime, Green, Emerald, Teal, Cyan, Sky, Blue, Indigo, Violet, Purple, Fuchsia, Pink, Rose, Primary, Secondary, Destructive, Success, Warning, Info, Muted
+
+## Density
+
+All widgets support `.Density(Density.Small)`, `.Density(Density.Medium)`, `.Density(Density.Large)`.
+Convenience methods: `.Small()`, `.Medium()`, `.Large()`.
+Density adjusts the overall visual size of a widget (text, padding, etc.).
+There is no `ButtonSize` enum — use `Density` for all widgets.
+
+## Size
+
+`.Width(Size.X)` and `.Height(Size.X)` set widget dimensions.
+`.Size(Size.X)` sets both width and height.
+
+Common Size values:
+
+- Size.Units(n) — Tailwind spacing scale (n × 0.25rem)
+- Size.Full() — 100%
+- Size.Fit() — fit-content
+- Size.Auto() — auto
+- Size.Px(n) — exact pixels
+- Size.Fraction(0.5f) — percentage, Size.Half(), Size.Third()
+
+Size is NOT the same as Density. Size controls dimensions; Density controls visual density.
+
+## Event Handling
+
+new Button("Click Me")
+  .Primary()
+  .OnClick(() => {
+    count.Set(count.Value + 1);
+})
+
+new TextInput().Default()
+    .Value(text.Value)
+    .OnChange(text.Set)
+    .OnBlur(() => Console.WriteLine("Blurred"))
+
+## Hooks
+
+- Most hooks that you know from React are available in Ivy. They follow the same principles as in React.
+- Hooks should only be called at the top level of a Build() method, not inside loops or conditions.
+
+### UseState
+
+var nameState = UseState("World");
+var iconsState = UseState<Icons[]>();
+
+If you don't specify a value, default(T) is used.
+
+UseState hook returns a state object IState<T> that provides:
+
+> WARNING: UseState returns `IState<T>`, NOT `State<T>`. There is no `State<T>` type in Ivy.
+
+- .Value property to read the current state.
+- .Set(newValue) method to update the state in UseEffect or in an event handler.
+
+Always use immutable types (e.g. records) with `UseState` — mutable classes that are modified in-place and passed back via `.Set()` will not trigger a re-render because the reference hasn't changed. Instead, create a new instance (e.g. using `with` expressions on records) before calling `.Set()`.
+
+### UseEffect
+
+void UseEffect(Action effect, params IEffectTriggers[] triggers)
+void UseEffect(Func<Task> asyncEffect, params IEffectTriggers[] triggers)
+void UseEffect(Func<IDisposable> effectWithCleanup, params IEffectTriggers[] triggers)
+void UseEffect(Func<Task<IDisposable>> asyncEffectWithCleanup, IEffectTriggers object[] triggers)
+
+- EffectTrigger.OnBuild() - runs after every build
+- EffectTrigger.OnMount() - runs once when the view is first mounted
+- EffectTrigger.OnStateChange(IState<T>) - runs when the specified state changes
+
+- IState<T> is automatically converted to EffectTrigger.OnStateChange
+- If no triggers are provided, the effect trigger is assumed to be OnMount.
+
+### UseQuery
+
+UseQuery is the **preferred pattern for data fetching** in Ivy. It should be favored over the UseEffect + UseState fetch pattern.
+
+var query = UseQuery(
+    key: "my-data",
+    fetcher: async (ct) => await LoadDataAsync(ct)
+);
+
+if (query.Loading) return Skeleton.Card();
+if (query.Error is { } error) return Callout.Error(error.Message);
+
+// Use query.Value
+
+QueryResult<T> properties:
+
+- .Value — the fetched data (default until loaded)
+- .Loading — true during initial fetch (no value yet)
+- .Validating — true during background revalidation
+- .Error — exception if the fetch failed
+- .Mutator — provides .Revalidate(), .Invalidate(), .Mutate(value, revalidate)
+
+**Do not combine UseQuery with DataTable for EF Core data.** When a DataTable can receive an EF Core `IQueryable` directly, pass it to `.ToDataTable()` without UseQuery. DataTables handle their own server-side data loading. (API data fetched via UseQuery → `.ToDataTable()` is fine.)
+
+Key conventions:
+
+- String: `"my-data"`
+- Tuple: `(nameof(MyBlade), entityId)`
+
+Common options (QueryOptions):
+
+- KeepPrevious: true — show stale data while revalidating with a new key
+- RevalidateOnMount: false — skip initial fetch when using initialValue
+- RefreshInterval: TimeSpan — poll at an interval
+- Scope: QueryScope.View — isolate cache to the view instance (default is Server)
+
+Tag-based invalidation (cross-component):
+var queryService = UseService<IQueryService>();
+queryService.RevalidateByTag(typeof(Product[]));        // collection
+queryService.RevalidateByTag((typeof(Product), id));    // single entity
+
+Static "hooks" pattern (reusable across views):
+public static QueryResult<T[]> UseMyRecords(IViewContext context, string filter)
+{
+    return context.UseQuery(
+        key: (nameof(UseMyRecords), filter),
+        fetcher: async ct => { /*fetch*/ },
+        tags: [typeof(T[])],
+        options: new QueryOptions { KeepPrevious = true }
+    );
+}
+
+Dependent fetching (wait for another query):
+var user = UseQuery(key: "user", fetcher: async ct => await GetUser(ct));
+var projects = UseQuery(
+    () => user.Value?.Id,   // null = idle, no fetch
+    async (userId, ct) => await GetProjects(userId, ct));
+
+[UseRef](https://docs.ivy.app/hooks/core/use-ref.md)
+[UseContext](https://docs.ivy.app/hooks/core/use-context.md)
+[UseQuery](https://docs.ivy.app/hooks/core/use-query.md)
+[UseMutation](https://docs.ivy.app/hooks/core/use-mutation.md)
+[UseSignal](https://docs.ivy.app/hooks/core/use-signal.md)
+[UseService](https://docs.ivy.app/hooks/core/use-service.md)
+[UseArgs](https://docs.ivy.app/hooks/core/use-args.md)
+[UseDownload](https://docs.ivy.app/hooks/core/use-download.md)
+[UseRefreshToken](https://docs.ivy.app/hooks/core/use-refresh-token.md)
+[UseTrigger](https://docs.ivy.app/hooks/core/use-trigger.md)
+[UseWebhook](https://docs.ivy.app/hooks/core/use-webhook.md)
+[UseAlert](https://docs.ivy.app/onboarding/concepts/alerts.md)
+
+## Inputs
+
+Ivy has several Input widgets for handling user input. There are rarely used directly - instead we use
+extension methods on IState<T> to bind state to inputs.
+
+var userNameState = UseState("");
+var input = userNameState.ToTextInput().Placeholder("Enter your name");
+
+Most inputs have extension methods for common configurations:
+userNameState.ToTextInput().Required().MaxLength(50).Placeholder("Enter your name");
+
+[TextInput](https://docs.ivy.app/widgets/inputs/text-input.md)
+[NumberInput](https://docs.ivy.app/widgets/inputs/number-input.md)
+[BoolInput](https://docs.ivy.app/widgets/inputs/bool-input.md)
+[SelectInput](https://docs.ivy.app/widgets/inputs/select-input.md)
+[AsyncSelectInput](https://docs.ivy.app/widgets/inputs/async-select-input.md)
+[DateTimeInput](https://docs.ivy.app/widgets/inputs/date-time-input.md)
+[DateRangeInput](https://docs.ivy.app/widgets/inputs/date-range-input.md)
+[ColorInput](https://docs.ivy.app/widgets/inputs/color-input.md)
+[CodeInput](https://docs.ivy.app/widgets/inputs/code-input.md)
+[FeedbackInput](https://docs.ivy.app/widgets/inputs/feedback-input.md)
+[FileInput](https://docs.ivy.app/widgets/inputs/file-input.md)
+
+## Common Hallucinations
+
+- Base class is `ViewBase` (NOT `AppBase` there is no `AppBase` class)
+- `Text` is a static helper - use `Text.P()`, `Text.H2()`, ...
+- `UseState<T>()` returns `IState<T>`, NOT `State<T>`
+- All types are in the `Ivy` namespace
+- `Colors` is a flat enum (e.g. `Colors.Red`, `Colors.Blue`) we have no shade levels
+- `DbContext` must never be injected directly! Always resolve `IDbContextFactory<T>` via `UseService` and create scoped instances with `CreateDbContextAsync()` inside query/mutation lambdas
+- **Nested layouts MUST use parentheses** — `Layout.Vertical() | (Layout.Horizontal() | child1 | child2)` — without parentheses, C# left-to-right `|` evaluation adds children to the outer layout, not the inner one. See the nested layout example in the Layouts section above.
+
+## CLI Commands
+
+Prefer using `ivy cli explain` for command discovery over MCP server tools as it provides a reliable, built-in structural breakdown.
+
+## Further Reading
+
+[Forms](https://docs.ivy.app/onboarding/concepts/forms.md)
+[DataTable](https://docs.ivy.app/widgets/advanced/data-table.md)
+[Table](https://docs.ivy.app/widgets/common/table.md)
+[Details](https://docs.ivy.app/widgets/common/details.md) - Display structured label-value pairs
+[Program.cs](https://docs.ivy.app/onboarding/concepts/program.md)
+[Size](https://docs.ivy.app/api-reference/ivy-shared/size.md)
+[Align](https://docs.ivy.app/api-reference/ivy-shared/align.md)
+[Downloads](https://docs.ivy.app/hooks/core/use-download.md)
+[Icons](https://raw.githubusercontent.com/Ivy-Interactive/Ivy-Framework/refs/heads/main/src/Ivy/Shared/Icons.cs)
+
+All Ivy documentation pages are listed on: <https://docs.ivy.app/sitemap.xml>.
+Add ".md" to the end of any URL to go directly to the Markdown version of the doc.

--- a/src/skills/ivy-create-app/references/ChatApp.cs
+++ b/src/skills/ivy-create-app/references/ChatApp.cs
@@ -1,0 +1,73 @@
+﻿using System.Collections.Immutable;
+using System.Text;
+using AiChatMessage = Microsoft.Extensions.AI.ChatMessage;
+using AiChatRole = Microsoft.Extensions.AI.ChatRole;
+using IChatClient = Microsoft.Extensions.AI.IChatClient;
+
+namespace MyProject.Apps;
+
+[App(title: "Chat", icon: Icons.MessageSquare)]
+public class ChatApp : ViewBase
+{
+    public override object? Build()
+    {
+        var chatClient = UseService<IChatClient>();
+        var messages = UseState(ImmutableArray.Create<ChatMessage>());
+        var history = UseState(ImmutableArray.Create<AiChatMessage>());
+        var isStreaming = UseState(false);
+
+        void OnSend(Event<Chat, string> e)
+        {
+            var userText = e.Value;
+
+            var updatedMessages = messages.Value
+                .Add(new ChatMessage(ChatSender.User, userText))
+                .Add(new ChatMessage(ChatSender.Assistant, new ChatStatus("Thinking...")));
+            messages.Set(updatedMessages);
+
+            var updatedHistory = history.Value
+                .Add(new AiChatMessage(AiChatRole.User, userText));
+            history.Set(updatedHistory);
+            isStreaming.Set(true);
+
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    var builder = new StringBuilder();
+                    await foreach (var update in chatClient.GetStreamingResponseAsync(updatedHistory.ToArray()))
+                    {
+                        builder.Append(update.Text);
+                        var streamed = messages.Value
+                            .RemoveAt(messages.Value.Length - 1)
+                            .Add(new ChatMessage(ChatSender.Assistant, builder.ToString()));
+                        messages.Set(streamed);
+                    }
+
+                    var responseText = builder.ToString();
+                    history.Set(history.Value
+                        .Add(new AiChatMessage(AiChatRole.Assistant, responseText)));
+                }
+                catch (Exception ex)
+                {
+                    var errorMessages = messages.Value
+                        .RemoveAt(messages.Value.Length - 1)
+                        .Add(new ChatMessage(ChatSender.Assistant, $"Error: {ex.Message}"));
+                    messages.Set(errorMessages);
+                }
+                finally
+                {
+                    isStreaming.Set(false);
+                }
+            });
+        }
+
+        void OnCancel(Event<Chat> e)
+        {
+            isStreaming.Set(false);
+        }
+
+        return new Chat(messages.Value.ToArray(), OnSend, OnCancel)
+            .Placeholder("Ask anything...");
+    }
+}

--- a/src/skills/ivy-create-app/references/DesignGuidelines.md
+++ b/src/skills/ivy-create-app/references/DesignGuidelines.md
@@ -1,0 +1,211 @@
+﻿# Design Guidelines
+
+## 1. Page Layout
+
+### Centered Max-Width (default)
+```csharp
+return Layout.TopCenter()
+    | (Layout.Vertical().Width(Size.Full().Max(200)).Margin(10)
+        | content);
+```
+- Always use `Layout.TopCenter()` — without it, content hugs left edge.
+- Never use `Layout.Vertical().AlignContent(Align.Center)` as top-level — it centers children but doesn't constrain width.
+
+### Full Center (rare)
+```csharp
+return Layout.Center()
+    | (Layout.Vertical().Gap(2) | urlInput | submitButton);
+```
+Reserve for truly minimal UIs (login, empty state, single action). Most apps should use `TopCenter()`.
+
+### Full-Height: Header + Content + Footer
+Only apply `.Height(Size.Full())` to the content row. Header/footer auto-size:
+```csharp
+Layout.Vertical().Height(Size.Full())
+    | (Layout.Horizontal().AlignContent(Align.Center) | title | dropdown)     // auto
+    | (Layout.Horizontal().Height(Size.Full()) | editor | preview)     // fills
+    | (Layout.Horizontal().AlignContent(Align.Center) | downloadButton)       // auto
+```
+
+### Full-Width Panels (editor + preview, input + output)
+```csharp
+return Layout.TopCenter()
+    | (Layout.Vertical().Width(Size.Full().Max(300)).Margin(10)
+        | Text.H1("Title")
+        | Text.Lead("Description")
+        | (Layout.Horizontal().Gap(6)
+            | (Layout.Vertical().Width(Size.Full()) | leftPanel)
+            | (Layout.Vertical().Width(Size.Full()) | rightPanel)));
+```
+- **Never** add `.Width(Size.Full())` to `Layout.TopCenter()` — it defeats centering and removes margin.
+- Use `.Width(Size.Full().Max(300))` on the inner container if panels need more room than the default max-width.
+
+## 2. Multi-Column & Panels
+
+### Split Panels
+Use plain `Layout.Vertical()` columns with headings — not `Card` wrappers (cards add borders/padding → heavy "card-in-card" feel):
+```csharp
+Layout.Horizontal()
+    | (Layout.Vertical().Width(Size.Full()) | Text.H3("Schema") | schema)
+    | (Layout.Vertical().Width(Size.Full()) | Text.H3("Preview") | preview)
+```
+
+### Blades
+`UseBlades()` is for CRUD/master-detail drill-down only. Not for dashboards or full-width layouts.
+
+### TabsLayout vs Separate Apps
+Separate apps = distinct entities with own CRUD. TabsLayout = views of same data (chart/table, settings categories, wizard steps).
+
+## 3. Grid
+```csharp
+// Wrong: Layout.Grid(3) — "3" renders as text child
+Layout.Grid().Columns(3).Gap(4)  // Correct
+```
+
+## 4. Visual Hierarchy & Spacing
+
+- Use `new Separator()` between major sections to prevent blending.
+- Add `.BottomMargin(2)` on the wrapping `LayoutView` between search/filter inputs and their content. Note: `BottomMargin` is a `LayoutView` method — do not call it on `Field` or input types.
+- Never use `Colors.White` for borders (invisible on white bg). Use `Colors.Gray` or `Colors.Slate`.
+- Gap default is 4 — do not add `.Gap(4)`.
+- Padding is rarely needed — layouts have appropriate defaults.
+
+## 5. Inputs & Validation
+
+### Input Labels
+Use `.WithField().Label()` — never call `.Label()` directly (resolves to `AxisExtensions.Label<T>()`, causes CS0311):
+```csharp
+nameState.ToTextInput().WithField().Label("Name");
+ageState.ToNumberInput().WithField().Label("Age");
+colorState.ToSelectInput(options).WithField().Label("Color");
+```
+Applies to all input types: SelectInputBase, NumberInputBase, TextInputBase, DateTimeInputBase, BoolInputBase, ColorInputBase, FileInputBase, FeedbackInputBase, CodeInputBase.
+
+### Validation & Errors
+
+**Forms**: Use `form.Validate()` and display errors inline. Example:
+```csharp
+Callout.Error("Name is required");
+```
+
+**API/Service Errors**: Wrap error messages in callouts:
+```csharp
+Callout.Error($"Could not save: {ex.Message}. Check your input and try again.");
+```
+
+**Streaming Response Errors** (IChatClient, etc.): When catching exceptions in streaming tasks, set the state to a `Callout.Error()` widget, NOT plain markdown. Example:
+```csharp
+catch (Exception ex)
+{
+    errorState.Set(Callout.Error(ex.Message));
+}
+// Then conditionally render: errorState.Value ?? new Markdown(responseText.Value)
+```
+
+Use `Callout.Error()` / `Callout.Warning()` — do not repurpose display widgets.
+
+### Text Input vs Textarea
+Use `.ToTextareaInput()` for multi-line content (descriptions, notes, pasted text). `.ToTextInput()` is single-line and truncates.
+
+## 6. Content Display
+
+### CodeInput vs CodeBlock
+- **Read-only:** `new CodeBlock(value, Languages.Json)`
+- **Editable:** `state.ToCodeInput()` — `.ToCodeInput()` is on `IAnyState`, not `string` (CS1929)
+
+### Html with Inline Styles
+Chain `.DangerouslyAllowScripts()` when Html has `style="..."` — sanitizer strips inline styles without it:
+```csharp
+new Html($"<span style=\"color: green\">{ch}</span>").DangerouslyAllowScripts();
+```
+
+### MetricView for KPIs
+```csharp
+Layout.Grid().Columns(3)
+    | new MetricView("Sales", Icons.DollarSign,
+        ctx => ctx.UseQuery("sales", () => Task.FromResult(new MetricRecord("$84.3K", 0.21, 0.21, "$400K"))))
+```
+`MetricRecord`: `MetricFormatted` (string), `TrendComparedToPreviousPeriod` (double?, 0.21 = +21%), `GoalAchieved` (double?, 0-1), `GoalFormatted` (string?). Abbreviate large numbers.
+
+### Progressive Disclosure
+Use `Expandable` for secondary content when items have >4-5 properties:
+```csharp
+Layout.Vertical()
+    | Text.H4(item.Name)
+    | Text(item.Summary).Color(Colors.Gray)
+    | new Expandable("Details", Layout.Vertical() | Text(item.FullDescription))
+```
+
+## 7. UX Interaction
+
+- **Toast after actions:** confirm create/delete/update succeeded:
+  ```csharp
+  var client = UseService<IClientProvider>();
+  client.Toast($"{item.Name} added!");
+  ```
+- **No duplicate info:** If Sheet title shows item name, don't repeat it in body.
+- **Confirm destructive actions:** Use `.WithConfirm()` — never delete on single click:
+  ```csharp
+  Button("Delete", _ => { items.Remove(item); UseService<IClientProvider>().Toast($"{item.Name} deleted"); },
+      variant: ButtonVariant.Destructive)
+      .WithConfirm($"Delete {item.Name}?", title: "Confirm Delete", confirmLabel: "Delete", destructive: true)
+  ```
+- **Empty states:** Show guidance toward first action, not blank area:
+  ```csharp
+  if (!items.Any())
+      yield return Layout.Center()
+          | (Layout.Vertical().Gap(2).AlignContent(Align.Center)
+              | Icons.Inbox.ToIcon().Color(Colors.Gray)
+              | Text("No items yet").Color(Colors.Gray)
+              | Button("Add your first item").OnClick(ShowAddForm));
+  ```
+- **Multi-step flows:** Show step progress (`Step {n} of {total}: {title}`) with `Separator` between header and content.
+
+## 8. Labeling and User Expectations
+
+- Only use "(editable)", "(optional)", or similar hints when they accurately describe the behavior
+- If content is read-only (using Table, Details, CodeBlock, or display-only widgets), do not label it as "(editable)"
+- Use "(read-only)" or no label at all for non-editable content
+- If you plan to make content editable later, implement the editing first, then add the label
+
+## 9. App Attribute - Group Parameter
+
+The `[App]` attribute's `group` parameter is nullable and has a runtime default value of `["Apps"]` (applied in `AppHelpers.cs`).
+
+**Best Practice**:
+- Omit the `group` parameter when using the default "Apps" group
+- Explicitly specify `group` only for non-default groups
+- Valid group names include: "Apps" (default), "Tools", "Settings", or custom group names
+
+**Examples**:
+
+Default group (omit parameter):
+```csharp
+[App(icon: Icons.Calculator)]
+public class CalculatorApp : ViewBase
+{
+    // group defaults to ["Apps"] at runtime
+}
+```
+
+Non-default group (must specify explicitly):
+```csharp
+[App(icon: Icons.Settings, group: ["Settings"])]
+public class PreferencesApp : ViewBase
+{
+    // explicitly in Settings group
+}
+```
+
+Multiple groups (specify explicitly):
+```csharp
+[App(icon: Icons.Database, group: ["Apps", "Data"])]
+public class DataExplorerApp : ViewBase
+{
+    // appears in both Apps and Data groups
+}
+```
+
+**CRITICAL**: When a specification explicitly defines a non-default `group` value (e.g., `group: ["Tools"]`, `group: ["Settings"]`), you MUST include it in the implementation. Omitting a non-default group value is an implementation error that fails to meet the specification requirements.
+
+**Reference**: See `ChatApp.cs` (line 9) for an example that correctly omits the default group parameter.

--- a/src/skills/ivy-create-app/references/OpenAIConnection.cs
+++ b/src/skills/ivy-create-app/references/OpenAIConnection.cs
@@ -1,0 +1,190 @@
+﻿using System.ClientModel;
+using Ivy;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using OpenAI;
+
+namespace MyProject.Connections.OpenAI;
+
+public class OpenAIConnection : IConnection, IHaveSecrets
+{
+    public string GetContext(string connectionPath) => """
+        # OpenAI Connection
+
+        The OpenAI connection provides access to the full OpenAI REST API, including chat completions, embeddings, image generation, audio transcription, assistants, file management, and more.
+
+        ## Getting the service
+
+        ```csharp
+        var client = UseService<OpenAIClient>();
+        ```
+
+        ## Chat Completions
+
+        ```csharp
+        using OpenAI.Chat;
+
+        var chatClient = client.GetChatClient("gpt-4o");
+        var completion = await chatClient.CompleteChatAsync("Hello, how are you?");
+        Console.WriteLine(completion.Value.Content[0].Text);
+        ```
+
+        ## Chat Completions with Streaming
+
+        ```csharp
+        using OpenAI.Chat;
+
+        var chatClient = client.GetChatClient("gpt-4o");
+        await foreach (var update in chatClient.CompleteChatStreamingAsync("Tell me a story."))
+        {
+            if (update.ContentUpdate.Count > 0)
+                Console.Write(update.ContentUpdate[0].Text);
+        }
+        ```
+
+        ## Generate Embeddings
+
+        ```csharp
+        using OpenAI.Embeddings;
+
+        var embeddingClient = client.GetEmbeddingClient("text-embedding-3-small");
+        var embedding = await embeddingClient.GenerateEmbeddingAsync("Some text to embed");
+        ReadOnlyMemory<float> vector = embedding.Value.ToFloats();
+        ```
+
+        ## Generate Images
+
+        ```csharp
+        using OpenAI.Images;
+
+        var imageClient = client.GetImageClient("dall-e-3");
+        var image = await imageClient.GenerateImageAsync("A sunset over mountains", new ImageGenerationOptions
+        {
+            Quality = GeneratedImageQuality.High,
+            Size = GeneratedImageSize.W1024xH1024,
+        });
+        Console.WriteLine(image.Value.ImageUri);
+        ```
+
+        ## Transcribe Audio
+
+        ```csharp
+        using OpenAI.Audio;
+
+        var audioClient = client.GetAudioClient("whisper-1");
+        var transcription = await audioClient.TranscribeAudioAsync("audio.mp3");
+        Console.WriteLine(transcription.Value.Text);
+        ```
+
+        ## Text to Speech
+
+        ```csharp
+        using OpenAI.Audio;
+
+        var audioClient = client.GetAudioClient("tts-1");
+        var speech = await audioClient.GenerateSpeechAsync("Hello world!", GeneratedSpeechVoice.Alloy);
+        // speech.Value contains the audio bytes
+        ```
+
+        ## Moderations
+
+        ```csharp
+        using OpenAI.Moderations;
+
+        var moderationClient = client.GetModerationClient("omni-moderation-latest");
+        var result = await moderationClient.ClassifyTextAsync("Some text to moderate");
+        Console.WriteLine($"Flagged: {result.Value.Flagged}");
+        ```
+
+        ## List Models
+
+        ```csharp
+        using OpenAI.Models;
+
+        var modelClient = client.GetOpenAIModelClient();
+        var models = await modelClient.GetModelsAsync();
+        foreach (var model in models.Value)
+            Console.WriteLine(model.Id);
+        ```
+
+        ## The OpenAIClient provides sub-clients for each API area:
+        - `GetChatClient(model)` — Chat completions
+        - `GetEmbeddingClient(model)` — Text embeddings
+        - `GetImageClient(model)` — Image generation
+        - `GetAudioClient(model)` — Audio transcription and TTS
+        - `GetAssistantClient()` — Assistants API
+        - `GetOpenAIFileClient()` — File uploads
+        - `GetOpenAIModelClient()` — Model listing
+        - `GetModerationClient(model)` — Content moderation
+        - `GetVectorStoreClient()` — Vector stores
+        """;
+
+    public string GetNamespace() => typeof(OpenAIConnection).Namespace!;
+
+    public string GetName() => "OpenAI";
+
+    public string GetConnectionType() => "Nuget:OpenAI";
+
+    public ConnectionEntity[] GetEntities() =>
+    [
+        new("ChatCompletion", "ChatCompletions"),
+        new("Embedding", "Embeddings"),
+        new("Image", "Images"),
+        new("AudioTranscription", "AudioTranscriptions"),
+        new("Assistant", "Assistants"),
+        new("File", "Files"),
+        new("Model", "Models"),
+        new("Moderation", "Moderations"),
+    ];
+
+    public void RegisterServices(Server server)
+    {
+        server.Services.AddSingleton(sp =>
+        {
+            var config = sp.GetRequiredService<IConfiguration>();
+            var apiKey = config["OpenAI:ApiKey"] ?? "";
+            var endpoint = config["OpenAI:Endpoint"] ?? "https://api.openai.com/v1";
+            return new OpenAIClient(
+                new ApiKeyCredential(apiKey),
+                new OpenAIClientOptions { Endpoint = new Uri(endpoint) });
+        });
+
+        server.Services.AddSingleton<IChatClient>(sp =>
+        {
+            var client = sp.GetRequiredService<OpenAIClient>();
+            return client
+                .GetChatClient("gpt-4o-mini")
+                .AsIChatClient();
+        });
+    }
+
+    public async Task<(bool ok, string? message)> TestConnection(IConfiguration config)
+    {
+        try
+        {
+            var apiKey = config["OpenAI:ApiKey"];
+            if (string.IsNullOrEmpty(apiKey))
+                return (false, "OpenAI:ApiKey is not configured. Please set your API key in user secrets.");
+
+            var endpoint = config["OpenAI:Endpoint"] ?? "https://api.openai.com/v1";
+            var client = new OpenAIClient(
+                new ApiKeyCredential(apiKey),
+                new OpenAIClientOptions { Endpoint = new Uri(endpoint) });
+            var modelClient = client.GetOpenAIModelClient();
+            var models = await modelClient.GetModelsAsync();
+            var count = models.Value.Count;
+            return (true, $"Connected successfully. Found {count} model(s) available.");
+        }
+        catch (Exception ex)
+        {
+            return (false, $"Connection test failed: {ex.Message}");
+        }
+    }
+
+    public Secret[] GetSecrets() =>
+    [
+        new Secret("OpenAI:ApiKey"),
+        new Secret("OpenAI:Endpoint", "https://api.openai.com/v1"),
+    ];
+}

--- a/src/skills/ivy-create-auth-connection/SKILL.md
+++ b/src/skills/ivy-create-auth-connection/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: ivy-create-auth-connection
+description: >
+  Add an authentication provider to an Ivy project. Supports Basic Auth (JWT),
+  Auth0, Supabase, Clerk, GitHub OAuth, Authelia, and Microsoft Entra ID.
+  Use when the user wants to add login, authentication, or identity to their project.
+allowed-tools: Bash(dotnet:*) Bash(ivy:*) Read Write Edit Glob Grep
+effort: medium
+argument-hint: "[auth provider name, e.g. Auth0, Supabase, Clerk]"
+---
+
+# ivy-create-auth-connection
+
+Add an authentication provider to an existing Ivy project. This skill guides you through selecting a provider, collecting the required credentials, and configuring the project.
+
+## Step 1: Validate the Project
+
+1. Verify this is a valid Ivy project. Check for a `.csproj` file and `Program.cs` in the working directory. If this is not an Ivy project, tell the user and stop.
+
+## Step 2: Choose an Auth Provider
+
+2. If the user has not already specified a provider, ask them to choose one from the supported list:
+
+| Provider | Description | Required Secrets |
+|---|---|---|
+| **Basic** | Simple username/password auth with JWT tokens. Good for internal tools or prototyping. | Users, HashSecret, JwtSecret, JwtIssuer, JwtAudience |
+| **Auth0** | Enterprise-grade identity platform with social logins, MFA, and SSO. | Domain, ClientId, ClientSecret, Audience, Namespace |
+| **Supabase** | Open-source Firebase alternative with built-in auth. Supports email/password, social logins, and SSO via WorkOS. | Url, ApiKey, LegacyJwtSecret |
+| **Clerk** | Modern authentication with prebuilt UI components and session management. | PublishableKey, SecretKey |
+| **GitHub** | GitHub OAuth for developer-facing applications. | ClientId, ClientSecret, RedirectUri |
+| **Authelia** | Self-hosted single sign-on and 2FA server. | Url |
+| **Microsoft Entra** | Azure Active Directory / Microsoft Entra ID for enterprise SSO. | TenantId, ClientId, ClientSecret |
+
+## Step 3: Collect Provider-Specific Credentials
+
+3. Based on the chosen provider, collect the required credentials from the user. Each provider requires different configuration values:
+
+### Basic Auth (JWT)
+- Ask the user for initial user credentials (username:password pairs, comma-separated)
+- Ask for a JWT issuer name (default: the project name)
+- Ask for a JWT audience name (default: the project name)
+- A hash secret and JWT secret are auto-generated
+
+### Auth0
+- Ask for the Auth0 Domain (e.g. `your-tenant.auth0.com`)
+- Ask for the Client ID from the Auth0 application
+- Ask for the Client Secret from the Auth0 application
+- Ask for the API Audience (e.g. `https://your-api.example.com`)
+- Optionally, Auth0 supports additional options like role-based access control and custom claims
+
+### Supabase
+- Ask for the Supabase project URL (e.g. `https://your-project.supabase.co`)
+- Ask for the Supabase anon/public API key
+- Optionally, ask for the legacy JWT secret (for direct JWT verification)
+- Supabase supports additional options like WorkOS SSO integration
+
+### Clerk
+- Ask for the Clerk Publishable Key (starts with `pk_`)
+- Ask for the Clerk Secret Key (starts with `sk_`)
+- Clerk supports additional options like organization-based access
+
+### GitHub OAuth
+- Ask for the GitHub OAuth App Client ID
+- Ask for the GitHub OAuth App Client Secret
+- Ask for the Redirect URI (e.g. `https://localhost:5001/callback`)
+
+### Authelia
+- Ask for the Authelia instance URL (e.g. `https://auth.example.com`)
+
+### Microsoft Entra ID
+- Ask for the Tenant ID
+- Ask for the Application (Client) ID
+- Ask for the Client Secret
+
+## Step 4: Generate the Auth Configuration
+
+4. The auth provider setup involves:
+   - Adding the required NuGet package for the provider
+   - Storing secrets in dotnet user secrets (with the provider-specific prefix)
+   - Updating `Program.cs` with `server.UseAuth<[ProviderClassName]>()`
+
+5. Initialize user secrets for the project:
+
+```bash
+dotnet user-secrets init
+```
+
+6. Set each required secret using `dotnet user-secrets set`. For example:
+
+```bash
+dotnet user-secrets set "Auth0:Domain" "your-tenant.auth0.com"
+dotnet user-secrets set "Auth0:ClientId" "your-client-id"
+```
+
+7. Use `ivy docs` or `ivy ask` to look up the specific auth provider documentation if you need details about the NuGet package name, the provider class name, or the `Program.cs` registration pattern for the chosen provider.
+
+## Step 5: Verify
+
+8. Run `dotnet build` to verify everything compiles. Fix any errors.
+
+9. If the project is in a git repository, create a commit with a descriptive message, for example: "Added [ProviderDisplayName] authentication."
+
+10. Tell the user the auth provider is ready and summarize what was configured:
+    - Auth provider package added
+    - Secrets stored with the provider prefix
+    - Program.cs updated with the auth registration
+
+## Recovery
+
+If the setup fails:
+
+1. Diagnose the root cause (invalid credentials, auth provider not configured, network issues):
+   - For invalid credentials: verify API keys, tokens, or OAuth client credentials are correct
+   - For provider config issues: check that the auth provider is registered in the app's configuration
+   - For network issues: verify the auth provider endpoint is accessible
+
+2. After fixing the underlying issue, either retry using the `/ivy-create-auth-connection` skill from scratch, or manually create the auth provider class and register it in `Program.cs`.
+
+3. Use `ivy ask "How do I configure [ProviderName] authentication?"` for provider-specific guidance.

--- a/src/skills/ivy-create-crud/SKILL.md
+++ b/src/skills/ivy-create-crud/SKILL.md
@@ -1,0 +1,340 @@
+---
+name: ivy-create-crud
+description: >
+  Create a CRUD app with list, detail, create, and edit views for an Ivy project.
+  Use when the user asks for CRUD views, master-detail views, data management screens,
+  entity management, or wants to build views for database tables. Handles blades,
+  dialogs, sheets, foreign key lookups, search, pagination, parent-child relationships,
+  and async select inputs.
+allowed-tools: Bash(dotnet:*) Read Write Edit Glob Grep
+effort: high
+argument-hint: "[entities to create CRUD views for]"
+---
+
+# ivy-create-crud
+
+Create a CRUD app with list, detail, create, and edit views for an Ivy project.
+
+## Reference Files
+
+Read these before implementing:
+- [references/AGENTS.md](references/AGENTS.md) -- Ivy framework API reference (widgets, hooks, layouts, inputs, colors)
+- [references/ProductsApp.cs](references/ProductsApp.cs) -- simple app entry point with UseBlades
+- [references/OrdersApp.cs](references/OrdersApp.cs) -- app entry point for entity with child relationships
+- [references/ProductListBlade.cs](references/ProductListBlade.cs) -- list blade with search, UseQuery, FuncView
+- [references/ProductDetailsBlade.cs](references/ProductDetailsBlade.cs) -- details blade with ToDetails, delete, edit trigger
+- [references/ProductCreateDialog.cs](references/ProductCreateDialog.cs) -- create dialog with ToForm, validation
+- [references/ProductEditSheet.cs](references/ProductEditSheet.cs) -- edit sheet with ToForm, Remove, revalidation
+- [references/OrderListBlade.cs](references/OrderListBlade.cs) -- list blade with FK resolution via Include
+- [references/OrderDetailsBlade.cs](references/OrderDetailsBlade.cs) -- details blade with related child cards
+- [references/OrderCreateDialog.cs](references/OrderCreateDialog.cs) -- create dialog with async select for FK
+- [references/OrderEditSheet.cs](references/OrderEditSheet.cs) -- edit sheet with FK fields
+- [references/OrderLinesBlade.cs](references/OrderLinesBlade.cs) -- child relationship blade with table
+- [references/OrderLineCreateDialog.cs](references/OrderLineCreateDialog.cs) -- child create dialog with parent FK
+- [references/OrderLineEditSheet.cs](references/OrderLineEditSheet.cs) -- child edit sheet with async select
+
+## Workflow
+
+This skill guides you through creating complete CRUD applications:
+
+1. **Plan** - Analyze the data models and propose CRUD views for selected entities
+2. **Review** - Present the plan for user approval (accept / request changes / cancel)
+3. **Implement** - Generate all CRUD files following reference patterns, one entity at a time
+
+## Step 1: Plan the CRUD App
+
+If the user has specified a database connection, read the connection context using `ivy cli explain connections/{ConnectionName}`. If not, ask the user which connection to use.
+
+Ask the user which entities they want CRUD views for (suggest all top-level entities as options).
+
+For each selected entity, determine:
+- **Singular name** and **plural name**
+- **Lucide icon** (PascalCase, e.g. `ShoppingBag`, `Users`, `FileText`)
+- Whether it is a **top-level entity** (gets its own App with list/details/create/edit) or a **child entity** (shown as a relationship blade on a parent's details view)
+- Child entities are those that primarily exist as children of another entity via a required foreign key (e.g., OrderLines belong to Orders)
+
+Detect **one-to-many relationships** from navigation properties and foreign keys:
+- A parent entity's details blade should show a related card linking to child blades
+- Child entities get: RelationshipBlade (table view), RelationshipCreateDialog, RelationshipEditSheet
+
+### Plan Format
+
+```
+# Plan
+
+## Create App: [PluralName]
+
+**Namespace**: `{ProjectNamespace}.Apps`
+**Connection**: `[ConnectionName]`
+**Entity**: `[SingularName]`
+**Icon**: `[LucideIcon]`
+**Group**: `Apps`
+**Layout**: `Blades`
+**Files**: `Apps\[PluralName]App.cs`
+
+Opens [Singular]ListBlade.
+
+### Create View: [Singular]ListBlade
+
+**Files**: `Apps\[PluralName]\[Singular]ListBlade.cs`
+**Namespace**: `{ProjectNamespace}.Apps.[PluralName]`
+
+List view with search. Shows [key fields]. Click opens [Singular]DetailsBlade. Create button opens [Singular]CreateDialog.
+
+### Create View: [Singular]DetailsBlade
+
+**Files**: `Apps\[PluralName]\[Singular]DetailsBlade.cs`
+**Namespace**: `{ProjectNamespace}.Apps.[PluralName]`
+
+Detail view showing [interesting fields]. Edit button opens [Singular]EditSheet. Delete button with confirmation.
+[If has children: Related card with links to child blades with count badges.]
+
+### Create View: [Singular]CreateDialog
+
+**Files**: `Apps\[PluralName]\[Singular]CreateDialog.cs`
+**Namespace**: `{ProjectNamespace}.Apps.[PluralName]`
+
+Create dialog with required fields. [List the fields.]
+
+### Create View: [Singular]EditSheet
+
+**Files**: `Apps\[PluralName]\[Singular]EditSheet.cs`
+**Namespace**: `{ProjectNamespace}.Apps.[PluralName]`
+
+Edit sheet with all editable fields. Removes Id, CreatedAt, UpdatedAt. [List notable field customizations.]
+
+### Create Relationship View: [ParentSingular][ChildPlural]Blade
+
+**Files**: `Apps\[PluralName]\[ParentSingular][ChildPlural]Blade.cs`
+**Namespace**: `{ProjectNamespace}.Apps.[PluralName]`
+
+Table view of [ChildPlural] for a given [ParentSingular]. Shows [key columns]. Add button opens [ParentSingular][ChildPlural]CreateDialog.
+
+### Create Relationship View: [ParentSingular][ChildPlural]CreateDialog
+
+**Files**: `Apps\[PluralName]\[ParentSingular][ChildPlural]CreateDialog.cs`
+**Namespace**: `{ProjectNamespace}.Apps.[PluralName]`
+
+Create dialog for adding a [ChildSingular] to a [ParentSingular]. Parent ID passed via constructor.
+
+### Create Relationship View: [ParentSingular][ChildPlural]EditSheet
+
+**Files**: `Apps\[PluralName]\[ParentSingular][ChildPlural]EditSheet.cs`
+**Namespace**: `{ProjectNamespace}.Apps.[PluralName]`
+
+Edit sheet for a [ChildSingular]. Takes child entity ID as parameter.
+```
+
+Repeat the `## Create App` block for each top-level entity selected.
+
+### Chrome Decision
+- If the plan has **only one `## Create App` block** (single entity) and no multi-app navigation needs, add a `### Update Program.cs` section that replaces `server.UseAppShell(...)` with `server.UseDefaultApp(typeof(TheAppClass));`.
+- If the plan has **multiple `## Create App` blocks** or the user explicitly wants sidebar navigation, add a `### Update Program.cs` section that ensures `server.UseAppShell(new AppShellSettings().DefaultApp<FirstAppClass>().UseTabs(preventDuplicates: true));` is present.
+
+Present the plan to the user and ask them to **Accept**, **Request Changes**, or **Cancel**.
+
+## Step 2: Handle Changes
+
+If the user requests changes, apply them to the plan and present the updated plan again.
+
+## Step 3: Implement
+
+Once approved, implement each entity's views in order.
+
+### Namespace Conventions
+
+- App files (`[PluralName]App.cs`): `namespace {ProjectNamespace}.Apps;`
+- View files (all blades, dialogs, sheets): `namespace {ProjectNamespace}.Apps.[PluralName];`
+
+### Required Using Directives
+
+Every generated `.cs` file must include explicit `using` statements. Do NOT rely on global usings.
+
+**Connection usings (when using a database connection):**
+- `using {ProjectNamespace}.Connections.{ConnectionName};` -- for context factory
+- `using {ProjectNamespace}.Connections.{ConnectionName}.Models;` -- for entity classes (only if project uses a Models subfolder)
+- `using Microsoft.EntityFrameworkCore;` -- for ToListAsync, FirstOrDefaultAsync, Include, etc.
+
+**Common Ivy usings by view type:**
+
+| View Type | Required Namespaces |
+|---|---|
+| All views | `Ivy`, `Ivy.Core.Hooks`, `Ivy.Hooks`, `Ivy.Shared`, `Ivy.Views` |
+| App entry point | + `Ivy.Apps` |
+| Blades | + `Ivy.Views.Blades` |
+| Details views | + `Ivy.Views.Builders` |
+| Forms (dialogs, sheets) | + `Ivy.Views.Forms`, `System.ComponentModel.DataAnnotations` |
+| Tables | + `Ivy.Views.Tables` |
+| Alerts/Callouts | + `Ivy.Views.Alerts` |
+| Async select inputs | + `Ivy.Widgets.Inputs` |
+
+Include only the namespaces your file actually uses.
+
+### Data Access Pattern
+
+Always use the context factory pattern:
+```csharp
+var factory = UseService<{ConnectionName}ContextFactory>();
+await using var db = factory.CreateDbContext();
+```
+
+### Program.cs Chrome Configuration
+
+Check if the approved plan includes a `### Update Program.cs` section. If it does:
+- If it specifies `UseDefaultApp`: Open `Program.cs` and replace the `server.UseAppShell(...)` line with `server.UseDefaultApp(typeof(AppClassName));`. Remove the `UseAppShell` line entirely.
+- If it specifies `UseAppShell`: Ensure `server.UseAppShell(new AppShellSettings().DefaultApp<AppClassName>().UseTabs(preventDuplicates: true));` is present in `Program.cs`.
+- Follow the approved plan exactly.
+
+### Per-View-Type Instructions
+
+#### App (`[PluralName]App.cs`)
+
+```csharp
+using {ProjectNamespace}.Apps.[PluralName];
+
+namespace {ProjectNamespace}.Apps;
+
+[App(icon: Icons.[Icon], group: ["[Group]"])]
+public class [PluralName]App : ViewBase
+{
+    public override object? Build()
+    {
+        return UseBlades(() => new [Singular]ListBlade(), "Search");
+    }
+}
+```
+
+#### ListBlade (`[Singular]ListBlade.cs`)
+
+- Define a `private record [Singular]ListRecord(int Id, ...)` with the key display fields. **For FK properties (e.g., `CustomerId`, `PartnerId`), do NOT include the raw ID. Instead, include a resolved name field (e.g., `string? CustomerName`) and project it via the navigation property in the `.Select()`.**
+- Use `UseRefreshToken()` for create/edit refresh flow.
+- `UseEffect` on `refreshToken` to pop, revalidate, and push to DetailsBlade.
+- `onItemClicked` pushes `[Singular]DetailsBlade(id)`.
+- Create button: `Icons.Plus.ToButton(...).Ghost().Tooltip("Create [Singular]").ToTrigger(isOpen => new [Singular]CreateDialog(isOpen, refreshToken))`.
+- Two UseQuery methods: `Use[Singular]ListRecords` (filtered list) and `Use[Singular]ListRecord` (single item for FuncView).
+- List query: filter with `.Where()`, order by `.OrderByDescending(e => e.CreatedAt)`, `.Take(50)`, tags: `[typeof([Entity][])]`.
+- Single item query: `RevalidateOnMount = false`, `initialValue: record`, tags: `[(typeof([Entity]), record.Id)]`.
+- Search input + create button in a horizontal header layout.
+- If entity has FK properties, ALWAYS `.Include()` the navigation property and project the human-readable name into the record -- NEVER expose raw FK IDs as display columns. Explicitly type as `IQueryable<Entity>` to avoid IIncludableQueryable type issues.
+
+#### DetailsBlade (`[Singular]DetailsBlade.cs`)
+
+- Constructor: `(int [entityCamelCase]Id)`.
+- Query the entity with `.Include()` for navigation properties.
+- Show loading skeleton: `if (query.Loading) return Skeleton.Card();`
+- Show not found callout if null.
+- Delete button with `.WithConfirm()`, pops and revalidates `typeof([Entity][])`.
+- Edit button with `.ToTrigger(isOpen => new [Singular]EditSheet(isOpen, [entityCamelCase]Id))`.
+- Details card using anonymous type `.ToDetails().RemoveEmpty().Builder(e => e.Id, e => e.CopyToClipboard())`.
+- Only include "interesting" fields. Exclude CreatedAt, UpdatedAt.
+- If entity has one-to-many children: add a related card with `ListItem` entries that push child blades with count badges.
+
+#### CreateDialog (`[Singular]CreateDialog.cs`)
+
+- Constructor: `(IState<bool> isOpen, RefreshToken refreshToken)`.
+- Define a `private record [Singular]CreateRequest` with `[Required]` attributes on required **nullable** fields (`string`, `int?`, `Guid?`, etc.). Do NOT add `[Required]` on non-nullable value types (`int`, `decimal`, `DateTime`, `bool`, etc.).
+- **CRITICAL: CreateRequest MUST NEVER include these auto-managed fields:**
+  - `Id` -- auto-generated by the database
+  - `CreatedAt` -- set in OnSubmit: `CreatedAt = DateTime.UtcNow`
+  - `UpdatedAt` -- set in OnSubmit: `UpdatedAt = DateTime.UtcNow`
+  - Any other auto-increment or computed fields
+- Use the SAME types as in the target entity to avoid type mismatches.
+- `UseState(() => new [Singular]CreateRequest())`.
+- `.ToForm().OnSubmit(OnSubmit).ToDialog(isOpen, title: "Create [Singular]", submitTitle: "Create")`.
+- Use `.Builder(e => e.ForeignKeyId, e => e.ToAsyncSelectInput(...))` for foreign key fields.
+- OnSubmit creates entity, sets CreatedAt/UpdatedAt if they exist, saves, returns ID via `refreshToken.Refresh(id)`.
+
+#### EditSheet (`[Singular]EditSheet.cs`)
+
+- Constructor: `(IState<bool> isOpen, int [entityCamelCase]Id)`.
+- Query entity by ID.
+- Loading state: `Skeleton.Form().ToSheet(isOpen, "Edit [Singular]")`.
+- `.ToForm().Remove(e => e.Id, e => e.CreatedAt, e => e.UpdatedAt)` - ONLY remove properties that actually exist on the entity.
+- Use `.Builder()` for custom inputs (TextArea for long text, AsyncSelect for FKs, etc.).
+- OnSubmit sets `UpdatedAt = DateTime.UtcNow` if property exists, updates entity, revalidates tags.
+
+#### RelationshipBlade (`[Parent][ChildPlural]Blade.cs`)
+
+- Constructor: `(int [parentCamelCase]Id)`.
+- Query child entities filtered by parent ID with `.Where(e => e.[ParentId] == [parentCamelCase]Id)`.
+- For FK properties on child entities, `.Include()` the navigation property and project the resolved name -- never show raw FK IDs as table columns.
+- Use `.ToTable()` with `.Totals()` for numeric columns and `.RemoveEmptyColumns()`.
+- Each row has Delete button with `.WithConfirm()` and Edit trigger to `[Parent][ChildPlural]EditSheet`.
+- Add button triggers `[Parent][ChildPlural]CreateDialog(isOpen, refreshToken, [parentCamelCase]Id)`.
+- UseEffect on refreshToken to revalidate both child list and parent tags.
+- Empty state: show Callout with info variant.
+
+#### RelationshipCreateDialog (`[Parent][ChildPlural]CreateDialog.cs`)
+
+- Constructor: `(IState<bool> isOpen, RefreshToken refreshToken, int [parentCamelCase]Id)`.
+- Parent ID is passed via constructor, NOT part of the form.
+- CreateRequest record MUST only have user input fields -- no parent FK, no Id, no CreatedAt, no UpdatedAt.
+- Set parent FK directly when creating entity: `[ParentId] = [parentCamelCase]Id`.
+
+#### RelationshipEditSheet (`[Parent][ChildPlural]EditSheet.cs`)
+
+- Constructor: `(IState<bool> isOpen, RefreshToken refreshToken, int [childCamelCase]Id)`.
+- For regular child entities with their own ID, only the child ID is needed.
+- For junction tables with composite keys, accept ALL key fields.
+- `.Remove()` the parent FK and ID fields that shouldn't be editable.
+
+### Pattern Sources
+- Use ONLY the reference documents in the `references/` folder and `ivy docs` / `ivy ask` for API patterns and code examples.
+- Do NOT read existing app files in the project's `Apps/` directory for patterns.
+
+### Critical Code Generation Rules
+
+#### Use Modern C# Features
+- Use file-scoped namespaces, primary constructors, collection expressions.
+- Use `record` for DTOs with `{ get; init; }` properties.
+
+#### Icon Usage
+Only use icons from the Icons enum. Common ones: `Icons.Pencil`, `Icons.Trash`, `Icons.Plus`, `Icons.ChevronRight`, `Icons.Search`, `Icons.Filter`.
+
+#### Entity Property Verification
+- ALWAYS check entity definitions before using any property.
+- Don't assume properties exist (CreatedAt, UpdatedAt, FullName, etc.).
+- Match property types exactly (int vs int?, DateTime vs string).
+- If navigational properties don't exist in the POCOs, don't use `.Include()`.
+
+#### ToForm() Rules
+- Only `.Remove()` properties that actually exist on the model.
+- Only `.Builder()` with builders you've seen in the reference examples.
+- ToMoneyInput MUST be followed by `.Currency("USD")` or appropriate currency.
+- ToAsyncMultiSelectInput does NOT exist.
+- Always provide explicit input builder to avoid CS0411 errors: `.Builder(e => e.Field, e => e.ToTextInput())`.
+
+#### Available Form Builders by Type
+
+**string:** `ToTextInput()`, `ToTextareaInput()`, `ToPasswordInput()`, `ToEmailInput()`, `ToUrlInput()`, `ToTelInput()`, `ToColorInput()`, `ToCodeInput()`
+**DateTime, DateTime?:** `ToDateInput()`, `ToDateTimeInput()`. Never use `ToTextareaInput()` for dates.
+**int, long, decimal, double, float:** `ToNumberInput()`, `ToFeedbackInput()`, `ToMoneyInput()` (MUST chain `.Currency()`)
+**Foreign keys:** `ToAsyncSelectInput(searchFn, lookupFn, placeholder)` -- single selection only
+
+#### Async Select Pattern
+For foreign key dropdowns, create two static methods:
+- `Use[Entity]Search(IViewContext context, string query)` - returns `QueryResult<Option<TKey?>[]>`
+- `Use[Entity]Lookup(IViewContext context, TKey? id)` - returns `QueryResult<Option<TKey?>?>`
+
+**CRITICAL: Return type MUST be `QueryResult<>`, NOT `Task<>`.** Always use `context.UseQuery()` which returns `QueryResult<>`.
+
+#### FK Validation in EditSheet
+
+When editing, entity FK properties are non-nullable (`int`, `Guid`). If the user clears a required FK field, the value becomes `0` or `Guid.Empty`. Add explicit validation:
+```csharp
+if (request.CustomerId == default)
+{
+    client.Error("Please select a customer.");
+    return;
+}
+```
+
+#### IQueryable Type with Include
+When using `.Include()` followed by `.Where()`, explicitly type as `IQueryable<Entity>` to avoid type mismatch:
+```csharp
+IQueryable<Order> query = db.Orders.Include(o => o.Customer);
+query = query.Where(o => o.StoreName.Contains(filter));
+```
+
+### After Implementation
+After writing all files for each entity, summarize what was created.

--- a/src/skills/ivy-create-crud/references/AGENTS.md
+++ b/src/skills/ivy-create-crud/references/AGENTS.md
@@ -1,0 +1,350 @@
+﻿# Introduction to the Ivy Framework for LLMs
+
+- Ivy is a declarative full-stack UI framework that allows developers to build user interfaces using a component-based approach very similar to React.
+- In Ivy, you only write one application in pure C# and we don't have a BE and FE distinction.
+- UI rendering is handled by Ivy.
+- When programming in Ivy you focus on building the logical structure of your application using a large set of pre-built widgets and views - you rarely need to specify any styling - Ivy just makes it look good by default.
+
+Terminology:
+
+- "Views" are the main building blocks of the UI, similar to React components.
+- "Hooks" are functions that allow views to manage state and side effects.
+- "Widgets" are the UI elements that make up the views. e.g., Button, TextBlock, StackPanel...
+- "Apps" are the top-level views that represent entire applications.
+
+A view is defined as a class that inherits from `ViewBase` and implements a `Build` method. The `Build` method returns either another view or a widget.
+
+> WARNING: There is NO `AppBase` class. ALL views and apps inherit from `ViewBase`.
+
+Widgets can have multiple children, but views can only return a single object (widget or view). To return multiple widgets from a view, you can use a `Fragment` use the Layout helpers. See below.
+
+public class MyView : ViewBase
+{
+  public override object? Build()
+  {
+    var count = UseState(0);
+    return Layout.Vertical()
+        | new Text($"Count: {count.Value}")
+        | new Button("Increment", () => count.Set(count.Value + 1));
+  }
+}
+
+The topmost view in an Ivy application is called an [App](https://docs.ivy.app/onboarding/concepts/apps.md) and is decorated with the `[App]` attribute. The attribute uses **named constructor parameters** (lowercase):
+
+[App(title: "Customers", icon: Icons.Rocket, group: new[] { "CRM" })]
+public class CustomersApp : ViewBase
+
+- `title` is optional — if omitted, it is derived from the class name (e.g. `CustomersApp` → "Customers").
+- `icon` uses the `Icons` enum — these are Lucide icons in PascalCase (e.g. `Icons.Link`, `Icons.Settings`, `Icons.Rocket`).
+- `group` groups the app in the navigation sidebar (e.g. `group: new[] { "Apps" }`).
+- There is no `chrome` parameter. Chrome is configured in `Program.cs` via `server.UseDefaultApp(typeof(MyApp))`. Always ensure `server.AddAppsFromAssembly()` is called before `UseDefaultApp` — without it, `[App]`-attributed classes are not registered and the server throws at runtime.
+- Use **lowercase** parameter names (`icon:`, `group:`), NOT PascalCase property names (`Icon =`, `Group =`) — PascalCase causes CS0655.
+
+An app is built into a tree of widgets. This is what's rendered to the screen.
+
+## Application Structure
+
+A typical Ivy project has this folder structure:
+
+MyProject/
+├── Program.cs                  # Entry point — configures and starts the Ivy server
+├── MyProject.csproj            # Project file
+├── Apps/                       # All app classes go here (convention)
+│   ├── DashboardApp.cs
+│   └── Settings/               # Subfolder namespaces become URL path segments
+│       └── UserProfileApp.cs   # → /settings/user-profile
+└── Connections/
+    └── MyDb/
+        ├── MyDbContext.cs
+        ├── MyDbContextFactory.cs
+        ├── MyDbConnection.cs
+        └── Product.cs          # Entity classes
+
+### Dependency Injection
+
+Register services in Program.cs, consume them in views with `UseService<T>()`:
+
+// Program.cs
+server.Services.AddSingleton<IMyService, MyService>();
+
+// In a view
+var myService = UseService<IMyService>();
+
+## Common Widgets
+
+[Button](https://docs.ivy.app/widgets/common/button.md)
+[Card](https://docs.ivy.app/widgets/common/card.md)
+[Badge](https://docs.ivy.app/widgets/common/badge.md)
+[Sheet](https://docs.ivy.app/widgets/advanced/sheet.md)
+[Progress](https://docs.ivy.app/widgets/common/progress.md)
+[Expandable](https://docs.ivy.app/widgets/common/expandable.md)
+[Tooltip](https://docs.ivy.app/widgets/common/tooltip.md)
+[DropDownMenu](https://docs.ivy.app/widgets/common/drop-down-menu.md)
+[Table](https://docs.ivy.app/widgets/common/table.md)
+[List](https://docs.ivy.app/widgets/common/list.md)
+[Details](https://docs.ivy.app/widgets/common/details.md)
+[Image](https://docs.ivy.app/widgets/primitives/image.md)
+[Avatar](https://docs.ivy.app/widgets/primitives/avatar.md)
+[Spacer](https://docs.ivy.app/widgets/primitives/spacer.md)
+[Callout](https://docs.ivy.app/widgets/primitives/callout.md)
+
+## Layouts
+
+- Use Layout.Vertical() or Layout.Horizontal() to create stack layouts.
+- Layout.Grid()
+— Layout.Wrap()
+- Add Children: Pipe child elements using the | operator to arrange them top-to-bottom (vertical) or left-to-right (horizontal).
+- Layouts can be customized with methods like .Gap(int number) to set spacing between children. Use .Left(), .Center(), or .Right() methods to control alignment.
+- The number in Gap(int number) works the same as in Tailwind CSS spacing scale (e.g., 1 = 0.25rem, 2 = 0.5rem, etc.).
+- Layouts have a default gap of 4 (1rem). Do NOT add `.Gap(4)` — it is the default and adds unnecessary noise. Only use `.Gap()` when you need a value other than 4.
+- `.Padding()` is rarely needed. Layouts and pages already have appropriate padding by default. Only add `.Padding()` when you need extra inner spacing for a specific design reason.
+
+// Basic Vertical Layout
+Layout.Vertical()
+    | new Badge("Top")
+    | new Badge("Middle")
+    | new Badge("Bottom");
+
+// Nested layouts with alignment
+Layout.Vertical().AlignContent(Align.Center)
+    | Text.Label("Header")
+    | (Layout.Horizontal()
+        | new Button("Previous")
+        | new Button("Next")); //NOTE: Parentheses are used to group the horizontal layout - THIS IS REQUIRED
+
+Grids:
+
+Layout.Grid()
+  .Columns(2)
+  .Rows(2)
+    | Text.Block("Cell 1")
+    | Text.Block("Cell 2")
+    ...
+
+Align values: TopLeft, TopCenter, TopRight, Left, Center, Right, BottomLeft, BottomCenter, BottomRight, Stretch
+
+[Layouts](https://docs.ivy.app/onboarding/concepts/layout.md)
+
+## Text
+
+The Text helper utility is used to create various semantic text elements.
+
+- Text.H1, Text.H2, : For headings.
+- Text.Lead: For prominent introductory text.
+- Text.P: For standard paragraphs.
+- Text.Block: For block-level content (e.g., list items).
+- Text.InlineCode: For displaying inline code snippets.
+- Test.Muted
+
+Styling Modifiers:
+.NoWrap():
+.Bold()
+.Italic()
+.StrikeThrough()
+.Color(Colors)
+
+Layout.Vertical()
+    | Text.H1("Getting Started")
+    | Text.P("This is a paragraph of text.").NoWrap()
+
+[Text](https://docs.ivy.app/widgets/primitives/text-block.md)
+
+## Colors
+
+Ivy.Colors enum has the following values:
+
+Black, White, Slate, Gray, Zinc, Neutral, Stone, Red, Orange, Amber, Yellow, Lime, Green, Emerald, Teal, Cyan, Sky, Blue, Indigo, Violet, Purple, Fuchsia, Pink, Rose, Primary, Secondary, Destructive, Success, Warning, Info, Muted
+
+## Density
+
+All widgets support `.Density(Density.Small)`, `.Density(Density.Medium)`, `.Density(Density.Large)`.
+Convenience methods: `.Small()`, `.Medium()`, `.Large()`.
+Density adjusts the overall visual size of a widget (text, padding, etc.).
+There is no `ButtonSize` enum — use `Density` for all widgets.
+
+## Size
+
+`.Width(Size.X)` and `.Height(Size.X)` set widget dimensions.
+`.Size(Size.X)` sets both width and height.
+
+Common Size values:
+
+- Size.Units(n) — Tailwind spacing scale (n × 0.25rem)
+- Size.Full() — 100%
+- Size.Fit() — fit-content
+- Size.Auto() — auto
+- Size.Px(n) — exact pixels
+- Size.Fraction(0.5f) — percentage, Size.Half(), Size.Third()
+
+Size is NOT the same as Density. Size controls dimensions; Density controls visual density.
+
+## Event Handling
+
+new Button("Click Me")
+  .Primary()
+  .OnClick(() => {
+    count.Set(count.Value + 1);
+})
+
+new TextInput().Default()
+    .Value(text.Value)
+    .OnChange(text.Set)
+    .OnBlur(() => Console.WriteLine("Blurred"))
+
+## Hooks
+
+- Most hooks that you know from React are available in Ivy. They follow the same principles as in React.
+- Hooks should only be called at the top level of a Build() method, not inside loops or conditions.
+
+### UseState
+
+var nameState = UseState("World");
+var iconsState = UseState<Icons[]>();
+
+If you don't specify a value, default(T) is used.
+
+UseState hook returns a state object IState<T> that provides:
+
+> WARNING: UseState returns `IState<T>`, NOT `State<T>`. There is no `State<T>` type in Ivy.
+
+- .Value property to read the current state.
+- .Set(newValue) method to update the state in UseEffect or in an event handler.
+
+Always use immutable types (e.g. records) with `UseState` — mutable classes that are modified in-place and passed back via `.Set()` will not trigger a re-render because the reference hasn't changed. Instead, create a new instance (e.g. using `with` expressions on records) before calling `.Set()`.
+
+### UseEffect
+
+void UseEffect(Action effect, params IEffectTriggers[] triggers)
+void UseEffect(Func<Task> asyncEffect, params IEffectTriggers[] triggers)
+void UseEffect(Func<IDisposable> effectWithCleanup, params IEffectTriggers[] triggers)
+void UseEffect(Func<Task<IDisposable>> asyncEffectWithCleanup, IEffectTriggers object[] triggers)
+
+- EffectTrigger.OnBuild() - runs after every build
+- EffectTrigger.OnMount() - runs once when the view is first mounted
+- EffectTrigger.OnStateChange(IState<T>) - runs when the specified state changes
+
+- IState<T> is automatically converted to EffectTrigger.OnStateChange
+- If no triggers are provided, the effect trigger is assumed to be OnMount.
+
+### UseQuery
+
+UseQuery is the **preferred pattern for data fetching** in Ivy. It should be favored over the UseEffect + UseState fetch pattern.
+
+var query = UseQuery(
+    key: "my-data",
+    fetcher: async (ct) => await LoadDataAsync(ct)
+);
+
+if (query.Loading) return Skeleton.Card();
+if (query.Error is { } error) return Callout.Error(error.Message);
+
+// Use query.Value
+
+QueryResult<T> properties:
+
+- .Value — the fetched data (default until loaded)
+- .Loading — true during initial fetch (no value yet)
+- .Validating — true during background revalidation
+- .Error — exception if the fetch failed
+- .Mutator — provides .Revalidate(), .Invalidate(), .Mutate(value, revalidate)
+
+**Do not combine UseQuery with DataTable for EF Core data.** When a DataTable can receive an EF Core `IQueryable` directly, pass it to `.ToDataTable()` without UseQuery. DataTables handle their own server-side data loading. (API data fetched via UseQuery → `.ToDataTable()` is fine.)
+
+Key conventions:
+
+- String: `"my-data"`
+- Tuple: `(nameof(MyBlade), entityId)`
+
+Common options (QueryOptions):
+
+- KeepPrevious: true — show stale data while revalidating with a new key
+- RevalidateOnMount: false — skip initial fetch when using initialValue
+- RefreshInterval: TimeSpan — poll at an interval
+- Scope: QueryScope.View — isolate cache to the view instance (default is Server)
+
+Tag-based invalidation (cross-component):
+var queryService = UseService<IQueryService>();
+queryService.RevalidateByTag(typeof(Product[]));        // collection
+queryService.RevalidateByTag((typeof(Product), id));    // single entity
+
+Static "hooks" pattern (reusable across views):
+public static QueryResult<T[]> UseMyRecords(IViewContext context, string filter)
+{
+    return context.UseQuery(
+        key: (nameof(UseMyRecords), filter),
+        fetcher: async ct => { /*fetch*/ },
+        tags: [typeof(T[])],
+        options: new QueryOptions { KeepPrevious = true }
+    );
+}
+
+Dependent fetching (wait for another query):
+var user = UseQuery(key: "user", fetcher: async ct => await GetUser(ct));
+var projects = UseQuery(
+    () => user.Value?.Id,   // null = idle, no fetch
+    async (userId, ct) => await GetProjects(userId, ct));
+
+[UseRef](https://docs.ivy.app/hooks/core/use-ref.md)
+[UseContext](https://docs.ivy.app/hooks/core/use-context.md)
+[UseQuery](https://docs.ivy.app/hooks/core/use-query.md)
+[UseMutation](https://docs.ivy.app/hooks/core/use-mutation.md)
+[UseSignal](https://docs.ivy.app/hooks/core/use-signal.md)
+[UseService](https://docs.ivy.app/hooks/core/use-service.md)
+[UseArgs](https://docs.ivy.app/hooks/core/use-args.md)
+[UseDownload](https://docs.ivy.app/hooks/core/use-download.md)
+[UseRefreshToken](https://docs.ivy.app/hooks/core/use-refresh-token.md)
+[UseTrigger](https://docs.ivy.app/hooks/core/use-trigger.md)
+[UseWebhook](https://docs.ivy.app/hooks/core/use-webhook.md)
+[UseAlert](https://docs.ivy.app/onboarding/concepts/alerts.md)
+
+## Inputs
+
+Ivy has several Input widgets for handling user input. There are rarely used directly - instead we use
+extension methods on IState<T> to bind state to inputs.
+
+var userNameState = UseState("");
+var input = userNameState.ToTextInput().Placeholder("Enter your name");
+
+Most inputs have extension methods for common configurations:
+userNameState.ToTextInput().Required().MaxLength(50).Placeholder("Enter your name");
+
+[TextInput](https://docs.ivy.app/widgets/inputs/text-input.md)
+[NumberInput](https://docs.ivy.app/widgets/inputs/number-input.md)
+[BoolInput](https://docs.ivy.app/widgets/inputs/bool-input.md)
+[SelectInput](https://docs.ivy.app/widgets/inputs/select-input.md)
+[AsyncSelectInput](https://docs.ivy.app/widgets/inputs/async-select-input.md)
+[DateTimeInput](https://docs.ivy.app/widgets/inputs/date-time-input.md)
+[DateRangeInput](https://docs.ivy.app/widgets/inputs/date-range-input.md)
+[ColorInput](https://docs.ivy.app/widgets/inputs/color-input.md)
+[CodeInput](https://docs.ivy.app/widgets/inputs/code-input.md)
+[FeedbackInput](https://docs.ivy.app/widgets/inputs/feedback-input.md)
+[FileInput](https://docs.ivy.app/widgets/inputs/file-input.md)
+
+## Common Hallucinations
+
+- Base class is `ViewBase` (NOT `AppBase` there is no `AppBase` class)
+- `Text` is a static helper - use `Text.P()`, `Text.H2()`, ...
+- `UseState<T>()` returns `IState<T>`, NOT `State<T>`
+- All types are in the `Ivy` namespace
+- `Colors` is a flat enum (e.g. `Colors.Red`, `Colors.Blue`) we have no shade levels
+- `DbContext` must never be injected directly! Always resolve `IDbContextFactory<T>` via `UseService` and create scoped instances with `CreateDbContextAsync()` inside query/mutation lambdas
+- **Nested layouts MUST use parentheses** — `Layout.Vertical() | (Layout.Horizontal() | child1 | child2)` — without parentheses, C# left-to-right `|` evaluation adds children to the outer layout, not the inner one. See the nested layout example in the Layouts section above.
+
+## CLI Commands
+
+Prefer using `ivy cli explain` for command discovery over MCP server tools as it provides a reliable, built-in structural breakdown.
+
+## Further Reading
+
+[Forms](https://docs.ivy.app/onboarding/concepts/forms.md)
+[DataTable](https://docs.ivy.app/widgets/advanced/data-table.md)
+[Table](https://docs.ivy.app/widgets/common/table.md)
+[Details](https://docs.ivy.app/widgets/common/details.md) - Display structured label-value pairs
+[Program.cs](https://docs.ivy.app/onboarding/concepts/program.md)
+[Size](https://docs.ivy.app/api-reference/ivy-shared/size.md)
+[Align](https://docs.ivy.app/api-reference/ivy-shared/align.md)
+[Downloads](https://docs.ivy.app/hooks/core/use-download.md)
+[Icons](https://raw.githubusercontent.com/Ivy-Interactive/Ivy-Framework/refs/heads/main/src/Ivy/Shared/Icons.cs)
+
+All Ivy documentation pages are listed on: <https://docs.ivy.app/sitemap.xml>.
+Add ".md" to the end of any URL to go directly to the Markdown version of the doc.

--- a/src/skills/ivy-create-crud/references/OrderCreateDialog.cs
+++ b/src/skills/ivy-create-crud/references/OrderCreateDialog.cs
@@ -1,0 +1,103 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Ivy;
+using MyProject.Connections.MyDb;
+using Microsoft.EntityFrameworkCore;
+
+namespace MyProject.Apps.Orders;
+
+public class OrderCreateDialog(IState<bool> isOpen, RefreshToken refreshToken) : ViewBase
+{
+    private record OrderCreateRequest
+    {
+        [Required]
+        public Guid? CustomerId { get; init; } = null;
+
+        [Required]
+        public string StoreName { get; init; } = "";
+
+        [Required]
+        public string StoreMarket { get; init; } = "";
+
+        [Required]
+        public string StoreType { get; init; } = "";
+
+        [Required]
+        public string Channel { get; init; } = "";
+
+        [Required]
+        public OrderStatus Status { get; init; }
+    }
+
+    public override object? Build()
+    {
+        var factory = UseService<MyDbContextFactory>();
+        var order = UseState(() => new OrderCreateRequest());
+
+        return order
+            .ToForm()
+            .Builder(e => e.CustomerId, e => e.ToAsyncSelectInput(UseCustomerSearch, UseCustomerLookup, placeholder: "Select Customer"))
+            .OnSubmit(OnSubmit)
+            .ToDialog(isOpen, title: "Create Order", submitTitle: "Create");
+
+        async Task OnSubmit(OrderCreateRequest request)
+        {
+            var orderId = await CreateOrderAsync(factory, request);
+            refreshToken.Refresh(orderId);
+        }
+    }
+
+    private async Task<int> CreateOrderAsync(MyDbContextFactory factory, OrderCreateRequest request)
+    {
+        await using var db = factory.CreateDbContext();
+
+        var order = new Order()
+        {
+            CustomerId = request.CustomerId!.Value,
+            StoreName = request.StoreName,
+            StoreMarket = request.StoreMarket,
+            StoreType = request.StoreType,
+            Channel = request.Channel,
+            Status = request.Status,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+
+        db.Orders.Add(order);
+        await db.SaveChangesAsync();
+
+        return order.Id;
+    }
+
+    private static QueryResult<Option<Guid?>[]> UseCustomerSearch(IViewContext context, string query)
+    {
+        var factory = context.UseService<MyDbContextFactory>();
+        return context.UseQuery(
+            key: (nameof(UseCustomerSearch), query),
+            fetcher: async ct =>
+            {
+                await using var db = factory.CreateDbContext();
+                return (await db.Customers
+                        .Where(e => e.FirstName.Contains(query) || e.LastName.Contains(query))
+                        .Select(e => new { e.Id, Name = e.FirstName + " " + e.LastName })
+                        .Take(50)
+                        .ToArrayAsync(ct))
+                    .Select(e => new Option<Guid?>(e.Name, e.Id))
+                    .ToArray();
+            });
+    }
+
+    private static QueryResult<Option<Guid?>?> UseCustomerLookup(IViewContext context, Guid? id)
+    {
+        var factory = context.UseService<MyDbContextFactory>();
+        return context.UseQuery(
+            key: (nameof(UseCustomerLookup), id),
+            fetcher: async ct =>
+            {
+                if (id == null) return null;
+                await using var db = factory.CreateDbContext();
+                var customer = await db.Customers.FirstOrDefaultAsync(e => e.Id == id, ct);
+                if (customer == null) return null;
+                return new Option<Guid?>(customer.FirstName + " " + customer.LastName, customer.Id);
+            });
+    }
+}

--- a/src/skills/ivy-create-crud/references/OrderDetailsBlade.cs
+++ b/src/skills/ivy-create-crud/references/OrderDetailsBlade.cs
@@ -1,0 +1,125 @@
+﻿using Ivy;
+using MyProject.Connections.MyDb;
+using Microsoft.EntityFrameworkCore;
+
+namespace MyProject.Apps.Orders;
+
+public class OrderDetailsBlade(int orderId) : ViewBase
+{
+    public override object? Build()
+    {
+        var factory = UseService<MyDbContextFactory>();
+        var blades = UseContext<IBladeContext>();
+        var queryService = UseService<IQueryService>();
+
+        var orderQuery = UseQuery(
+            key: (nameof(OrderDetailsBlade), orderId),
+            fetcher: async ct =>
+            {
+                await using var db = factory.CreateDbContext();
+                return await db.Orders.Include(e => e.Customer).SingleOrDefaultAsync(e => e.Id == orderId, ct);
+            },
+            tags: [(typeof(Order), orderId)]
+        );
+
+        //used in details card
+        var totalAmountQuery = UseQuery(
+            key: (nameof(OrderDetailsBlade), "totalAmount", orderId),
+            fetcher: async ct =>
+            {
+                await using var db = factory.CreateDbContext();
+                return await db.Lines.Where(e => e.OrderId == orderId).SumAsync(e => e.Quantity * e.Price - e.Discount, ct);
+            },
+            tags: [(typeof(Order), orderId)]
+        );
+
+        //used in related card to show the number of lines in the order
+        var lineCountQuery = UseQuery(
+            key: (nameof(OrderDetailsBlade), "lineCount", orderId),
+            fetcher: async ct =>
+            {
+                await using var db = factory.CreateDbContext();
+                return await db.Lines.CountAsync(e => e.OrderId == orderId, ct);
+            },
+            tags: [(typeof(Order), orderId), typeof(Line[])]
+        );
+
+        if (orderQuery.Loading) return Skeleton.Card();
+
+        if (orderQuery.Value == null)
+        {
+            return new Callout($"Order '{orderId}' not found. It may have been deleted.")
+                .Variant(CalloutVariant.Warning);
+        }
+
+        var orderValue = orderQuery.Value;
+
+        var deleteBtn = new Button("Delete", onClick: async _ =>
+            {
+                blades.Pop(refresh: true);
+                await DeleteAsync(factory);
+                queryService.RevalidateByTag(typeof(Order[]));
+            })
+            .Variant(ButtonVariant.Destructive)
+            .Icon(Icons.Trash)
+            .WithConfirm("Are you sure you want to delete this order?", "Delete Order");
+
+        var editBtn = new Button("Edit")
+            .Outline()
+            .Icon(Icons.Pencil)
+            .ToTrigger((isOpen) => new OrderEditSheet(isOpen, orderId));
+
+        var statusBadge = new Badge(orderValue.Status.GetDescription())
+            .Variant(orderValue.Status switch
+            {
+                OrderStatus.Shipped => BadgeVariant.Success,
+                OrderStatus.Delivered => BadgeVariant.Info,
+                OrderStatus.Cancelled => BadgeVariant.Destructive,
+                OrderStatus.InProgress => BadgeVariant.Warning,
+                _ => BadgeVariant.Secondary
+            });
+
+        var detailsCard = new Card(
+            content: new
+            {
+                orderValue.Id,
+                CustomerName = $"{orderValue.Customer.FirstName} {orderValue.Customer.LastName}",
+                orderValue.StoreName,
+                orderValue.StoreMarket,
+                orderValue.StoreType,
+                orderValue.Channel,
+                orderValue.Status,
+                TotalAmount = totalAmountQuery.Value
+            }.ToDetails()
+                .RemoveEmpty()
+                .Builder(e => e.Id, e => e.CopyToClipboard())
+                .Builder(e => e.Status, e => e.Func((OrderStatus _) => statusBadge)),
+            footer: Layout.Horizontal().Gap(2).AlignContent(Align.Right)
+                    | deleteBtn
+                    | editBtn
+        ).Title("Order Details").Width(Size.Units(100));
+
+        var relatedCard = new Card(
+            new List(
+                new ListItem("Lines", onClick: _ =>
+                {
+                    blades.Push(this, new OrderLinesBlade(orderId), "Lines");
+                }, badge: lineCountQuery.Value.ToString("N0")) //we include a badge with the number of lines to show the user how many lines are in the order
+            ));
+
+        return new Fragment()
+               | new BladeHeader(Text.Literal($"Order #{orderValue.Id}"))
+               | (Layout.Vertical() | detailsCard | relatedCard);
+    }
+
+    private async Task DeleteAsync(MyDbContextFactory dbFactory)
+    {
+        await using var db = dbFactory.CreateDbContext();
+        var order = await db.Orders.FirstOrDefaultAsync(e => e.Id == orderId);
+        if (order != null)
+        {
+            db.Orders.Remove(order);
+            await db.SaveChangesAsync();
+        }
+    }
+}

--- a/src/skills/ivy-create-crud/references/OrderEditSheet.cs
+++ b/src/skills/ivy-create-crud/references/OrderEditSheet.cs
@@ -1,0 +1,77 @@
+﻿using Ivy;
+using MyProject.Connections.MyDb;
+using Microsoft.EntityFrameworkCore;
+
+namespace MyProject.Apps.Orders;
+
+public class OrderEditSheet(IState<bool> isOpen, int orderId) : ViewBase
+{
+    public override object? Build()
+    {
+        var factory = UseService<MyDbContextFactory>();
+        var queryService = UseService<IQueryService>();
+
+        var orderQuery = UseQuery(
+            key: (typeof(Order), orderId),
+            fetcher: async ct =>
+            {
+                await using var db = factory.CreateDbContext();
+                return await db.Orders.FirstAsync(e => e.Id == orderId, ct);
+            },
+            tags: [(typeof(Order), orderId)]
+        );
+
+        if (orderQuery.Loading || orderQuery.Value == null)
+            return Skeleton.Form().ToSheet(isOpen, "Edit Order");
+
+        return orderQuery.Value
+            .ToForm()
+            .Remove(e => e.Id, e => e.CreatedAt, e => e.UpdatedAt)
+            .Builder(e => e.CustomerId, e => e.ToAsyncSelectInput(UseCustomerSearch, UseCustomerLookup, placeholder: "Select Customer"))
+            .OnSubmit(OnSubmit)
+            .ToSheet(isOpen, "Edit Order");
+
+        async Task OnSubmit(Order? request)
+        {
+            if (request == null) return;
+            await using var db = factory.CreateDbContext();
+            request.UpdatedAt = DateTime.UtcNow;
+            db.Orders.Update(request);
+            await db.SaveChangesAsync();
+            queryService.RevalidateByTag((typeof(Order), orderId));
+        }
+    }
+
+    private static QueryResult<Option<Guid?>[]> UseCustomerSearch(IViewContext context, string query)
+    {
+        var factory = context.UseService<MyDbContextFactory>();
+        return context.UseQuery(
+            key: (nameof(UseCustomerSearch), query),
+            fetcher: async ct =>
+            {
+                await using var db = factory.CreateDbContext();
+                return (await db.Customers
+                        .Where(e => e.FirstName.Contains(query) || e.LastName.Contains(query))
+                        .Select(e => new { e.Id, FullName = e.FirstName + " " + e.LastName })
+                        .Take(50)
+                        .ToArrayAsync(ct))
+                    .Select(e => new Option<Guid?>(e.FullName, e.Id))
+                    .ToArray();
+            });
+    }
+
+    private static QueryResult<Option<Guid?>?> UseCustomerLookup(IViewContext context, Guid? id)
+    {
+        var factory = context.UseService<MyDbContextFactory>();
+        return context.UseQuery(
+            key: (nameof(UseCustomerLookup), id),
+            fetcher: async ct =>
+            {
+                if (id == null) return null;
+                await using var db = factory.CreateDbContext();
+                var customer = await db.Customers.FirstOrDefaultAsync(e => e.Id == id, ct);
+                if (customer == null) return null;
+                return new Option<Guid?>(customer.FirstName + " " + customer.LastName, customer.Id);
+            });
+    }
+}

--- a/src/skills/ivy-create-crud/references/OrderLineCreateDialog.cs
+++ b/src/skills/ivy-create-crud/references/OrderLineCreateDialog.cs
@@ -1,0 +1,100 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Ivy;
+using MyProject.Connections.MyDb;
+
+using Microsoft.EntityFrameworkCore;
+
+namespace MyProject.Apps.Orders;
+
+public class OrderLineCreateDialog(IState<bool> isOpen, RefreshToken refreshToken, int orderId) : ViewBase
+{
+    // We only include the required fields from the entity.
+    // ALWAYS include the required fields of the entity!
+    // ALWAYS use the same type as in the target entity, so we don't run into issues when saving the entity to the database.
+    private record OrderLineCreateRequest
+    {
+        [Required]
+        public int? ProductId { get; init; } = null;
+
+        public int Quantity { get; init; } = 1;
+
+        public decimal Discount { get; init; } = 0;
+    }
+
+    public override object? Build()
+    {
+        var factory = UseService<MyDbContextFactory>();
+        var orderLine = UseState(() => new OrderLineCreateRequest());
+
+        return orderLine
+            .ToForm()
+            //We only specify Builder if we want to customize the input control for the field - ToForm() will scaffold the form based on the properties of the record
+            //ToAsyncSelectInput allows us to select foreign keys
+            .Builder(e => e.ProductId, e => e.ToAsyncSelectInput(UseProductSearch, UseProductLookup, placeholder: "Select Product"))
+            .OnSubmit(OnSubmit)
+            .ToDialog(isOpen, title: "Add Product to Order", submitTitle: "Add");
+
+        async Task OnSubmit(OrderLineCreateRequest request)
+        {
+            var lineId = await CreateOrderLineAsync(factory, request);
+            refreshToken.Refresh(lineId);
+        }
+    }
+
+    private async Task<int> CreateOrderLineAsync(MyDbContextFactory factory, OrderLineCreateRequest request)
+    {
+        await using var db = factory.CreateDbContext();
+
+        // Get the product to get its price
+        var product = await db.Products.FirstOrDefaultAsync(p => p.Id == request.ProductId!.Value);
+        if (product == null)
+            throw new Exception("Product not found");
+
+        var line = new Line()
+        {
+            OrderId = orderId,
+            ProductId = request.ProductId!.Value,
+            Quantity = request.Quantity,
+            Price = product.Price,
+            Discount = request.Discount,
+        };
+
+        db.Lines.Add(line);
+        await db.SaveChangesAsync();
+
+        return line.Id;
+    }
+
+    private static QueryResult<Option<int?>[]> UseProductSearch(IViewContext context, string query)
+    {
+        var factory = context.UseService<MyDbContextFactory>();
+        return context.UseQuery(
+            key: (nameof(UseProductSearch), query),
+            fetcher: async ct =>
+            {
+                await using var db = factory.CreateDbContext();
+                return (await db.Products
+                        .Where(e => e.Name.Contains(query))
+                        .Select(e => new { e.Id, e.Name })
+                        .Take(50)
+                        .ToArrayAsync(ct))
+                    .Select(e => new Option<int?>(e.Name, e.Id))
+                    .ToArray();
+            });
+    }
+
+    private static QueryResult<Option<int?>?> UseProductLookup(IViewContext context, int? id)
+    {
+        var factory = context.UseService<MyDbContextFactory>();
+        return context.UseQuery(
+            key: (nameof(UseProductLookup), id),
+            fetcher: async ct =>
+            {
+                if (id == null) return null;
+                await using var db = factory.CreateDbContext();
+                var product = await db.Products.FirstOrDefaultAsync(e => e.Id == id, ct);
+                if (product == null) return null;
+                return new Option<int?>(product.Name, product.Id);
+            });
+    }
+}

--- a/src/skills/ivy-create-crud/references/OrderLineEditSheet.cs
+++ b/src/skills/ivy-create-crud/references/OrderLineEditSheet.cs
@@ -1,0 +1,80 @@
+﻿using Ivy;
+using MyProject.Connections.MyDb;
+
+using Microsoft.EntityFrameworkCore;
+
+namespace MyProject.Apps.Orders;
+
+public class OrderLineEditSheet(IState<bool> isOpen, RefreshToken refreshToken, int lineId) : ViewBase
+{
+    public override object? Build()
+    {
+        var factory = UseService<MyDbContextFactory>();
+        var queryService = UseService<IQueryService>();
+
+        var lineQuery = UseQuery(
+            key: (typeof(Line), lineId),
+            fetcher: async ct =>
+            {
+                await using var db = factory.CreateDbContext();
+                return await db.Lines.FirstAsync(e => e.Id == lineId, ct);
+            },
+            tags: [(typeof(Line), lineId)]
+        );
+
+        if (lineQuery.Loading || lineQuery.Value == null)
+            return Skeleton.Form().ToSheet(isOpen, "Edit Order Line");
+
+        return lineQuery.Value
+            .ToForm()
+            .Builder(e => e.ProductId, e => e.ToAsyncSelectInput(UseProductSearch, UseProductLookup, placeholder: "Select Product"))
+            .Place(e => e.Quantity, e => e.Price) // Place quantity and price side by side
+            .Remove(e => e.Id, e => e.OrderId) // Remove fields that shouldn't be editable
+            .OnSubmit(OnSubmit)
+            .ToSheet(isOpen, "Edit Order Line");
+
+        async Task OnSubmit(Line? request)
+        {
+            if (request == null) return;
+            await using var db = factory.CreateDbContext();
+            db.Lines.Update(request);
+            await db.SaveChangesAsync();
+            queryService.RevalidateByTag((typeof(Line), lineId));
+            queryService.RevalidateByTag(typeof(Line[]));
+            refreshToken.Refresh();
+        }
+    }
+
+    private static QueryResult<Option<int?>[]> UseProductSearch(IViewContext context, string query)
+    {
+        var factory = context.UseService<MyDbContextFactory>();
+        return context.UseQuery(
+            key: (nameof(UseProductSearch), query),
+            fetcher: async ct =>
+            {
+                await using var db = factory.CreateDbContext();
+                return (await db.Products
+                        .Where(e => e.Name.Contains(query))
+                        .Select(e => new { e.Id, e.Name })
+                        .Take(50)
+                        .ToArrayAsync(ct))
+                    .Select(e => new Option<int?>(e.Name, e.Id))
+                    .ToArray();
+            });
+    }
+
+    private static QueryResult<Option<int?>?> UseProductLookup(IViewContext context, int? id)
+    {
+        var factory = context.UseService<MyDbContextFactory>();
+        return context.UseQuery(
+            key: (nameof(UseProductLookup), id),
+            fetcher: async ct =>
+            {
+                if (id == null) return null;
+                await using var db = factory.CreateDbContext();
+                var product = await db.Products.FirstOrDefaultAsync(e => e.Id == id, ct);
+                if (product == null) return null;
+                return new Option<int?>(product.Name, product.Id);
+            });
+    }
+}

--- a/src/skills/ivy-create-crud/references/OrderLinesBlade.cs
+++ b/src/skills/ivy-create-crud/references/OrderLinesBlade.cs
@@ -1,0 +1,112 @@
+﻿using Ivy;
+using MyProject.Connections.MyDb;
+
+using Microsoft.EntityFrameworkCore;
+
+namespace MyProject.Apps.Orders;
+
+public class OrderLinesBlade(int orderId) : ViewBase
+{
+    private enum RowAction { Edit, Delete }
+
+    public override object? Build()
+    {
+        var factory = UseService<MyDbContextFactory>();
+        var queryService = UseService<IQueryService>();
+        var refreshToken = UseRefreshToken();
+
+        var editSheetOpen = UseState(() => false);
+        var editingLineId = UseState(() => 0);
+
+        var linesQuery = UseQuery(
+            key: (nameof(OrderLinesBlade), orderId),
+            fetcher: async ct =>
+            {
+                await using var db = factory.CreateDbContext();
+                return await db.Lines.Include(e => e.Product).Where(e => e.OrderId == orderId).ToArrayAsync(ct);
+            },
+            tags: [typeof(Line[]), (typeof(Order), orderId)]
+        );
+
+        UseEffect(() =>
+        {
+            if (refreshToken.ReturnValue is int)
+            {
+                linesQuery.Mutator.Revalidate();
+                queryService.RevalidateByTag((typeof(Order), orderId));
+            }
+        }, [refreshToken]);
+
+        if (linesQuery.Loading) return Skeleton.Card();
+
+        if (linesQuery.Value == null || linesQuery.Value.Length == 0)
+        {
+            var addBtnEmpty = new Button("Add Line").Icon(Icons.Plus).Outline()
+                .ToTrigger((isOpen) => new OrderLineCreateDialog(isOpen, refreshToken, orderId));
+
+            return new Fragment()
+                   | new BladeHeader(addBtnEmpty)
+                   | new Callout("No order lines found. Add a line to get started.").Variant(CalloutVariant.Info);
+        }
+
+        var dataTable = linesQuery.Value.Select(e => new
+        {
+            e.Id,
+            Product = e.Product.Name,
+            Quantity = e.Quantity,
+            Price = e.Price,
+            Discount = e.Discount,
+            DiscountCode = e.DiscountCode,
+            LineTotal = e.Quantity * e.Price - e.Discount,
+            e.Refunded,
+        }).AsQueryable()
+            .ToDataTable(idSelector: e => e.Id)
+            .RefreshToken(refreshToken)
+            .Header(e => e.LineTotal, "Line Total")
+            .Header(e => e.DiscountCode, "Discount Code")
+            .Footer(e => e.LineTotal, "Total", values => values.Sum())
+            .Footer(e => e.Quantity, "Total", values => values.Sum())
+            .RowActions(
+                MenuItem.Default(Icons.Pencil).Tag(RowAction.Edit),
+                MenuItem.Default(Icons.Trash).Tag(RowAction.Delete)
+            )
+            .OnRowAction(args =>
+            {
+                var e = args.Value;
+                if (!Enum.TryParse<RowAction>(e.Tag?.ToString(), ignoreCase: true, out var action)) return ValueTask.CompletedTask;
+                if (!int.TryParse(e.Id?.ToString() ?? "", out int lineId)) return ValueTask.CompletedTask;
+
+                switch (action)
+                {
+                    case RowAction.Edit:
+                        editingLineId.Set(lineId);
+                        editSheetOpen.Set(true);
+                        break;
+                    case RowAction.Delete:
+                        return DeleteAndRefreshAsync(factory, lineId, linesQuery, queryService);
+                }
+                return ValueTask.CompletedTask;
+            });
+
+        var addBtn = new Button("Add Line").Icon(Icons.Plus).Outline()
+            .ToTrigger((isOpen) => new OrderLineCreateDialog(isOpen, refreshToken, orderId));
+
+        return new Fragment()
+               | new BladeHeader(addBtn)
+               | dataTable
+               | new OrderLineEditSheet(editSheetOpen, refreshToken, editingLineId.Value);
+    }
+
+    private async ValueTask DeleteAndRefreshAsync(MyDbContextFactory factory, int lineId, QueryResult<Line[]> linesQuery, IQueryService queryService)
+    {
+        await using var db = factory.CreateDbContext();
+        var line = await db.Lines.SingleOrDefaultAsync(e => e.Id == lineId);
+        if (line != null)
+        {
+            db.Lines.Remove(line);
+            await db.SaveChangesAsync();
+        }
+        linesQuery.Mutator.Revalidate();
+        queryService.RevalidateByTag((typeof(Order), orderId));
+    }
+}

--- a/src/skills/ivy-create-crud/references/OrderListBlade.cs
+++ b/src/skills/ivy-create-crud/references/OrderListBlade.cs
@@ -1,0 +1,125 @@
+﻿using Ivy;
+using MyProject.Connections.MyDb;
+using Microsoft.EntityFrameworkCore;
+
+namespace MyProject.Apps.Orders;
+
+public class OrderListBlade : ViewBase
+{
+    private record OrderListRecord(int Id, string StoreName, string? CustomerName, OrderStatus Status);
+
+    public override object? Build()
+    {
+        var blades = UseContext<IBladeContext>();
+        var refreshToken = UseRefreshToken();
+
+        // Filter state for search
+        var filter = UseState("");
+
+        var ordersQuery = UseOrderListRecords(Context, filter.Value);
+
+        UseEffect(() =>
+        {
+            if (refreshToken.ReturnValue is int orderId)
+            {
+                blades.Pop(this);
+                ordersQuery.Mutator.Revalidate();
+                blades.Push(this, new OrderDetailsBlade(orderId));
+            }
+        }, [refreshToken]);
+
+        var onItemClicked = new Action<Event<ListItem>>(e =>
+        {
+            var order = (OrderListRecord)e.Sender.Tag!;
+            blades.Push(this, new OrderDetailsBlade(order.Id), order.StoreName);
+        });
+
+        object CreateItem(OrderListRecord listRecord) => new FuncView(context =>
+        {
+            var itemQuery = UseOrderListRecord(context, listRecord);
+            if (itemQuery.Loading || itemQuery.Value == null)
+            {
+                return new ListItem();
+            }
+            var record = itemQuery.Value;
+            var statusBadge = new Badge(record.Status.GetDescription())
+                .Variant(record.Status switch
+                {
+                    OrderStatus.Cancelled => BadgeVariant.Destructive,
+                    OrderStatus.PendingReview => BadgeVariant.Warning,
+                    OrderStatus.InProgress => BadgeVariant.Warning,
+                    OrderStatus.Shipped => BadgeVariant.Success,
+                    OrderStatus.Delivered => BadgeVariant.Info,
+                    _ => BadgeVariant.Secondary
+                });
+            return new ListItem(title: record.StoreName, subtitle: record.CustomerName, onClick: onItemClicked, tag: record)
+                .Content(statusBadge);
+        });
+
+        var createBtn = Icons.Plus.ToButton(_ =>
+        {
+            blades.Pop(this);
+        }).Ghost().Tooltip("Create Order").ToTrigger((isOpen) => new OrderCreateDialog(isOpen, refreshToken));
+
+        var items = (ordersQuery.Value ?? []).Select(CreateItem);
+
+        var header = Layout.Horizontal().Gap(1)
+                     | filter.ToSearchInput().Placeholder("Search").Width(Size.Grow())
+                     | createBtn;
+
+        return new Fragment()
+               | new BladeHeader(header)
+               | (ordersQuery.Value == null ? Text.Muted("Loading...") : new List(items));
+    }
+
+    private static QueryResult<OrderListRecord[]> UseOrderListRecords(IViewContext context, string filter)
+    {
+        var factory = context.UseService<MyDbContextFactory>();
+        return context.UseQuery(
+            key: (nameof(UseOrderListRecords), filter),
+            fetcher: async ct =>
+            {
+                await using var db = factory.CreateDbContext();
+
+                var linq = db.Orders.Include(o => o.Customer).AsQueryable();
+
+                if (!string.IsNullOrWhiteSpace(filter))
+                {
+                    filter = filter.Trim();
+                    linq = linq.Where(e => e.StoreName.Contains(filter) || e.Customer.FirstName.Contains(filter) || e.Customer.LastName.Contains(filter));
+                }
+
+                return await linq
+                    .OrderByDescending(e => e.CreatedAt)
+                    .Take(50)
+                    .Select(e => new OrderListRecord(e.Id, e.StoreName, e.Customer != null ? $"{e.Customer.FirstName} {e.Customer.LastName}" : null, e.Status))
+                    .ToArrayAsync(ct);
+            },
+            tags: [typeof(Order[])],
+            options: new QueryOptions()
+            {
+                KeepPrevious = true
+            }
+        );
+    }
+
+    private static QueryResult<OrderListRecord?> UseOrderListRecord(IViewContext context, OrderListRecord record)
+    {
+        var factory = context.UseService<MyDbContextFactory>();
+        return context.UseQuery(
+            key: (nameof(UseOrderListRecord), record.Id),
+            fetcher: async ct =>
+            {
+                await using var db = factory.CreateDbContext();
+                return await db.Orders
+                    .Include(e => e.Customer)
+                    .Where(e => e.Id == record.Id)
+                    .Select(e => new OrderListRecord(e.Id, e.StoreName, e.Customer != null ? $"{e.Customer.FirstName} {e.Customer.LastName}" : null, e.Status))
+                    .FirstOrDefaultAsync(ct);
+            },
+            options: new QueryOptions { RevalidateOnMount = false },
+            initialValue: record,
+            tags: [(typeof(Order), record.Id)]
+        );
+    }
+}

--- a/src/skills/ivy-create-crud/references/OrdersApp.cs
+++ b/src/skills/ivy-create-crud/references/OrdersApp.cs
@@ -1,0 +1,14 @@
+﻿using Ivy;
+using MyProject.Apps.Orders;
+
+namespace MyProject.Apps;
+
+[App(icon: Icons.ShoppingCart, group: ["Apps"])]
+public class OrdersApp : ViewBase
+{
+    public override object? Build()
+    {
+        var blades = UseBlades;
+        return blades(() => new OrderListBlade(), "Search");
+    }
+}

--- a/src/skills/ivy-create-crud/references/ProductCreateDialog.cs
+++ b/src/skills/ivy-create-crud/references/ProductCreateDialog.cs
@@ -1,0 +1,104 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Ivy;
+using MyProject.Connections.MyDb;
+using Microsoft.EntityFrameworkCore;
+
+namespace MyProject.Apps.Products;
+
+public class ProductCreateDialog(IState<bool> isOpen, RefreshToken refreshToken) : ViewBase
+{
+    // We only include the required fields from the entity.
+    // ALWAYS include the required fields of the entity!
+    // ALWAYS use the same type as in the target entity, so we don't run into issues when saving the entity to the database.
+    private record ProductCreateRequest
+    {
+        [Required]
+        public string Name { get; init; } = "";
+
+        [Required]
+        public string Department { get; init; } = "";
+
+        [Required]
+        public int? CategoryId { get; init; } = null;
+    }
+
+    public override object? Build()
+    {
+        var factory = UseService<MyDbContextFactory>();
+        var customer = UseState(() => new ProductCreateRequest());
+
+        return customer
+            .ToForm()
+            // IMPORTANT: No .Remove() needed here! The CreateRequest record only contains user input fields.
+            // We don't have Id, CreatedAt, UpdatedAt in the request model, so there's nothing to remove.
+            //We only specify Builder if we want to customize the input control for the field - ToForm() will scaffold the form based on the properties of the record
+            //ToAsyncSelectInput allows us to select foreign keys
+            .Builder(e => e.CategoryId, e => e.ToAsyncSelectInput(UseCategorySearch, UseCategoryLookup, placeholder: "Select Category"))
+            .OnSubmit(OnSubmit)
+            .ToDialog(isOpen, title: "Create Product", submitTitle: "Create");
+
+        async Task OnSubmit(ProductCreateRequest request)
+        {
+            var productId = await CreateProductAsync(factory, request);
+            refreshToken.Refresh(productId);
+        }
+    }
+
+    private async Task<int> CreateProductAsync(MyDbContextFactory factory, ProductCreateRequest request)
+    {
+        await using var db = factory.CreateDbContext();
+
+        var product = new Product()
+        {
+            Name = request.Name,
+            CategoryId = request.CategoryId!.Value,
+            Department = request.Department,
+            // IMPORTANT: Only set CreatedAt and UpdatedAt if these properties exist on the entity!
+            // Check the entity definition first. Some entities (especially junction tables) may not have these.
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+
+        db.Products.Add(product);
+        await db.SaveChangesAsync();
+
+        return product.Id;
+    }
+
+    // IMPORTANT: AsyncSelect helper methods MUST return QueryResult<>, NOT Task<>.
+    // Search signature: QueryResult<Option<TKey?>[]> MethodName(IViewContext context, string query)
+    // Lookup signature: QueryResult<Option<TKey?>?> MethodName(IViewContext context, TKey? id)
+    // Use context.UseQuery() inside the method body to return QueryResult.
+    private static QueryResult<Option<int?>[]> UseCategorySearch(IViewContext context, string query)
+    {
+        var factory = context.UseService<MyDbContextFactory>();
+        return context.UseQuery(
+            key: (nameof(UseCategorySearch), query),
+            fetcher: async ct =>
+            {
+                await using var db = factory.CreateDbContext();
+                return (await db.Categories
+                        .Where(e => e.Name.Contains(query))
+                        .Select(e => new { e.Id, e.Name })
+                        .Take(50)
+                        .ToArrayAsync(ct))
+                    .Select(e => new Option<int?>(e.Name, e.Id))
+                    .ToArray();
+            });
+    }
+
+    private static QueryResult<Option<int?>?> UseCategoryLookup(IViewContext context, int? id)
+    {
+        var factory = context.UseService<MyDbContextFactory>();
+        return context.UseQuery(
+            key: (nameof(UseCategoryLookup), id),
+            fetcher: async ct =>
+            {
+                if (id == null) return null;
+                await using var db = factory.CreateDbContext();
+                var category = await db.Categories.FirstOrDefaultAsync(e => e.Id == id, ct);
+                if (category == null) return null;
+                return new Option<int?>(category.Name, category.Id);
+            });
+    }
+}

--- a/src/skills/ivy-create-crud/references/ProductDetailsBlade.cs
+++ b/src/skills/ivy-create-crud/references/ProductDetailsBlade.cs
@@ -1,0 +1,100 @@
+﻿using Ivy;
+using MyProject.Connections.MyDb;
+using Microsoft.EntityFrameworkCore;
+
+namespace MyProject.Apps.Products;
+
+public class ProductDetailsBlade(int productId) : ViewBase
+{
+    public override object? Build()
+    {
+        var factory = UseService<MyDbContextFactory>();
+        var blades = UseContext<IBladeContext>();
+        var queryService = UseService<IQueryService>();
+
+        var productQuery = UseQuery(
+            key: (nameof(ProductDetailsBlade), productId),
+            fetcher: async ct =>
+            {
+                await using var db = factory.CreateDbContext();
+                return await db.Products.Include(e => e.Category).SingleOrDefaultAsync(e => e.Id == productId, ct);
+            },
+            tags: [(typeof(Product), productId)]
+        );
+
+        // We can also include interesting computed fields
+        var soldQuery = UseQuery(
+            key: (nameof(ProductDetailsBlade), "sold", productId),
+            fetcher: async ct =>
+            {
+                await using var db = factory.CreateDbContext();
+                return await db.Lines.Where(e => e.ProductId == productId).SumAsync(e => e.Quantity, ct);
+            },
+            tags: [(typeof(Product), productId)]
+        );
+
+        if (productQuery.Loading) return Skeleton.Card();
+
+        if (productQuery.Value == null)
+        {
+            return new Callout($"Product '{productId}' not found. It may have been deleted.")
+                .Variant(CalloutVariant.Warning);
+        }
+
+        var productValue = productQuery.Value;
+
+        var deleteBtn = new Button("Delete", onClick: async _ =>
+            {
+                blades.Pop(refresh: true);
+                await DeleteAsync(factory);
+                queryService.RevalidateByTag(typeof(Product[]));
+            })
+            .Variant(ButtonVariant.Destructive)
+            .Icon(Icons.Trash)
+            .WithConfirm("Are you sure you want to delete this product?", "Delete Product");
+
+        var editBtn = new Button("Edit")
+            .Variant(ButtonVariant.Outline)
+            .Icon(Icons.Pencil)
+            .Width(Size.Grow())
+            //We can assume that a <Entity>EditSheet has been defined in a previous step
+            .ToTrigger((isOpen) => new ProductEditSheet(isOpen, productId));
+
+        var detailsCard = new Card(
+            content: new
+            {
+                // We include some of the interesting fields of the entity here
+                Id = productValue.Id,
+                Name = productValue.Name,
+                Department = productValue.Department,
+                Category = productValue.Category.Name,
+                Description = productValue.Description,
+                // We can also include interesting computed fields
+                Sold = soldQuery.Value,
+            }
+                .ToDetails()
+                //Description is that likely has a lot of text, so we make it multiline
+                .Multiline(e => e.Description)
+                .RemoveEmpty() // Removes "empty" fields from the details
+                .Builder(e => e.Id, e => e.CopyToClipboard()),
+            footer: Layout.Horizontal().Gap(2).AlignContent(Align.Right)
+                    | deleteBtn
+                    | editBtn
+        ).Title("Product Details").Width(Size.Units(100));
+
+        return new Fragment()
+               | new BladeHeader(Text.Literal(productValue.Name))
+               | (Layout.Vertical() | detailsCard);
+    }
+
+    private async Task DeleteAsync(MyDbContextFactory dbFactory)
+    {
+        await using var db = dbFactory.CreateDbContext();
+        var product = await db.Products.FirstOrDefaultAsync(e => e.Id == productId);
+        if (product != null)
+        {
+            db.Products.Remove(product);
+            await db.SaveChangesAsync();
+        }
+    }
+}

--- a/src/skills/ivy-create-crud/references/ProductEditSheet.cs
+++ b/src/skills/ivy-create-crud/references/ProductEditSheet.cs
@@ -1,0 +1,91 @@
+﻿using Ivy;
+using MyProject.Connections.MyDb;
+using Microsoft.EntityFrameworkCore;
+
+namespace MyProject.Apps.Products;
+
+public class ProductEditSheet(IState<bool> isOpen, int productId) : ViewBase
+{
+    public override object? Build()
+    {
+        var factory = UseService<MyDbContextFactory>();
+        var queryService = UseService<IQueryService>();
+
+        var productQuery = UseQuery(
+            key: (typeof(Product), productId),
+            fetcher: async ct =>
+            {
+                await using var db = factory.CreateDbContext();
+                return await db.Products.FirstAsync(e => e.Id == productId, ct);
+            },
+            tags: [(typeof(Product), productId)]
+        );
+
+        if (productQuery.Loading || productQuery.Value == null)
+            return Skeleton.Form().ToSheet(isOpen, "Edit Product");
+
+        return productQuery.Value
+            .ToForm()
+            // ToForm() will scaffold the form based on the properties of the record and create the appropriate builder for input controls
+            // .Build(<expression>, e => To...) will allow us to customize the input control for the field
+            // NOTE! Only use this if you're sure about the syntax, otherwise leave it and let the inputs be scaffolded
+            .Builder(e => e.Rating, e => e.ToFeedbackInput())
+            .Builder(e => e.Description, e => e.ToTextareaInput())
+            .Place(e => e.Name, e => e.Department) // Place will specify the order of the fields
+            .PlaceHorizontal(e => e.Width, e => e.Height) // This will place the fields side by side - useful for related fields such as width and height or first name and last name
+            .Group("Details", e => e.Description, e => e.Brand, e => e.Size, e => e.Variant, e => e.Color) // This will group the fields in a collapsible group - useful for related fields - like address
+                                                                                                           // IMPORTANT: Only remove properties that exist on the entity! Check the entity definition first.
+            .Remove(e => e.Id, e => e.CreatedAt, e => e.UpdatedAt) // We remove these fields from the form as users should not be able to edit them
+            .Builder(e => e.CategoryId, e => e.ToAsyncSelectInput(UseCategorySearch, UseCategoryLookup, placeholder: "Select Category"))
+            .OnSubmit(OnSubmit)
+            .ToSheet(isOpen, "Edit Product");
+
+        async Task OnSubmit(Product? request)
+        {
+            if (request == null) return;
+            await using var db = factory.CreateDbContext();
+            // IMPORTANT: Only set UpdatedAt if the property exists on the entity!
+            // Check the entity definition first. If UpdatedAt doesn't exist, remove this line.
+            // For non-nullable DateTime: always set without null check
+            // For nullable DateTime?: can check for null if needed
+            // WARNING: Never compare non-nullable DateTime to null (causes CS8073)
+            request.UpdatedAt = DateTime.UtcNow; //Note: For DateTime properties use DateTime.UtcNow directly. For string properties use DateTime.UtcNow.ToString("O") instead.
+            db.Products.Update(request);
+            await db.SaveChangesAsync();
+            queryService.RevalidateByTag((typeof(Product), productId));
+        }
+    }
+
+    private static QueryResult<Option<int?>[]> UseCategorySearch(IViewContext context, string query)
+    {
+        var factory = context.UseService<MyDbContextFactory>();
+        return context.UseQuery(
+            key: (nameof(UseCategorySearch), query),
+            fetcher: async ct =>
+            {
+                await using var db = factory.CreateDbContext();
+                return (await db.Categories
+                        .Where(e => e.Name.Contains(query))
+                        .Select(e => new { e.Id, e.Name })
+                        .Take(50)
+                        .ToArrayAsync(ct))
+                    .Select(e => new Option<int?>(e.Name, e.Id))
+                    .ToArray();
+            });
+    }
+
+    private static QueryResult<Option<int?>?> UseCategoryLookup(IViewContext context, int? id)
+    {
+        var factory = context.UseService<MyDbContextFactory>();
+        return context.UseQuery(
+            key: (nameof(UseCategoryLookup), id),
+            fetcher: async ct =>
+            {
+                if (id == null) return null;
+                await using var db = factory.CreateDbContext();
+                var category = await db.Categories.FirstOrDefaultAsync(e => e.Id == id, ct);
+                if (category == null) return null;
+                return new Option<int?>(category.Name, category.Id);
+            });
+    }
+}

--- a/src/skills/ivy-create-crud/references/ProductListBlade.cs
+++ b/src/skills/ivy-create-crud/references/ProductListBlade.cs
@@ -1,0 +1,116 @@
+﻿using MyProject.Connections.MyDb;
+using Microsoft.EntityFrameworkCore;
+
+namespace MyProject.Apps.Products;
+
+public class ProductListBlade : ViewBase
+{
+    private record ProductListRecord(int Id, string Name, string? Department);
+
+    public override object? Build()
+    {
+        //This blade will display a list of products - we choose to include the name and department of the product as these are the most relevant fields for the user.
+
+        var blades = UseContext<IBladeContext>();
+        var refreshToken = UseRefreshToken();
+
+        // Filter state for search
+        var filter = UseState("");
+
+        var productsQuery = UseProductListRecords(Context, filter.Value);
+
+        UseEffect(() =>
+        {
+            if (refreshToken.ReturnValue is int productId)
+            {
+                blades.Pop(this);
+                productsQuery.Mutator.Revalidate();
+                //We can assume that a <Entity>DetailsBlade has been defined in a previous step
+                blades.Push(this, new ProductDetailsBlade(productId));
+            }
+        }, [refreshToken]);
+
+        var onItemClicked = new Action<Event<ListItem>>(e =>
+        {
+            var product = (ProductListRecord)e.Sender.Tag!;
+            //We can assume that a <Entity>DetailsBlade has been defined in a previous step
+            blades.Push(this, new ProductDetailsBlade(product.Id), product.Name);
+        });
+
+        object CreateItem(ProductListRecord listRecord) => new FuncView(context =>
+        {
+            var itemQuery = UseProductListRecord(context, listRecord);
+            if (itemQuery.Loading || itemQuery.Value == null)
+            {
+                return new ListItem();
+            }
+            var record = itemQuery.Value;
+            return new ListItem(title: record.Name, subtitle: record.Department, onClick: onItemClicked, tag: record);
+        });
+
+        var createBtn = Icons.Plus.ToButton(_ =>
+        {
+            blades.Pop(this); // make sure only the current blade is visible
+        }).Ghost().Tooltip("Create Product").ToTrigger((isOpen) => new ProductCreateDialog(isOpen, refreshToken));
+
+        var items = (productsQuery.Value ?? []).Select(CreateItem);
+
+        var header = Layout.Horizontal().Gap(1)
+                     | filter.ToSearchInput().Placeholder("Search").Width(Size.Grow())
+                     | createBtn;
+
+        return new Fragment()
+               | new BladeHeader(header)
+               | (productsQuery.Value == null ? Text.Muted("Loading...") : new List(items));
+    }
+
+    private static QueryResult<ProductListRecord[]> UseProductListRecords(IViewContext context, string filter)
+    {
+        var factory = context.UseService<MyDbContextFactory>();
+        return context.UseQuery(
+            key: (nameof(UseProductListRecords), filter),
+            fetcher: async ct =>
+            {
+                await using var db = factory.CreateDbContext();
+
+                var linq = db.Products.AsQueryable();
+
+                if (!string.IsNullOrWhiteSpace(filter))
+                {
+                    filter = filter.Trim();
+                    linq = linq.Where(e => e.Name.Contains(filter) || e.Department.Contains(filter));
+                }
+
+                return await linq
+                    .OrderByDescending(e => e.CreatedAt)
+                    .Take(50)
+                    .Select(e => new ProductListRecord(e.Id, e.Name, e.Category != null ? e.Category.Name : null))
+                    .ToArrayAsync(ct);
+            },
+            tags: [typeof(Product[])],
+            options: new QueryOptions()
+            {
+                KeepPrevious = true
+            }
+        );
+    }
+
+    private static QueryResult<ProductListRecord?> UseProductListRecord(IViewContext context, ProductListRecord record)
+    {
+        var factory = context.UseService<MyDbContextFactory>();
+        return context.UseQuery(
+            key: (nameof(UseProductListRecord), record.Id),
+            fetcher: async ct =>
+            {
+                await using var db = factory.CreateDbContext();
+                return await db.Products
+                    .Where(e => e.Id == record.Id)
+                    .Select(e => new ProductListRecord(e.Id, e.Name, e.Category != null ? e.Category.Name : null))
+                    .FirstOrDefaultAsync(ct);
+            },
+            options: new QueryOptions { RevalidateOnMount = false },
+            initialValue: record,
+            tags: [(typeof(Product), record.Id)]
+        );
+    }
+}

--- a/src/skills/ivy-create-crud/references/ProductsApp.cs
+++ b/src/skills/ivy-create-crud/references/ProductsApp.cs
@@ -1,0 +1,14 @@
+﻿using Ivy;
+using MyProject.Apps.Products;
+
+namespace MyProject.Apps;
+
+[App(icon: Icons.ShoppingBag, group: ["Apps"])]
+public class ProductsApp : ViewBase
+{
+    public override object? Build()
+    {
+        var blades = UseBlades;
+        return blades(() => new ProductListBlade(), "Search");
+    }
+}

--- a/src/skills/ivy-create-dashboard/SKILL.md
+++ b/src/skills/ivy-create-dashboard/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: ivy-create-dashboard
+description: >
+  Create a Dashboard app with metrics, charts, and KPIs for an Ivy project.
+  Use when the user asks for a dashboard, analytics page, KPI view, reporting view,
+  data visualization app, or metrics overview. Handles MetricView cards, line charts,
+  bar charts, pie charts, area charts, date range filtering, and grid layouts.
+allowed-tools: Bash(dotnet:*) Read Write Edit Glob Grep
+effort: high
+argument-hint: "[description of the dashboard to create]"
+---
+
+# ivy-create-dashboard
+
+Create a Dashboard app with metrics, charts, and KPIs for an Ivy project.
+
+## Reference Files
+
+Read these before implementing:
+- [references/AGENTS.md](references/AGENTS.md) -- Ivy framework API reference (widgets, hooks, layouts, inputs, colors)
+- [references/DashboardApp.cs](references/DashboardApp.cs) -- app structure with HeaderLayout, date range selector, grid layout
+- [references/TotalSalesMetricView.cs](references/TotalSalesMetricView.cs) -- MetricView with trend and goal
+- [references/OrdersMetricView.cs](references/OrdersMetricView.cs) -- MetricView with count aggregation
+- [references/CustomerRetentionRateMetricView.cs](references/CustomerRetentionRateMetricView.cs) -- MetricView with rate calculation
+- [references/SalesByDayLineChartView.cs](references/SalesByDayLineChartView.cs) -- line chart pattern (daily granularity)
+- [references/OrdersByChannelPieChartView.cs](references/OrdersByChannelPieChartView.cs) -- pie chart pattern
+- [references/SalesByCategoryBarChartView.cs](references/SalesByCategoryBarChartView.cs) -- bar chart pattern
+- [references/SalesByStoreTypeAreaChartView.cs](references/SalesByStoreTypeAreaChartView.cs) -- area chart pattern
+
+## Workflow
+
+This skill guides you through creating a complete dashboard application:
+
+1. **Plan** - Analyze the data models and propose metrics + charts
+2. **Review** - Present the plan for user approval (accept / request changes / cancel)
+3. **Implement** - Generate all dashboard files following reference patterns
+
+## Step 1: Plan the Dashboard
+
+If the user has specified a database connection, read the connection context using `ivy cli explain connections/{ConnectionName}`. If not, ask the user which connection to use.
+
+Analyze the data models and suggest approximately 6 metrics (numeric KPIs) and 6 charts.
+
+### Metric Guidelines
+- At least one metric should be a "North Star Metric" - the single most important KPI capturing core value
+- All metrics must be numerical (not categorical). Avoid metrics better represented as charts (e.g., "Sales by Region")
+- The dashboard automatically compares metrics with the previous period - factor this into calculation descriptions
+
+### Chart Guidelines
+- Prefer Line charts unless another type clearly fits better
+- Line chart granularity should be daily
+- Verify all data models and fields exist before suggesting metrics/charts
+
+### Plan Format
+
+Present the plan using this markdown structure:
+
+```
+# Dashboard Plan
+
+**Connection**: `{ConnectionName}`
+**Icon**: `LayoutDashboard`
+
+## Metrics
+
+### Metric: [Title]
+
+**Icon**: `[LucideIcon]`
+**File**: `Apps/Dashboard/[ClassName]MetricView.cs`
+**Namespace**: `{ProjectNamespace}.Apps.Dashboard`
+**Calculation**: `[description of how to calculate, including comparison to previous period]`
+
+## Charts
+
+### Chart: [Title] ([ChartType])
+
+**File**: `Apps/Dashboard/[ClassName][ChartType]ChartView.cs`
+**Namespace**: `{ProjectNamespace}.Apps.Dashboard`
+**Calculation**: `[description including dimensions and measures]`
+```
+
+### Chrome Decision
+- If the dashboard is the **only app** in the project and no multi-app navigation is needed, add a `### Update Program.cs` section that replaces `server.UseAppShell(...)` with `server.UseDefaultApp(typeof(DashboardApp));`.
+- If the project has **multiple apps** or the user explicitly wants sidebar navigation, add a `### Update Program.cs` section that ensures `server.UseAppShell(...)` is present.
+
+Present the plan to the user and ask them to **Accept**, **Request Changes**, or **Cancel**.
+
+## Step 2: Handle Changes
+
+If the user requests changes, apply them to the plan and present the updated plan again.
+
+## Step 3: Implement
+
+Once approved, implement all dashboard files following the reference patterns exactly.
+
+### Project Structure
+
+```
+Apps/
+  DashboardApp.cs                          # Namespace: {ProjectNamespace}.Apps
+  Dashboard/
+    {ClassName}MetricView.cs               # Namespace: {ProjectNamespace}.Apps.Dashboard
+    {ClassName}{ChartType}ChartView.cs     # Namespace: {ProjectNamespace}.Apps.Dashboard
+```
+
+### Required Using Directives
+
+Every generated `.cs` file must include explicit `using` statements. Do NOT rely on global usings.
+
+**Connection usings:**
+- `using {ProjectNamespace}.Connections.{ConnectionName};` -- for context factory
+- `using {ProjectNamespace}.Connections.{ConnectionName}.Models;` -- for entity classes (only if the project uses a Models subfolder; check the connection context)
+- `using Microsoft.EntityFrameworkCore;` -- for ToListAsync, SumAsync, CountAsync, etc.
+
+**Dashboard app:** `Ivy`, `Ivy.Apps`, `Ivy.Core.Hooks`, `Ivy.Hooks`, `Ivy.Shared`, `Ivy.Views`, `Ivy.Views.Dashboards`
+**Metric views:** `Ivy`, `Ivy.Core.Hooks`, `Ivy.Hooks`, `Ivy.Shared`, `Ivy.Views`, `Ivy.Views.Dashboards`
+**Chart views:** `Ivy`, `Ivy.Core.Hooks`, `Ivy.Hooks`, `Ivy.Shared`, `Ivy.Views`, `Ivy.Views.Charts`
+
+### Program.cs Chrome Configuration
+
+Check if the approved plan includes a `### Update Program.cs` section. If it does:
+- If it specifies `UseDefaultApp`: Open `Program.cs` and replace the `server.UseAppShell(...)` line with `server.UseDefaultApp(typeof(DashboardApp));`. Remove the `UseAppShell` line entirely. Do NOT keep both.
+- If it specifies `UseAppShell`: Ensure `server.UseAppShell(...)` is present in `Program.cs`.
+- Follow the approved plan exactly.
+
+### Implementation Instructions
+
+1. Read the reference files listed above for exact code patterns.
+2. Create `Apps/DashboardApp.cs`:
+   - Namespace: `{ProjectNamespace}.Apps`
+   - Using: `{ProjectNamespace}.Apps.Dashboard`
+   - Attribute: `[App(icon: Icons.LayoutDashboard, group: ["Apps"])]`
+   - Follow the DashboardApp reference exactly (date range selector, grid layout, HeaderLayout, etc.)
+3. For each metric in the plan, create `Apps/Dashboard/{ClassName}.cs`:
+   - Namespace: `{ProjectNamespace}.Apps.Dashboard`
+   - Follow the metric reference patterns (MetricView, UseQuery, trend calculation, goals)
+   - Constructor: `(DateTime fromDate, DateTime toDate)`
+4. For each chart in the plan, create `Apps/Dashboard/{ClassName}.cs`:
+   - Namespace: `{ProjectNamespace}.Apps.Dashboard`
+   - Follow the chart reference patterns for the specific chart type
+   - Constructor: `(DateTime fromDate, DateTime toDate)`
+5. Use the correct ContextFactory name based on the connection.
+6. Keep all numbers as double to avoid conversion issues.
+7. After writing all files, summarize what was created.
+
+### Common Pitfalls
+
+These are critical rules for generating correct dashboard code:
+
+#### EF Core Limitations
+- Do NOT use `Split()`, `Join()`, `Reverse()`, `Last()`, `LastOrDefault()`, or custom methods in LINQ queries - they cannot be translated to SQL.
+- Use `Substring()` and `IndexOf()` instead of `Split()` and `Last()`.
+- **IMPORTANT**: Never use positional record constructors (`new ChartData(...)`) inside EF Core LINQ expressions (`.Select()`, `.GroupBy().Select()`, etc.). EF Core/SQLite cannot translate them to SQL. Instead:
+  1. Use anonymous types in the server-side query: `.Select(x => new { x.Name, Total = x.Sum(...) })`
+  2. Materialize with `.ToArrayAsync()` / `.ToListAsync()`
+  3. Project to record types client-side: `raw.Select(x => new ChartData(x.Name, x.Total)).ToArray()`
+
+#### Nullable Types
+- `DateTime?` does not have `.Date` - use `.Value.Date` or filter nulls with `.Where(x => x.Date.HasValue)` first.
+- For `UseState` with nullable types, use explicit cast: `(object?)null`, not just `null`.
+- Call `.Value.ToString("N2")` on nullable types, not `.ToString("N2")` directly.
+- Only use null-coalescing `??` with actually nullable types.
+
+#### GroupBy
+- Always use **named types** (not anonymous types) when using GroupBy followed by aggregation.
+
+#### Aggregation
+- Chart measures MUST use aggregation functions (`.Sum()`, `.Count()`, `.Average()`), never direct property access - even on pre-aggregated data.
+- Check `.Any()` before calling `.Average()` to avoid exceptions on empty collections.
+- `Include()` navigation properties before referencing foreign key relationships.
+
+#### Junction Tables
+- Junction/bridge tables often lack `CreatedAt`/`UpdatedAt` fields. Verify before filtering by date - use related entity timestamps instead.
+
+#### Status Fields
+- Always verify the actual type of status ID fields (`int`, `int?`, `string`) before comparisons.
+- Use actual database seed values, not undefined constants.
+
+#### Date Fields
+- Check entity definitions to determine if date fields are `DateTime` or `string`. If `string`, use `DateTime.Parse()`.
+
+#### ViewBase Inheritance
+- **All metric and chart view classes MUST extend `ViewBase`** and use `public override object? Build()`.
+- Plain classes without `: ViewBase` will render as their `ToString()` output when used with the `|` layout operator.

--- a/src/skills/ivy-create-dashboard/references/AGENTS.md
+++ b/src/skills/ivy-create-dashboard/references/AGENTS.md
@@ -1,0 +1,350 @@
+﻿# Introduction to the Ivy Framework for LLMs
+
+- Ivy is a declarative full-stack UI framework that allows developers to build user interfaces using a component-based approach very similar to React.
+- In Ivy, you only write one application in pure C# and we don't have a BE and FE distinction.
+- UI rendering is handled by Ivy.
+- When programming in Ivy you focus on building the logical structure of your application using a large set of pre-built widgets and views - you rarely need to specify any styling - Ivy just makes it look good by default.
+
+Terminology:
+
+- "Views" are the main building blocks of the UI, similar to React components.
+- "Hooks" are functions that allow views to manage state and side effects.
+- "Widgets" are the UI elements that make up the views. e.g., Button, TextBlock, StackPanel...
+- "Apps" are the top-level views that represent entire applications.
+
+A view is defined as a class that inherits from `ViewBase` and implements a `Build` method. The `Build` method returns either another view or a widget.
+
+> WARNING: There is NO `AppBase` class. ALL views and apps inherit from `ViewBase`.
+
+Widgets can have multiple children, but views can only return a single object (widget or view). To return multiple widgets from a view, you can use a `Fragment` use the Layout helpers. See below.
+
+public class MyView : ViewBase
+{
+  public override object? Build()
+  {
+    var count = UseState(0);
+    return Layout.Vertical()
+        | new Text($"Count: {count.Value}")
+        | new Button("Increment", () => count.Set(count.Value + 1));
+  }
+}
+
+The topmost view in an Ivy application is called an [App](https://docs.ivy.app/onboarding/concepts/apps.md) and is decorated with the `[App]` attribute. The attribute uses **named constructor parameters** (lowercase):
+
+[App(title: "Customers", icon: Icons.Rocket, group: new[] { "CRM" })]
+public class CustomersApp : ViewBase
+
+- `title` is optional — if omitted, it is derived from the class name (e.g. `CustomersApp` → "Customers").
+- `icon` uses the `Icons` enum — these are Lucide icons in PascalCase (e.g. `Icons.Link`, `Icons.Settings`, `Icons.Rocket`).
+- `group` groups the app in the navigation sidebar (e.g. `group: new[] { "Apps" }`).
+- There is no `chrome` parameter. Chrome is configured in `Program.cs` via `server.UseDefaultApp(typeof(MyApp))`. Always ensure `server.AddAppsFromAssembly()` is called before `UseDefaultApp` — without it, `[App]`-attributed classes are not registered and the server throws at runtime.
+- Use **lowercase** parameter names (`icon:`, `group:`), NOT PascalCase property names (`Icon =`, `Group =`) — PascalCase causes CS0655.
+
+An app is built into a tree of widgets. This is what's rendered to the screen.
+
+## Application Structure
+
+A typical Ivy project has this folder structure:
+
+MyProject/
+├── Program.cs                  # Entry point — configures and starts the Ivy server
+├── MyProject.csproj            # Project file
+├── Apps/                       # All app classes go here (convention)
+│   ├── DashboardApp.cs
+│   └── Settings/               # Subfolder namespaces become URL path segments
+│       └── UserProfileApp.cs   # → /settings/user-profile
+└── Connections/
+    └── MyDb/
+        ├── MyDbContext.cs
+        ├── MyDbContextFactory.cs
+        ├── MyDbConnection.cs
+        └── Product.cs          # Entity classes
+
+### Dependency Injection
+
+Register services in Program.cs, consume them in views with `UseService<T>()`:
+
+// Program.cs
+server.Services.AddSingleton<IMyService, MyService>();
+
+// In a view
+var myService = UseService<IMyService>();
+
+## Common Widgets
+
+[Button](https://docs.ivy.app/widgets/common/button.md)
+[Card](https://docs.ivy.app/widgets/common/card.md)
+[Badge](https://docs.ivy.app/widgets/common/badge.md)
+[Sheet](https://docs.ivy.app/widgets/advanced/sheet.md)
+[Progress](https://docs.ivy.app/widgets/common/progress.md)
+[Expandable](https://docs.ivy.app/widgets/common/expandable.md)
+[Tooltip](https://docs.ivy.app/widgets/common/tooltip.md)
+[DropDownMenu](https://docs.ivy.app/widgets/common/drop-down-menu.md)
+[Table](https://docs.ivy.app/widgets/common/table.md)
+[List](https://docs.ivy.app/widgets/common/list.md)
+[Details](https://docs.ivy.app/widgets/common/details.md)
+[Image](https://docs.ivy.app/widgets/primitives/image.md)
+[Avatar](https://docs.ivy.app/widgets/primitives/avatar.md)
+[Spacer](https://docs.ivy.app/widgets/primitives/spacer.md)
+[Callout](https://docs.ivy.app/widgets/primitives/callout.md)
+
+## Layouts
+
+- Use Layout.Vertical() or Layout.Horizontal() to create stack layouts.
+- Layout.Grid()
+— Layout.Wrap()
+- Add Children: Pipe child elements using the | operator to arrange them top-to-bottom (vertical) or left-to-right (horizontal).
+- Layouts can be customized with methods like .Gap(int number) to set spacing between children. Use .Left(), .Center(), or .Right() methods to control alignment.
+- The number in Gap(int number) works the same as in Tailwind CSS spacing scale (e.g., 1 = 0.25rem, 2 = 0.5rem, etc.).
+- Layouts have a default gap of 4 (1rem). Do NOT add `.Gap(4)` — it is the default and adds unnecessary noise. Only use `.Gap()` when you need a value other than 4.
+- `.Padding()` is rarely needed. Layouts and pages already have appropriate padding by default. Only add `.Padding()` when you need extra inner spacing for a specific design reason.
+
+// Basic Vertical Layout
+Layout.Vertical()
+    | new Badge("Top")
+    | new Badge("Middle")
+    | new Badge("Bottom");
+
+// Nested layouts with alignment
+Layout.Vertical().AlignContent(Align.Center)
+    | Text.Label("Header")
+    | (Layout.Horizontal()
+        | new Button("Previous")
+        | new Button("Next")); //NOTE: Parentheses are used to group the horizontal layout - THIS IS REQUIRED
+
+Grids:
+
+Layout.Grid()
+  .Columns(2)
+  .Rows(2)
+    | Text.Block("Cell 1")
+    | Text.Block("Cell 2")
+    ...
+
+Align values: TopLeft, TopCenter, TopRight, Left, Center, Right, BottomLeft, BottomCenter, BottomRight, Stretch
+
+[Layouts](https://docs.ivy.app/onboarding/concepts/layout.md)
+
+## Text
+
+The Text helper utility is used to create various semantic text elements.
+
+- Text.H1, Text.H2, : For headings.
+- Text.Lead: For prominent introductory text.
+- Text.P: For standard paragraphs.
+- Text.Block: For block-level content (e.g., list items).
+- Text.InlineCode: For displaying inline code snippets.
+- Test.Muted
+
+Styling Modifiers:
+.NoWrap():
+.Bold()
+.Italic()
+.StrikeThrough()
+.Color(Colors)
+
+Layout.Vertical()
+    | Text.H1("Getting Started")
+    | Text.P("This is a paragraph of text.").NoWrap()
+
+[Text](https://docs.ivy.app/widgets/primitives/text-block.md)
+
+## Colors
+
+Ivy.Colors enum has the following values:
+
+Black, White, Slate, Gray, Zinc, Neutral, Stone, Red, Orange, Amber, Yellow, Lime, Green, Emerald, Teal, Cyan, Sky, Blue, Indigo, Violet, Purple, Fuchsia, Pink, Rose, Primary, Secondary, Destructive, Success, Warning, Info, Muted
+
+## Density
+
+All widgets support `.Density(Density.Small)`, `.Density(Density.Medium)`, `.Density(Density.Large)`.
+Convenience methods: `.Small()`, `.Medium()`, `.Large()`.
+Density adjusts the overall visual size of a widget (text, padding, etc.).
+There is no `ButtonSize` enum — use `Density` for all widgets.
+
+## Size
+
+`.Width(Size.X)` and `.Height(Size.X)` set widget dimensions.
+`.Size(Size.X)` sets both width and height.
+
+Common Size values:
+
+- Size.Units(n) — Tailwind spacing scale (n × 0.25rem)
+- Size.Full() — 100%
+- Size.Fit() — fit-content
+- Size.Auto() — auto
+- Size.Px(n) — exact pixels
+- Size.Fraction(0.5f) — percentage, Size.Half(), Size.Third()
+
+Size is NOT the same as Density. Size controls dimensions; Density controls visual density.
+
+## Event Handling
+
+new Button("Click Me")
+  .Primary()
+  .OnClick(() => {
+    count.Set(count.Value + 1);
+})
+
+new TextInput().Default()
+    .Value(text.Value)
+    .OnChange(text.Set)
+    .OnBlur(() => Console.WriteLine("Blurred"))
+
+## Hooks
+
+- Most hooks that you know from React are available in Ivy. They follow the same principles as in React.
+- Hooks should only be called at the top level of a Build() method, not inside loops or conditions.
+
+### UseState
+
+var nameState = UseState("World");
+var iconsState = UseState<Icons[]>();
+
+If you don't specify a value, default(T) is used.
+
+UseState hook returns a state object IState<T> that provides:
+
+> WARNING: UseState returns `IState<T>`, NOT `State<T>`. There is no `State<T>` type in Ivy.
+
+- .Value property to read the current state.
+- .Set(newValue) method to update the state in UseEffect or in an event handler.
+
+Always use immutable types (e.g. records) with `UseState` — mutable classes that are modified in-place and passed back via `.Set()` will not trigger a re-render because the reference hasn't changed. Instead, create a new instance (e.g. using `with` expressions on records) before calling `.Set()`.
+
+### UseEffect
+
+void UseEffect(Action effect, params IEffectTriggers[] triggers)
+void UseEffect(Func<Task> asyncEffect, params IEffectTriggers[] triggers)
+void UseEffect(Func<IDisposable> effectWithCleanup, params IEffectTriggers[] triggers)
+void UseEffect(Func<Task<IDisposable>> asyncEffectWithCleanup, IEffectTriggers object[] triggers)
+
+- EffectTrigger.OnBuild() - runs after every build
+- EffectTrigger.OnMount() - runs once when the view is first mounted
+- EffectTrigger.OnStateChange(IState<T>) - runs when the specified state changes
+
+- IState<T> is automatically converted to EffectTrigger.OnStateChange
+- If no triggers are provided, the effect trigger is assumed to be OnMount.
+
+### UseQuery
+
+UseQuery is the **preferred pattern for data fetching** in Ivy. It should be favored over the UseEffect + UseState fetch pattern.
+
+var query = UseQuery(
+    key: "my-data",
+    fetcher: async (ct) => await LoadDataAsync(ct)
+);
+
+if (query.Loading) return Skeleton.Card();
+if (query.Error is { } error) return Callout.Error(error.Message);
+
+// Use query.Value
+
+QueryResult<T> properties:
+
+- .Value — the fetched data (default until loaded)
+- .Loading — true during initial fetch (no value yet)
+- .Validating — true during background revalidation
+- .Error — exception if the fetch failed
+- .Mutator — provides .Revalidate(), .Invalidate(), .Mutate(value, revalidate)
+
+**Do not combine UseQuery with DataTable for EF Core data.** When a DataTable can receive an EF Core `IQueryable` directly, pass it to `.ToDataTable()` without UseQuery. DataTables handle their own server-side data loading. (API data fetched via UseQuery → `.ToDataTable()` is fine.)
+
+Key conventions:
+
+- String: `"my-data"`
+- Tuple: `(nameof(MyBlade), entityId)`
+
+Common options (QueryOptions):
+
+- KeepPrevious: true — show stale data while revalidating with a new key
+- RevalidateOnMount: false — skip initial fetch when using initialValue
+- RefreshInterval: TimeSpan — poll at an interval
+- Scope: QueryScope.View — isolate cache to the view instance (default is Server)
+
+Tag-based invalidation (cross-component):
+var queryService = UseService<IQueryService>();
+queryService.RevalidateByTag(typeof(Product[]));        // collection
+queryService.RevalidateByTag((typeof(Product), id));    // single entity
+
+Static "hooks" pattern (reusable across views):
+public static QueryResult<T[]> UseMyRecords(IViewContext context, string filter)
+{
+    return context.UseQuery(
+        key: (nameof(UseMyRecords), filter),
+        fetcher: async ct => { /*fetch*/ },
+        tags: [typeof(T[])],
+        options: new QueryOptions { KeepPrevious = true }
+    );
+}
+
+Dependent fetching (wait for another query):
+var user = UseQuery(key: "user", fetcher: async ct => await GetUser(ct));
+var projects = UseQuery(
+    () => user.Value?.Id,   // null = idle, no fetch
+    async (userId, ct) => await GetProjects(userId, ct));
+
+[UseRef](https://docs.ivy.app/hooks/core/use-ref.md)
+[UseContext](https://docs.ivy.app/hooks/core/use-context.md)
+[UseQuery](https://docs.ivy.app/hooks/core/use-query.md)
+[UseMutation](https://docs.ivy.app/hooks/core/use-mutation.md)
+[UseSignal](https://docs.ivy.app/hooks/core/use-signal.md)
+[UseService](https://docs.ivy.app/hooks/core/use-service.md)
+[UseArgs](https://docs.ivy.app/hooks/core/use-args.md)
+[UseDownload](https://docs.ivy.app/hooks/core/use-download.md)
+[UseRefreshToken](https://docs.ivy.app/hooks/core/use-refresh-token.md)
+[UseTrigger](https://docs.ivy.app/hooks/core/use-trigger.md)
+[UseWebhook](https://docs.ivy.app/hooks/core/use-webhook.md)
+[UseAlert](https://docs.ivy.app/onboarding/concepts/alerts.md)
+
+## Inputs
+
+Ivy has several Input widgets for handling user input. There are rarely used directly - instead we use
+extension methods on IState<T> to bind state to inputs.
+
+var userNameState = UseState("");
+var input = userNameState.ToTextInput().Placeholder("Enter your name");
+
+Most inputs have extension methods for common configurations:
+userNameState.ToTextInput().Required().MaxLength(50).Placeholder("Enter your name");
+
+[TextInput](https://docs.ivy.app/widgets/inputs/text-input.md)
+[NumberInput](https://docs.ivy.app/widgets/inputs/number-input.md)
+[BoolInput](https://docs.ivy.app/widgets/inputs/bool-input.md)
+[SelectInput](https://docs.ivy.app/widgets/inputs/select-input.md)
+[AsyncSelectInput](https://docs.ivy.app/widgets/inputs/async-select-input.md)
+[DateTimeInput](https://docs.ivy.app/widgets/inputs/date-time-input.md)
+[DateRangeInput](https://docs.ivy.app/widgets/inputs/date-range-input.md)
+[ColorInput](https://docs.ivy.app/widgets/inputs/color-input.md)
+[CodeInput](https://docs.ivy.app/widgets/inputs/code-input.md)
+[FeedbackInput](https://docs.ivy.app/widgets/inputs/feedback-input.md)
+[FileInput](https://docs.ivy.app/widgets/inputs/file-input.md)
+
+## Common Hallucinations
+
+- Base class is `ViewBase` (NOT `AppBase` there is no `AppBase` class)
+- `Text` is a static helper - use `Text.P()`, `Text.H2()`, ...
+- `UseState<T>()` returns `IState<T>`, NOT `State<T>`
+- All types are in the `Ivy` namespace
+- `Colors` is a flat enum (e.g. `Colors.Red`, `Colors.Blue`) we have no shade levels
+- `DbContext` must never be injected directly! Always resolve `IDbContextFactory<T>` via `UseService` and create scoped instances with `CreateDbContextAsync()` inside query/mutation lambdas
+- **Nested layouts MUST use parentheses** — `Layout.Vertical() | (Layout.Horizontal() | child1 | child2)` — without parentheses, C# left-to-right `|` evaluation adds children to the outer layout, not the inner one. See the nested layout example in the Layouts section above.
+
+## CLI Commands
+
+Prefer using `ivy cli explain` for command discovery over MCP server tools as it provides a reliable, built-in structural breakdown.
+
+## Further Reading
+
+[Forms](https://docs.ivy.app/onboarding/concepts/forms.md)
+[DataTable](https://docs.ivy.app/widgets/advanced/data-table.md)
+[Table](https://docs.ivy.app/widgets/common/table.md)
+[Details](https://docs.ivy.app/widgets/common/details.md) - Display structured label-value pairs
+[Program.cs](https://docs.ivy.app/onboarding/concepts/program.md)
+[Size](https://docs.ivy.app/api-reference/ivy-shared/size.md)
+[Align](https://docs.ivy.app/api-reference/ivy-shared/align.md)
+[Downloads](https://docs.ivy.app/hooks/core/use-download.md)
+[Icons](https://raw.githubusercontent.com/Ivy-Interactive/Ivy-Framework/refs/heads/main/src/Ivy/Shared/Icons.cs)
+
+All Ivy documentation pages are listed on: <https://docs.ivy.app/sitemap.xml>.
+Add ".md" to the end of any URL to go directly to the Markdown version of the doc.

--- a/src/skills/ivy-create-dashboard/references/CustomerRetentionRateMetricView.cs
+++ b/src/skills/ivy-create-dashboard/references/CustomerRetentionRateMetricView.cs
@@ -1,0 +1,82 @@
+﻿using Ivy;
+using MyProject.Connections.MyDb;
+using Microsoft.EntityFrameworkCore;
+
+namespace MyProject.Apps.Dashboard;
+
+public class CustomerRetentionRateMetricView(DateTime fromDate, DateTime toDate) : ViewBase
+{
+    public override object? Build()
+    {
+        return new MetricView(
+            "Customer Retention Rate",
+            Icons.Repeat,
+            UseMetricData
+        );
+    }
+
+    private QueryResult<MetricRecord> UseMetricData(IViewContext context)
+    {
+        var factory = context.UseService<MyDbContextFactory>();
+
+        return context.UseQuery(
+            key: (nameof(CustomerRetentionRateMetricView), fromDate, toDate),
+            fetcher: async ct =>
+            {
+                await using var db = factory.CreateDbContext();
+
+                var currentPeriodCustomers = await db.Customers
+                    .Where(c => c.Orders.Any(o => o.CreatedAt >= fromDate && o.CreatedAt <= toDate))
+                    .Include(customer => customer.Orders) // !IMPORTANT: Include orders to avoid N+1 query
+                    .ToListAsync(ct);
+
+                var currentPeriodRetainedCustomers = currentPeriodCustomers
+                    .Count(c => c.Orders.Count(o => o.CreatedAt >= fromDate && o.CreatedAt <= toDate) > 1);
+
+                var currentRetentionRate = (double)currentPeriodRetainedCustomers / currentPeriodCustomers.Count * 100;
+
+                var periodLength = toDate - fromDate;
+                var previousFromDate = fromDate.AddDays(-periodLength.TotalDays);
+                var previousToDate = fromDate.AddDays(-1);
+
+                var previousPeriodCustomers = await db.Customers
+                    .Where(c => c.Orders.Any(o => o.CreatedAt >= previousFromDate && o.CreatedAt <= previousToDate))
+                    .ToListAsync(ct);
+
+                var previousPeriodRetainedCustomers = previousPeriodCustomers
+                    .Count(c => c.Orders.Count(o => o.CreatedAt >= previousFromDate && o.CreatedAt <= previousToDate) > 1);
+
+                double? previousRetentionRate = null;
+                if (previousPeriodCustomers.Count > 0)
+                {
+                    previousRetentionRate = (double)previousPeriodRetainedCustomers / previousPeriodCustomers.Count * 100;
+                }
+
+                if (previousRetentionRate == null || previousRetentionRate == 0)
+                {
+                    //We have nothing to compare to
+                    return new MetricRecord(
+                        MetricFormatted: currentRetentionRate.ToString("N2") + "%",
+                        TrendComparedToPreviousPeriod: null,
+                        GoalAchieved: null,
+                        GoalFormatted: null
+                    );
+                }
+
+                double? trend = null;
+                trend = (currentRetentionRate - previousRetentionRate.Value) / previousRetentionRate.Value;
+
+                var goal = previousRetentionRate.Value * 1.1;
+                double? goalAchievement = goal > 0 ? currentRetentionRate / goal : null;
+
+                return new MetricRecord(
+                    MetricFormatted: currentRetentionRate.ToString("N2") + "%",
+                    TrendComparedToPreviousPeriod: trend,
+                    GoalAchieved: goalAchievement,
+                    GoalFormatted: goal.ToString("N2") + "%"
+                );
+            },
+            options: new QueryOptions { Expiration = TimeSpan.FromMinutes(5) }
+        );
+    }
+}

--- a/src/skills/ivy-create-dashboard/references/DashboardApp.cs
+++ b/src/skills/ivy-create-dashboard/references/DashboardApp.cs
@@ -1,0 +1,85 @@
+﻿using System.ComponentModel;
+using Ivy;
+using MyProject.Apps.Dashboard;
+
+namespace MyProject.Apps;
+
+[App(icon: Icons.LayoutDashboard, group: ["Apps"])]
+public class DashboardApp : ViewBase
+{
+    private enum DateRange
+    {
+        [Description("7d")]
+        Last7Days = 1,
+        [Description("14d")]
+        Last14Days = 2,
+        [Description("30d")]
+        Last30Days = 3
+    }
+
+    private (DateTime fromDate, DateTime toDate) GetDateRange(DateRange range)
+    {
+        var toDate = DateTime.UtcNow.Date.AddDays(1);
+        DateTime fromDate = range switch
+        {
+            DateRange.Last7Days => toDate.AddDays(-7),
+            DateRange.Last14Days => toDate.AddDays(-14),
+            DateRange.Last30Days => toDate.AddDays(-30),
+            _ => toDate.AddDays(-30)
+        };
+        return (fromDate, toDate);
+    }
+
+    public override object? Build()
+    {
+        var range = UseState<DateRange>(DateRange.Last30Days);
+        var threshold = UseState(50.0);
+        var isRefreshing = UseState(false);
+        var refreshToken = UseRefreshToken();
+        var client = UseService<IClientProvider>();
+
+        var header = Layout.Horizontal().AlignContent(Align.SpaceBetween).AlignContent(Align.Center)
+                     | Text.H3("Sales Dashboard")
+                     | (Layout.Horizontal().Gap(3).AlignContent(Align.Center)
+                        | threshold.ToSliderInput().Min(0).Max(100).Step(1).WithField().Label("Filter Threshold")
+                        | new Button("Refresh Data", async _ =>
+                        {
+                            isRefreshing.Set(true);
+                            await Task.Delay(500);
+                            isRefreshing.Set(false);
+                            refreshToken.Refresh();
+                            client.Toast("Data refreshed successfully");
+                        }).Primary().Loading(isRefreshing.Value).Icon(Icons.RefreshCw)
+                        | range.ToSelectInput().Variant(SelectInputVariant.Toggle).Small())
+            ;
+
+        var (fromDate, toDate) = GetDateRange(range.Value);
+
+        var metrics =
+                Layout.Grid().Columns(4)
+                | new TotalSalesMetricView(fromDate, toDate)
+                | new MarginMetricView(fromDate, toDate)
+                | new OrdersMetricView(fromDate, toDate)
+                | new BasketSizeMetricView(fromDate, toDate)
+                | new CustomerRetentionRateMetricView(fromDate, toDate)
+            ;
+
+        var charts =
+                Layout.Grid().Columns(3)
+                | new SalesByDayLineChartView(fromDate, toDate)
+                | new OrdersByChannelPieChartView(fromDate, toDate)
+                | new SalesByCategoryPieChartView(fromDate, toDate)
+                | new AverageOrderValueOverTimeLineChartView(fromDate, toDate)
+                | new SalesByStoreTypeAreaChartView(fromDate, toDate)
+                | new SalesByCategoryBarChartView(fromDate, toDate)
+            ;
+
+        var body = Layout.TopCenter()
+                   | (Layout.Vertical().Width(Size.Full().Max(300)).TopMargin(10)
+                      | metrics
+                      | charts)
+            ;
+
+        return new HeaderLayout(header, body);
+    }
+}

--- a/src/skills/ivy-create-dashboard/references/OrdersByChannelPieChartView.cs
+++ b/src/skills/ivy-create-dashboard/references/OrdersByChannelPieChartView.cs
@@ -1,0 +1,61 @@
+﻿using Ivy;
+using MyProject.Connections.MyDb;
+using Microsoft.EntityFrameworkCore;
+
+namespace MyProject.Apps.Dashboard;
+
+public class OrdersByChannelPieChartView(DateTime fromDate, DateTime toDate) : ViewBase
+{
+    private record ChartData(string Channel);
+
+    public override object? Build()
+    {
+        var query = UseChartData(Context);
+        var card = new Card().Title("Orders by Channel").Height(Size.Units(80));
+
+        if (query.Error != null)
+        {
+            return card | new ErrorTeaserView(query.Error);
+        }
+
+        if (query.Loading || query.Value == null)
+        {
+            return card | new Skeleton();
+        }
+
+        var totalOrders = query.Value.Length;
+        PieChartTotal total = new(Format.Number(@"[<1000]0;[<10000]0.0,""K"";0,""K""", totalOrders), "Orders");
+
+        // ToPieChart(dimension, measure, style?, total?)
+        var chart = query.Value.ToPieChart(
+            dimension: e => e.Channel,
+            measure: e => e.Count(),
+            PieChartStyles.Dashboard,
+            total);
+
+        return card | chart;
+    }
+
+    private QueryResult<ChartData[]> UseChartData(IViewContext context)
+    {
+        var factory = context.UseService<MyDbContextFactory>();
+
+        return context.UseQuery(
+            key: (nameof(OrdersByChannelPieChartView), fromDate, toDate),
+            fetcher: async ct =>
+            {
+                await using var db = factory.CreateDbContext();
+                // IMPORTANT: Use anonymous types in Select() for EF Core compatibility.
+                // Positional record constructors cannot be translated to SQL.
+                var raw = await db.Orders
+                    .Where(o => o.CreatedAt >= fromDate && o.CreatedAt <= toDate)
+                    .Select(e => new { e.Channel })
+                    .ToArrayAsync(ct);
+                var data = raw.Select(x => new ChartData(x.Channel)).ToArray();
+
+                return data;
+            },
+            options: new QueryOptions { Expiration = TimeSpan.FromMinutes(5) }
+        );
+    }
+}

--- a/src/skills/ivy-create-dashboard/references/OrdersMetricView.cs
+++ b/src/skills/ivy-create-dashboard/references/OrdersMetricView.cs
@@ -1,0 +1,68 @@
+﻿using Ivy;
+using MyProject.Connections.MyDb;
+using Microsoft.EntityFrameworkCore;
+
+namespace MyProject.Apps.Dashboard;
+
+public class OrdersMetricView(DateTime fromDate, DateTime toDate) : ViewBase
+{
+    public override object? Build()
+    {
+        return new MetricView(
+            "Orders",
+            Icons.ShoppingCart,
+            UseMetricData
+        );
+    }
+
+    private QueryResult<MetricRecord> UseMetricData(IViewContext context)
+    {
+        var factory = context.UseService<MyDbContextFactory>();
+
+        return context.UseQuery(
+            key: (nameof(OrdersMetricView), fromDate, toDate),
+            fetcher: async ct =>
+            {
+                await using var db = factory.CreateDbContext();
+
+                var currentPeriodOrders = await db.Orders
+                    .Where(o => o.CreatedAt >= fromDate && o.CreatedAt <= toDate)
+                    .CountAsync(ct);
+
+                var periodLength = toDate - fromDate;
+                var previousFromDate = fromDate.AddDays(-periodLength.TotalDays);
+                var previousToDate = fromDate.AddDays(-1);
+
+                var previousPeriodOrders = await db.Orders
+                    .Where(o => o.CreatedAt >= previousFromDate && o.CreatedAt <= previousToDate)
+                    .CountAsync(ct);
+
+                if (previousPeriodOrders == 0)
+                {
+                    //We have nothing to compare to
+                    return new MetricRecord(
+                        MetricFormatted: currentPeriodOrders.ToString("N0"),
+                        TrendComparedToPreviousPeriod: null,
+                        GoalAchieved: null,
+                        GoalFormatted: null
+                    );
+                }
+
+                double? trend = ((double)currentPeriodOrders - previousPeriodOrders) / previousPeriodOrders;
+
+                // Goal is 10% more than previous period orders
+                var goal = previousPeriodOrders * 1.1;
+                double? goalAchievement = goal > 0 ? currentPeriodOrders / goal : null;
+
+                //Use C0 to format numbers that represent currency
+                return new MetricRecord(
+                    MetricFormatted: currentPeriodOrders.ToString("N0"),
+                    TrendComparedToPreviousPeriod: trend,
+                    GoalAchieved: goalAchievement,
+                    GoalFormatted: goal.ToString("N0")
+                );
+            },
+            options: new QueryOptions { Expiration = TimeSpan.FromMinutes(5) }
+        );
+    }
+}

--- a/src/skills/ivy-create-dashboard/references/SalesByCategoryBarChartView.cs
+++ b/src/skills/ivy-create-dashboard/references/SalesByCategoryBarChartView.cs
@@ -1,0 +1,60 @@
+﻿using Ivy;
+using MyProject.Connections.MyDb;
+using Microsoft.EntityFrameworkCore;
+
+namespace MyProject.Apps.Dashboard;
+
+public class SalesByCategoryBarChartView(DateTime fromDate, DateTime toDate) : ViewBase
+{
+    private record ChartData(string Name, double Revenue);
+
+    public override object? Build()
+    {
+        var query = UseChartData(Context);
+        var card = new Card().Title("Sales by Category").Height(Size.Units(80));
+
+        if (query.Error != null)
+        {
+            return card | new ErrorTeaserView(query.Error);
+        }
+
+        if (query.Loading || query.Value == null)
+        {
+            return card | new Skeleton();
+        }
+
+        // ToBarChart(dimension, measures[], style?)
+        var chart = query.Value.ToBarChart(e => e.Name, [e => e.Sum(f => f.Revenue)], BarChartStyles.Dashboard);
+
+        return card | chart;
+    }
+
+    private QueryResult<ChartData[]> UseChartData(IViewContext context)
+    {
+        var factory = context.UseService<MyDbContextFactory>();
+
+        return context.UseQuery(
+            key: (nameof(SalesByCategoryBarChartView), fromDate, toDate),
+            fetcher: async ct =>
+            {
+                await using var db = factory.CreateDbContext();
+                // IMPORTANT: Use anonymous types in Select() for EF Core compatibility.
+                // Positional record constructors cannot be translated to SQL.
+                var raw = await db.Categories
+                    .Select(cat => new
+                    {
+                        cat.Name,
+                        Revenue = cat.Products
+                            .SelectMany(p => p.Lines)
+                            .Where(l => l.Order.CreatedAt >= fromDate && l.Order.CreatedAt <= toDate)
+                            .Sum(l => (double)(l.Quantity * l.Price))
+                    })
+                    .ToArrayAsync(ct);
+                var data = raw.Select(x => new ChartData(x.Name, x.Revenue)).ToArray();
+
+                return data;
+            },
+            options: new QueryOptions { Expiration = TimeSpan.FromMinutes(5) }
+        );
+    }
+}

--- a/src/skills/ivy-create-dashboard/references/SalesByDayLineChartView.cs
+++ b/src/skills/ivy-create-dashboard/references/SalesByDayLineChartView.cs
@@ -1,0 +1,62 @@
+﻿using Ivy;
+using MyProject.Connections.MyDb;
+using Microsoft.EntityFrameworkCore;
+
+namespace MyProject.Apps.Dashboard;
+
+public class SalesByDayLineChartView(DateTime fromDate, DateTime toDate) : ViewBase
+{
+    private record ChartData(string Date, decimal Amount);
+
+    public override object? Build()
+    {
+        var query = UseChartData(Context);
+        var card = new Card().Title("Sales by Day").Height(Size.Units(80));
+
+        if (query.Error != null)
+        {
+            return card | new ErrorTeaserView(query.Error);
+        }
+
+        if (query.Loading || query.Value == null)
+        {
+            return card | new Skeleton();
+        }
+
+        // ToLineChart(dimension, measures[], style?)
+        var chart = query.Value.ToLineChart(
+            e => e.Date,
+            [e => e.Sum(f => f.Amount)],
+            LineChartStyles.Dashboard);
+
+        return card | chart;
+    }
+
+    private QueryResult<ChartData[]> UseChartData(IViewContext context)
+    {
+        var factory = context.UseService<MyDbContextFactory>();
+
+        return context.UseQuery(
+            key: (nameof(SalesByDayLineChartView), fromDate, toDate),
+            fetcher: async ct =>
+            {
+                await using var db = factory.CreateDbContext();
+                // IMPORTANT: Use anonymous types in Select() for EF Core compatibility.
+                // Positional record constructors cannot be translated to SQL.
+                var raw = await db.Orders
+                    .Where(o => o.CreatedAt >= fromDate && o.CreatedAt <= toDate)
+                    .OrderBy(o => o.CreatedAt)
+                    .Select(e => new
+                    {
+                        Date = e.CreatedAt.Date.ToString("d MMM"),
+                        Amount = e.Lines.Sum(l => (l.Price - l.Discount) * l.Quantity)
+                    })
+                    .ToArrayAsync(ct);
+                var data = raw.Select(x => new ChartData(x.Date, x.Amount)).ToArray();
+
+                return data;
+            },
+            options: new QueryOptions { Expiration = TimeSpan.FromMinutes(5) }
+        );
+    }
+}

--- a/src/skills/ivy-create-dashboard/references/SalesByStoreTypeAreaChartView.cs
+++ b/src/skills/ivy-create-dashboard/references/SalesByStoreTypeAreaChartView.cs
@@ -1,0 +1,67 @@
+﻿using Ivy;
+using MyProject.Connections.MyDb;
+using Microsoft.EntityFrameworkCore;
+
+namespace MyProject.Apps.Dashboard;
+
+public class SalesByStoreTypeAreaChartView(DateTime fromDate, DateTime toDate) : ViewBase
+{
+    private record ChartData(string Date, decimal Amount, string StoreType);
+
+    public override object? Build()
+    {
+        var query = UseChartData(Context);
+        var card = new Card().Title("Sales by Store Type").Height(Size.Units(80));
+
+        if (query.Error != null)
+        {
+            return card | new ErrorTeaserView(query.Error);
+        }
+
+        if (query.Loading || query.Value == null)
+        {
+            return card | new Skeleton();
+        }
+
+        // ToAreaChart(dimension, measures[], style?)
+        var chart = query.Value.ToAreaChart(
+            e => e.Date,
+            [
+                e => e.Where(f => f.StoreType == "Online").Sum(f => f.Amount),
+                e => e.Where(f => f.StoreType == "Retail").Sum(f => f.Amount),
+                e => e.Where(f => f.StoreType == "Wholesale").Sum(f => f.Amount),
+            ],
+            AreaChartStyles.Dashboard);
+
+        return card | chart;
+    }
+
+    private QueryResult<ChartData[]> UseChartData(IViewContext context)
+    {
+        var factory = context.UseService<MyDbContextFactory>();
+
+        return context.UseQuery(
+            key: (nameof(SalesByStoreTypeAreaChartView), fromDate, toDate),
+            fetcher: async ct =>
+            {
+                await using var db = factory.CreateDbContext();
+                // IMPORTANT: Use anonymous types in Select() for EF Core compatibility.
+                // Positional record constructors cannot be translated to SQL.
+                var raw = await db.Orders
+                    .Where(o => o.CreatedAt >= fromDate && o.CreatedAt <= toDate)
+                    .OrderBy(o => o.CreatedAt)
+                    .Select(e => new
+                    {
+                        Date = e.CreatedAt.Date.ToString("d MMM"),
+                        Amount = e.Lines.Sum(l => (l.Price - l.Discount) * l.Quantity),
+                        e.StoreType
+                    })
+                    .ToArrayAsync(ct);
+                var data = raw.Select(x => new ChartData(x.Date, x.Amount, x.StoreType)).ToArray();
+
+                return data;
+            },
+            options: new QueryOptions { Expiration = TimeSpan.FromMinutes(5) }
+        );
+    }
+}

--- a/src/skills/ivy-create-dashboard/references/TotalSalesMetricView.cs
+++ b/src/skills/ivy-create-dashboard/references/TotalSalesMetricView.cs
@@ -1,0 +1,62 @@
+﻿using Ivy;
+using MyProject.Connections.MyDb;
+using Microsoft.EntityFrameworkCore;
+
+namespace MyProject.Apps.Dashboard;
+
+public class TotalSalesMetricView(DateTime fromDate, DateTime toDate) : ViewBase
+{
+    public override object? Build()
+    {
+        return new MetricView(
+            "Total Sales",
+            Icons.DollarSign,
+            UseMetricData
+        );
+    }
+
+    private QueryResult<MetricRecord> UseMetricData(IViewContext context)
+    {
+        var factory = context.UseService<MyDbContextFactory>();
+
+        return context.UseQuery(
+            key: (nameof(TotalSalesMetricView), fromDate, toDate),
+            fetcher: async ct =>
+            {
+                await using var db = factory.CreateDbContext();
+
+                var currentPeriodSales = await db.Lines
+                    .Where(l => l.Order!.CreatedAt >= fromDate && l.Order.CreatedAt <= toDate)
+                    .Select(l => (double)(l.Price * l.Quantity))
+                    .SumAsync(ct);
+
+                var periodLength = toDate - fromDate;
+                var previousFromDate = fromDate.AddDays(-periodLength.TotalDays);
+                var previousToDate = fromDate.AddDays(-1);
+
+                var previousPeriodSales = await db.Lines
+                    .Where(l => l.Order!.CreatedAt >= previousFromDate && l.Order.CreatedAt <= previousToDate)
+                    .Select(l => (double)(l.Price * l.Quantity))
+                    .SumAsync(ct);
+
+                double? trend = null;
+                if (previousPeriodSales > 0)
+                {
+                    trend = (currentPeriodSales - previousPeriodSales) / previousPeriodSales;
+                }
+
+                // Goal is 20% more than previous period sales:
+                var goal = previousPeriodSales * 1.2;
+                double? goalAchievement = goal > 0 ? currentPeriodSales / goal : null;
+
+                return new MetricRecord(
+                    MetricFormatted: $"{currentPeriodSales:C0}",
+                    TrendComparedToPreviousPeriod: trend,
+                    GoalAchieved: goalAchievement,
+                    GoalFormatted: $"{goal:C0}"
+                );
+            },
+            options: new QueryOptions { Expiration = TimeSpan.FromMinutes(5) }
+        );
+    }
+}

--- a/src/skills/ivy-create-db-connection/SKILL.md
+++ b/src/skills/ivy-create-db-connection/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: ivy-create-db-connection
+description: >
+  Add a database connection to an Ivy project. Supports SQL Server, Postgres,
+  Supabase, MySQL, MariaDB, SQLite, Airtable, Oracle, Spanner, ClickHouse,
+  and Snowflake. Scaffolds a DbContext from an existing database with Entity
+  Framework. Use when the user wants to connect to a database.
+allowed-tools: Bash(dotnet:*) Bash(ivy:*) Read Write Edit Glob Grep
+effort: medium
+argument-hint: "[database provider, e.g. Postgres, SqlServer, Sqlite]"
+---
+
+# ivy-create-db-connection
+
+Add a database connection to an existing Ivy project. This skill guides you through selecting a database provider, collecting connection details, and generating a DbContext with Entity Framework scaffolding.
+
+## Step 1: Validate the Project
+
+1. Verify this is a valid Ivy project. Check for a `.csproj` file and `Program.cs` in the working directory. If this is not an Ivy project, tell the user and stop.
+
+2. Clean up any empty connection folders under `Connections/` if they exist.
+
+## Step 2: Choose a Database Provider
+
+3. If the user has not already specified a provider, ask them to choose one from the supported list:
+
+| Provider | Display Name | Connection String Template | Supports Schemas | Default Schema |
+|---|---|---|---|---|
+| **SqlServer** | SQL Server | `Server=localhost;Database={name};Trusted_Connection=True;TrustServerCertificate=True;` | Yes | `dbo` |
+| **Postgres** | Postgres | `Host=localhost;Database={name};Username=postgres;Password=postgres;` | Yes | `public` |
+| **Supabase** | Supabase | `Host=db.<project-ref>.supabase.co;Database=postgres;Username=postgres;Password=<password>;Port=5432;` | Yes | `public` |
+| **MySql** | MySQL | `Server=localhost;Database={name};User=root;Password=root;` | No | -- |
+| **MariaDb** | MariaDB | `Server=localhost;Database={name};User=root;Password=root;` | No | -- |
+| **Sqlite** | SQLite | `Data Source={name}.db;` | No | -- |
+| **Airtable** | Airtable | (custom) | No | -- |
+| **Oracle** | Oracle | `Data Source=localhost:1521/XEPDB1;User Id=system;Password=oracle;` | No | -- |
+| **Spanner** | Spanner | `Data Source=projects/<project>/instances/<instance>/databases/<database>;` | No | -- |
+| **ClickHouse** | ClickHouse | `Host=localhost;Port=8123;Database={name};` | No | -- |
+| **Snowflake** | Snowflake | `account=<account>;host=<account>.snowflakecomputing.com;user=<user>;password=<password>;db={name};schema=PUBLIC;warehouse=<warehouse>;` | No | -- |
+
+## Step 3: Collect Connection Details
+
+4. Ask the user for a connection name in **PascalCase** (e.g. "MyDatabase", "SalesDb"). The name must match the regex `^[A-Z][a-zA-Z0-9]*$`. If the name is invalid, ask the user to provide a valid one.
+
+5. Collect the connection string. The user may provide either:
+   - A complete connection string -- pass it through as-is
+   - Individual database credentials (host, port, user, password, database name) -- construct the full connection string using the provider's template
+
+   Connection string formats by provider:
+   - **Postgres / Supabase**: `Host={host};Port={port};Database={db};Username={user};Password={password}`
+   - **SQL Server**: `Server={host},{port};Database={db};User Id={user};Password={password};TrustServerCertificate=True`
+   - **MySQL / MariaDB**: `Server={host};Port={port};Database={db};User={user};Password={password};`
+   - **Oracle**: `Data Source={host}:{port}/{service};User Id={user};Password={password};`
+
+   If the connection string cannot be inferred from context, ask the user for it.
+
+6. For providers that support schemas (SQL Server, Postgres, Supabase), ask the user which database schema to use. Recommend the provider's default schema (e.g. `dbo` for SQL Server, `public` for Postgres/Supabase).
+
+## Step 4: Generate the Connection
+
+7. Create the connection directory at `Connections/[ConnectionName]/`.
+
+8. The connection generation involves:
+   - Adding the provider-specific EF Core NuGet packages
+   - Storing the connection string in dotnet user secrets as `ConnectionStrings:[ConnectionName]`
+   - Scaffolding the DbContext and entity classes from the database using `dotnet ef dbcontext scaffold`
+   - Creating the connection class implementing `IConnection`
+
+9. Initialize user secrets and store the connection string:
+
+```bash
+dotnet user-secrets init
+dotnet user-secrets set "ConnectionStrings:[ConnectionName]" "[connection-string]"
+```
+
+10. Use `ivy docs` or `ivy ask` to look up provider-specific guidance if you need details about the EF Core provider package name, scaffolding options, or connection registration pattern.
+
+Expected directory structure after completion:
+
+```
+[UserProject]/
+├── [UserProject].csproj
+├── Program.cs
+├── Connections/
+│   └── [ConnectionName]/
+│       ├── [ConnectionName]Connection.cs
+│       ├── [ConnectionName]Context.cs
+│       └── (Entity classes...)
+```
+
+## Step 5: Verify
+
+11. Run `dotnet build` to verify everything compiles. Fix any errors.
+
+12. Run `dotnet build` to verify the project compiles. Then test the connection by running `dotnet run` and verifying the app starts without errors. If the test fails, investigate and fix the issue. Common causes:
+    - Build errors: identify and fix compilation issues
+    - Network/auth errors: verify connection string, credentials, and server reachability
+    - SSL issues: check TrustServerCertificate or SSL mode settings
+
+13. If the project is in a git repository, create a commit with a descriptive message, for example: "Added [ProviderDisplayName] connection '[ConnectionName]'."
+
+14. Tell the user the connection is ready and summarize:
+    - Connection name and provider
+    - Files generated in `Connections/[ConnectionName]/`
+    - Connection string stored in dotnet user secrets as `ConnectionStrings:[ConnectionName]`
+    - Schema used (if applicable)
+
+15. After confirming the connection works, review the user's original request. If they asked to generate apps from the database (e.g., "generate apps for each table", "create CRUD apps"), use the `/ivy-create-crud` or `/ivy-create-app` skill for each entity. Use `ivy cli explain connections/[ConnectionName]` to get the list of entities.
+
+## Recovery
+
+If the setup fails:
+
+1. Diagnose the root cause (build errors, SSL settings, credentials, network issues):
+   - For build errors: use `dotnet build` to identify and fix compilation issues
+   - For network/auth errors: verify connection string, credentials, and server reachability
+
+2. After fixing the underlying issue, either retry using the `/ivy-create-db-connection` skill from scratch, or manually create the connection:
+   - Create a DbContext class in `Connections/[ConnectionName]/`
+   - Create entity classes matching the database tables
+   - Register the connection in Program.cs
+   - Test the connection with a simple query
+
+3. Use `ivy ask "How do I create a DbContext?"` or `ivy ask "How do I register a database connection?"` for API guidance.

--- a/src/skills/ivy-create-external-widget/SKILL.md
+++ b/src/skills/ivy-create-external-widget/SKILL.md
@@ -1,0 +1,295 @@
+---
+name: ivy-create-external-widget
+description: >
+  Create a new Ivy External Widget backed by React npm packages. Use when the user asks
+  to create a widget, external widget, React widget, custom component, or wrap an npm
+  package as an Ivy widget. Scaffolds a C# + React project, installs npm dependencies,
+  implements the widget class and React component, and verifies the build.
+allowed-tools: Bash(dotnet:*) Bash(npm:*) Bash(npx:*) Bash(ivy:*) Read Write Edit Glob Grep
+effort: high
+---
+
+# ivy-create-external-widget
+
+Create a new Ivy External Widget that wraps React npm packages with C# bindings.
+
+## Reference Files
+
+Before implementing, fetch the external widgets documentation using `ivy docs` with the query: "external widgets".
+
+## Workflow
+
+1. **Understand the widget purpose** -- Ask the user what widget they need if it is not already clear from context.
+
+2. **Research npm packages** -- Search the web for the best React npm package(s) for the use case. Packages MUST be open-source with a copyleft-compatible license (MIT, Apache-2.0, BSD, ISC, MPL-2.0, etc.). Look for packages that are well-maintained, popular, and have good TypeScript support.
+
+3. **Present options** -- Show the user 2-4 npm package options. Include the package name, description, license, and weekly downloads if available. Ask the user to pick one.
+
+4. **Ask for a widget name** -- Suggest a name similar to the chosen React package but without the word "React" in it. Names must be in PascalCase. Ask the user to confirm.
+
+5. **Determine the namespace** -- If the working directory already has a `.csproj` file, extract the namespace from it. Otherwise, suggest `Ivy.Widgets.<WidgetName>` as a default namespace and ask the user to confirm.
+
+6. **Scaffold the widget project** -- Create the widget project structure with:
+   - `[WidgetName].cs` -- the C# widget class
+   - `frontend/` -- the React frontend project
+
+   If the project already has a Widgets folder, move the new widget there and adjust the namespace accordingly.
+
+7. **Install npm dependencies** -- Run in the `frontend/` directory:
+   ```
+   cd [WorkingDirectory]/frontend && npm install [NpmPackages]
+   ```
+
+8. **Implement the widget** -- Follow the Ivy External Widget Guide below to create:
+   - The C# widget class (`[WidgetName].cs`) -- define props, events, and extension methods that map to the npm package's API
+   - The React component (`frontend/src/[WidgetName].tsx`) -- wrap the npm package component with Ivy's event system, using the conditional event firing pattern
+   - The export file (`frontend/src/index.ts`) -- export the new component
+   - A sample app (`.samples/Apps/[WidgetName]App.cs`)
+   - Update README.md to document the widget, its props, events, and which npm packages it uses
+
+9. **Verify the build** -- Run `dotnet build` to make sure the project compiles. Fix any errors.
+
+---
+
+# Ivy External Widget Guide
+
+## Architecture
+
+- **C# Widget Class**: Defines props, events, and the widget's API surface
+- **React Component**: The frontend implementation loaded at runtime
+- **IIFE Bundle**: The React component is bundled as an IIFE and exposed on `window.{GlobalName}`
+
+## C# Widget Definition
+
+Create a `.cs` file with a record that inherits from `WidgetBase<T>`:
+
+```csharp
+using Ivy;
+using Ivy.Core;
+using Ivy.Core.ExternalWidgets;
+
+namespace MyNamespace;
+
+[ExternalWidget("frontend/dist/{GlobalName}.js", ExportName = "MyWidget")]
+public record MyWidget : WidgetBase<MyWidget>
+{
+    internal MyWidget()
+    {
+        Width = Size.Full();
+        Height = Size.Full();
+    }
+
+    [Prop] public string? Title { get; set; }
+    [Prop] public int Count { get; set; }
+    [Prop] public bool Disabled { get; set; }
+
+    [Event] public Func<Event<MyWidget>, ValueTask>? OnClick { get; set; }
+    [Event] public Func<Event<MyWidget, string>, ValueTask>? OnChange { get; set; }
+}
+
+public static class MyWidgetExtensions
+{
+    public static MyWidget Title(this MyWidget widget, string title) =>
+        widget with { Title = title };
+
+    public static MyWidget Count(this MyWidget widget, int count) =>
+        widget with { Count = count };
+
+    public static MyWidget HandleClick(this MyWidget widget, Action handler) =>
+        widget with { OnClick = _ => { handler(); return ValueTask.CompletedTask; } };
+
+    public static MyWidget HandleChange(this MyWidget widget, Action<string> handler) =>
+        widget with { OnChange = e => { handler(e.Value); return ValueTask.CompletedTask; } };
+}
+```
+
+## React Component
+
+Create a `.tsx` file in `frontend/src/`:
+
+```tsx
+import React from 'react';
+import { IvyEventHandler } from './types';
+import { getWidth, getHeight } from './styles';
+
+interface MyWidgetProps {
+  id: string;
+  width?: string;
+  height?: string;
+  events?: string[];
+  onIvyEvent: IvyEventHandler;
+  title?: string;
+  count?: number;
+  disabled?: boolean;
+}
+
+export const MyWidget: React.FC<MyWidgetProps> = ({
+  id,
+  width = 'Full',
+  height = 'Full',
+  events = [],
+  onIvyEvent,
+  title,
+  count,
+  disabled,
+}) => {
+  const handleClick = () => {
+    if (events.includes('OnClick')) {
+      onIvyEvent('OnClick', id, []);
+    }
+  };
+
+  const handleChange = (value: string) => {
+    if (events.includes('OnChange')) {
+      onIvyEvent('OnChange', id, [value]);
+    }
+  };
+
+  const style: React.CSSProperties = {
+    ...getWidth(width),
+    ...getHeight(height),
+  };
+
+  return (
+    <div style={style}>
+      <h3>{title}</h3>
+      <p>Count: {count}</p>
+      <button onClick={handleClick} disabled={disabled}>Click me</button>
+      <input onChange={(e) => handleChange(e.target.value)} />
+    </div>
+  );
+};
+```
+
+## Export the Component
+
+Add the export to `frontend/src/index.ts`:
+
+```typescript
+import { MyWidget } from './MyWidget';
+
+if (typeof window !== 'undefined') {
+  (window as Record<string, unknown>).{GlobalName} = {
+    MyWidget,
+  };
+}
+
+export { MyWidget };
+```
+
+## Sample App
+
+The `.samples/` folder contains a runnable Ivy project. Create or update the app in `.samples/Apps/[WidgetName]App.cs`:
+
+```csharp
+using Ivy;
+using [Namespace];
+
+namespace [Namespace].Samples.Apps;
+
+[App]
+public class MyWidgetApp : ViewBase
+{
+    public override object Build() =>
+        new MyWidget();
+}
+```
+
+## Key Concepts
+
+### ExternalWidget Attribute
+
+```csharp
+[ExternalWidget("frontend/dist/{GlobalName}.js", ExportName = "MyWidget")]
+```
+
+- First parameter: Path to the bundled JS file (embedded resource)
+- `ExportName`: The name of the React component in the bundle's exports
+
+### Props vs Events
+
+- `[Prop]`: Data passed from C# to React. PascalCase in C#, auto-converted to camelCase in React.
+- `[Event]`: Callbacks from React to C#. Name with `On` prefix (e.g., `OnClick`, `OnChange`).
+
+### Event Handler Signature
+
+In React, call `onIvyEvent(eventName, widgetId, args)`:
+- `eventName`: PascalCase with 'On' prefix (e.g., 'OnClick', 'OnChange')
+- `widgetId`: Always pass `id`
+- `args`: Array of arguments to pass to the C# handler
+
+### Conditional Event Firing
+
+Always check the `events` array before firing:
+
+```tsx
+const handleClick = () => {
+  if (events.includes('OnClick')) {
+    onIvyEvent('OnClick', id, []);
+  }
+};
+```
+
+### Event Types
+
+- `Event<TWidget>` -- event with no value. Properties: `.Id` (the widget ID)
+- `Event<TWidget, TValue>` -- event with a value. Properties: `.Id` (the widget ID), `.Value` (the value of type `TValue` passed from React)
+
+Use `Event<TWidget>` for simple notifications (e.g., button clicks) and `Event<TWidget, TValue>` when React needs to pass data back to C# (e.g., input changes, selections).
+
+### Key Namespaces
+
+- `Ivy` -- `WidgetBase<T>`, `ViewBase`, `Layout`, `Text`, `Icons`, `Size`, `Colors`, `ChromeSettings`
+- `Ivy.Core` -- `PropAttribute`, `EventAttribute`, `Event<TWidget>`, `Event<TWidget, TValue>`
+- `Ivy.Core.ExternalWidgets` -- `ExternalWidgetAttribute`
+
+### Size Props
+
+Use helper functions for sizing:
+
+```typescript
+import { getWidth, getHeight } from './styles';
+
+const style: React.CSSProperties = {
+  ...getWidth(width),
+  ...getHeight(height),
+};
+```
+
+## Smooth Input Handling Pattern
+
+For input widgets, use local state with server sync to prevent laggy typing:
+
+```tsx
+const [localValue, setLocalValue] = useState(value || '');
+const [isFocused, setIsFocused] = useState(false);
+const localValueRef = useRef(localValue);
+
+useEffect(() => {
+  if (!isFocused && value !== localValueRef.current) {
+    queueMicrotask(() => setLocalValue(value || ''));
+  }
+}, [value, isFocused]);
+
+useEffect(() => {
+  localValueRef.current = localValue;
+}, [localValue]);
+
+const handleChange = useCallback((newValue: string) => {
+  setLocalValue(newValue);
+  if (events.includes('OnChange') && onIvyEvent) {
+    onIvyEvent('OnChange', id, [newValue]);
+  }
+}, [events, onIvyEvent, id]);
+```
+
+## Important Guidelines
+
+- Never use `<summary>` XML documentation blocks
+- Update README.md when making changes
+- Create app files for each widget in `.samples/Apps/[WidgetName]App.cs`
+- Use react-icons/lucide for icons
+- Prefer shadcn building blocks when UI components are needed
+- Default to full width and height (`Width = Size.Full()`, `Height = Size.Full()`)
+- Always include a default constructor (use `internal`)
+- Default prop values must be specified both in C# and React

--- a/src/skills/ivy-create-graphql-connection/SKILL.md
+++ b/src/skills/ivy-create-graphql-connection/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: ivy-create-graphql-connection
+description: >
+  Create a GraphQL API connection using StrawberryShake code generation. Use when
+  the user wants to add a GraphQL connection, integrate a GraphQL API, set up
+  StrawberryShake, or add GraphQL support to their Ivy project.
+allowed-tools:
+  - Bash(dotnet:*)
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+effort: high
+---
+
+# Create a GraphQL Connection
+
+This skill creates a GraphQL API connection in an Ivy project using StrawberryShake for typed client generation. It researches the API, collects configuration, generates the connection files, and verifies the build.
+
+## Prerequisites
+
+- The working directory must be a valid Ivy project.
+- The user should know (or you should research) the GraphQL endpoint URL and authentication method.
+
+## Workflow
+
+### 1. Research the API
+
+If the GraphQL endpoint URL is not already known, research the API to find:
+
+1. The GraphQL endpoint URL (usually ends in `/graphql`)
+2. The authentication method (bearer token, API key header, query parameter)
+3. Any specific header or parameter names for auth
+
+Use web search and documentation to find this information.
+
+If the endpoint URL is already known, skip to step 2.
+
+### 2. Collect Inputs
+
+Gather the following information from the user (ask the user for any values not already known):
+
+1. **GraphQL Endpoint URL** -- must be a valid HTTP/HTTPS URL
+2. **Connection Name** -- PascalCase name for the connection (e.g., `GitHubGraphQL`). Must match `^[A-Z][a-zA-Z0-9]*$` and not conflict with existing connections.
+3. **Authentication Token** -- the API token or key (treat as secret)
+4. **Auth Delivery Method** -- how the token is sent to the API. Options:
+   - `bearer` -- Bearer token in the Authorization header
+   - `queryParam` -- Query parameter (e.g., `?token=xxx`)
+   - `customHeader` -- Custom header (e.g., `X-Api-Key`)
+
+   The auth method may be auto-detected by probing the endpoint. If auto-detection fails, ask the user.
+5. If `customHeader` is selected, ask for the **Auth Header Name** (default: `X-Api-Key`)
+6. If `queryParam` is selected, ask for the **Auth Query Param Name** (default: `token`)
+
+### 3. Generate the Connection
+
+The generation service will:
+
+- Create the connection folder at `Connections/[ConnectionName]/`
+- Configure StrawberryShake for the GraphQL endpoint
+- Store the endpoint URL in dotnet user secrets as `[ConnectionName]:EndpointUrl`
+- Store the authentication token in dotnet user secrets as `[ConnectionName]:Token`
+
+### 4. Build and Verify
+
+Run `dotnet build` to trigger StrawberryShake code generation. The `I[ConnectionName]Client` interface does not exist until the first build completes.
+
+After building, test the connection to verify it works. If the test fails, investigate and fix the issue.
+
+### 5. Completion
+
+Tell the user the connection is ready and show them how to use it. Remind them to edit the `.graphql` query files to define the queries they need.
+
+The connection folder structure will be at `Connections/[ConnectionName]/`.
+
+## Recovery Guidance
+
+If the connection setup fails, follow these recovery steps:
+
+1. **Diagnose the root cause** (e.g., invalid endpoint, auth issues, network problems, schema introspection failure):
+   - For invalid endpoint: Verify the GraphQL endpoint URL is accessible and returns a valid response to `{ __typename }`
+   - For auth issues: Ensure the authentication token is correct and the auth delivery method (header, query param) matches the API's requirements
+   - For network problems: Check network connectivity and firewall settings
+   - For schema introspection failure: Verify the endpoint supports introspection queries (some production APIs disable it)
+
+2. **After fixing the underlying issue**, choose ONE of these approaches:
+
+   **Option A: Retry the skill** (recommended for transient failures like network timeouts or temporary introspection issues)
+   - Use the `/ivy-create-graphql-connection` skill to restart the connection setup from scratch.
+
+   **Option B: Manual GraphQL connection creation** (recommended for persistent failures or APIs with introspection disabled)
+   - Create a GraphQL client class in `Connections/[ConnectionName]/`
+   - Manually define types based on the API documentation (if introspection is unavailable)
+   - Configure the client with the endpoint URL and authentication method
+   - Test the connection with a simple query
+
+3. **Do NOT proceed** to generating apps or widgets until the connection is successfully established and tested with a sample query.

--- a/src/skills/ivy-create-openapi-connection/SKILL.md
+++ b/src/skills/ivy-create-openapi-connection/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: ivy-create-openapi-connection
+description: >
+  Create an OpenAPI/REST API connection using Refitter code generation. Use when
+  the user wants to add an OpenAPI connection, connect to a REST API, integrate a
+  Swagger spec, set up Refitter, or add OpenAPI or REST support to their Ivy project.
+allowed-tools:
+  - Bash(dotnet:*)
+  - Bash(refitter:*)
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+effort: high
+---
+
+# Create an OpenAPI Connection
+
+This skill creates an OpenAPI/REST API connection in an Ivy project using Refitter for typed client generation. It collects the spec URL, analyzes the spec for size, handles large specs with filtering or pivoting, and generates the connection.
+
+## Prerequisites
+
+- The working directory must be a valid Ivy project.
+- The user should know (or you should find) the OpenAPI specification URL.
+
+## Workflow
+
+### 1. Collect Inputs
+
+Gather the following information from the user (ask the user for any values not already known):
+
+1. **OpenAPI Spec URL** -- must be a valid HTTP/HTTPS URL pointing to an OpenAPI/Swagger specification (JSON or YAML)
+
+   If the spec cannot be fetched or parsed, the URL will be rejected with an error message. Ask the user for a corrected URL.
+
+2. **Auth Scheme** -- automatically detected from the OpenAPI spec's security schemes. If detection fails, defaults to `bearer` with `Authorization` header.
+
+3. **Connection Name** -- PascalCase name for the connection (e.g., `StripeApi`). Must match `^[A-Z][a-zA-Z0-9]*$` and not conflict with existing connections. A name is suggested based on the spec URL.
+
+4. **API Endpoint URL** -- the base URL for API calls. Suggested from the spec's server/host configuration.
+
+5. **Auth Credentials** -- Bearer token or API key depending on the detected auth scheme (treat as secret).
+
+### 2. Analyze the Spec
+
+After inputs are collected, the OpenAPI spec is analyzed for size and endpoint count. If analysis fails, proceed to generation anyway (Refitter will report its own errors).
+
+### 3. Handle Large Specs
+
+If the spec is oversized (very large file size or many endpoints), you must choose one of the following strategies:
+
+**Warning: Very large OpenAPI specifications** (many KB, hundreds of endpoints) are likely to produce thousands of types, build errors from name conflicts, and may crash the session.
+
+The available endpoints from the spec will be listed. Choose one of:
+
+1. **FilterEndpoints** -- Select only the endpoints needed. Provide an array of path regex patterns (e.g., `["/v1/chat/.*", "/v1/models"]`) matching the listed paths. Refitter uses regex matching on these patterns. This is preferred when only a small number of endpoints are needed.
+
+2. **ProceedFull** -- Generate a client for the full spec anyway (not recommended for specs this large).
+
+3. **PivotToAdHoc** -- Abandon the OpenAPI approach and create a lightweight ad-hoc HTTP connection instead (recommended when you only need a few endpoints). This will switch to a different connection workflow.
+
+If only a small number of endpoints are needed for the user's task, prefer FilterEndpoints or PivotToAdHoc.
+
+If the spec is not oversized, skip directly to generation.
+
+### 4. Generate the Connection
+
+The Refitter code generation service will:
+
+- Create the connection folder at `Connections/[ConnectionName]/`
+- Generate typed C# client interfaces and models from the OpenAPI spec
+- Apply endpoint filters if specified
+- Store the endpoint URL in dotnet user secrets as `[ConnectionName]:EndpointUrl`
+- Store the authentication token in dotnet user secrets
+
+### 5. Build and Verify
+
+After generation, build the project and test the connection. If the test fails, investigate and fix the issue.
+
+### 6. Completion
+
+Tell the user the connection is ready and show them how to use it.
+
+The connection folder structure will be at `Connections/[ConnectionName]/`.
+
+## Recovery Guidance
+
+If the connection setup fails, follow these recovery steps:
+
+1. **Diagnose the root cause** (e.g., invalid spec URL/path, malformed OpenAPI spec, codegen failure, auth config issues):
+   - For invalid spec location: Verify the OpenAPI spec URL is accessible or the file path exists
+   - For malformed spec: Validate the spec using an OpenAPI validator (https://editor.swagger.io/)
+   - For codegen failure: Check for unsupported OpenAPI features or version mismatches
+   - For auth issues: Verify authentication configuration matches the spec's security schemes
+
+2. **After fixing the underlying issue**, choose ONE of these approaches:
+
+   **Option A: Retry the skill** (recommended for transient failures like network timeouts or temporary spec URL issues)
+   - Use the `/ivy-create-openapi-connection` skill to restart the connection setup from scratch.
+
+   **Option B: Manual OpenAPI connection creation** (recommended for persistent failures like codegen issues)
+   - Manually create client classes in `Connections/[ConnectionName]/`
+   - Implement methods for the required API endpoints based on the spec
+   - Configure authentication (API keys, OAuth, etc.) based on the spec's security schemes
+   - Test the connection with a sample API call
+
+3. **Do NOT proceed** to generating apps or widgets until the connection is successfully established and tested with a sample API call.

--- a/src/skills/ivy-create-soap-connection/SKILL.md
+++ b/src/skills/ivy-create-soap-connection/SKILL.md
@@ -1,0 +1,330 @@
+---
+name: ivy-create-soap-connection
+description: >
+  Add a SOAP/WSDL web service connection to an Ivy project. Generates a typed
+  client from a WSDL URL using dotnet-svcutil. Supports no auth, HTTP Basic,
+  Bearer token, and custom header authentication. Use when the user wants to
+  connect to a SOAP service, WSDL endpoint, or WCF service.
+allowed-tools: Bash(dotnet:*) Bash(svcutil:*) Bash(ivy:*) Read Write Edit Glob Grep
+effort: high
+argument-hint: "[WSDL URL of the SOAP service]"
+---
+
+# ivy-create-soap-connection
+
+Add a SOAP web service connection to an existing Ivy project. This skill guides you through collecting the WSDL URL, authentication details, and generating a typed client using `dotnet-svcutil`.
+
+## Step 1: Validate the Project
+
+1. Verify this is a valid Ivy project. Check for a `.csproj` file and `Program.cs` in the working directory. If this is not an Ivy project, tell the user and stop.
+
+2. Clean up any empty connection folders under `Connections/` if they exist.
+
+## Step 2: Collect the WSDL URL
+
+3. Ask the user for the WSDL URL if not already provided. The URL must be a valid HTTP or HTTPS URL (matching `^https?://.+$`). If the URL is invalid, ask the user to provide a valid one.
+
+4. Validate that the URL is accessible and points to a WSDL document.
+
+## Step 3: Collect Connection Details
+
+5. Ask the user for a connection name in **PascalCase** (e.g. "PaymentService", "WeatherApi"). The name must match the regex `^[A-Z][a-zA-Z0-9]*$`. A name is suggested based on the WSDL URL hostname. If the name is invalid or already in use, ask the user to provide a different one.
+
+6. Ask the user for the SOAP service endpoint URL. This is the actual service URL that the client will call at runtime (not the WSDL URL). A suggestion is derived from the WSDL URL hostname.
+
+7. Ask the user to select the authentication type:
+
+| Auth Type | Description | Required Credentials |
+|---|---|---|
+| **none** | No authentication | -- |
+| **basic** | HTTP Basic (username + password) | Username, Password |
+| **bearer** | Bearer token | Token |
+| **custom-header** | Custom header (name + value) | Header Name, Token/Value |
+
+8. Based on the chosen auth type, collect the required credentials:
+   - **basic**: Ask for username and password (password is a secret)
+   - **bearer**: Ask for the bearer token (secret)
+   - **custom-header**: Ask for the header name and the header value (value is a secret)
+   - **none**: No credentials needed
+
+## Step 4: Generate the Connection
+
+9. Create the connection directory at `Connections/[ConnectionName]/`.
+
+10. Ensure dotnet tools are installed. The `dotnet-svcutil` tool is required:
+
+```bash
+dotnet tool install --global dotnet-svcutil
+```
+
+11. Initialize user secrets and store credentials:
+
+```bash
+dotnet user-secrets init
+dotnet user-secrets set "[ConnectionName]:EndpointUrl" "[endpoint-url]"
+```
+
+For auth credentials, also store them in user secrets:
+- **basic**: `[ConnectionName]:Username` and `[ConnectionName]:Password`
+- **bearer** or **custom-header**: `[ConnectionName]:Token`
+
+12. Add the required WCF NuGet packages:
+
+```bash
+dotnet add package System.ServiceModel.Http
+dotnet add package System.ServiceModel.Primitives
+```
+
+13. Run `dotnet-svcutil` to generate the client from the WSDL:
+
+```bash
+dotnet-svcutil [WsdlUrl] --outputDir Connections/[ConnectionName] --namespace "*,[ProjectNamespace].Connections.[ConnectionName]" --noLogo
+```
+
+This generates a `Reference.cs` file containing the service client class (inheriting from `System.ServiceModel.ClientBase<T>`).
+
+14. Verify that `Reference.cs` was generated in the connection directory. If generation fails:
+    - Verify that the WSDL URL is accessible and valid
+    - Check that .NET SDK is installed and `dotnet-svcutil` is available
+    - Verify the service uses SOAP 1.1 or 1.2
+
+### Create the ClientFactory
+
+15. Create `Connections/[ConnectionName]/[ConnectionName]ClientFactory.cs`. This class reads credentials from configuration and creates the SOAP client with the appropriate binding and authentication:
+
+```csharp
+using System.Reflection;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+using System.ServiceModel.Description;
+using System.ServiceModel.Dispatcher;
+using Microsoft.Extensions.Configuration;
+
+namespace [ProjectNamespace].Connections.[ConnectionName];
+
+public static class [ConnectionName]ClientFactory
+{
+    public static [ServiceClientClassName] CreateClient()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddEnvironmentVariables()
+            .AddUserSecrets(Assembly.GetEntryAssembly()!)
+            .Build();
+
+        var endpointUrl = configuration.GetValue<string>("[ConnectionName]:EndpointUrl")
+            ?? throw new Exception("[ConnectionName]:EndpointUrl is required");
+
+        var endpointUri = new Uri(endpointUrl);
+        Binding binding;
+
+        if (endpointUri.Scheme == "https")
+        {
+            var httpsBinding = new BasicHttpsBinding();
+            httpsBinding.Security.Mode = BasicHttpsSecurityMode.Transport;
+            binding = httpsBinding;
+        }
+        else
+        {
+            binding = new BasicHttpBinding();
+        }
+
+        var endpoint = new EndpointAddress(endpointUrl);
+        var client = new [ServiceClientClassName](binding, endpoint);
+
+        // For basic auth:
+        // var username = configuration.GetValue<string>("[ConnectionName]:Username")
+        //     ?? throw new Exception("[ConnectionName]:Username is required");
+        // var password = configuration.GetValue<string>("[ConnectionName]:Password")
+        //     ?? throw new Exception("[ConnectionName]:Password is required");
+        // client.ClientCredentials.UserName.UserName = username;
+        // client.ClientCredentials.UserName.Password = password;
+
+        // For bearer auth:
+        // var token = configuration.GetValue<string>("[ConnectionName]:Token")
+        //     ?? throw new Exception("[ConnectionName]:Token is required");
+        // client.Endpoint.EndpointBehaviors.Add(
+        //     new AuthHeaderBehavior("Authorization", $"Bearer {token}"));
+
+        // For custom-header auth:
+        // var token = configuration.GetValue<string>("[ConnectionName]:Token")
+        //     ?? throw new Exception("[ConnectionName]:Token is required");
+        // client.Endpoint.EndpointBehaviors.Add(
+        //     new AuthHeaderBehavior("[HeaderName]", token));
+
+        return client;
+    }
+
+    // Include these classes when using bearer or custom-header auth:
+
+    private class AuthHeaderBehavior(string headerName, string headerValue) : IEndpointBehavior
+    {
+        public void Validate(ServiceEndpoint endpoint) { }
+        public void AddBindingParameters(ServiceEndpoint endpoint, BindingParameterCollection bindingParameters) { }
+        public void ApplyDispatchBehavior(ServiceEndpoint endpoint, EndpointDispatcher endpointDispatcher) { }
+
+        public void ApplyClientBehavior(ServiceEndpoint endpoint, ClientRuntime clientRuntime)
+        {
+            clientRuntime.ClientMessageInspectors.Add(new AuthHeaderInspector(headerName, headerValue));
+        }
+    }
+
+    private class AuthHeaderInspector(string headerName, string headerValue) : IClientMessageInspector
+    {
+        public object? BeforeSendRequest(ref Message request, IClientChannel channel)
+        {
+            var httpRequestProperty = new System.ServiceModel.Channels.HttpRequestMessageProperty();
+            httpRequestProperty.Headers[headerName] = headerValue;
+
+            if (request.Properties.ContainsKey(HttpRequestMessageProperty.Name))
+            {
+                request.Properties[HttpRequestMessageProperty.Name] = httpRequestProperty;
+            }
+            else
+            {
+                request.Properties.Add(HttpRequestMessageProperty.Name, httpRequestProperty);
+            }
+
+            return null;
+        }
+
+        public void AfterReceiveReply(ref Message reply, object correlationState) { }
+    }
+}
+```
+
+Uncomment and use only the auth section matching the chosen auth type. Remove the `AuthHeaderBehavior` and `AuthHeaderInspector` classes if auth type is `none` or `basic`.
+
+The `[ServiceClientClassName]` is detected from the generated `Reference.cs` -- look for a class inheriting from `System.ServiceModel.ClientBase<T>` (e.g. `SomeServiceClient`). If detection fails, default to `[ConnectionName]Client`.
+
+### Create the Connection class
+
+16. Create `Connections/[ConnectionName]/[ConnectionName]Connection.cs` implementing `IConnection` and `IHaveSecrets`:
+
+```csharp
+using Ivy;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using System.Reflection;
+
+namespace [ProjectNamespace].Connections.[ConnectionName];
+
+public class [ConnectionName]Connection : IConnection, IHaveSecrets
+{
+    public string GetContext(string connectionPath)
+    {
+        var connectionFile = nameof([ConnectionName]Connection) + ".cs";
+        var clientFactoryFile = nameof([ConnectionName]ClientFactory) + ".cs";
+        var files = Directory.GetFiles(connectionPath, "*.*", SearchOption.TopDirectoryOnly)
+            .Where(f => !f.EndsWith(connectionFile) && !f.EndsWith(clientFactoryFile))
+            .Select(File.ReadAllText)
+            .ToArray();
+        return string.Join(Environment.NewLine, files);
+    }
+
+    public string GetName() => "[ConnectionName]";
+
+    public string GetNamespace() => typeof([ConnectionName]Connection).Namespace!;
+
+    public string GetConnectionType() => "Soap.Wsdl";
+
+    public ConnectionEntity[] GetEntities()
+    {
+        var clientType = typeof([ServiceClientClassName]);
+        var methods = clientType.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Where(m => m.Name.EndsWith("Async"))
+            .ToArray();
+
+        return methods
+            .Select(m => new ConnectionEntity(m.Name, m.Name))
+            .ToArray();
+    }
+
+    public void RegisterServices(Server server)
+    {
+        server.Services.AddTransient(_ => [ConnectionName]ClientFactory.CreateClient());
+    }
+
+    public Secret[] GetSecrets()
+    {
+        return
+        [
+            new Secret("[ConnectionName]:EndpointUrl"),
+            // For basic auth:
+            // new Secret("[ConnectionName]:Username"),
+            // new Secret("[ConnectionName]:Password"),
+            // For bearer or custom-header auth:
+            // new Secret("[ConnectionName]:Token"),
+        ];
+    }
+
+    public async Task<(bool ok, string? message)> TestConnection(IConfiguration config)
+    {
+        try
+        {
+            var client = [ConnectionName]ClientFactory.CreateClient();
+            return (true, null);
+        }
+        catch (Exception ex)
+        {
+            return (false, $"Connection test failed: {ex.Message}");
+        }
+    }
+}
+```
+
+Adjust the `GetSecrets()` method to include only the secrets relevant to the chosen auth type.
+
+Expected directory structure after completion:
+
+```
+[UserProject]/
+├── [UserProject].csproj
+├── Program.cs
+├── Connections/
+│   └── [ConnectionName]/
+│       ├── [ConnectionName]Connection.cs
+│       ├── [ConnectionName]ClientFactory.cs
+│       └── Reference.cs (generated by svcutil)
+```
+
+## Step 5: Verify
+
+17. Run `dotnet build` to verify everything compiles. Fix any errors.
+
+18. Run `dotnet build` to verify the project compiles. Then test the connection by running `dotnet run` and verifying the app starts without errors. If the test fails, investigate and fix the issue.
+
+19. If the project is in a git repository, create a commit with a descriptive message, for example: "Added SOAP connection '[ConnectionName]'."
+
+20. Tell the user the connection is ready and show them how to use it. Example usage:
+
+```csharp
+public class SomeView : ViewBase
+{
+    public object? Build()
+    {
+        var client = UseService<[ServiceClientClassName]>();
+        // Call SOAP operations, e.g.:
+        // var result = await client.SomeOperationAsync(request);
+        ...
+    }
+}
+```
+
+## Recovery
+
+If the setup fails:
+
+1. Diagnose the root cause (invalid WSDL URL, svcutil failure, incompatible SOAP version, auth issues):
+   - For invalid WSDL location: verify the WSDL URL is accessible or the file path exists
+   - For svcutil failure: check that .NET SDK is installed and `dotnet-svcutil` is available
+   - For SOAP version issues: verify the service uses SOAP 1.1 or 1.2 (WS-* extensions may not be fully supported)
+   - For auth issues: check if the SOAP service requires WS-Security or HTTP auth
+
+2. After fixing the underlying issue, either retry using the `/ivy-create-soap-connection` skill from scratch, or manually create the connection:
+   - Run svcutil manually: `dotnet-svcutil [wsdl-url] --outputDir Connections/[ConnectionName]/`
+   - Add the generated classes to your project
+   - Configure the SOAP client endpoint and binding in code
+   - Implement authentication if required (WS-Security, HTTP Basic, etc.)
+   - Test the connection with a sample SOAP operation
+
+3. Use `ivy ask "How do I create a SOAP connection?"` or `ivy ask "How do I configure SOAP authentication?"` for API guidance.

--- a/src/skills/ivy-create-theme/SKILL.md
+++ b/src/skills/ivy-create-theme/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: ivy-create-theme
+description: >
+  Create or modify a custom Ivy theme. Use when the user asks to create a theme, change
+  colors, update typography, modify the look and feel, customize the UI appearance, set
+  dark mode colors, or adjust border radius, spacing, or other visual styling in their
+  Ivy project.
+allowed-tools: Bash(dotnet:*) Bash(ivy:*) Read Write Edit Glob Grep
+effort: medium
+---
+
+# ivy-create-theme
+
+Create or modify a custom theme in an Ivy project.
+
+## Getting Started
+
+1. Use `ivy docs` to read about theming (query: "theming" or "custom theme").
+2. Check if the user's `Program.cs` already has a `UseTheme(...)` call.
+   - If it does, follow the **Modify an Existing Theme** path.
+   - If it does not, follow the **Create a New Theme** path.
+
+## Path A: Create a New Theme
+
+1. If it is not clear from context, ask the user for details about the theme they want to create (colors, typography, dark/light preferences, etc.).
+
+2. Create a file at `Themes/[ThemeName].cs` with a class that extends `Theme`:
+
+```csharp
+using Ivy;
+
+namespace [ProjectNamespace].Themes;
+
+public class MyTheme : Theme
+{
+    public MyTheme()
+    {
+        Name = "MyTheme";
+        Colors = new ThemeColorScheme
+        {
+            Light = new ThemeColors { /* ... */ },
+            Dark = new ThemeColors { /* ... */ }
+        };
+        ...
+    }
+}
+```
+
+3. In `Program.cs`, add `.UseTheme(new MyTheme())` to the server builder chain. This MUST be BEFORE `.Run()`. The framework auto-detects the subclass and creates a factory via `Activator.CreateInstance` for hot reload.
+
+### Inline Configuration Approach
+
+If the user prefers inline configuration instead of a separate class:
+
+In `Program.cs`, add `.UseTheme(theme => { ... })` to the server builder chain. This MUST be BEFORE `.Run()`. The framework wraps the callback in a factory for hot reload.
+
+```csharp
+.UseTheme(theme =>
+{
+    theme.Name = "MyTheme";
+    theme.Colors = new ThemeColorScheme
+    {
+        Light = new ThemeColors { /* ... */ },
+        Dark = new ThemeColors { /* ... */ }
+    };
+})
+```
+
+## Path B: Modify an Existing Theme
+
+1. Find the existing `UseTheme(...)` call in `Program.cs`. Determine which pattern is used:
+   - `UseTheme(new MyTheme())` -- find and edit the theme subclass file
+   - `UseTheme(theme => { ... })` -- edit the inline callback in Program.cs
+   - `UseTheme(SomeTheme.Create)` -- find and edit the factory method
+
+2. Ask the user what they want to change (colors, typography, border radius, etc.) if it is not already clear from context.
+
+3. Apply the changes to the theme definition.
+
+## Verification
+
+1. Run `dotnet build` to verify everything compiles. Fix any errors.
+
+2. If the user asks to commit, create a git commit with a descriptive message.
+
+3. Present a short summary to the user describing what was created or changed.

--- a/src/skills/ivy-create-using-reference-connection/SKILL.md
+++ b/src/skills/ivy-create-using-reference-connection/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: ivy-create-using-reference-connection
+description: >
+  Create a connection from the Ivy catalog of pre-built reference connections. Use
+  when the user wants to add a reference connection, browse the Ivy catalog, use a
+  pre-built connection template, or set up a catalog connection in their Ivy project.
+allowed-tools:
+  - Bash(dotnet:*)
+  - Bash(ivy:*)
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+effort: medium
+---
+
+# Create a Connection Using a Reference
+
+This skill creates a connection in an Ivy project using a pre-built reference connection from the Ivy catalog. Reference connections provide templates with NuGet packages, secrets configuration, and example implementation files that guide the agent in building the actual connection.
+
+## Prerequisites
+
+- The working directory must be a valid Ivy project.
+
+## Concepts
+
+**Reference connections** are pre-built connection templates maintained in the Ivy catalog. Each reference connection includes:
+
+- **NuGet packages** required for the connection (with optional documentation and GitHub links)
+- **Secrets** that need to be configured (API keys, tokens, endpoints)
+- **Reference files** containing example implementations that show how to build the connection class, tests, and demo apps
+
+The reference files are exposed as guidance -- they are not copied directly into the project. Instead, you should read them and create a similar implementation adapted to the user's project.
+
+## Workflow
+
+### 1. Select a Reference Connection
+
+If a reference connection name is not already specified, list the available connections from the Ivy catalog.
+
+Ask the user which reference connection they want to use. Present the connection names as options along with their descriptions, services, and tags.
+
+### 2. Download the Reference
+
+Download the selected reference connection from the Ivy catalog. This fetches the reference files and metadata to a local folder.
+
+If the download fails, report the error to the user.
+
+### 3. Collect Secrets
+
+If the reference connection requires secrets (API keys, tokens, etc.), ask the user for each secret value. Each secret has a key and description explaining what it is for.
+
+If no secrets are required, skip to the next step.
+
+### 4. Install and Set Up
+
+This step performs several automated actions:
+
+1. **Store secrets** -- If secrets were collected, initialize dotnet user-secrets and store each secret value. The secret keys use the format `ConnectionName:SecretKey`.
+
+2. **Install NuGet packages** -- Add all required NuGet packages from the reference connection. Run `dotnet restore` after installation.
+
+3. **Create the connection directory** -- Create `Connections/[ConnectionName]/` in the project.
+
+### 5. Build the Connection
+
+Using the reference files as guidance, create the connection implementation:
+
+- Read each reference file to understand the example implementation patterns
+- Create a similar implementation adapted to the user's project under `Connections/[ConnectionName]/`
+- The implementation should include the connection class, any models, and configuration
+
+**Package Management Rules:**
+1. Add `<PackageReference>` elements to the .csproj file
+2. Immediately run `dotnet add package [PackageName]` for each package to ensure proper restore
+3. Then run `dotnet build` to verify compilation
+
+**Secret Handling Rules:**
+- Do NOT run `dotnet user-secrets` commands -- the workflow has already stored all collected secrets automatically.
+- If the user specified custom values in their prompt (API keys, tokens, endpoints, etc.), set them as preset values in the connection's `GetSecrets()` method:
+
+```csharp
+public Secret[] GetSecrets() =>
+[
+    new Secret("OpenAI:ApiKey", "sk-user-provided-key"),
+    new Secret("OpenAI:Endpoint", "https://custom-endpoint.com/"),
+];
+```
+
+This applies to ALL user-supplied values including API keys and tokens -- presets are how the system delivers credentials at runtime.
+
+### 6. Verify
+
+Test the connection using the test tool with the connection name. If the test fails, investigate and fix the issue.
+
+### 7. Completion
+
+Report the results:
+- Connection name
+- NuGet packages installed
+- Secrets stored (with prefix `[ConnectionName]:`)
+- Reference files that were used as guidance
+
+The reference files remain available for building applications with this connection. Use the Read tool to review any reference file for implementation patterns.

--- a/src/skills/ivy-deploy-to-desktop/SKILL.md
+++ b/src/skills/ivy-deploy-to-desktop/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: ivy-deploy-to-desktop
+description: >
+  Deploy an Ivy project as a standalone desktop application. Use when the user asks to
+  publish, deploy, package, or export their Ivy app as a desktop app, native app,
+  executable, or .exe. Scaffolds a desktop wrapper project using Ivy.Desktop, generates
+  a Program.cs, publishes with dotnet, and copies the executable to the user's desktop.
+allowed-tools: Bash(dotnet:*) Bash(ivy:*) Read Write Edit Glob Grep
+effort: high
+disable-model-invocation: true
+---
+
+# ivy-deploy-to-desktop
+
+Deploy an Ivy project as a standalone desktop application using Ivy.Desktop.
+
+## Workflow
+
+1. **Verify the project** -- Confirm the working directory is a valid Ivy project and that it builds successfully with `dotnet build`. If it does not build, stop and ask the user to fix build errors first.
+
+2. **Determine the project namespace** -- Find the root namespace from the `.csproj` file or existing source files.
+
+3. **Scaffold the desktop project** -- Create a desktop wrapper project under `.ivy/publish/[Namespace].Desktop/`. This is a separate .NET project that references the main Ivy project and adds the Ivy.Desktop package.
+
+4. **Generate Program.cs** -- Write a `Program.cs` for the desktop wrapper following the rules in the generation guide below.
+
+5. **Publish the application** -- Run `dotnet publish -c Release` on the desktop project to produce a self-contained executable.
+
+6. **Copy to desktop** -- Place the published executable on the user's desktop so it is ready to run.
+
+## Step 4: Generating Program.cs
+
+Write a `Program.cs` for the desktop project (`[Namespace].Desktop`) at `.ivy/publish/[Namespace].Desktop/Program.cs`.
+
+Before generating, read the original web project's `Program.cs` and list the files in the project's `Apps/` directory.
+
+The generated Program.cs must:
+
+1. Use `Ivy` and `Ivy.Desktop` namespaces.
+2. Create a `new Server(new ServerArgs { Silent = true })`.
+3. **Assembly references** -- For `AddAppsFromAssembly` and `AddConnectionsFromAssembly`, you MUST pass an explicit assembly reference because the entry assembly in the desktop project is different from the main app assembly. Find a class from the original project (e.g., an `[App]` class) and use `typeof(ThatClass).Assembly` as the argument:
+   ```csharp
+   var targetAssembly = typeof(MyNamespace.Apps.SomeAppClass).Assembly;
+   server.AddAppsFromAssembly(targetAssembly);
+   server.AddConnectionsFromAssembly(targetAssembly);
+   ```
+4. Preserve any other service registrations from the original (e.g. `server.UseCulture(...)`, any `server.Add*` calls).
+5. **Chrome handling:**
+   - Count the number of apps in the `Apps/` directory.
+   - If there are **multiple apps**, preserve the chrome configuration (e.g. `UseAppShell`) in the desktop version so users can navigate between apps via the sidebar.
+   - If there is only a **single app**, do NOT add `UseAppShell`. Use `server.UseDefaultApp(typeof(TheApp))` instead. Single-app desktop applications should not have a sidebar.
+6. **Window sizing** -- Choose appropriate `.Size(width, height)` values for the `DesktopWindow` based on the apps found in `Apps/`:
+   - Multi-app projects with chrome/sidebar: `1280, 800` or larger
+   - Single-app dashboards or data-heavy apps: `1200, 800`
+   - Single-app form/tool apps (calculators, converters, simple utilities): `800, 600`
+   - Single-app narrow/focused apps (chat, single-column): `500, 700`
+   - When unsure, default to `1024, 768`
+7. Replace the web server startup with:
+   ```csharp
+   return new DesktopWindow(server)
+       .Title("[AppTitle]")
+       .Size(WIDTH, HEIGHT)  // Use the dimensions chosen in step 6
+       .Run();
+   ```
+8. Do NOT include any web host building, `app.Run()`, `builder.Build()`, Kestrel, or HTTP pipeline code.
+
+**CRITICAL:** Write ONLY to `.ivy/publish/[Namespace].Desktop/Program.cs`. Do NOT create any files in the main project directory. Do NOT create a `.Desktop` subfolder in the main project. The desktop project lives under `.ivy/publish/[Namespace].Desktop/` -- all desktop files must go there.
+
+Output ONLY raw C# code, no markdown fences or explanation.
+
+## Troubleshooting
+
+If the publish step fails:
+
+1. Ensure the project builds successfully with `dotnet build`.
+2. Check that the Ivy.Desktop NuGet package is available.
+3. Verify you have the .NET 10 SDK installed.
+4. If the error mentions "Ambiguous project name", create a `Directory.Build.props` in the desktop project directory with content `<Project></Project>` to isolate the project from the parent directory tree.
+
+### Recovery Steps
+
+1. Diagnose using the troubleshooting steps above to identify the root cause.
+
+2. After fixing the underlying issue, choose ONE of these approaches:
+
+   **Option A: Retry from scratch** (recommended for transient failures like NuGet package issues or temporary build failures) -- re-run the full workflow from step 1.
+
+   **Option B: Manual desktop publish** (recommended for persistent workflow failures):
+   - Run `dotnet publish -c Release -r <rid>` (e.g., `-r win-x64`, `-r osx-arm64`, `-r linux-x64`)
+   - Locate the published executable in `bin/Release/net10.0/{rid}/publish/`
+   - Copy the executable to the user's desktop (see "Desktop Copy" below)
+
+   Use `ivy docs` to find deployment patterns: "How do I publish an Ivy app as a desktop application?"
+
+3. Do NOT skip the desktop copy step -- the executable must be accessible on the desktop for the user.
+
+### Desktop Copy
+
+If you recover manually, you MUST copy the published executable to the user's desktop:
+- Publish location: `bin/Release/net10.0/{rid}/publish/`
+- Desktop folder: Use the system desktop path (e.g., `C:\Users\{user}\Desktop\`)
+- Copy the `.exe` file (Windows) or the binary (macOS/Linux) to the desktop
+
+## Completion
+
+When the publish succeeds, inform the user:
+- The application name
+- The output location (on their desktop)
+- That it is ready to run

--- a/src/skills/ivy-generate-db-connection/SKILL.md
+++ b/src/skills/ivy-generate-db-connection/SKILL.md
@@ -1,0 +1,232 @@
+---
+name: ivy-generate-db-connection
+description: >
+  Generate a new database with AI-assisted schema design, EF Core Code First
+  entities, migrations, and Bogus data seeding. Use when the user asks to generate
+  a database, create a database schema, design a data model, set up Entity Framework,
+  or work with DBML schemas in their Ivy project.
+allowed-tools:
+  - Bash(dotnet:*)
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+effort: high
+---
+
+# Generate a Database Connection
+
+This skill generates a complete database connection in an Ivy project using AI-assisted schema design. It walks through DBML schema generation, database provider configuration, EF Core entity generation, migrations, and Bogus data seeding.
+
+## Prerequisites
+
+- The working directory must be a valid Ivy project.
+- `dotnet ef` tool will be installed automatically if not present.
+- `dotnet user-secrets` will be initialized automatically.
+
+## Reference Documents
+
+The following reference files in the `references/` folder contain detailed rules for each generation phase. Read the relevant ones at each step:
+
+- `DbmlGeneratePrompt.md` -- DBML schema generation syntax and rules
+- `DbmlToDataContextPrompt.md` -- EF Core entity generation rules (converting DBML to C# entities and DbContext)
+- `DbmlToDataContext-Sqlite.md` -- SQLite-specific entity generation notes
+- `DbmlToDataContext-Postgres.md` -- PostgreSQL-specific entity generation notes
+- `DbmlToDataContext-SqlServer.md` -- SQL Server-specific entity generation notes
+- `DbmlToDataContext-MySql.md` -- MySQL/MariaDB-specific entity generation notes
+- `DataSeederPrompt.md` -- Bogus data seeder generation rules (comprehensive, ~825 lines)
+- `DataSeeder-Sqlite.md` -- SQLite-specific seeding notes
+- `DataSeeder-Postgres.md` -- PostgreSQL-specific seeding notes
+- `DataSeeder-SqlServer.md` -- SQL Server-specific seeding notes
+- `DataSeeder-MySql.md` -- MySQL/MariaDB-specific seeding notes
+
+## Workflow
+
+### 1. Ensure Prerequisites
+
+Before starting, verify:
+
+- `dotnet ef` is installed (run `dotnet ef --version`). If not installed, run `dotnet tool install --global dotnet-ef`.
+- Initialize user-secrets: `dotnet user-secrets init` in the project directory.
+
+Snapshot the `.csproj` file before any modifications so it can be restored on failure.
+
+### 2. Collect Database Description
+
+Ask the user to describe the database they want to create. Explain that you will generate a database schema from their description, create Entity Framework Core entities, and set up migrations.
+
+Ask the user about:
+- What kind of data will be stored (e.g., users, products, orders)
+- The relationships between entities (e.g., a user has many orders)
+- Any specific fields or constraints they need
+- Any enums or status fields
+
+If the user gives a general category (e.g., "CRM", "e-commerce", "blog") or says they want something standard, proceed with a reasonable default schema for that domain. Do NOT keep asking for more details -- the user will be able to review and modify the schema in the next step.
+
+If the user has already specified a database type (e.g., "sqlite", "postgres"), note it so it will not be asked again later.
+
+### 3. Generate DBML Schema
+
+Read `references/DbmlGeneratePrompt.md` for the detailed DBML generation rules.
+
+Generate a DBML schema from the user's description following these key rules:
+- Use PascalCase for all table and column names
+- Table names must be singular
+- Use .NET-friendly data types
+- Define tables in DAG order (independent tables first)
+- Place all `Ref:` declarations at the end
+- Do NOT create empty enums
+- Include Id primary keys and CreatedAt/UpdatedAt timestamps
+
+Present the generated DBML schema to the user for review.
+
+### 4. Handle Revisions
+
+If the user requests changes to the schema, revise the DBML accordingly and present it again. Repeat until the user approves.
+
+Once approved, save the DBML schema and proceed.
+
+### 5. Configure Database Provider
+
+Collect the database provider configuration. If the database type was specified in step 2, use it. Otherwise, ask the user to choose from:
+
+- **SQLite** -- local file-based database
+- **Postgres** -- PostgreSQL (also used for Supabase)
+- **SqlServer** -- Microsoft SQL Server
+- **MySql** -- MySQL (also used for MariaDB)
+
+Depending on the provider, collect connection details:
+- For SQLite: the database file path (defaults to a local `.db` file)
+- For external databases: host, port, database name, username, password
+
+**Test the connection:**
+- For SQLite: verify the directory is writable
+- For external databases: attempt a basic connectivity check
+
+If the connection fails, ask the user if they want to try with different settings.
+
+**Store the connection string** in dotnet user-secrets as `ConnectionStrings:[ConnectionName]` (for non-SQLite providers).
+
+If the target database is not empty, ask the user whether to:
+1. Drop and recreate (data will be lost)
+2. Use a different database
+3. Cancel
+
+### 6. Generate EF Core Entities
+
+Read `references/DbmlToDataContextPrompt.md` for detailed entity generation rules. Also read the provider-specific reference for the chosen database:
+- SQLite: `references/DbmlToDataContext-Sqlite.md`
+- Postgres/Supabase: `references/DbmlToDataContext-Postgres.md`
+- SQL Server: `references/DbmlToDataContext-SqlServer.md`
+- MySQL/MariaDB: `references/DbmlToDataContext-MySql.md`
+
+Generate individual C# files:
+- One file per entity class in `Connections/[ConnectionName]/Models/` (e.g., `Connections/[ConnectionName]/Models/User.cs`)
+- The DbContext class in `Connections/[ConnectionName]/[ConnectionName]Context.cs`
+
+Key rules:
+- Use namespace `[ProjectNamespace].Connections.[ConnectionName].Models` for entity classes
+- Use namespace `[ProjectNamespace].Connections.[ConnectionName]` for the DbContext
+- The DbContext constructor must accept `DbContextOptions<[ConnectionName]Context>`
+- Do NOT include an `OnConfiguring` method
+- Use PascalCase for all C# names
+- Initialize all non-nullable string properties with `= null!;` and all navigation properties with `= null!;`
+- Generate COMPLETE code for ALL entities -- do not skip or abbreviate
+- Always include explicit `using` directives in every file
+- The DbContext MUST contain `DbSet<T>` properties for every entity
+
+### 7. Build and Fix
+
+Build the project with `dotnet build`. If the build fails, read the affected files, fix the errors, and build again. Repeat until the build succeeds.
+
+After a successful build, validate that the DbContext contains `DbSet<T>` properties for every entity defined in the DBML. If any are missing:
+
+1. Ensure a model class exists in `Connections/[ConnectionName]/Models/`
+2. Add the missing `DbSet<T>` property to the DbContext
+3. Add any required `OnModelCreating` configuration
+4. Do not remove or modify existing DbSet properties
+5. Build again
+
+This validation can be attempted up to 3 times. If entities are still missing after 3 attempts, the workflow fails.
+
+### 8. Create and Apply Migration
+
+Create the initial migration:
+
+```
+dotnet ef migrations add AddEntities --output-dir Connections/[ConnectionName]/Migrations --context [ConnectionName]Context -- [ConnectionString]
+```
+
+Apply the migration:
+
+```
+dotnet ef database update --context [ConnectionName]Context -- [ConnectionString]
+```
+
+Both commands will be retried up to 3 times on failure with increasing delays.
+
+### 9. Generate Data Seeder
+
+Read `references/DataSeederPrompt.md` for detailed seeder generation rules. Also read the provider-specific seeder reference:
+- SQLite: `references/DataSeeder-Sqlite.md`
+- Postgres/Supabase: `references/DataSeeder-Postgres.md`
+- SQL Server: `references/DataSeeder-SqlServer.md`
+- MySQL/MariaDB: `references/DataSeeder-MySql.md`
+
+First, add the Bogus NuGet package: `dotnet add package Bogus`
+
+Generate a `DataSeeder.cs` file in `Connections/[ConnectionName]/` with:
+
+- Class name: `DataSeeder`
+- Namespace: `[ProjectNamespace].Connections.[ConnectionName]`
+- Two methods:
+  - `public async System.Threading.Tasks.Task SeedAsync([ConnectionName]Context context)` -- seeds bogus data
+  - `public async System.Threading.Tasks.Task ClearAsync([ConnectionName]Context context)` -- deletes all non-enum/lookup table data in reverse dependency order
+- Uses the Bogus library for fake data generation
+- Seeds entities in dependency order (independent tables first)
+- Checks `AnyAsync()` before seeding each entity type to avoid duplicates
+- Does NOT seed enum/lookup tables already seeded via `HasData()` in migrations -- only queries them for FK references
+
+Build the project after generating the seeder. If the build fails, fix and rebuild.
+
+### 10. Run the Seeder
+
+Run the seeder to populate the database with fake data. The seeder is executed via a helper tool.
+
+If the seeder fails at runtime:
+1. Analyze the runtime errors carefully
+2. Read the `DataSeeder.cs` file and any relevant entity/DbContext files
+3. Fix the errors in `DataSeeder.cs`
+4. Common runtime issues:
+   - Foreign key constraint violations (seeding in wrong order)
+   - Duplicate key violations (unique constraint on seeded data)
+   - Type mismatches (wrong data types for columns)
+   - Null reference exceptions (missing required fields)
+   - Re-seeding enum/lookup tables already populated via `HasData()` in migrations
+   - Missing `SaveChangesAsync()` between dependent entity groups
+5. For "no such table" errors: run `dotnet ef database update --context [ContextName]` to re-apply existing migrations. Do NOT run `dotnet ef migrations add` -- migrations already exist.
+6. Scope is limited to fixing `DataSeeder.cs` and the DbContext. Do not restructure project service registration or migration infrastructure.
+
+The seeder will be retried up to 3 times. If it still fails after 3 attempts, the database structure is intact but unseeded.
+
+### 11. Completion
+
+Report the results to the user:
+
+- Connection name and provider
+- DBML schema that was generated
+- EF Core entities created in `Connections/[ConnectionName]/`
+- DbContext class name: `[ConnectionName]Context`
+- Initial migration created and applied
+- Connection string stored in user secrets (for non-SQLite)
+- Whether fake data was seeded successfully
+
+If git is available, commit the changes with a message like: `Generated [Provider] database '[ConnectionName]' with AI-assisted schema.`
+
+## Failure Recovery
+
+If the workflow fails at any point:
+- The `.csproj` file is rolled back to its pre-workflow state
+- The connection folder at `Connections/[ConnectionName]/` is cleaned up
+- The user can retry the skill from scratch

--- a/src/skills/ivy-generate-db-connection/references/DataSeeder-MySql.md
+++ b/src/skills/ivy-generate-db-connection/references/DataSeeder-MySql.md
@@ -1,0 +1,3 @@
+﻿# MySQL/MariaDB Seeding Notes
+
+The target database is MySQL using Pomelo.EntityFrameworkCore.MySql.

--- a/src/skills/ivy-generate-db-connection/references/DataSeeder-Postgres.md
+++ b/src/skills/ivy-generate-db-connection/references/DataSeeder-Postgres.md
@@ -1,0 +1,42 @@
+﻿# PostgreSQL Seeding Notes
+
+The target database is PostgreSQL using Npgsql.EntityFrameworkCore.PostgreSQL.
+
+## Critical DateTime Handling
+
+ALWAYS use `DateTime.UtcNow` for timestamps, NEVER `DateTime.Now`.
+
+PostgreSQL `timestamptz` columns require UTC values. Using `DateTime.Now` will cause:
+`Cannot write DateTime with Kind=Local to PostgreSQL type 'timestamp with time zone'`
+
+### DateTime Seeding Rules
+
+1. ALWAYS use `DateTime.UtcNow` for current timestamps
+2. DO NOT use `DateTime.Now` - it creates local time which PostgreSQL will reject or convert incorrectly
+3. For past/future dates, use the refDate parameter with `DateTime.UtcNow`:
+   - `f.Date.Past(1, DateTime.UtcNow)`
+   - `f.Date.Future(1, DateTime.UtcNow)`
+   - `f.Date.Recent(30, DateTime.UtcNow)`
+4. For Between dates, ensure both bounds are UTC:
+   - `f.Date.Between(DateTime.UtcNow.AddMonths(-6), DateTime.UtcNow)`
+
+### Why UTC is Required
+
+- PostgreSQL's timestamptz stores all timestamps in UTC internally
+- When you provide a non-UTC DateTime, PostgreSQL converts it based on the server's timezone
+- This can lead to incorrect timestamps and timezone-related bugs
+- Using `DateTime.UtcNow` ensures consistent, correct timestamps regardless of server timezone configuration
+
+### Common Mistake
+
+WRONG:
+```csharp
+.RuleFor(e => e.CreatedAt, f => f.Date.Past(1))  // Missing refDate, uses DateTime.Now
+.RuleFor(e => e.UpdatedAt, (f, e) => f.Date.Between(e.CreatedAt, DateTime.Now))
+```
+
+CORRECT:
+```csharp
+.RuleFor(e => e.CreatedAt, f => f.Date.Past(1, DateTime.UtcNow))
+.RuleFor(e => e.UpdatedAt, (f, e) => f.Date.Between(e.CreatedAt, DateTime.UtcNow))
+```

--- a/src/skills/ivy-generate-db-connection/references/DataSeeder-SqlServer.md
+++ b/src/skills/ivy-generate-db-connection/references/DataSeeder-SqlServer.md
@@ -1,0 +1,3 @@
+﻿# SQL Server Seeding Notes
+
+The target database is SQL Server using Microsoft.EntityFrameworkCore.SqlServer.

--- a/src/skills/ivy-generate-db-connection/references/DataSeeder-Sqlite.md
+++ b/src/skills/ivy-generate-db-connection/references/DataSeeder-Sqlite.md
@@ -1,0 +1,19 @@
+﻿# SQLite Seeding Notes
+
+The target database is SQLite using Microsoft.EntityFrameworkCore.Sqlite.
+
+## DateTime Handling
+
+SQLite stores DateTime values as TEXT, REAL, or INTEGER (depending on configuration). Default EF Core behavior stores DateTime as TEXT in ISO 8601 format. Both `DateTime.Now` and `DateTime.UtcNow` work correctly.
+
+## DateTimeOffset LINQ Limitation
+
+IMPORTANT: When using SQLite, `DateTimeOffset` columns cannot be compared in LINQ `Where` clauses. The SQLite EF Core provider cannot translate `DateTimeOffset` comparisons to SQL, causing runtime errors ("LINQ expression could not be translated") even though the code compiles successfully.
+
+For date filtering, either:
+- Store dates as `DateTime` (not `DateTimeOffset`) in SQLite models
+- Or load records first, then filter `DateTimeOffset` ranges in memory:
+  ```csharp
+  var entries = await db.TimeEntries.Where(t => t.CompanyId == id).ToListAsync();
+  var filtered = entries.Where(t => t.ClockInAt >= start && t.ClockInAt <= end);
+  ```

--- a/src/skills/ivy-generate-db-connection/references/DataSeederPrompt.md
+++ b/src/skills/ivy-generate-db-connection/references/DataSeederPrompt.md
@@ -1,0 +1,983 @@
+﻿# Data Seeder Generation Guide
+
+Generate a data seeder class using the Bogus library for Entity Framework Core.
+
+## Output Requirements
+
+- Class name: `DataSeeder`
+- Plain class (no interface) with two methods:
+  - `public async System.Threading.Tasks.Task SeedAsync({ContextClass} context)` - seeds bogus data
+  - `public async System.Threading.Tasks.Task ClearAsync({ContextClass} context)` - deletes all non-enum/lookup table data in reverse dependency order
+- Uses the Bogus library for fake data generation
+- File-scoped namespace
+- DO NOT include the namespace in usings
+- ALWAYS include `using System;`
+- Use `System.Threading.Tasks.Task` as return type (fully qualified to avoid conflicts with entity models)
+- Use C# 12+ syntax
+- Generate complete, compilable code
+- No comments in generated code
+- No markdown formatting in output
+- All closing braces must be present
+
+## Enum/Lookup Table Rules
+
+- **Do NOT seed** enum/lookup tables that are already seeded via `HasData()` in `OnModelCreating` - these are part of migrations and always present
+- Only **query** enum/lookup tables to get FK references: `var statuses = await context.OrderStatuses.ToArrayAsync();`
+- In `ClearAsync`, do NOT delete from enum/lookup tables - only delete from tables with bogus data
+
+## ClearAsync Requirements
+
+The `ClearAsync` method must:
+1. Delete from tables in **reverse dependency order** (dependent tables first, independent tables last)
+2. Skip enum/lookup tables that are seeded via `HasData()` in migrations
+3. Use `RemoveRange` + `SaveChangesAsync` for each table
+4. Example:
+```csharp
+public async System.Threading.Tasks.Task ClearAsync(MyContext context)
+{
+    context.OrderLines.RemoveRange(await context.OrderLines.ToArrayAsync());
+    await context.SaveChangesAsync();
+    context.Orders.RemoveRange(await context.Orders.ToArrayAsync());
+    await context.SaveChangesAsync();
+    context.Products.RemoveRange(await context.Products.ToArrayAsync());
+    await context.SaveChangesAsync();
+    context.Customers.RemoveRange(await context.Customers.ToArrayAsync());
+    await context.SaveChangesAsync();
+    // Do NOT clear OrderStatuses - seeded via HasData() in migrations
+}
+```
+
+## Top 5 Critical Rules
+
+1. **No async in RuleFor**: Never use `await` inside `.RuleFor()` lambdas. They are synchronous. Pre-fetch async data BEFORE creating the Faker instance.
+2. **Variable naming**: Use `{entityName}ToAdd` or `new{EntityName}` for variables in seeding blocks. Use plain `{entityName}` for queried collections.
+3. **Faker<T> vs Faker**: `Faker<T>` is for defining rules via `.RuleFor()`. `Faker` (non-generic) is for generating individual values like `.Internet.Email()`, `.Random.Int()`, etc.
+4. **Explicit types in do-while**: Use `string email;` not `var email;` before do-while loops.
+5. **No DependentOn**: Bogus does not have a `.DependentOn()` method. Set foreign keys directly: `.RuleFor(p => p.DepartmentId, f => f.PickRandom(departments).Id)`.
+6. **Date distribution**: Ensure the majority of seeded date/time values fall within the last 30 days using `f.Date.Recent(30)` instead of `f.Date.Past(1)`. This keeps seeded data relevant and visible in typical date-filtered views.
+
+### Quick Example of Rules 1, 2 & 3
+
+WRONG - Causes CS4034, CS0136 and CS1061 errors:
+```csharp
+if (!await _context.Users.AnyAsync())
+{
+    var usedEmails = new HashSet<string>();
+    var userFaker = new Faker<User>()
+        .RuleFor(u => u.Name, f => f.Person.FullName)
+        .RuleFor(u => u.CreatedAt, f => f.Date.Recent(30));
+
+    var users = new List<User>();
+    for (int i = 0; i < 100; i++)
+    {
+        string email;
+        do
+        {
+            email = userFaker.Internet.Email();  // CS1061: Faker<User> has no 'Internet' property!
+        } while (!usedEmails.Add(email));
+
+        var user = userFaker.Generate();
+        user.Email = email;
+        users.Add(user);
+    }
+    _context.Users.AddRange(users);
+    await _context.SaveChangesAsync();
+}
+var users = await _context.Users.ToArrayAsync();  // CS0136: 'users' already declared above!
+
+if (!await _context.Orders.AnyAsync())
+{
+    var newOrders = new Faker<Order>()
+        .RuleFor(o => o.CustomerName, f => f.Name.FullName())
+        .RuleFor(o => o.StatusId, f => f.PickRandom(await _context.OrderStatuses.ToArrayAsync()).Id)  // CS4034: Cannot use 'await' in RuleFor lambda!
+        .Generate(100);
+    _context.Orders.AddRange(newOrders);
+    await _context.SaveChangesAsync();
+}
+```
+
+CORRECT - Pre-fetch data, proper variable naming, and Faker usage:
+```csharp
+if (!await _context.Users.AnyAsync())
+{
+    var usedEmails = new HashSet<string>();
+    var faker = new Faker();  // Plain Faker for data generation!
+    var userFaker = new Faker<User>()
+        .RuleFor(u => u.Name, f => f.Person.FullName)
+        .RuleFor(u => u.CreatedAt, f => f.Date.Recent(30))
+        .RuleFor(u => u.UpdatedAt, (f, u) => f.Date.Between(u.CreatedAt, DateTime.UtcNow));
+
+    var usersList = new List<User>();
+    for (int i = 0; i < 100; i++)
+    {
+        string email;
+        do
+        {
+            email = faker.Internet.Email();  // Use plain 'faker' for data generation!
+        } while (!usedEmails.Add(email));
+
+        var user = userFaker.Generate();
+        user.Email = email;
+        usersList.Add(user);
+    }
+    _context.Users.AddRange(usersList);
+    await _context.SaveChangesAsync();
+}
+var users = await _context.Users.ToArrayAsync();  // Different name: 'users' - no conflict!
+
+// Seeding Orders - pre-fetch lookup data FIRST
+if (!await _context.Orders.AnyAsync())
+{
+    var orderStatuses = await _context.OrderStatuses.ToArrayAsync();  // Pre-fetch BEFORE creating Faker!
+    var newOrders = new Faker<Order>()
+        .RuleFor(o => o.CustomerName, f => f.Name.FullName())
+        .RuleFor(o => o.StatusId, f => f.PickRandom(orderStatuses).Id)  // Use pre-fetched variable - no await!
+        .RuleFor(o => o.CreatedAt, f => f.Date.Recent(30))
+        .RuleFor(o => o.UpdatedAt, (f, o) => f.Date.Between(o.CreatedAt ?? DateTime.UtcNow.AddMonths(-2), DateTime.UtcNow))
+        .Generate(100);
+    _context.Orders.AddRange(newOrders);
+    await _context.SaveChangesAsync();
+}
+```
+
+## Seeding Strategy
+
+### Analyze the Data Model
+
+- Identify all entity types and map relationships (one-to-one, one-to-many, many-to-many)
+- Note required fields, constraints, and unique indexes
+- Identify auto-generated properties (primary keys with ValueGeneratedOnAdd or database-generated identity columns)
+- Check for entities already seeded via `.HasData()` in `OnModelCreating` - these should NOT be created in the seeder, only queried
+- Identify one-to-one relationships by looking for `HasOne(...).WithOne(...)` configuration and non-collection navigation properties
+- DO NOT SEED C# enum types - they don't exist as database tables
+
+### Seeding Order
+
+1. **First Priority - Lookup/Reference Tables:** Check if empty, seed immediately, save changes, query into arrays
+2. **Second Priority - Independent Entities:** Seed entities with no foreign key dependencies, save after each
+3. **Third Priority - Dependent Entities:** Seed entities referencing lookups/others using `f.PickRandom(lookupArray).Id`
+4. Always `SaveChangesAsync()` after each entity type before seeding dependents
+5. Check `AnyAsync()` before seeding to avoid duplicates
+6. For entities seeded via `HasData()` in OnModelCreating, just query them - don't re-seed
+
+### Data Volume and Time Range Requirements
+
+The seeded data is used to generate dashboards with KPIs and charts. Follow these requirements:
+
+**Time-Based Data (Orders, Transactions, Events, etc.):**
+- Generate data spanning at least 90 days to show meaningful trends in line charts
+- Distribute data across the entire time range, with emphasis on recent periods
+- Use `f.Date.Between(DateTime.UtcNow.AddDays(-90), DateTime.UtcNow)` instead of `f.Date.Recent(30)`
+- Create more recent data than older data to show growth (60% in last 30 days, 30% in days 30-60, 10% in days 60-90)
+
+**Data Volume for KPIs:**
+- Transactional entities (orders, sales, events): minimum 500-1000 records
+- Master data (customers, products): minimum 100-300 records
+- Relationship/detail entities (order lines, reviews): multiple per parent entity
+
+**Positive Trending Data for KPIs:**
+- **Sales/Revenue**: Increase order values and frequency over time
+- **Customer Growth**: More customers created in recent periods than older periods
+- **Engagement Metrics**: Higher activity (reviews, orders per customer) in recent periods
+- **Quality Metrics**: Skew ratings/scores toward positive values (e.g., 70% of reviews should be 4-5 stars)
+- **Fulfillment/Success**: Favor positive status values (e.g., more "Delivered" than "Cancelled")
+
+### Implementation Patterns for Trends
+
+**Growing Transaction Volume:**
+```csharp
+var orders = new List<Order>();
+var faker = new Faker();
+
+// Period 1 (60-90 days ago): 100 orders
+for (int i = 0; i < 100; i++)
+{
+    orders.Add(new Order
+    {
+        OrderDate = faker.Date.Between(DateTime.UtcNow.AddDays(-90), DateTime.UtcNow.AddDays(-60)),
+        TotalAmount = faker.Random.Decimal(50, 300),
+        CustomerId = faker.PickRandom(customers).Id,
+        StatusId = faker.PickRandom(orderStatuses).Id,
+        CreatedAt = faker.Date.Between(DateTime.UtcNow.AddDays(-90), DateTime.UtcNow.AddDays(-60)),
+        UpdatedAt = faker.Date.Between(DateTime.UtcNow.AddDays(-90), DateTime.UtcNow)
+    });
+}
+
+// Period 2 (30-60 days ago): 200 orders (2x growth)
+for (int i = 0; i < 200; i++)
+{
+    orders.Add(new Order
+    {
+        OrderDate = faker.Date.Between(DateTime.UtcNow.AddDays(-60), DateTime.UtcNow.AddDays(-30)),
+        TotalAmount = faker.Random.Decimal(60, 350),
+        CustomerId = faker.PickRandom(customers).Id,
+        StatusId = faker.PickRandom(orderStatuses).Id,
+        CreatedAt = faker.Date.Between(DateTime.UtcNow.AddDays(-60), DateTime.UtcNow.AddDays(-30)),
+        UpdatedAt = faker.Date.Between(DateTime.UtcNow.AddDays(-60), DateTime.UtcNow)
+    });
+}
+
+// Period 3 (last 30 days): 400 orders (2x growth again)
+for (int i = 0; i < 400; i++)
+{
+    orders.Add(new Order
+    {
+        OrderDate = faker.Date.Between(DateTime.UtcNow.AddDays(-30), DateTime.UtcNow),
+        TotalAmount = faker.Random.Decimal(70, 400),
+        CustomerId = faker.PickRandom(customers).Id,
+        StatusId = faker.PickRandom(orderStatuses).Id,
+        CreatedAt = faker.Date.Between(DateTime.UtcNow.AddDays(-30), DateTime.UtcNow),
+        UpdatedAt = faker.Date.Between(DateTime.UtcNow.AddDays(-30), DateTime.UtcNow)
+    });
+}
+```
+
+**Positive-Skewed Ratings:**
+```csharp
+var rating = faker.Random.Double() < 0.7
+    ? faker.Random.Int(4, 5)  // 70% are 4-5 stars
+    : faker.Random.Int(1, 3); // 30% are 1-3 stars
+```
+
+**Status Distribution with Positive Bias:**
+```csharp
+var statusId = faker.Random.Double() switch
+{
+    < 0.70 => deliveredStatus.Id,    // 70% delivered
+    < 0.90 => processingStatus.Id,   // 20% processing
+    _ => cancelledStatus.Id          // 10% cancelled
+};
+```
+
+## One-to-One Relationship Seeding
+
+One-to-one relationships require exactly one dependent entity per principal entity. NEVER use `PickRandom()` for one-to-one relationships.
+
+**How to detect:** Look for `HasOne(...).WithOne(...)` in OnModelCreating and non-collection navigation properties.
+
+WRONG - Using PickRandom violates one-to-one constraint:
+```csharp
+var newTranscripts = new Faker<Transcript>()
+    .RuleFor(t => t.StudentId, f => f.PickRandom(students).Id)  // Multiple transcripts per student!
+    .Generate(200);
+```
+
+CORRECT - Iterate through principal entities:
+```csharp
+var newTranscripts = new List<Transcript>();
+var transcriptFaker = new Faker<Transcript>()
+    .RuleFor(t => t.CumulativeGPA, f => f.Random.Decimal(2.0m, 4.0m))
+    .RuleFor(t => t.CreatedAt, f => f.Date.Recent(30))
+    .RuleFor(t => t.UpdatedAt, (f, t) => f.Date.Between(t.CreatedAt, DateTime.UtcNow));
+
+foreach (var student in students)
+{
+    var transcript = transcriptFaker.Generate();
+    transcript.StudentId = student.Id;
+    newTranscripts.Add(transcript);
+}
+_context.Transcripts.AddRange(newTranscripts);
+await _context.SaveChangesAsync();
+```
+
+## Common Patterns
+
+```csharp
+// Unique fields
+var usedEmails = new HashSet<string>();
+var emailFaker = new Faker();
+string email;
+do { email = emailFaker.Internet.Email(); } while (!usedEmails.Add(email));
+
+// Many-to-many junction tables (avoid duplicate composite keys)
+var selectedIds = new HashSet<int>();
+if (selectedIds.Add(item.Id)) { /* add junction record */ }
+
+// Don't set auto-generated primary keys
+// Reference saved entities for foreign keys
+var items = await context.Items.ToArrayAsync();
+.RuleFor(o => o.ItemId, f => f.PickRandom(items).Id)
+```
+
+## Common Mistakes to Avoid
+
+### 1. Async/Await in RuleFor Lambdas
+
+WRONG:
+```csharp
+.RuleFor(o => o.StatusId, f => f.PickRandom(await _context.OrderStatuses.ToArrayAsync()).Id)  // CS4034!
+```
+CORRECT: Pre-fetch data before creating Faker (see Quick Example above).
+
+### 2. Variable Naming Conflicts (CS0136)
+
+**Pattern 1: If Blocks (Seeding vs Querying)**
+- Inside if blocks (seeding): Use prefix `new` or suffix `ToAdd`
+- Outside if blocks (querying): Use simple names
+
+```csharp
+if (!await _context.Artists.AnyAsync())
+{
+    var newArtists = new Faker<Artist>()
+        .RuleFor(a => a.Name, f => f.Person.FullName)
+        .Generate(50);
+    _context.Artists.AddRange(newArtists);
+    await _context.SaveChangesAsync();
+}
+var artists = await _context.Artists.ToArrayAsync();  // No conflict!
+```
+
+**Pattern 2: Foreach Loops - THE MOST COMMON CS0136 ERROR**
+
+WRONG:
+```csharp
+foreach (var game in games)
+{
+    var achievements = new Faker<Achievement>()  // declared here
+        .RuleFor(a => a.GameId, _ => game.Id)
+        .Generate(5);
+    newAchievements.AddRange(achievements);
+}
+var achievements = await _context.Achievements.ToArrayAsync(); // CS0136!
+```
+
+CORRECT - Use descriptive prefix:
+```csharp
+var newAchievements = new List<Achievement>();
+foreach (var game in games)
+{
+    var gameAchievements = new Faker<Achievement>()  // Prefixed with 'game'
+        .RuleFor(a => a.GameId, _ => game.Id)
+        .Generate(5);
+    newAchievements.AddRange(gameAchievements);
+}
+_context.Achievements.AddRange(newAchievements);
+await _context.SaveChangesAsync();
+var achievements = await _context.Achievements.ToArrayAsync(); // No conflict!
+```
+
+### 3. Never Call Random Methods Multiple Times in the Same RuleFor
+
+Each call generates a DIFFERENT random value, causing index-out-of-range errors.
+
+WRONG:
+```csharp
+.RuleFor(s => s.Title, f => f.Lorem.Sentence(4).Substring(0, Math.Min(255, f.Lorem.Sentence(4).Length)))
+```
+
+CORRECT:
+```csharp
+.RuleFor(s => s.Title, f => {
+    var sentence = f.Lorem.Sentence(4);
+    return sentence.Substring(0, Math.Min(255, sentence.Length));
+})
+```
+
+### 4. Faker<T> vs Faker Scope Confusion
+
+`Faker<T>` does NOT have `.Internet`, `.Person`, `.Random`, etc. properties.
+
+WRONG:
+```csharp
+var userFaker = new Faker<User>().RuleFor(u => u.Name, f => f.Person.FullName);
+email = userFaker.Internet.Email();  // CS1061: Faker<User> has no 'Internet'!
+```
+
+CORRECT:
+```csharp
+var faker = new Faker();  // Non-generic for data generation
+var userFaker = new Faker<User>().RuleFor(u => u.Name, f => f.Person.FullName);
+email = faker.Internet.Email();  // Use plain Faker
+```
+
+### 5. Not Assigning the Result of Faker.Generate()
+
+WRONG:
+```csharp
+var journalists = new List<Journalist>();
+var journalistFaker = new Faker<Journalist>()
+    .RuleFor(j => j.Name, f => f.Name.FullName())
+    .Generate(50);  // Result not assigned! List stays empty!
+```
+
+CORRECT:
+```csharp
+var journalistFaker = new Faker<Journalist>()
+    .RuleFor(j => j.Name, f => f.Name.FullName());
+var journalists = journalistFaker.Generate(50);  // Assign the result!
+```
+
+### 6. Setting Auto-Generated Primary Keys
+
+WRONG:
+```csharp
+.RuleFor(l => l.Id, f => f.UniqueIndex)  // Id is auto-generated!
+```
+
+CORRECT: Don't set Id - let the database generate it. Only set Id when entity uses `ValueGeneratedNever()`.
+
+### 7. Hardcoding Foreign Keys Without Ensuring Reference Data Exists
+
+WRONG:
+```csharp
+.RuleFor(l => l.TypeId, f => f.PickRandom(1, 2))  // These IDs might not exist!
+```
+
+CORRECT: Create/save reference data first, then use `f.PickRandom(logTypes).Id`.
+
+### 8. Re-seeding Entities Already Seeded via HasData()
+
+WRONG:
+```csharp
+context.OutreachStatuses.AddRange(outreachStatuses);  // UNIQUE constraint violation!
+```
+
+CORRECT: Just query existing records: `var outreachStatuses = await context.OutreachStatuses.ToArrayAsync();`
+
+Check `OnModelCreating` for `.HasData()` calls before creating lookup/reference data.
+
+### 9. Lambda Parameter Shadowing
+
+WRONG:
+```csharp
+.RuleFor(f => f.CreatedAt, f => f.Date.Recent(30))
+.RuleFor(f => f.UpdatedAt, f => f.Date.Between(f.CreatedAt, DateTime.UtcNow))
+// f.CreatedAt tries to access CreatedAt on Faker, not the entity!
+```
+
+CORRECT - Use two-parameter lambda with descriptive entity name:
+```csharp
+.RuleFor(f => f.CreatedAt, f => f.Date.Recent(30))
+.RuleFor(f => f.UpdatedAt, (f, file) => f.Date.Between(file.CreatedAt, DateTime.UtcNow))
+```
+
+Rules:
+- Use `f =>` when you only need Faker to generate random data
+- Use `(f, entity) =>` when you need to access properties already set on the entity
+- ALWAYS use descriptive names like `course`, `professor`, `student` instead of `c`, `p`, `s`
+- CRITICAL: When CreatedAt is nullable (DateTime?), use null-coalescing: `entity.CreatedAt ?? DateTime.UtcNow.AddMonths(-2)`
+
+### 10. Using PickRandom for One-to-One Relationships
+
+See dedicated section above. Iterate through principal entities instead.
+
+### 11. Duplicate Composite Keys in Many-to-Many
+
+WRONG:
+```csharp
+for (int i = 0; i < count; i++)
+{
+    startupFounders.Add(new StartupFounder
+    {
+        StartupId = startup.Id,
+        FounderId = faker.PickRandom(founders).Id  // Same founder may be picked twice!
+    });
+}
+```
+
+CORRECT:
+```csharp
+var selectedFounders = new HashSet<int>();
+for (int i = 0; i < count && selectedFounders.Count < founders.Count; i++)
+{
+    var founder = faker.PickRandom(founders);
+    if (selectedFounders.Add(founder.Id))
+    {
+        startupFounders.Add(new StartupFounder { StartupId = startup.Id, FounderId = founder.Id });
+    }
+}
+```
+
+### 12. Unique Constraint Violations
+
+For fields with unique constraints, use `HashSet` to track used values:
+```csharp
+var usedTagNames = new HashSet<string>();
+var wordFaker = new Faker();
+while (tags.Count < 30)
+{
+    var tagName = wordFaker.Lorem.Word();
+    if (usedTagNames.Add(tagName))
+    {
+        var tag = tagFaker.Generate();
+        tag.Name = tagName;
+        tags.Add(tag);
+    }
+}
+```
+
+### 13. Random.Int() Returns an Integer, Not a Collection
+
+WRONG:
+```csharp
+var items = new Faker().Random.Int(1, 3).Select(_ => new Item { ... });  // Can't Select on int!
+```
+
+CORRECT: Use the integer to control a loop.
+
+### 14. Count Property vs Count() Method
+
+Use `.Count()` LINQ method (not `.Count` property) on collections generated by Bogus `.Generate()`.
+
+### 15. No Join Method on string[]
+
+WRONG: `f.Lorem.Words(2).Join(" ")`
+CORRECT: `string.Join(" ", f.Lorem.Words(2))`
+
+### 16. Commerce.Price() Returns a String
+
+WRONG: `.RuleFor(p => p.Price, f => f.Commerce.Price(1, 1000, 2))`
+CORRECT: `.RuleFor(p => p.Price, f => f.Random.Decimal(1, 1000))`
+
+### 17. Non-Existent Methods
+
+These DO NOT exist in Bogus:
+- `f.Education` (entire dataset) - Create custom arrays and use `f.PickRandom()`
+- `f.Commerce.Industry` - Create your own industry list
+- `f.Date.FutureRefDate` - Use `f.Date.Future(int yearsToGoForward, DateTime? refDate)`
+- `.DependentOn()` - Set properties directly
+- `.Approximately()` - Use conditional logic
+
+**Fallback Strategy:** When Bogus doesn't have a dataset, create a custom array and use `f.PickRandom()`:
+```csharp
+var degreeNames = new[] {
+    "Computer Science", "Mathematics", "Physics", "Chemistry", "Biology",
+    "Engineering", "Business Administration", "Economics", "Psychology"
+};
+var name = f.PickRandom(degreeNames);
+```
+
+### 18. Using 'f' Parameter Outside RuleFor
+
+WRONG:
+```csharp
+foreach (var customer in customers)
+{
+    var customerDeals = new Faker<Deal>()
+        .RuleFor(d => d.CustomerId, _ => customer.Id)
+        .Generate(f.Random.Int(1, 5)); // 'f' is not in scope here!
+}
+```
+
+CORRECT:
+```csharp
+var faker = new Faker();
+foreach (var customer in customers)
+{
+    var customerDeals = new Faker<Deal>()
+        .RuleFor(d => d.CustomerId, _ => customer.Id)
+        .Generate(faker.Random.Int(1, 5));
+}
+```
+
+## Bogus API Reference
+
+The following is the COMPLETE list of available Bogus datasets. There is NO Education dataset or any other datasets not listed here.
+
+```
+Bogus.Faker [Class]
+  Address: Bogus.DataSets.Address
+  Commerce: Bogus.DataSets.Commerce
+  Company: Bogus.DataSets.Company
+  Database: Bogus.DataSets.Database
+  Date: Bogus.DataSets.Date
+  Finance: Bogus.DataSets.Finance
+  Hacker: Bogus.DataSets.Hacker
+  Image: Bogus.DataSets.Images
+  Internet: Bogus.DataSets.Internet
+  Lorem: Bogus.DataSets.Lorem
+  Music: Bogus.DataSets.Music
+  Name: Bogus.DataSets.Name
+  Person: Bogus.Person
+  Phone: Bogus.DataSets.PhoneNumbers
+  Random: Bogus.Randomizer
+  Rant: Bogus.DataSets.Rant
+  System: Bogus.DataSets.System
+  Vehicle: Bogus.DataSets.Vehicle
+  PickRandom(IEnumerable<T> arg0)
+  PickRandom(IList<T> arg0)
+  PickRandom(T[] arg0)
+
+Bogus.DataSets.Date [Class]
+  Between(DateTime start, DateTime end): DateTime
+  BetweenDateOnly(DateOnly start, DateOnly end): DateOnly
+  BetweenOffset(DateTimeOffset start, DateTimeOffset end): DateTimeOffset
+  BetweenTimeOnly(TimeOnly start, TimeOnly end): TimeOnly
+  Future(int yearsToGoForward, DateTime? refDate)
+  FutureDateOnly(int yearsToGoForward, DateOnly? refDate)
+  FutureOffset(int yearsToGoForward, DateTimeOffset? refDate)
+  Month(bool abbreviation, bool useContext): string
+  Past(int yearsToGoBack, DateTime? refDate)
+  PastDateOnly(int yearsToGoBack, DateOnly? refDate)
+  PastOffset(int yearsToGoBack, DateTimeOffset? refDate)
+  Recent(int days, DateTime? refDate)
+  RecentDateOnly(int days, DateOnly? refDate)
+  RecentOffset(int days, DateTimeOffset? refDate)
+  Soon(int days, DateTime? refDate)
+  SoonDateOnly(int days, DateOnly? refDate)
+  SoonOffset(int days, DateTimeOffset? refDate)
+  Timespan(TimeSpan? maxSpan)
+  TimeZoneString(): string
+  Weekday(bool abbreviation, bool useContext): string
+
+Bogus.DataSets.Address
+  BuildingNumber(): string
+  CardinalDirection(bool useAbbreviation = false): string
+  City(): string
+  CityPrefix(): string
+  CitySuffix(): string
+  Country(): string
+  CountryCode(Iso3166Format format = Alpha2): string
+  County(): string
+  Direction(bool useAbbreviation = false): string
+  FullAddress(): string
+  Latitude(double min = -90, double max = 90): double
+  Longitude(double min = -180, double max = 180): double
+  OrdinalDirection(bool useAbbreviation = false): string
+  SecondaryAddress(): string
+  State(): string
+  StateAbbr(): string
+  StreetAddress(bool useFullAddress = false): string
+  StreetName(): string
+  StreetSuffix(): string
+  ZipCode(string format = null): string
+
+Bogus.DataSets.Commerce
+  Categories(int num): string[]
+  Color(): string
+  Department(int max = 3, bool returnMax = false): string
+  Ean13(): string
+  Ean8(): string
+  Price(decimal min = 1, decimal max = 1000, int decimals = 2, string symbol = ""): string
+  Product(): string
+  ProductAdjective(): string
+  ProductDescription(): string
+  ProductMaterial(): string
+  ProductName(): string
+
+// NOTE: There is no Industry() method in the Company dataset.
+// NOTE: There is NO Education dataset in Bogus at all.
+
+Bogus.DataSets.Company
+  Bs(): string
+  CatchPhrase(): string
+  CompanyName(int? formatIndex)
+  CompanyName(string format): string
+  CompanySuffix(): string
+
+Bogus.DataSets.Finance
+  Account(int length = 8): string
+  AccountName(): string
+  Amount(decimal min = 0, decimal max = 1000, int decimals = 2): decimal
+  Bic(): string
+  BitcoinAddress(): string
+  CreditCardCvv(): string
+  CreditCardNumber(CardType provider = null): string
+  Currency(bool includeFundCodes): Currency
+  EthereumAddress(): string
+  Iban(bool formatted = false, string countryCode = null): string
+  LitecoinAddress(): string
+  RoutingNumber(): string
+  TransactionType(): string
+
+Bogus.DataSets.Hacker
+  Abbreviation(): string
+  Adjective(): string
+  IngVerb(): string
+  Noun(): string
+  Phrase(): string
+  Verb(): string
+
+Bogus.DataSets.Images
+  DataUri(int width, int height, string htmlColor = "grey"): string
+  PicsumUrl(int width, int height, bool grayscale, bool blur, int? imageId)
+  PlaceholderUrl(int width, int height, string text, string format, string backColor, string textColor): string
+
+Bogus.DataSets.Internet
+  Avatar(): string
+  Color(byte baseRed, byte baseGreen, byte baseBlue, bool grayscale, ColorFormat format): string
+  DomainName(): string
+  DomainSuffix(): string
+  DomainWord(): string
+  Email(string firstName, string lastName, string provider, string uniqueSuffix): string
+  ExampleEmail(string firstName, string lastName): string
+  Ip(): string
+  IpAddress(): IPAddress
+  Ipv6(): string
+  Ipv6Address(): IPAddress
+  Mac(string separator = ":"): string
+  Password(int length = 10, bool memorable = false, string regexPattern = "\\w", string prefix = ""): string
+  Port(): int
+  Protocol(): string
+  Url(): string
+  UrlRootedPath(string fileExt): string
+  UrlWithPath(string protocol, string domain, string fileExt): string
+  UserAgent(): string
+  UserName(string firstName, string lastName): string
+
+Bogus.DataSets.Lorem
+  Letter(int num = 1): string
+  Lines(int? lineCount, string separator)
+  Paragraph(int min = 3): string
+  Paragraphs(int count = 3, string separator = "\n\n"): string
+  Paragraphs(int min, int max, string separator = "\n\n"): string
+  Sentence(int? wordCount, int? range)
+  Sentences(int? sentenceCount, string separator)
+  Slug(int wordcount = 3): string
+  Text(): string
+  Word(): string
+  Words(int num = 3): string[]
+
+Bogus.DataSets.Music
+  Genre(): string
+
+Bogus.DataSets.Name
+  FirstName(Gender? gender)
+  FullName(Gender? gender)
+  JobArea(): string
+  JobDescriptor(): string
+  JobTitle(): string
+  JobType(): string
+  LastName(Gender? gender)
+  Prefix(Gender? gender)
+  Suffix(): string
+
+Bogus.DataSets.PhoneNumbers
+  PhoneNumber(string format = null): string
+  PhoneNumberFormat(int phoneFormatsArrayIndex = 0): string
+
+Bogus.DataSets.Rant
+  Review(string product = "product"): string
+  Reviews(string product = "product", int lines = 2): string[]
+
+Bogus.DataSets.System
+  AndroidId(): string
+  ApplePushToken(): string
+  BlackBerryPin(): string
+  CommonFileExt(): string
+  CommonFileName(string ext): string
+  CommonFileType(): string
+  DirectoryPath(): string
+  Exception(): Exception
+  FileExt(string mimeType): string
+  FileName(string ext): string
+  FilePath(): string
+  FileType(): string
+  MimeType(): string
+  Semver(): string
+  Version(): Version
+
+Bogus.DataSets.Vehicle
+  Fuel(): string
+  Manufacturer(): string
+  Model(): string
+  Type(): string
+  Vin(bool strict = false): string
+
+Bogus.Randomizer [Class]
+  AlphaNumeric(int length): string
+  ArrayElement(T[] arg0)
+  ArrayElements(T[] array, int? count)
+  Bool(): bool
+  Bool(float weight): bool
+  Byte(byte min = 0, byte max = 255): byte
+  Bytes(int count): byte[]
+  Char(char min, char max): char
+  Chars(char min, char max, int count = 5): char[]
+  ClampString(string str, int? min, int? max)
+  CollectionItem(ICollection<T> arg0)
+  Decimal(decimal min = 0, decimal max = 1): decimal
+  Digits(int count, int minDigit = 0, int maxDigit = 9): int[]
+  Double(double min = 0, double max = 1): double
+  Enum(T[] exclude)
+  EnumValues(int? count, T[] exclude)
+  Even(int min = 0, int max = 1): int
+  Float(float min = 0, float max = 1): float
+  Guid(): Guid
+  Hash(int length = 40, bool upperCase = false): string
+  Hexadecimal(int length, string prefix): string
+  Int(int min = -2147483648, int max = 2147483647): int
+  ListItem(List<T> arg0)
+  ListItem(IList<T> arg0)
+  ListItems(IList<T> items, int? count)
+  ListItems(List<T> items, int? count)
+  Long(long min, long max): long
+  Number(int max): int
+  Number(int min = 0, int max = 1): int
+  Odd(int min = 0, int max = 1): int
+  Replace(string format): string
+  ReplaceNumbers(string format, char symbol = '#'): string
+  Short(short min, short max): short
+  Shuffle(IEnumerable<T> items)
+  String(int? length, char minChar, char maxChar)
+  String(int minLength, int maxLength, char minChar, char maxChar): string
+  String2(int length, string chars = "abcdefghijklmnopqrstuvwxyz"): string
+  String2(int minLength, int maxLength, string chars): string
+  UInt(uint min = 0, uint max = 4294967295): uint
+  ULong(ulong min = 0, ulong max = 18446744073709551615): ulong
+  UShort(ushort min = 0, ushort max = 65535): ushort
+  Uuid(): Guid
+  WeightedRandom(T[] items, float[] weights)
+  Word(): string
+  Words(int? count)
+  WordsArray(int min, int max): string[]
+  WordsArray(int count): string[]
+```
+
+## Full Example
+
+```csharp
+using Bogus;
+using Microsoft.EntityFrameworkCore;
+using System;
+
+namespace ProjectNamespace;
+
+public class DataSeeder
+{
+    public async System.Threading.Tasks.Task SeedAsync(DataContext context)
+    {
+        if (!await context.DealStates.AnyAsync())
+        {
+            var dealStateNames = new[] { "Sourced", "Due Diligence", "Investment Committee", "Term Sheet", "Closing", "Portfolio", "Exit", "Passed" };
+            var newDealStates = dealStateNames.Select(name => new DealState { Name = name }).ToList();
+            context.DealStates.AddRange(newDealStates);
+            await context.SaveChangesAsync();
+        }
+
+        if (!await context.Genders.AnyAsync())
+        {
+            var genderNames = new[] { "Male", "Female", "Other" };
+            var newGenders = genderNames.Select(name => new Gender { Name = name }).ToList();
+            context.Genders.AddRange(newGenders);
+            await context.SaveChangesAsync();
+        }
+
+        if (!await context.Industries.AnyAsync())
+        {
+            var industryNames = new[] { "Technology", "Healthcare", "Finance", "Consumer", "Ecommerce", "SaaS", "Biotech", "Robotics", "AI", "Blockchain" };
+            var newIndustries = industryNames.Select(name => new Industry { Name = name }).ToList();
+            context.Industries.AddRange(newIndustries);
+            await context.SaveChangesAsync();
+        }
+
+        var dealStates = await context.DealStates.ToArrayAsync();
+        var genders = await context.Genders.ToArrayAsync();
+        var industries = await context.Industries.ToArrayAsync();
+
+        if (!await context.Startups.AnyAsync())
+        {
+            var newStartups = new Faker<Startup>()
+                .RuleFor(s => s.Name, f => {
+                    var companyName = f.Company.CompanyName();
+                    return companyName.Substring(0, Math.Min(100, companyName.Length));
+                })
+                .RuleFor(s => s.CreatedAt, f => f.Date.Between(DateTime.UtcNow.AddMonths(-2), DateTime.UtcNow))
+                .RuleFor(s => s.UpdatedAt, (f, x) => f.Date.Between(x.CreatedAt ?? DateTime.UtcNow.AddMonths(-2), DateTime.UtcNow))
+                .RuleFor(s => s.IndustryId, f => f.PickRandom(industries).Id)
+                .Generate(200);
+            context.Startups.AddRange(newStartups);
+            await context.SaveChangesAsync();
+        }
+
+        var startups = await context.Startups.ToArrayAsync();
+
+        if (!await context.Partners.AnyAsync())
+        {
+            var newPartners = new Faker<Partner>()
+                .RuleFor(p => p.Name, f => f.Person.FullName)
+                .RuleFor(p => p.Email, f => f.Internet.Email())
+                .RuleFor(p => p.CreatedAt, f => f.Date.Between(DateTime.UtcNow.AddMonths(-2), DateTime.UtcNow))
+                .RuleFor(p => p.UpdatedAt, (f, x) => f.Date.Between(x.CreatedAt ?? DateTime.UtcNow.AddMonths(-2), DateTime.UtcNow))
+                .Generate(15);
+            context.Partners.AddRange(newPartners);
+            await context.SaveChangesAsync();
+        }
+
+        var partners = await context.Partners.ToArrayAsync();
+
+        var faker = new Faker();
+
+        if (!await context.Founders.AnyAsync())
+        {
+            var newFounders = new List<Founder>();
+            foreach (var startup in startups)
+            {
+                var count = faker.Random.Int(1, 3);
+                var startupFounders = new Faker<Founder>()
+                    .RuleFor(f => f.Name, x => x.Name.FullName())
+                    .RuleFor(f => f.Email, x => x.Internet.Email())
+                    .RuleFor(f => f.GenderId, x => x.PickRandom(genders).Id)
+                    .RuleFor(f => f.Age, x => x.Random.Int(20, 60))
+                    .RuleFor(f => f.CreatedAt, f => f.Date.Between(DateTime.UtcNow.AddMonths(-2), DateTime.UtcNow))
+                    .RuleFor(f => f.UpdatedAt, (f, x) => f.Date.Between(x.CreatedAt ?? DateTime.UtcNow.AddMonths(-2), DateTime.UtcNow))
+                    .RuleFor(f => f.StartupId, _ => startup.Id)
+                    .Generate(count);
+                newFounders.AddRange(startupFounders);
+            }
+            context.Founders.AddRange(newFounders);
+            await context.SaveChangesAsync();
+        }
+
+        var founders = await context.Founders.ToArrayAsync();
+
+        if (!await context.Deals.AnyAsync())
+        {
+            var newDeals = new List<Deal>();
+            for (int i = 0; i < 200; i++)
+            {
+                newDeals.Add(new Deal
+                {
+                    CreatedAt = faker.Date.Between(DateTime.UtcNow.AddMonths(-2), DateTime.UtcNow),
+                    UpdatedAt = faker.Date.Between(DateTime.UtcNow.AddMonths(-2), DateTime.UtcNow),
+                    StartupId = faker.PickRandom(startups).Id,
+                    PartnerId = faker.PickRandom(partners).Id,
+                    DealAmount = faker.Random.Int(100_000, 10_000_000),
+                    DealStateId = faker.PickRandom(dealStates).Id
+                });
+            }
+            context.Deals.AddRange(newDeals);
+            await context.SaveChangesAsync();
+        }
+
+        if (!await context.StartupPartners.AnyAsync())
+        {
+            var newStartupPartners = new List<StartupPartner>();
+            foreach (var startup in startups)
+            {
+                var numPartners = faker.Random.Int(1, 3);
+                var selectedPartners = new HashSet<int>();
+                for (int i = 0; i < numPartners && selectedPartners.Count < partners.Count; i++)
+                {
+                    var partner = faker.PickRandom(partners);
+                    if (selectedPartners.Add(partner.Id))
+                    {
+                        newStartupPartners.Add(new StartupPartner
+                        {
+                            StartupId = startup.Id,
+                            PartnerId = partner.Id
+                        });
+                    }
+                }
+            }
+            context.StartupPartners.AddRange(newStartupPartners);
+            await context.SaveChangesAsync();
+        }
+    }
+
+    public async System.Threading.Tasks.Task ClearAsync(DataContext context)
+    {
+        context.StartupPartners.RemoveRange(await context.StartupPartners.ToArrayAsync());
+        await context.SaveChangesAsync();
+        context.Deals.RemoveRange(await context.Deals.ToArrayAsync());
+        await context.SaveChangesAsync();
+        context.Founders.RemoveRange(await context.Founders.ToArrayAsync());
+        await context.SaveChangesAsync();
+        context.Partners.RemoveRange(await context.Partners.ToArrayAsync());
+        await context.SaveChangesAsync();
+        context.Startups.RemoveRange(await context.Startups.ToArrayAsync());
+        await context.SaveChangesAsync();
+        // Do NOT clear DealStates, Genders, Industries - seeded via HasData()
+    }
+}
+```

--- a/src/skills/ivy-generate-db-connection/references/DbmlGeneratePrompt.md
+++ b/src/skills/ivy-generate-db-connection/references/DbmlGeneratePrompt.md
@@ -1,0 +1,93 @@
+﻿# DBML Generation Guide
+
+You are generating DBML (Database Markup Language) code as specified by https://dbml.dbdiagram.io/docs/.
+
+## DBML Output Requirements
+
+* Generate valid DBML code according to the official specification
+* Use PascalCase for all table and column names (C# convention)
+* Table names must be singular (e.g., `User` not `Users`)
+* Use .NET-friendly data types: `int`, `string`, `DateTime`, `Guid`, `decimal`, `bool`, `byte[]`, `DateOnly`, `TimeOnly`, `DateTimeOffset`, `double`, `float`, `long`
+* Use descriptive names that reflect the purpose of each element
+* Implement proper relationships using:
+  - ref: syntax for foreign keys
+  - Appropriate relationship types (>, <, -, <>)
+* Include essential fields in all tables:
+  - Primary key (typically Id)
+  - Timestamps (CreatedAt, UpdatedAt) unless specified otherwise
+* **CRITICAL**: DO NOT create empty enums. Only define enums that have at least one value. If you cannot determine the enum values, use a `string` field instead.
+
+## Entity Ordering Requirements
+
+**CRITICAL**: Tables MUST be defined in DAG (Directed Acyclic Graph) order based on their dependencies:
+
+* Tables with NO foreign key dependencies must be listed FIRST
+* Tables that reference other tables must be listed AFTER the tables they reference
+* All `Ref:` declarations must appear at the end, after all table definitions
+
+Example:
+```dbml
+// 1. Independent tables first
+Table User {
+  Id int [pk, increment]
+  Name string [not null]
+  Email string [not null, unique]
+  CreatedAt DateTime [not null]
+}
+
+// 2. Dependent tables
+Table Post {
+  Id int [pk, increment]
+  UserId int [not null]
+  Title string [not null]
+  Content string [not null]
+  CreatedAt DateTime [not null]
+}
+
+// 3. All refs at the end
+Ref: Post.UserId > User.Id
+```
+
+## Composite Primary Keys
+
+```dbml
+Table PostTag {
+  PostId int [not null]
+  TagId int [not null]
+  indexes {
+    (PostId, TagId) [pk]
+  }
+}
+```
+
+## Common Mistakes to Avoid
+
+1. Each field can only have ONE settings bracket: `name string [not null, unique]` (NOT `name string [not null] [unique]`)
+2. Refs must be top-level, NOT inside table definitions
+3. Enums must be top-level, NOT inside table definitions
+4. DO NOT specify [nullable] - use [null] or [not null]
+5. DO NOT specify any indexes other than composite primary keys
+6. DO NOT include comments in the DBML code
+
+## Enum Syntax
+
+```dbml
+Enum OrderStatus {
+  Pending
+  Processing
+  Shipped
+  Delivered
+  Cancelled
+}
+
+Table Order {
+  Id int [pk, increment]
+  Status OrderStatus [not null]
+}
+```
+
+If enum values contain spaces, use double quotes: `"Not Yet Set"`
+
+## After Generation
+
+Present the DBML schema to the user for review.

--- a/src/skills/ivy-generate-db-connection/references/DbmlToDataContext-MySql.md
+++ b/src/skills/ivy-generate-db-connection/references/DbmlToDataContext-MySql.md
@@ -1,0 +1,23 @@
+﻿# MySQL/MariaDB-Specific Notes
+
+The target database is MySQL using Pomelo.EntityFrameworkCore.MySql.
+
+## Data Type Mappings
+
+- Boolean: MySQL uses TINYINT(1). EF Core handles this automatically.
+- GUID/UUID: No native UUID. Use `[Column(TypeName = "char(36)")]` for Guid properties.
+- DateTime precision: Use `[Column(TypeName = "datetime(6)")]` for microseconds.
+- JSON: MySQL 5.7+ supports native JSON. Use `[Column(TypeName = "json")]`.
+
+## Enum Handling
+
+MySQL supports ENUM types with EnumToStringConverter:
+```csharp
+modelBuilder.Entity<TheEntity>(eb =>
+{
+    eb.Property(e => e.TheEnumProperty)
+      .HasConversion(new EnumToStringConverter<TheEnumType>());
+});
+```
+
+For simplicity in Code First generation, prefer using lookup tables (same pattern as SQLite/SqlServer) instead of native MySQL enums.

--- a/src/skills/ivy-generate-db-connection/references/DbmlToDataContext-Postgres.md
+++ b/src/skills/ivy-generate-db-connection/references/DbmlToDataContext-Postgres.md
@@ -1,0 +1,53 @@
+﻿# PostgreSQL-Specific Notes
+
+The target database is PostgreSQL using Npgsql.EntityFrameworkCore.PostgreSQL.
+
+## Critical DateTime Handling
+
+PostgreSQL `timestamptz` only accepts UTC DateTime values. Configure in OnModelCreating:
+```csharp
+.HasConversion(v => v.ToUniversalTime(), v => DateTime.SpecifyKind(v, DateTimeKind.Utc))
+```
+Alternative: Use `DateTimeOffset` for timezone-aware dates.
+
+## Data Type Mappings
+
+- JSON: `[Column(TypeName = "jsonb")]`
+- Arrays: Use C# arrays or `List<T>` directly
+- UUID: Use `Guid`, configure as `.HasColumnType("uuid")`
+- Serial/Identity: `[DatabaseGenerated(DatabaseGeneratedOption.Identity)]`
+
+## Enum Handling
+
+PostgreSQL supports native enum types. To use them correctly with Npgsql v10+, configuration must happen in two places:
+
+### 1. In the DbContext's `OnModelCreating`
+
+Register each enum type in the model:
+```csharp
+protected override void OnModelCreating(ModelBuilder modelBuilder)
+{
+    modelBuilder.HasPostgresEnum<TheEnumType>("the_postgres_enum_name");
+    // ... rest of model config
+}
+```
+
+### 2. In the Connection's `RegisterServices` method
+
+The `NpgsqlDataSourceBuilder` must map each enum BEFORE the data source is used. This goes in the Connection class's `RegisterServices(Server server)` method — NOT in `OnConfiguring` or `Program.cs`:
+```csharp
+var connectionString = server.Configuration["ConnectionStrings:DbName"];
+var dataSourceBuilder = new NpgsqlDataSourceBuilder(connectionString);
+dataSourceBuilder.MapEnum<TheEnumType>("the_postgres_enum_name");
+var dataSource = dataSourceBuilder.Build();
+```
+
+Then pass the data source (not the connection string) to `UseNpgsql`:
+```csharp
+server.Services.AddDbContext<MyDbContext>(options =>
+    options.UseNpgsql(dataSource));
+```
+
+**Important**: The enum type name string must match the actual PostgreSQL enum type name exactly (e.g., `"test_run_state"`), including schema if not `public`.
+
+**Note**: Do NOT use `OnConfiguring` for this. Do NOT modify `Program.cs`. All service registration is self-contained in the Connection's `RegisterServices` method — a connection must be removable by deleting its folder.

--- a/src/skills/ivy-generate-db-connection/references/DbmlToDataContext-SqlServer.md
+++ b/src/skills/ivy-generate-db-connection/references/DbmlToDataContext-SqlServer.md
@@ -1,0 +1,38 @@
+﻿# SQL Server-Specific Notes
+
+The target database is SQL Server using Microsoft.EntityFrameworkCore.SqlServer.
+
+## Enums
+
+SQL Server does not support enums natively. For every enum in DBML, generate:
+
+1. A lookup entity with `Id` (int) and `DescriptionText` (string), seeded with the enum values.
+2. For every referencing entity: an int FK property and a navigation property.
+
+Example for enum `Gender { Male, Female, Other }`:
+
+```csharp
+public class Gender
+{
+    public int Id { get; set; }
+    public string DescriptionText { get; set; } = null!;
+
+    public static Gender[] GetSeedData() =>
+    [
+        new() { Id = 1, DescriptionText = "Male" },
+        new() { Id = 2, DescriptionText = "Female" },
+        new() { Id = 3, DescriptionText = "Other" }
+    ];
+}
+```
+
+In OnModelCreating:
+```csharp
+modelBuilder.Entity<Gender>(entity =>
+{
+    entity.HasKey(e => e.Id);
+    entity.Property(e => e.Id).ValueGeneratedNever();
+    entity.Property(e => e.DescriptionText).IsRequired().HasMaxLength(200);
+    entity.HasData(Gender.GetSeedData());
+});
+```

--- a/src/skills/ivy-generate-db-connection/references/DbmlToDataContext-Sqlite.md
+++ b/src/skills/ivy-generate-db-connection/references/DbmlToDataContext-Sqlite.md
@@ -1,0 +1,65 @@
+﻿# SQLite-Specific Notes
+
+The target database is SQLite using Microsoft.EntityFrameworkCore.Sqlite.
+
+## Enums
+
+SQLite does not support enums natively. For every enum in DBML, generate:
+
+1. A lookup entity with `Id` (int) and `DescriptionText` (string), seeded with the enum values.
+2. For every referencing entity: an int FK property and a navigation property.
+
+Example for enum `Gender { Male, Female, Other }`:
+
+```csharp
+public class Gender
+{
+    public int Id { get; set; }
+    public string DescriptionText { get; set; } = null!;
+
+    public static Gender[] GetSeedData() =>
+    [
+        new() { Id = 1, DescriptionText = "Male" },
+        new() { Id = 2, DescriptionText = "Female" },
+        new() { Id = 3, DescriptionText = "Other" }
+    ];
+}
+```
+
+In OnModelCreating:
+```csharp
+modelBuilder.Entity<Gender>(entity =>
+{
+    entity.HasKey(e => e.Id);
+    entity.Property(e => e.Id).ValueGeneratedNever();
+    entity.Property(e => e.DescriptionText).IsRequired().HasMaxLength(200);
+    entity.HasData(Gender.GetSeedData());
+});
+```
+
+## Composite Primary Keys (Junction Tables)
+
+Junction/join tables with composite primary keys (from DBML `indexes { (FkA, FkB) [pk] }`) MUST be configured in `OnModelCreating` using `HasKey`:
+
+```csharp
+modelBuilder.Entity<StartupFounder>(entity =>
+{
+    entity.HasKey(e => new { e.StartupId, e.FounderId });
+});
+```
+
+This is required because `[Key]` data annotations cannot express composite keys. Without this configuration, EF Core will fail at runtime with "requires a primary key to be defined".
+
+## DateTimeOffset LINQ Limitation
+
+IMPORTANT: When using SQLite, `DateTimeOffset` columns cannot be compared in LINQ `Where` clauses. The SQLite EF Core provider cannot translate `DateTimeOffset` comparisons to SQL, causing runtime errors ("LINQ expression could not be translated") even though the code compiles successfully.
+
+Prefer `DateTime` over `DateTimeOffset` for date/time properties in SQLite models. If `DateTimeOffset` must be used (e.g. from the DBML spec), add a comment on those properties warning about the LINQ limitation:
+
+```csharp
+/// <summary>
+/// WARNING: DateTimeOffset cannot be compared in LINQ Where clauses on SQLite.
+/// Filter in memory after loading, or convert to DateTime.
+/// </summary>
+public DateTimeOffset ClockInAt { get; set; }
+```

--- a/src/skills/ivy-generate-db-connection/references/DbmlToDataContextPrompt.md
+++ b/src/skills/ivy-generate-db-connection/references/DbmlToDataContextPrompt.md
@@ -1,0 +1,87 @@
+﻿# Entity Framework Core Code First Generation Guide
+
+Convert DBML specifications into EF Core Code First entities with data annotations and Fluent API.
+
+## Output Specifications
+
+* Create well-structured C# POCO classes for each table
+* Generate a complete DbContext class with:
+  - DbSet properties for each entity
+  - OnModelCreating method with Fluent API configurations
+* Use appropriate EF Core attributes: [Key], [Required], [MaxLength], [Table], [Column], [ForeignKey]
+* Use PascalCase for all C# class names and properties
+* Initialize non-nullable string properties with `= null!;`
+* Initialize navigation properties with `= null!;`
+* Use nullable types only when truly optional
+
+## Required Using Directives
+
+Entity files:
+- `using System.ComponentModel.DataAnnotations;` — for [Key], [Required], [MaxLength], [Column], etc.
+- `using System.ComponentModel.DataAnnotations.Schema;` — for [Table], [ForeignKey], [DatabaseGenerated]
+- `using Microsoft.EntityFrameworkCore;` — only if using EF-specific attributes like [Index]
+
+DbContext file:
+- `using Microsoft.EntityFrameworkCore;` — for DbContext, DbSet<T>, ModelBuilder
+- `using {Namespace}.Models;` — to reference entity classes from the Models subdirectory
+
+Always include all required usings explicitly. Do not rely on global usings or implicit usings for non-System namespaces.
+
+## File Organization
+
+Generate individual files using the Write tool:
+- One `.cs` file per entity class
+- One `.cs` file for the DbContext class
+- Use file-scoped namespaces
+
+## Relationships
+
+### One-to-Many
+For `Ref: Post.UserId > User.Id`:
+- User class: `public ICollection<Post> Posts { get; set; } = null!;`
+- Post class: `public User User { get; set; } = null!;`
+- Fluent API: `.HasOne(e => e.User).WithMany(e => e.Posts).HasForeignKey(e => e.UserId)`
+
+### One-to-One
+Use `HasOne...WithOne` with non-collection navigation properties.
+
+### Many-to-Many (explicit junction table)
+Navigation properties on principal entities must reference the junction entity type:
+```csharp
+public class Student { public ICollection<StudentCourse> StudentCourses { get; set; } = null!; }
+public class Course { public ICollection<StudentCourse> StudentCourses { get; set; } = null!; }
+```
+
+**Composite Primary Keys:** Junction tables with composite primary keys defined in DBML (e.g., `(StudentId, CourseId) [pk]`) MUST have `HasKey` configured in `OnModelCreating`, because data annotations `[Key]` cannot define composite keys:
+```csharp
+modelBuilder.Entity<StudentCourse>(entity =>
+{
+    entity.HasKey(e => new { e.StudentId, e.CourseId });
+});
+```
+This is required for ALL join/junction tables with composite primary keys — without it, EF Core will fail with "requires a primary key to be defined".
+
+## Navigation Property Naming
+
+CRITICAL: Navigation property names MUST NOT match their containing class name (causes CS0542).
+- Use role-based names: `PickupLocation`, `DropoffLocation`
+- For self-referencing: `FollowerUser`, `FolloweeUser`
+
+## Multiple FKs to Same Entity
+
+When an entity has multiple FKs to the same target, explicitly configure ALL relationships in OnModelCreating.
+
+## DbContext Constructor
+
+```csharp
+public MyContext(DbContextOptions<MyContext> options) : base(options) { }
+```
+
+Do NOT include an OnConfiguring method.
+
+## Notes
+
+* Use C# 12+ syntax with file-scoped namespaces
+* Generate COMPLETE code for ALL entities - never truncate
+* DO NOT include comments in generated code
+* Favor data annotations where possible, Fluent API for complex configs


### PR DESCRIPTION
Convert all Ivy workflow state machines into standalone Claude Code skills
with YAML frontmatter, explicit reference file links, and trigger keywords.

Skills created:
- Apps: ivy-create-dashboard, ivy-create-crud, ivy-create-app
- Connections: ivy-create-any-connection, ivy-create-auth-connection,
  ivy-create-db-connection, ivy-create-graphql-connection,
  ivy-create-openapi-connection, ivy-create-soap-connection,
  ivy-create-using-reference-connection, ivy-generate-db-connection
- Conversions: ivy-convert-airtable, ivy-convert-excel, ivy-convert-lovable,
  ivy-convert-odoo, ivy-convert-reflex, ivy-convert-retool, ivy-convert-streamlit
- Other: ivy-deploy-to-desktop, ivy-create-external-widget, ivy-create-theme

Also adds CopyReferences.ps1 to sync reference files from canonical sources
and ConvertingWorkflowsToSkills.md documenting lessons learned.
