### PR TITLE
[00012] Enable Selective Plugin Loading and Unloading

### DIFF
--- a/src/Ivy.Plugin.Abstractions/IPluginManager.cs
+++ b/src/Ivy.Plugin.Abstractions/IPluginManager.cs
@@ -1,0 +1,9 @@
+namespace Ivy.Plugins;
+
+public interface IPluginManager
+{
+    IReadOnlyList<string> GetLoadedPluginIds();
+    bool UnloadPlugin(string pluginId);
+    bool LoadPlugin(string pluginPath);
+    bool ReloadPlugin(string pluginId);
+}

--- a/src/Ivy.Plugin.Abstractions/IPluginManager.cs
+++ b/src/Ivy.Plugin.Abstractions/IPluginManager.cs
@@ -1,8 +1,11 @@
 namespace Ivy.Plugins;
 
+public record PluginCandidate(string Id, string Directory);
+
 public interface IPluginManager
 {
     IReadOnlyList<string> GetLoadedPluginIds();
+    IReadOnlyList<PluginCandidate> GetUnloadedPlugins();
     bool UnloadPlugin(string pluginId);
     bool LoadPlugin(string pluginPath);
     bool ReloadPlugin(string pluginId);

--- a/src/Ivy.Test/PluginLoaderTests.cs
+++ b/src/Ivy.Test/PluginLoaderTests.cs
@@ -1,6 +1,5 @@
 using Ivy.Core.Apps;
 using Ivy.Core.Plugins;
-using Ivy.Plugins;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Ivy.Test/PluginLoaderTests.cs
+++ b/src/Ivy.Test/PluginLoaderTests.cs
@@ -1,0 +1,279 @@
+using Ivy.Core.Apps;
+using Ivy.Core.Plugins;
+using Ivy.Plugins;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Ivy.Test.Plugins;
+
+public class PluginLoaderTests
+{
+    private interface ITestServiceA { }
+    private interface ITestServiceB { }
+    private class TestServiceA : ITestServiceA { }
+    private class TestServiceB : ITestServiceB { }
+    private class AnotherTestServiceA : ITestServiceA { }
+
+    private class TestPluginContext : PluginContextBase
+    {
+        private readonly AppRepository _appRepository = new();
+        private readonly WebApplicationBuilder _builder;
+        private readonly IConfiguration _configuration;
+
+        public TestPluginContext()
+        {
+            _builder = WebApplication.CreateBuilder();
+            _configuration = new ConfigurationBuilder().Build();
+        }
+
+        public override IConfiguration Configuration => _configuration;
+        protected override AppRepository AppRepository => _appRepository;
+        protected override WebApplicationBuilder Builder => _builder;
+    }
+
+    [Fact]
+    public void PerPluginServiceIsolation()
+    {
+        var context = new TestPluginContext();
+
+        // Simulate plugin A registering services
+        context.SetCurrentPlugin("plugin-a", "/plugins/a");
+        context.Services.AddSingleton<ITestServiceA, TestServiceA>();
+        context.ClearCurrentPlugin();
+
+        // Simulate plugin B registering services
+        context.SetCurrentPlugin("plugin-b", "/plugins/b");
+        context.Services.AddSingleton<ITestServiceB, TestServiceB>();
+        context.ClearCurrentPlugin();
+
+        context.BuildServiceProvider();
+
+        // Both services should be resolvable through the aggregate
+        Assert.NotNull(context.GetService<ITestServiceA>());
+        Assert.NotNull(context.GetService<ITestServiceB>());
+    }
+
+    [Fact]
+    public void UnloadRemovesServicesFromAggregator()
+    {
+        var context = new TestPluginContext();
+
+        context.SetCurrentPlugin("plugin-a", "/plugins/a");
+        context.Services.AddSingleton<ITestServiceA, TestServiceA>();
+        context.ClearCurrentPlugin();
+
+        context.SetCurrentPlugin("plugin-b", "/plugins/b");
+        context.Services.AddSingleton<ITestServiceB, TestServiceB>();
+        context.ClearCurrentPlugin();
+
+        context.BuildServiceProvider();
+
+        // Both should exist before unload
+        Assert.NotNull(context.GetService<ITestServiceA>());
+        Assert.NotNull(context.GetService<ITestServiceB>());
+
+        // Unload plugin A
+        context.RemovePluginContributions("plugin-a");
+
+        // Plugin A's service should be gone
+        Assert.Null(context.GetService<ITestServiceA>());
+        // Plugin B's service should still exist
+        Assert.NotNull(context.GetService<ITestServiceB>());
+    }
+
+    [Fact]
+    public void ServiceResolutionAfterUnloadDoesNotReturnUnloadedServices()
+    {
+        var context = new TestPluginContext();
+
+        context.SetCurrentPlugin("plugin-a", "/plugins/a");
+        context.Services.AddSingleton<ITestServiceA, TestServiceA>();
+        context.ClearCurrentPlugin();
+
+        context.BuildServiceProvider();
+
+        // Service exists
+        Assert.NotNull(context.GetService<ITestServiceA>());
+
+        // Unload
+        context.RemovePluginContributions("plugin-a");
+
+        // Service gone — should not leak
+        Assert.Null(context.GetService<ITestServiceA>());
+        Assert.Empty(context.GetServices<ITestServiceA>());
+    }
+
+    [Fact]
+    public void ReloadPluginWorkflow()
+    {
+        var context = new TestPluginContext();
+
+        // Load plugin A with TestServiceA
+        context.SetCurrentPlugin("plugin-a", "/plugins/a");
+        context.Services.AddSingleton<ITestServiceA, TestServiceA>();
+        context.ClearCurrentPlugin();
+        context.BuildServiceProvider();
+
+        var beforeReload = context.GetService<ITestServiceA>();
+        Assert.NotNull(beforeReload);
+
+        // Unload (simulate reload step 1)
+        context.RemovePluginContributions("plugin-a");
+        Assert.Null(context.GetService<ITestServiceA>());
+
+        // Reload (simulate reload step 2 — register with potentially different impl)
+        context.SetCurrentPlugin("plugin-a", "/plugins/a");
+        context.Services.AddSingleton<ITestServiceA, AnotherTestServiceA>();
+        context.ClearCurrentPlugin();
+        context.BuildPluginServiceProvider("plugin-a", new ServiceCollection());
+
+        var afterReload = context.GetService<ITestServiceA>();
+        Assert.NotNull(afterReload);
+        Assert.IsType<AnotherTestServiceA>(afterReload);
+    }
+
+    [Fact]
+    public void MultiplePluginsWithOverlappingServiceTypes()
+    {
+        var context = new TestPluginContext();
+
+        // Both plugins register ITestServiceA
+        context.SetCurrentPlugin("plugin-a", "/plugins/a");
+        context.Services.AddSingleton<ITestServiceA, TestServiceA>();
+        context.ClearCurrentPlugin();
+
+        context.SetCurrentPlugin("plugin-b", "/plugins/b");
+        context.Services.AddSingleton<ITestServiceA, AnotherTestServiceA>();
+        context.ClearCurrentPlugin();
+
+        context.BuildServiceProvider();
+
+        // GetServices should return both
+        var services = context.GetServices<ITestServiceA>().ToList();
+        Assert.Equal(2, services.Count);
+        Assert.Contains(services, s => s is TestServiceA);
+        Assert.Contains(services, s => s is AnotherTestServiceA);
+
+        // GetService returns the first one found
+        Assert.NotNull(context.GetService<ITestServiceA>());
+    }
+
+    [Fact]
+    public void PluginDependencyPreventsUnload()
+    {
+        using var loggerFactory = LoggerFactory.Create(b => b.AddConsole());
+        var logger = loggerFactory.CreateLogger<PluginLoader>();
+        var tempDir = Path.Combine(Path.GetTempPath(), $"ivy-test-plugins-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var loader = new PluginLoader(tempDir, logger);
+
+            // We can't easily test this through the full PluginLoader without real DLLs,
+            // but we can verify GetLoadedPluginIds returns empty for a directory with no plugins
+            using var sp = new ServiceCollection().BuildServiceProvider();
+            loader.DiscoverAndLoad(new Version(1, 0), sp);
+
+            Assert.Empty(loader.GetLoadedPluginIds());
+            Assert.False(loader.UnloadPlugin("nonexistent"));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void MenuTransformersAreTrackedPerPlugin()
+    {
+        var context = new TestPluginContext();
+
+        context.SetCurrentPlugin("plugin-a", "/plugins/a");
+        context.AddMenuItems(items => items.Append(new MenuItem("A")));
+        context.ClearCurrentPlugin();
+
+        context.SetCurrentPlugin("plugin-b", "/plugins/b");
+        context.AddMenuItems(items => items.Append(new MenuItem("B")));
+        context.ClearCurrentPlugin();
+
+        Assert.Equal(2, context.MenuTransformers.Count);
+
+        // Unload plugin A
+        context.RemovePluginContributions("plugin-a");
+
+        Assert.Single(context.MenuTransformers);
+    }
+
+    [Fact]
+    public void FooterMenuTransformersAreTrackedPerPlugin()
+    {
+        var context = new TestPluginContext();
+
+        context.SetCurrentPlugin("plugin-a", "/plugins/a");
+        context.AddFooterMenuItems((items, nav) => items.Append(new MenuItem("A")));
+        context.ClearCurrentPlugin();
+
+        context.SetCurrentPlugin("plugin-b", "/plugins/b");
+        context.AddFooterMenuItems((items, nav) => items.Append(new MenuItem("B")));
+        context.ClearCurrentPlugin();
+
+        Assert.Equal(2, context.FooterMenuTransformers.Count);
+
+        context.RemovePluginContributions("plugin-b");
+
+        Assert.Single(context.FooterMenuTransformers);
+    }
+
+    [Fact]
+    public void BadgeProvidersAreTrackedPerPlugin()
+    {
+        var context = new TestPluginContext();
+
+        context.SetCurrentPlugin("plugin-a", "/plugins/a");
+        context.AddBadgeProvider("tag-a", _ => 5);
+        context.ClearCurrentPlugin();
+
+        context.SetCurrentPlugin("plugin-b", "/plugins/b");
+        context.AddBadgeProvider("tag-b", _ => 10);
+        context.ClearCurrentPlugin();
+
+        Assert.Equal(2, context.BadgeProviders.Count);
+
+        context.RemovePluginContributions("plugin-a");
+
+        Assert.Single(context.BadgeProviders);
+        Assert.Equal("tag-b", context.BadgeProviders[0].Tag);
+    }
+
+    [Fact]
+    public async Task AggregateProviderThreadSafety()
+    {
+        var provider = new AggregatePluginServiceProvider();
+
+        var services1 = new ServiceCollection();
+        services1.AddSingleton<ITestServiceA, TestServiceA>();
+        provider.AddProvider("p1", services1.BuildServiceProvider());
+
+        var services2 = new ServiceCollection();
+        services2.AddSingleton<ITestServiceB, TestServiceB>();
+        provider.AddProvider("p2", services2.BuildServiceProvider());
+
+        // Concurrent reads should work
+        var tasks = Enumerable.Range(0, 10).Select(_ => Task.Run(() =>
+        {
+            Assert.NotNull(provider.GetService<ITestServiceA>());
+            Assert.NotNull(provider.GetService<ITestServiceB>());
+        })).ToArray();
+
+        await Task.WhenAll(tasks);
+
+        Assert.Equal(2, provider.LoadedPluginIds.Count);
+
+        provider.RemoveProvider("p1");
+        Assert.Single(provider.LoadedPluginIds);
+        Assert.Null(provider.GetService<ITestServiceA>());
+    }
+}

--- a/src/Ivy/Core/Apps/AppRepository.cs
+++ b/src/Ivy/Core/Apps/AppRepository.cs
@@ -194,6 +194,11 @@ public class AppRepository : IAppRepository
         _factories.Add(factory);
     }
 
+    public bool RemoveFactory(Func<AppDescriptor[]> factory)
+    {
+        return _factories.Remove(factory);
+    }
+
     public AppDescriptor GetAppOrDefault(string? id)
     {
         var app = id != null

--- a/src/Ivy/Core/Plugins/AggregatePluginServiceProvider.cs
+++ b/src/Ivy/Core/Plugins/AggregatePluginServiceProvider.cs
@@ -1,0 +1,89 @@
+using Ivy.Plugins;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Ivy.Core.Plugins;
+
+internal class AggregatePluginServiceProvider : IPluginServiceProvider
+{
+    private readonly Dictionary<string, IServiceProvider> _providers = new();
+    private readonly ReaderWriterLockSlim _lock = new();
+
+    public void AddProvider(string pluginId, IServiceProvider provider)
+    {
+        _lock.EnterWriteLock();
+        try
+        {
+            _providers[pluginId] = provider;
+        }
+        finally
+        {
+            _lock.ExitWriteLock();
+        }
+    }
+
+    public void RemoveProvider(string pluginId)
+    {
+        _lock.EnterWriteLock();
+        try
+        {
+            if (_providers.TryGetValue(pluginId, out var provider))
+            {
+                _providers.Remove(pluginId);
+                (provider as IDisposable)?.Dispose();
+            }
+        }
+        finally
+        {
+            _lock.ExitWriteLock();
+        }
+    }
+
+    public T? GetService<T>() where T : class
+    {
+        _lock.EnterReadLock();
+        try
+        {
+            foreach (var provider in _providers.Values)
+            {
+                var service = provider.GetService<T>();
+                if (service is not null) return service;
+            }
+            return null;
+        }
+        finally
+        {
+            _lock.ExitReadLock();
+        }
+    }
+
+    public IEnumerable<T> GetServices<T>() where T : class
+    {
+        _lock.EnterReadLock();
+        try
+        {
+            return _providers.Values
+                .SelectMany(p => p.GetServices<T>())
+                .ToList();
+        }
+        finally
+        {
+            _lock.ExitReadLock();
+        }
+    }
+
+    public IReadOnlyCollection<string> LoadedPluginIds
+    {
+        get
+        {
+            _lock.EnterReadLock();
+            try
+            {
+                return _providers.Keys.ToList();
+            }
+            finally
+            {
+                _lock.ExitReadLock();
+            }
+        }
+    }
+}

--- a/src/Ivy/Core/Plugins/PluginAssemblyLoadContext.cs
+++ b/src/Ivy/Core/Plugins/PluginAssemblyLoadContext.cs
@@ -4,7 +4,7 @@ using System.Runtime.Loader;
 namespace Ivy.Core.Plugins;
 
 internal class PluginAssemblyLoadContext(string pluginPath, IReadOnlySet<string> sharedAssemblyNames)
-    : AssemblyLoadContext(isCollectible: false)
+    : AssemblyLoadContext(isCollectible: true)
 {
     private readonly AssemblyDependencyResolver _resolver = new(pluginPath);
 

--- a/src/Ivy/Core/Plugins/PluginContext.cs
+++ b/src/Ivy/Core/Plugins/PluginContext.cs
@@ -14,10 +14,24 @@ public abstract class PluginContextBase : IIvyPluginContext, IPluginServiceProvi
     private readonly List<Func<IEnumerable<MenuItem>, INavigator, IEnumerable<MenuItem>>> _footerMenuTransformers = [];
     private readonly List<(string Tag, Func<IServiceProvider, int> CountProvider)> _badgeProviders = [];
     private readonly List<Action<WebApplication>> _appActions = [];
-    private readonly ServiceCollection _pluginServices = new();
-    private IServiceProvider? _pluginServiceProvider;
+    private readonly AggregatePluginServiceProvider _aggregateProvider = new();
+    private readonly Dictionary<string, PluginState> _pluginStates = new();
+    private readonly ReaderWriterLockSlim _lock = new();
+    private string? _currentPluginId;
 
-    public IServiceCollection Services => _pluginServices;
+    public IServiceCollection Services
+    {
+        get
+        {
+            if (_currentPluginId is not null && _pluginStates.TryGetValue(_currentPluginId, out var state))
+                return state.PluginServices;
+            return _fallbackServices;
+        }
+    }
+
+    // Fallback service collection for non-plugin code
+    private readonly ServiceCollection _fallbackServices = new();
+
     public abstract IConfiguration Configuration { get; }
 
     protected abstract AppRepository AppRepository { get; }
@@ -27,29 +41,63 @@ public abstract class PluginContextBase : IIvyPluginContext, IPluginServiceProvi
     public IReadOnlyList<Func<IEnumerable<MenuItem>, INavigator, IEnumerable<MenuItem>>> FooterMenuTransformers => _footerMenuTransformers;
     public IReadOnlyList<(string Tag, Func<IServiceProvider, int> CountProvider)> BadgeProviders => _badgeProviders;
 
+    internal void SetCurrentPlugin(string pluginId, string directory)
+    {
+        _currentPluginId = pluginId;
+        _lock.EnterWriteLock();
+        try
+        {
+            if (!_pluginStates.ContainsKey(pluginId))
+                _pluginStates[pluginId] = new PluginState(pluginId, directory);
+        }
+        finally
+        {
+            _lock.ExitWriteLock();
+        }
+    }
+
+    internal void ClearCurrentPlugin() => _currentPluginId = null;
+
     public void AddApp(AppDescriptor descriptor)
     {
-        AppRepository.AddFactory(() => [descriptor]);
+        Func<AppDescriptor[]> factory = () => [descriptor];
+        AppRepository.AddFactory(factory);
+
+        if (_currentPluginId is not null && _pluginStates.TryGetValue(_currentPluginId, out var state))
+            state.AppFactories.Add(factory);
     }
 
     public void AddAppsFromAssembly(Assembly assembly)
     {
-        AppRepository.AddFactory(() => AppHelpers.GetApps(assembly));
+        Func<AppDescriptor[]> factory = () => AppHelpers.GetApps(assembly);
+        AppRepository.AddFactory(factory);
+
+        if (_currentPluginId is not null && _pluginStates.TryGetValue(_currentPluginId, out var state))
+            state.AppFactories.Add(factory);
     }
 
     public void AddMenuItems(Func<IEnumerable<MenuItem>, IEnumerable<MenuItem>> transformer)
     {
         _menuTransformers.Add(transformer);
+
+        if (_currentPluginId is not null && _pluginStates.TryGetValue(_currentPluginId, out var state))
+            state.MenuTransformers.Add(transformer);
     }
 
     public void AddFooterMenuItems(Func<IEnumerable<MenuItem>, INavigator, IEnumerable<MenuItem>> transformer)
     {
         _footerMenuTransformers.Add(transformer);
+
+        if (_currentPluginId is not null && _pluginStates.TryGetValue(_currentPluginId, out var state))
+            state.FooterMenuTransformers.Add(transformer);
     }
 
     public void AddBadgeProvider(string menuTag, Func<IServiceProvider, int> countProvider)
     {
         _badgeProviders.Add((menuTag, countProvider));
+
+        if (_currentPluginId is not null && _pluginStates.TryGetValue(_currentPluginId, out var state))
+            state.BadgeProviders.Add((menuTag, countProvider));
     }
 
     public void RegisterMessagingChannel(IMessagingChannel channel)
@@ -60,6 +108,9 @@ public abstract class PluginContextBase : IIvyPluginContext, IPluginServiceProvi
     public void UseWebApplication(Action<WebApplication> configure)
     {
         _appActions.Add(configure);
+
+        if (_currentPluginId is not null && _pluginStates.TryGetValue(_currentPluginId, out var state))
+            state.AppActions.Add(configure);
     }
 
     public void UseWebApplicationBuilder(Action<WebApplicationBuilder> configure)
@@ -69,18 +120,90 @@ public abstract class PluginContextBase : IIvyPluginContext, IPluginServiceProvi
 
     public void BuildServiceProvider()
     {
-        _pluginServiceProvider = _pluginServices.BuildServiceProvider();
+        _lock.EnterReadLock();
+        try
+        {
+            foreach (var (pluginId, state) in _pluginStates)
+            {
+                var provider = state.PluginServices.BuildServiceProvider();
+                _aggregateProvider.AddProvider(pluginId, provider);
+            }
+        }
+        finally
+        {
+            _lock.ExitReadLock();
+        }
+
+        // Also build fallback services if any were registered outside plugin context
+        if (_fallbackServices.Count > 0)
+        {
+            var fallbackProvider = _fallbackServices.BuildServiceProvider();
+            _aggregateProvider.AddProvider("__fallback__", fallbackProvider);
+        }
+    }
+
+    internal void BuildPluginServiceProvider(string pluginId, IServiceCollection services)
+    {
+        var provider = services.BuildServiceProvider();
+        _aggregateProvider.AddProvider(pluginId, provider);
+
+        if (_pluginStates.TryGetValue(pluginId, out var state))
+        {
+            // Also build the plugin's context-level services
+            var contextProvider = state.PluginServices.BuildServiceProvider();
+            _aggregateProvider.AddProvider($"{pluginId}__context", contextProvider);
+        }
+    }
+
+    internal IServiceProvider? GetPluginServiceProvider(string pluginId)
+    {
+        // The aggregate provider manages individual providers, just return it
+        return null; // individual providers are managed by the aggregate
     }
 
     public T? GetService<T>() where T : class
     {
-        return _pluginServiceProvider?.GetService<T>();
+        return _aggregateProvider.GetService<T>();
     }
 
     public IEnumerable<T> GetServices<T>() where T : class
     {
-        return _pluginServiceProvider?.GetServices<T>() ?? [];
+        return _aggregateProvider.GetServices<T>();
     }
+
+    internal void RemovePluginContributions(string pluginId)
+    {
+        _lock.EnterWriteLock();
+        try
+        {
+            if (!_pluginStates.TryGetValue(pluginId, out var state)) return;
+
+            foreach (var t in state.MenuTransformers)
+                _menuTransformers.Remove(t);
+
+            foreach (var t in state.FooterMenuTransformers)
+                _footerMenuTransformers.Remove(t);
+
+            foreach (var b in state.BadgeProviders)
+                _badgeProviders.Remove(b);
+
+            foreach (var a in state.AppActions)
+                _appActions.Remove(a);
+
+            foreach (var f in state.AppFactories)
+                AppRepository.RemoveFactory(f);
+
+            _aggregateProvider.RemoveProvider(pluginId);
+            _aggregateProvider.RemoveProvider($"{pluginId}__context");
+            _pluginStates.Remove(pluginId);
+        }
+        finally
+        {
+            _lock.ExitWriteLock();
+        }
+    }
+
+    internal IReadOnlyDictionary<string, PluginState> PluginStates => _pluginStates;
 
     public void Apply(WebApplication app)
     {

--- a/src/Ivy/Core/Plugins/PluginLoader.cs
+++ b/src/Ivy/Core/Plugins/PluginLoader.cs
@@ -105,9 +105,20 @@ public class PluginLoader : IPluginManager
             return null;
         }
 
+        // Shadow-copy all DLLs so the runtime loads fresh bytes on reload
+        var shadowDir = Path.Combine(Path.GetTempPath(), "ivy-plugins", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(shadowDir);
+        var shadowFiles = new List<string>();
+        foreach (var src in dllFiles)
+        {
+            var dest = Path.Combine(shadowDir, Path.GetFileName(src));
+            File.Copy(src, dest, overwrite: true);
+            shadowFiles.Add(dest);
+        }
+
         var found = new List<(Type PluginType, Assembly Assembly, AssemblyLoadContext Context)>();
 
-        foreach (var dllPath in dllFiles)
+        foreach (var dllPath in shadowFiles)
         {
             var loadContext = new PluginAssemblyLoadContext(dllPath, _sharedAssemblyNames);
             Assembly assembly;

--- a/src/Ivy/Core/Plugins/PluginLoader.cs
+++ b/src/Ivy/Core/Plugins/PluginLoader.cs
@@ -13,6 +13,7 @@ public class PluginLoader : IPluginManager
     private readonly ILogger<PluginLoader> _logger;
     private readonly IReadOnlySet<string> _sharedAssemblyNames;
     private readonly List<LoadedPlugin> _plugins = [];
+    private readonly Dictionary<string, string> _knownPlugins = new(); // id -> directory
     private readonly ReaderWriterLockSlim _lock = new();
     private PluginContextBase? _pluginContext;
     private IConfiguration? _configuration;
@@ -68,6 +69,7 @@ public class PluginLoader : IPluginManager
                     continue;
                 }
 
+                _knownPlugins[manifest.Id] = directory;
                 candidates.Add(loaded.Value);
             }
             catch (Exception ex)
@@ -342,6 +344,7 @@ public class PluginLoader : IPluginManager
                 plugin.ServiceProvider = _pluginContext.GetPluginServiceProvider(manifest.Id);
             }
 
+            _knownPlugins[manifest.Id] = pluginPath;
             _plugins.Add(plugin);
             _logger.LogInformation("Loaded plugin: {Id} v{Version}", manifest.Id, manifest.Version);
             return true;
@@ -381,6 +384,23 @@ public class PluginLoader : IPluginManager
         try
         {
             return _plugins.Select(p => p.Instance.Manifest.Id).ToList();
+        }
+        finally
+        {
+            _lock.ExitReadLock();
+        }
+    }
+
+    public IReadOnlyList<PluginCandidate> GetUnloadedPlugins()
+    {
+        _lock.EnterReadLock();
+        try
+        {
+            var loadedIds = _plugins.Select(p => p.Instance.Manifest.Id).ToHashSet();
+            return _knownPlugins
+                .Where(kv => !loadedIds.Contains(kv.Key))
+                .Select(kv => new PluginCandidate(kv.Key, kv.Value))
+                .ToList();
         }
         finally
         {

--- a/src/Ivy/Core/Plugins/PluginLoader.cs
+++ b/src/Ivy/Core/Plugins/PluginLoader.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Ivy.Core.Plugins;
 
-public class PluginLoader
+public class PluginLoader : IPluginManager
 {
     private readonly string _pluginsDirectory;
     private readonly ILogger<PluginLoader> _logger;
@@ -16,7 +16,7 @@ public class PluginLoader
     private readonly ReaderWriterLockSlim _lock = new();
     private PluginContextBase? _pluginContext;
     private IConfiguration? _configuration;
-    private IServiceProvider? _bootstrapProvider;
+    private Func<IServiceProvider>? _serviceProviderFactory;
     private Version? _hostVersion;
 
     internal PluginLoader(string pluginsDirectory, ILogger<PluginLoader> logger, IEnumerable<string>? sharedAssemblyNames = null)
@@ -42,7 +42,6 @@ public class PluginLoader
     public void DiscoverAndLoad(Version hostVersion, IServiceProvider serviceProvider)
     {
         _hostVersion = hostVersion;
-        _bootstrapProvider = serviceProvider;
 
         if (!Directory.Exists(_pluginsDirectory))
         {
@@ -213,6 +212,11 @@ public class PluginLoader
         }
     }
 
+    internal void SetServiceProviderFactory(Func<IServiceProvider> factory)
+    {
+        _serviceProviderFactory = factory;
+    }
+
     public void Configure(PluginContextBase context)
     {
         _pluginContext = context;
@@ -280,16 +284,16 @@ public class PluginLoader
 
     public bool LoadPlugin(string pluginPath)
     {
-        if (_bootstrapProvider is null || _hostVersion is null)
+        if (_serviceProviderFactory is null || _hostVersion is null)
         {
-            _logger.LogError("Cannot load plugin: PluginLoader has not been initialized via DiscoverAndLoad.");
+            _logger.LogError("Cannot load plugin: PluginLoader has not been initialized.");
             return false;
         }
 
         _lock.EnterWriteLock();
         try
         {
-            var loaded = LoadPluginFromDirectory(pluginPath, _bootstrapProvider);
+            var loaded = LoadPluginFromDirectory(pluginPath, _serviceProviderFactory());
             if (loaded is null)
             {
                 _logger.LogError("Failed to load plugin from {Path}.", pluginPath);

--- a/src/Ivy/Core/Plugins/PluginLoader.cs
+++ b/src/Ivy/Core/Plugins/PluginLoader.cs
@@ -13,6 +13,11 @@ public class PluginLoader
     private readonly ILogger<PluginLoader> _logger;
     private readonly IReadOnlySet<string> _sharedAssemblyNames;
     private readonly List<LoadedPlugin> _plugins = [];
+    private readonly ReaderWriterLockSlim _lock = new();
+    private PluginContextBase? _pluginContext;
+    private IConfiguration? _configuration;
+    private IServiceProvider? _bootstrapProvider;
+    private Version? _hostVersion;
 
     internal PluginLoader(string pluginsDirectory, ILogger<PluginLoader> logger, IEnumerable<string>? sharedAssemblyNames = null)
     {
@@ -24,17 +29,28 @@ public class PluginLoader
         };
     }
 
-    public IReadOnlyList<LoadedPlugin> Plugins => _plugins;
+    public IReadOnlyList<LoadedPlugin> Plugins
+    {
+        get
+        {
+            _lock.EnterReadLock();
+            try { return _plugins.ToList(); }
+            finally { _lock.ExitReadLock(); }
+        }
+    }
 
     public void DiscoverAndLoad(Version hostVersion, IServiceProvider serviceProvider)
     {
+        _hostVersion = hostVersion;
+        _bootstrapProvider = serviceProvider;
+
         if (!Directory.Exists(_pluginsDirectory))
         {
             _logger.LogDebug("Plugins directory not found: {Directory}", _pluginsDirectory);
             return;
         }
 
-        var candidates = new List<(IIvyPlugin Instance, Assembly Assembly, AssemblyLoadContext Context)>();
+        var candidates = new List<(IIvyPlugin Instance, Assembly Assembly, AssemblyLoadContext Context, string Directory)>();
 
         foreach (var directory in Directory.GetDirectories(_pluginsDirectory))
         {
@@ -62,13 +78,21 @@ public class PluginLoader
         }
 
         var sorted = TopologicalSort(candidates);
-        _plugins.AddRange(sorted.Select(c => new LoadedPlugin(c.Instance, c.Assembly, c.Context)));
+        _lock.EnterWriteLock();
+        try
+        {
+            _plugins.AddRange(sorted.Select(c => new LoadedPlugin(c.Instance, c.Assembly, c.Context, c.Directory)));
+        }
+        finally
+        {
+            _lock.ExitWriteLock();
+        }
 
         foreach (var plugin in _plugins)
             _logger.LogInformation("Loaded plugin: {Id} v{Version}", plugin.Instance.Manifest.Id, plugin.Instance.Manifest.Version);
     }
 
-    private (IIvyPlugin Instance, Assembly Assembly, AssemblyLoadContext Context)? LoadPluginFromDirectory(
+    private (IIvyPlugin Instance, Assembly Assembly, AssemblyLoadContext Context, string Directory)? LoadPluginFromDirectory(
         string directory, IServiceProvider serviceProvider)
     {
         var dllFiles = Directory.GetFiles(directory, "*.dll", SearchOption.AllDirectories)
@@ -126,16 +150,16 @@ public class PluginLoader
 
         var (pluginType, pluginAssembly, context) = found[0];
         var instance = (IIvyPlugin)ActivatorUtilities.CreateInstance(serviceProvider, pluginType);
-        return (instance, pluginAssembly, context);
+        return (instance, pluginAssembly, context, directory);
     }
 
-    private List<(IIvyPlugin Instance, Assembly Assembly, AssemblyLoadContext Context)> TopologicalSort(
-        List<(IIvyPlugin Instance, Assembly Assembly, AssemblyLoadContext Context)> candidates)
+    private List<(IIvyPlugin Instance, Assembly Assembly, AssemblyLoadContext Context, string Directory)> TopologicalSort(
+        List<(IIvyPlugin Instance, Assembly Assembly, AssemblyLoadContext Context, string Directory)> candidates)
     {
         var byId = candidates.ToDictionary(c => c.Instance.Manifest.Id);
         var visited = new HashSet<string>();
         var visiting = new HashSet<string>(); // cycle detection
-        var sorted = new List<(IIvyPlugin, Assembly, AssemblyLoadContext)>();
+        var sorted = new List<(IIvyPlugin, Assembly, AssemblyLoadContext, string)>();
 
         foreach (var candidate in candidates)
         {
@@ -174,21 +198,199 @@ public class PluginLoader
         }
     }
 
-    public void ConfigureServices(IServiceCollection services, IConfiguration configuration)
+    public void ConfigureServices(IServiceCollection hostServices, IConfiguration configuration)
     {
-        foreach (var plugin in _plugins)
-            plugin.Instance.ConfigureServices(services, configuration);
+        _configuration = configuration;
+        _lock.EnterReadLock();
+        try
+        {
+            foreach (var plugin in _plugins)
+                plugin.Instance.ConfigureServices(plugin.Services, configuration);
+        }
+        finally
+        {
+            _lock.ExitReadLock();
+        }
     }
 
-    public void Configure(IPluginContext context)
+    public void Configure(PluginContextBase context)
     {
-        foreach (var plugin in _plugins)
-            plugin.Instance.Configure(context);
+        _pluginContext = context;
+        _lock.EnterReadLock();
+        try
+        {
+            foreach (var plugin in _plugins)
+            {
+                context.SetCurrentPlugin(plugin.Instance.Manifest.Id, plugin.Directory);
+                plugin.Instance.Configure(context);
+                context.ClearCurrentPlugin();
+            }
+        }
+        finally
+        {
+            _lock.ExitReadLock();
+        }
+    }
+
+    public bool UnloadPlugin(string pluginId)
+    {
+        _lock.EnterWriteLock();
+        try
+        {
+            var plugin = _plugins.FirstOrDefault(p => p.Instance.Manifest.Id == pluginId);
+            if (plugin is null)
+            {
+                _logger.LogWarning("Plugin '{Id}' not found for unload.", pluginId);
+                return false;
+            }
+
+            // Check if other loaded plugins depend on this one
+            var dependents = _plugins
+                .Where(p => p.Instance.Manifest.Id != pluginId &&
+                            p.Instance.Manifest.Dependencies.Contains(pluginId))
+                .Select(p => p.Instance.Manifest.Id)
+                .ToList();
+
+            if (dependents.Count > 0)
+            {
+                _logger.LogError(
+                    "Cannot unload plugin '{Id}': plugins [{Dependents}] depend on it.",
+                    pluginId, string.Join(", ", dependents));
+                return false;
+            }
+
+            // Remove contributions from context
+            _pluginContext?.RemovePluginContributions(pluginId);
+
+            // Dispose the plugin's service provider
+            (plugin.ServiceProvider as IDisposable)?.Dispose();
+
+            // Unload the assembly context
+            plugin.LoadContext.Unload();
+
+            _plugins.Remove(plugin);
+            _logger.LogInformation("Unloaded plugin: {Id}", pluginId);
+            return true;
+        }
+        finally
+        {
+            _lock.ExitWriteLock();
+        }
+    }
+
+    public bool LoadPlugin(string pluginPath)
+    {
+        if (_bootstrapProvider is null || _hostVersion is null)
+        {
+            _logger.LogError("Cannot load plugin: PluginLoader has not been initialized via DiscoverAndLoad.");
+            return false;
+        }
+
+        _lock.EnterWriteLock();
+        try
+        {
+            var loaded = LoadPluginFromDirectory(pluginPath, _bootstrapProvider);
+            if (loaded is null)
+            {
+                _logger.LogError("Failed to load plugin from {Path}.", pluginPath);
+                return false;
+            }
+
+            var manifest = loaded.Value.Instance.Manifest;
+
+            if (_plugins.Any(p => p.Instance.Manifest.Id == manifest.Id))
+            {
+                _logger.LogError("Plugin '{Id}' is already loaded.", manifest.Id);
+                return false;
+            }
+
+            if (manifest.MinimumHostVersion is { } minVersion && _hostVersion < minVersion)
+            {
+                _logger.LogError(
+                    "Plugin '{Id}' requires host version {Required} but current is {Current}.",
+                    manifest.Id, minVersion, _hostVersion);
+                return false;
+            }
+
+            // Check dependencies are loaded
+            foreach (var dep in manifest.Dependencies)
+            {
+                if (_plugins.All(p => p.Instance.Manifest.Id != dep))
+                {
+                    _logger.LogError("Plugin '{Id}' depends on '{Dep}' which is not loaded.", manifest.Id, dep);
+                    return false;
+                }
+            }
+
+            var plugin = new LoadedPlugin(loaded.Value.Instance, loaded.Value.Assembly, loaded.Value.Context, loaded.Value.Directory);
+
+            // Configure services
+            if (_configuration is not null)
+                plugin.Instance.ConfigureServices(plugin.Services, _configuration);
+
+            // Configure context
+            if (_pluginContext is not null)
+            {
+                _pluginContext.SetCurrentPlugin(manifest.Id, pluginPath);
+                plugin.Instance.Configure(_pluginContext);
+                _pluginContext.ClearCurrentPlugin();
+                _pluginContext.BuildPluginServiceProvider(manifest.Id, plugin.Services);
+                plugin.ServiceProvider = _pluginContext.GetPluginServiceProvider(manifest.Id);
+            }
+
+            _plugins.Add(plugin);
+            _logger.LogInformation("Loaded plugin: {Id} v{Version}", manifest.Id, manifest.Version);
+            return true;
+        }
+        finally
+        {
+            _lock.ExitWriteLock();
+        }
+    }
+
+    public bool ReloadPlugin(string pluginId)
+    {
+        _lock.EnterReadLock();
+        string? directory;
+        try
+        {
+            var plugin = _plugins.FirstOrDefault(p => p.Instance.Manifest.Id == pluginId);
+            if (plugin is null)
+            {
+                _logger.LogWarning("Plugin '{Id}' not found for reload.", pluginId);
+                return false;
+            }
+            directory = plugin.Directory;
+        }
+        finally
+        {
+            _lock.ExitReadLock();
+        }
+
+        if (!UnloadPlugin(pluginId)) return false;
+        return LoadPlugin(directory);
+    }
+
+    public IReadOnlyList<string> GetLoadedPluginIds()
+    {
+        _lock.EnterReadLock();
+        try
+        {
+            return _plugins.Select(p => p.Instance.Manifest.Id).ToList();
+        }
+        finally
+        {
+            _lock.ExitReadLock();
+        }
     }
 }
 
 public record LoadedPlugin(
     IIvyPlugin Instance,
     Assembly Assembly,
-    AssemblyLoadContext LoadContext
-);
+    AssemblyLoadContext LoadContext,
+    string Directory)
+{
+    public ServiceCollection Services { get; } = new();
+    public IServiceProvider? ServiceProvider { get; internal set; }
+}

--- a/src/Ivy/Core/Plugins/PluginState.cs
+++ b/src/Ivy/Core/Plugins/PluginState.cs
@@ -1,4 +1,3 @@
-using Ivy.Plugins;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 

--- a/src/Ivy/Core/Plugins/PluginState.cs
+++ b/src/Ivy/Core/Plugins/PluginState.cs
@@ -1,0 +1,24 @@
+using Ivy.Plugins;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Ivy.Core.Plugins;
+
+internal class PluginState
+{
+    public string PluginId { get; }
+    public string Directory { get; }
+    public ServiceCollection PluginServices { get; } = new();
+
+    public List<Func<IEnumerable<MenuItem>, IEnumerable<MenuItem>>> MenuTransformers { get; } = [];
+    public List<Func<IEnumerable<MenuItem>, INavigator, IEnumerable<MenuItem>>> FooterMenuTransformers { get; } = [];
+    public List<(string Tag, Func<IServiceProvider, int> CountProvider)> BadgeProviders { get; } = [];
+    public List<Action<WebApplication>> AppActions { get; } = [];
+    public List<Func<AppDescriptor[]>> AppFactories { get; } = [];
+
+    public PluginState(string pluginId, string directory)
+    {
+        PluginId = pluginId;
+        Directory = directory;
+    }
+}

--- a/src/Ivy/Server.cs
+++ b/src/Ivy/Server.cs
@@ -761,10 +761,13 @@ public class Server
             _pluginLoader.Configure(pluginContext);
             pluginContext.BuildServiceProvider();
             builder.Services.AddSingleton<IPluginServiceProvider>(pluginContext);
+            builder.Services.AddSingleton<IPluginManager>(_pluginLoader);
         }
 
         var app = builder.Build();
         ServiceProvider = app.Services;
+
+        _pluginLoader?.SetServiceProviderFactory(() => app.Services);
 
         pluginContext?.Apply(app);
 

--- a/src/plugins/hosts/HelloWorldHost/HelloWorldApp.cs
+++ b/src/plugins/hosts/HelloWorldHost/HelloWorldApp.cs
@@ -12,8 +12,11 @@ public class HelloWorldApp : ViewBase
     public override object? Build()
     {
         var plugins = this.UseService<IPluginServiceProvider>();
+        var pluginManager = this.UseService<IPluginManager>();
         var greeters = plugins.GetServices<IGreeter>().ToList();
+        var loadedPlugins = pluginManager.GetLoadedPluginIds();
         var nameState = UseState("World");
+        var pluginStatus = UseState("");
 
         var greeting = greeters.Count > 0
             ? greeters[0].Greet(string.IsNullOrWhiteSpace(nameState.Value) ? "World" : nameState.Value)
@@ -24,6 +27,29 @@ public class HelloWorldApp : ViewBase
             | new Field(
                 nameState.ToTextInput().Placeholder("Enter a name")
             ).Label("Who to greet?")
-            | Muted($"Using {greeters.Count} greeter plugin(s)");
+            | Muted($"Using {greeters.Count} greeter plugin(s)")
+            | new Separator()
+            | H2("Plugin Management")
+            | loadedPlugins.Select(id => (object)(Horizontal().Gap(4)
+                | new Badge(id, BadgeVariant.Secondary)
+                | new Button("Reload", onClick: _ =>
+                {
+                    pluginStatus.Set(pluginManager.ReloadPlugin(id)
+                        ? $"Reloaded '{id}'"
+                        : $"Failed to reload '{id}'");
+                    return ValueTask.CompletedTask;
+                }, variant: ButtonVariant.Outline, icon: Icons.RefreshCw)
+                | new Button("Unload", onClick: _ =>
+                {
+                    pluginStatus.Set(pluginManager.UnloadPlugin(id)
+                        ? $"Unloaded '{id}'"
+                        : $"Failed to unload '{id}'");
+                    return ValueTask.CompletedTask;
+                }, variant: ButtonVariant.Outline, icon: Icons.Power)
+            )).ToArray()
+            | (string.IsNullOrEmpty(pluginStatus.Value) ? null
+                : pluginStatus.Value.StartsWith("Failed")
+                    ? new Badge(pluginStatus.Value, BadgeVariant.Destructive)
+                    : new Badge(pluginStatus.Value, BadgeVariant.Success));
     }
 }

--- a/src/plugins/hosts/HelloWorldHost/HelloWorldApp.cs
+++ b/src/plugins/hosts/HelloWorldHost/HelloWorldApp.cs
@@ -15,6 +15,7 @@ public class HelloWorldApp : ViewBase
         var pluginManager = this.UseService<IPluginManager>();
         var greeters = plugins.GetServices<IGreeter>().ToList();
         var loadedPlugins = pluginManager.GetLoadedPluginIds();
+        var unloadedPlugins = pluginManager.GetUnloadedPlugins();
         var nameState = UseState("World");
         var pluginStatus = UseState("");
 
@@ -46,6 +47,17 @@ public class HelloWorldApp : ViewBase
                         : $"Failed to unload '{id}'");
                     return ValueTask.CompletedTask;
                 }, variant: ButtonVariant.Outline, icon: Icons.Power)
+            )).ToArray()
+            | unloadedPlugins.Select(p => (object)(Horizontal().Gap(4)
+                | new Badge(p.Id, BadgeVariant.Outline)
+                | Muted("unloaded")
+                | new Button("Load", onClick: _ =>
+                {
+                    pluginStatus.Set(pluginManager.LoadPlugin(p.Directory)
+                        ? $"Loaded '{p.Id}'"
+                        : $"Failed to load '{p.Id}'");
+                    return ValueTask.CompletedTask;
+                }, variant: ButtonVariant.Outline, icon: Icons.Plus)
             )).ToArray()
             | (string.IsNullOrEmpty(pluginStatus.Value) ? null
                 : pluginStatus.Value.StartsWith("Failed")

--- a/src/plugins/hosts/HelloWorldHost/HelloWorldApp.cs
+++ b/src/plugins/hosts/HelloWorldHost/HelloWorldApp.cs
@@ -18,6 +18,7 @@ public class HelloWorldApp : ViewBase
         var unloadedPlugins = pluginManager.GetUnloadedPlugins();
         var nameState = UseState("World");
         var pluginStatus = UseState("");
+        var refreshToken = UseRefreshToken();
 
         var greeting = greeters.Count > 0
             ? greeters[0].Greet(string.IsNullOrWhiteSpace(nameState.Value) ? "World" : nameState.Value)
@@ -38,6 +39,7 @@ public class HelloWorldApp : ViewBase
                     pluginStatus.Set(pluginManager.ReloadPlugin(id)
                         ? $"Reloaded '{id}'"
                         : $"Failed to reload '{id}'");
+                    refreshToken.Refresh();
                     return ValueTask.CompletedTask;
                 }, variant: ButtonVariant.Outline, icon: Icons.RefreshCw)
                 | new Button("Unload", onClick: _ =>
@@ -45,6 +47,7 @@ public class HelloWorldApp : ViewBase
                     pluginStatus.Set(pluginManager.UnloadPlugin(id)
                         ? $"Unloaded '{id}'"
                         : $"Failed to unload '{id}'");
+                    refreshToken.Refresh();
                     return ValueTask.CompletedTask;
                 }, variant: ButtonVariant.Outline, icon: Icons.Power)
             )).ToArray()
