### PR TITLE
[00118] Fix Contributors 'Repository or file not found' error on Tendril docs

### DIFF
--- a/src/frontend/src/widgets/article/GitHubContributors.tsx
+++ b/src/frontend/src/widgets/article/GitHubContributors.tsx
@@ -48,18 +48,10 @@ export const getCommitsUrl = (githubUrl: string): string => {
 
     // Expected format: /owner/repo/blob/branch/path/to/file
     if (pathParts.length >= 6 && pathParts[3] === "blob") {
-      let owner = pathParts[1];
-      let repo = pathParts[2];
+      const owner = pathParts[1];
+      const repo = pathParts[2];
       const branch = pathParts[4];
-      let filePath = pathParts.slice(5).join("/");
-
-      // Mono-repo mapping support
-      if (owner.toLowerCase() === "ivy-interactive") {
-        if (repo.toLowerCase() === "ivy-tendril" || repo.toLowerCase() === "ivy-framework") {
-          filePath = `${repo}/${filePath}`;
-          repo = "ivy";
-        }
-      }
+      const filePath = pathParts.slice(5).join("/");
 
       // Generate commits URL for the specific branch and file path
       return `https://github.com/${owner}/${repo}/commits/${branch}/${filePath}`;
@@ -84,18 +76,10 @@ export const getApiUrl = (githubUrl: string): string | null => {
       return null;
     }
 
-    let owner = pathParts[1];
-    let repo = pathParts[2];
+    const owner = pathParts[1];
+    const repo = pathParts[2];
     const branch = pathParts[4];
-    let filePath = pathParts.slice(5).join("/");
-
-    // Mono-repo mapping support
-    if (owner.toLowerCase() === "ivy-interactive") {
-      if (repo.toLowerCase() === "ivy-tendril" || repo.toLowerCase() === "ivy-framework") {
-        filePath = `${repo}/${filePath}`;
-        repo = "ivy";
-      }
-    }
+    const filePath = pathParts.slice(5).join("/");
 
     // Use the branch from the URL
     return `https://api.github.com/repos/${owner}/${repo}/commits?path=${encodeURIComponent(filePath)}&sha=${branch}&per_page=20`;

--- a/src/frontend/src/widgets/article/__tests__/GitHubContributors.test.ts
+++ b/src/frontend/src/widgets/article/__tests__/GitHubContributors.test.ts
@@ -16,23 +16,23 @@ describe("GitHubContributors utility functions", () => {
       expect(getApiUrl(url)).toBe(expectedApiUrl);
     });
 
-    it("should apply mono-repo mapping for Ivy-Tendril", () => {
+    it("should NOT remap Ivy-Tendril to the Ivy monorepo", () => {
       const url =
-        "https://github.com/Ivy-Interactive/Ivy-Tendril/blob/development/src/Ivy.Tendril.Docs/Docs/01_Introduction.md";
+        "https://github.com/Ivy-Interactive/Ivy-Tendril/blob/development/src/Docs/01_Introduction.md";
       const expectedApiUrl =
-        "https://api.github.com/repos/Ivy-Interactive/ivy/commits?path=Ivy-Tendril%2Fsrc%2FIvy.Tendril.Docs%2FDocs%2F01_Introduction.md&sha=development&per_page=20";
+        "https://api.github.com/repos/Ivy-Interactive/Ivy-Tendril/commits?path=src%2FDocs%2F01_Introduction.md&sha=development&per_page=20";
       expect(getApiUrl(url)).toBe(expectedApiUrl);
     });
 
-    it("should apply mono-repo mapping for Ivy-Framework", () => {
+    it("should NOT remap Ivy-Framework to the Ivy monorepo", () => {
       const url =
-        "https://github.com/ivy-interactive/ivy-framework/blob/main/src/frontend/src/file.tsx";
+        "https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/frontend/src/file.tsx";
       const expectedApiUrl =
-        "https://api.github.com/repos/ivy-interactive/ivy/commits?path=ivy-framework%2Fsrc%2Ffrontend%2Fsrc%2Ffile.tsx&sha=main&per_page=20";
+        "https://api.github.com/repos/Ivy-Interactive/Ivy-Framework/commits?path=src%2Ffrontend%2Fsrc%2Ffile.tsx&sha=main&per_page=20";
       expect(getApiUrl(url)).toBe(expectedApiUrl);
     });
 
-    it("should not apply mono-repo mapping for other Ivy-Interactive repos", () => {
+    it("should handle other Ivy-Interactive repos directly", () => {
       const url = "https://github.com/Ivy-Interactive/OtherRepo/blob/main/src/file.ts";
       const expectedApiUrl =
         "https://api.github.com/repos/Ivy-Interactive/OtherRepo/commits?path=src%2Ffile.ts&sha=main&per_page=20";
@@ -54,19 +54,19 @@ describe("GitHubContributors utility functions", () => {
       expect(getCommitsUrl(url)).toBe(expectedCommitsUrl);
     });
 
-    it("should apply mono-repo mapping for Ivy-Tendril", () => {
+    it("should NOT remap Ivy-Tendril commits URL", () => {
       const url =
-        "https://github.com/Ivy-Interactive/Ivy-Tendril/blob/development/src/Ivy.Tendril.Docs/Docs/01_Introduction.md";
+        "https://github.com/Ivy-Interactive/Ivy-Tendril/blob/development/src/Docs/01_Introduction.md";
       const expectedCommitsUrl =
-        "https://github.com/Ivy-Interactive/ivy/commits/development/Ivy-Tendril/src/Ivy.Tendril.Docs/Docs/01_Introduction.md";
+        "https://github.com/Ivy-Interactive/Ivy-Tendril/commits/development/src/Docs/01_Introduction.md";
       expect(getCommitsUrl(url)).toBe(expectedCommitsUrl);
     });
 
-    it("should apply mono-repo mapping for Ivy-Framework", () => {
+    it("should NOT remap Ivy-Framework commits URL", () => {
       const url =
-        "https://github.com/ivy-interactive/ivy-framework/blob/main/src/frontend/src/file.tsx";
+        "https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/frontend/src/file.tsx";
       const expectedCommitsUrl =
-        "https://github.com/ivy-interactive/ivy/commits/main/ivy-framework/src/frontend/src/file.tsx";
+        "https://github.com/Ivy-Interactive/Ivy-Framework/commits/main/src/frontend/src/file.tsx";
       expect(getCommitsUrl(url)).toBe(expectedCommitsUrl);
     });
   });


### PR DESCRIPTION
## Summary

Removed incorrect mono-repo mapping from the `GitHubContributors` component that was remapping `Ivy-Interactive/Ivy-Tendril` and `Ivy-Interactive/Ivy-Framework` GitHub API URLs to the `Ivy-Interactive/ivy` monorepo. These repos are standalone and the mapping caused the GitHub Commits API to query the wrong repository, resulting in "Repository or file not found" errors on the Tendril docs welcome page. Updated tests to verify URLs are passed through directly without remapping.

## Files Modified

- **src/frontend/src/widgets/article/GitHubContributors.tsx** — Removed mono-repo mapping blocks from `getCommitsUrl` and `getApiUrl`. Changed `let` declarations to `const` for variables that are no longer reassigned.
- **src/frontend/src/widgets/article/__tests__/GitHubContributors.test.ts** — Replaced 4 mono-repo mapping test cases with 4 new tests verifying that Ivy-Tendril and Ivy-Framework URLs are NOT remapped.

## Commits

- b4050fc9b [00118] Remove incorrect mono-repo mapping for Ivy-Tendril and Ivy-Framework in GitHubContributors

Closes https://github.com/Ivy-Interactive/Ivy-Tendril/issues/357