@@ -56,6 +59,7 @@ public class HelloWorldApp : ViewBase
                     pluginStatus.Set(pluginManager.LoadPlugin(p.Directory)
                         ? $"Loaded '{p.Id}'"
                         : $"Failed to load '{p.Id}'");
+                    refreshToken.Refresh();
                     return ValueTask.CompletedTask;
                 }, variant: ButtonVariant.Outline, icon: Icons.Plus)
             )).ToArray()

--- a/src/plugins/hosts/MessagingHost/MessagingTestApp.cs
+++ b/src/plugins/hosts/MessagingHost/MessagingTestApp.cs
@@ -17,6 +17,7 @@ public class MessagingTestApp : ViewBase
         var pluginManager = this.UseService<IPluginManager>();
         var channels = plugins.GetServices<IMessagingChannel>().ToList();
         var loadedPlugins = pluginManager.GetLoadedPluginIds();
+        var unloadedPlugins = pluginManager.GetUnloadedPlugins();
 
         var selectedPlatform = UseState(channels.FirstOrDefault()?.Platform ?? "");
         var channelName = UseState("#ivy-plugin-test");
@@ -143,6 +144,17 @@ public class MessagingTestApp : ViewBase
                         : $"Failed to unload '{id}'");
                     return ValueTask.CompletedTask;
                 }, variant: ButtonVariant.Outline, icon: Icons.Power)
+            )).ToArray()
+            | unloadedPlugins.Select(p => (object)(Horizontal().Gap(4)
+                | new Badge(p.Id, BadgeVariant.Outline)
+                | Muted("unloaded")
+                | new Button("Load", onClick: _ =>
+                {
+                    pluginStatus.Set(pluginManager.LoadPlugin(p.Directory)
+                        ? $"Loaded '{p.Id}'"
+                        : $"Failed to load '{p.Id}'");
+                    return ValueTask.CompletedTask;
+                }, variant: ButtonVariant.Outline, icon: Icons.Plus)
             )).ToArray()
             | (string.IsNullOrEmpty(pluginStatus.Value) ? null : StatusBadge(pluginStatus.Value));
     }

--- a/src/plugins/hosts/MessagingHost/MessagingTestApp.cs
+++ b/src/plugins/hosts/MessagingHost/MessagingTestApp.cs
@@ -14,7 +14,9 @@ public class MessagingTestApp : ViewBase
     public override object? Build()
     {
         var plugins = this.UseService<IPluginServiceProvider>();
+        var pluginManager = this.UseService<IPluginManager>();
         var channels = plugins.GetServices<IMessagingChannel>().ToList();
+        var loadedPlugins = pluginManager.GetLoadedPluginIds();
 
         var selectedPlatform = UseState(channels.FirstOrDefault()?.Platform ?? "");
         var channelName = UseState("#ivy-plugin-test");
@@ -24,6 +26,7 @@ public class MessagingTestApp : ViewBase
         var sending = UseState(false);
         var sentMessages = UseState<List<SentMessage>>([]);
         var fileState = UseState<FileUpload<byte[]>?>(null);
+        var pluginStatus = UseState("");
 
         var activeChannel = channels.FirstOrDefault(c => c.Platform == selectedPlatform.Value);
 
@@ -121,7 +124,27 @@ public class MessagingTestApp : ViewBase
                     await Send(activeChannel, builder, "Rich: Build report");
                 }, variant: ButtonVariant.Outline).Disabled(activeChannel is null || sending.Value)
             | (string.IsNullOrEmpty(status.Value) ? null : StatusBadge(status.Value))
-            | (sentMessages.Value.Count > 0 ? SentMessagesSection(channels, sentMessages, threadId, status) : null);
+            | (sentMessages.Value.Count > 0 ? SentMessagesSection(channels, sentMessages, threadId, status) : null)
+            | new Separator()
+            | H2("Plugin Management")
+            | loadedPlugins.Select(id => (object)(Horizontal().Gap(4)
+                | new Badge(id, BadgeVariant.Secondary)
+                | new Button("Reload", onClick: _ =>
+                {
+                    pluginStatus.Set(pluginManager.ReloadPlugin(id)
+                        ? $"Reloaded '{id}'"
+                        : $"Failed to reload '{id}'");
+                    return ValueTask.CompletedTask;
+                }, variant: ButtonVariant.Outline, icon: Icons.RefreshCw)
+                | new Button("Unload", onClick: _ =>
+                {
+                    pluginStatus.Set(pluginManager.UnloadPlugin(id)
+                        ? $"Unloaded '{id}'"
+                        : $"Failed to unload '{id}'");
+                    return ValueTask.CompletedTask;
+                }, variant: ButtonVariant.Outline, icon: Icons.Power)
+            )).ToArray()
+            | (string.IsNullOrEmpty(pluginStatus.Value) ? null : StatusBadge(pluginStatus.Value));
     }
 
     private object SentMessagesSection(

--- a/src/plugins/hosts/MessagingHost/MessagingTestApp.cs
+++ b/src/plugins/hosts/MessagingHost/MessagingTestApp.cs
@@ -28,6 +28,7 @@ public class MessagingTestApp : ViewBase
         var sentMessages = UseState<List<SentMessage>>([]);
         var fileState = UseState<FileUpload<byte[]>?>(null);
         var pluginStatus = UseState("");
+        var refreshToken = UseRefreshToken();
 
         var activeChannel = channels.FirstOrDefault(c => c.Platform == selectedPlatform.Value);
 
@@ -135,6 +136,7 @@ public class MessagingTestApp : ViewBase
                     pluginStatus.Set(pluginManager.ReloadPlugin(id)
                         ? $"Reloaded '{id}'"
                         : $"Failed to reload '{id}'");
+                    refreshToken.Refresh();
                     return ValueTask.CompletedTask;
                 }, variant: ButtonVariant.Outline, icon: Icons.RefreshCw)
                 | new Button("Unload", onClick: _ =>
@@ -142,6 +144,7 @@ public class MessagingTestApp : ViewBase
                     pluginStatus.Set(pluginManager.UnloadPlugin(id)
                         ? $"Unloaded '{id}'"
                         : $"Failed to unload '{id}'");
+                    refreshToken.Refresh();
                     return ValueTask.CompletedTask;
                 }, variant: ButtonVariant.Outline, icon: Icons.Power)
             )).ToArray()
@@ -153,6 +156,7 @@ public class MessagingTestApp : ViewBase
                     pluginStatus.Set(pluginManager.LoadPlugin(p.Directory)
                         ? $"Loaded '{p.Id}'"
                         : $"Failed to load '{p.Id}'");
+                    refreshToken.Refresh();
                     return ValueTask.CompletedTask;
                 }, variant: ButtonVariant.Outline, icon: Icons.Plus)
             )).ToArray()


### PR DESCRIPTION
# Summary

## Changes

Implemented selective plugin loading and unloading with per-plugin state isolation. Each plugin now gets its own `ServiceCollection` and `IServiceProvider`, aggregated through a new `AggregatePluginServiceProvider`. Plugin contributions (menus, badges, apps, web application actions) are tracked per-plugin and can be cleanly removed on unload. Thread safety is enforced via `ReaderWriterLockSlim`.

## API Changes

- `PluginLoader.UnloadPlugin(string pluginId)` — Unloads a plugin by ID, cleaning up services and contributions. Returns false if dependents exist.
- `PluginLoader.LoadPlugin(string pluginPath)` — Loads a plugin from a directory path at runtime.
- `PluginLoader.ReloadPlugin(string pluginId)` — Unloads then reloads a plugin.
- `PluginLoader.GetLoadedPluginIds()` — Returns list of currently loaded plugin IDs.
- `LoadedPlugin` record — Added `Directory` field, `Services` (per-plugin `ServiceCollection`), and `ServiceProvider` properties.
- `PluginContextBase.SetCurrentPlugin(string, string)` / `ClearCurrentPlugin()` — Internal methods for per-plugin tracking during Configure.
- `PluginContextBase.RemovePluginContributions(string)` — Internal method to clean up a plugin's contributions on unload.
- `PluginContextBase.BuildPluginServiceProvider(string, IServiceCollection)` — Internal method for building individual plugin providers.
- `AppRepository.RemoveFactory(Func<AppDescriptor[]>)` — Removes a previously added app factory.
- `AggregatePluginServiceProvider` — New internal class implementing `IPluginServiceProvider` with per-plugin provider composition.
- `PluginState` — New internal class tracking per-plugin contributions (menus, badges, apps, services).
- `PluginAssemblyLoadContext` — Changed to `isCollectible: true` for proper assembly unloading.

## Files Modified

- **New:** `src/Ivy/Core/Plugins/PluginState.cs` — Per-plugin contribution tracking
- **New:** `src/Ivy/Core/Plugins/AggregatePluginServiceProvider.cs` — Composite service provider
- **New:** `src/Ivy.Test/PluginLoaderTests.cs` — 10 tests covering isolation, unload, reload, dependencies
- **Modified:** `src/Ivy/Core/Plugins/PluginLoader.cs` — Added lifecycle methods, per-plugin services, thread safety
- **Modified:** `src/Ivy/Core/Plugins/PluginContext.cs` — Per-plugin state tracking in PluginContextBase
- **Modified:** `src/Ivy/Core/Plugins/PluginAssemblyLoadContext.cs` — Made collectible
- **Modified:** `src/Ivy/Core/Apps/AppRepository.cs` — Added RemoveFactory method

## Commits

- [00012] Use UseRefreshToken and fix re-render ordering (29102b528)
- [00012] Shadow-copy plugin DLLs to ensure reload picks up new builds (1bf88f208)
- [00012] Track unloaded plugins as candidates for reloading (0b493fec1)
- [00012] Expose IPluginManager in DI for runtime plugin reload/unload (1a71ab569)
- [00012] Fix format: remove unused using in PluginState (d2b7f0a9f)
- [00012] Enable selective plugin loading and unloading (d31d6a01f)