### PR TITLE
[00119] Fix clipboard crash on plain HTTP by adding execCommand fallback

### DIFF
--- a/src/frontend/src/components/CopyToClipboardButton.tsx
+++ b/src/frontend/src/components/CopyToClipboardButton.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Copy, Check } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { copyToClipboard } from "@/lib/clipboard";
 import { Densities } from "@/types/density";
 import { cva } from "class-variance-authority";
 
@@ -52,24 +53,11 @@ const CopyToClipboardButton: React.FC<CopyToClipboardButtonProps> = ({
 
   const handleCopy = async () => {
     try {
-      await navigator.clipboard.writeText(textToCopy);
+      await copyToClipboard(textToCopy);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
-    } catch {
-      try {
-        const textarea = document.createElement("textarea");
-        textarea.value = textToCopy;
-        textarea.style.position = "fixed";
-        textarea.style.opacity = "0";
-        document.body.appendChild(textarea);
-        textarea.select();
-        document.execCommand("copy");
-        document.body.removeChild(textarea);
-        setCopied(true);
-        setTimeout(() => setCopied(false), 2000);
-      } catch (fallbackErr) {
-        console.error("Copy failed:", fallbackErr);
-      }
+    } catch (err) {
+      console.error("Copy failed:", err);
     }
   };
 

--- a/src/frontend/src/components/ErrorDisplay.tsx
+++ b/src/frontend/src/components/ErrorDisplay.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { Button } from "./ui/button";
 import { ClipboardCopy, Check } from "lucide-react";
+import { copyToClipboard } from "@/lib/clipboard";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { createPrismTheme } from "@/lib/prismTheme";
 
@@ -22,7 +23,7 @@ export const ErrorDisplay: React.FC<ErrorDisplayProps> = ({ title, message, stac
       .filter(Boolean)
       .join("\n\n");
 
-    navigator.clipboard.writeText(errorDetails);
+    copyToClipboard(errorDetails);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };

--- a/src/frontend/src/components/ErrorDisplay.tsx
+++ b/src/frontend/src/components/ErrorDisplay.tsx
@@ -14,7 +14,7 @@ interface ErrorDisplayProps {
 export const ErrorDisplay: React.FC<ErrorDisplayProps> = ({ title, message, stackTrace }) => {
   const [copied, setCopied] = useState(false);
 
-  const copyToClipboard = () => {
+  const handleCopy = () => {
     const errorDetails = [
       title && `Title: ${title}`,
       message && `Message: ${message}`,
@@ -63,7 +63,7 @@ export const ErrorDisplay: React.FC<ErrorDisplayProps> = ({ title, message, stac
       )}
 
       <div className="shrink-0 pt-4 border-t">
-        <Button onClick={copyToClipboard} className="flex items-center gap-2" variant="outline">
+        <Button onClick={handleCopy} className="flex items-center gap-2" variant="outline">
           {copied ? (
             <Check className="h-4 w-4 text-primary animate-in fade-in duration-500" />
           ) : (

--- a/src/frontend/src/hooks/use-backend.tsx
+++ b/src/frontend/src/hooks/use-backend.tsx
@@ -7,6 +7,7 @@ import { showError } from "@/hooks/use-error-sheet";
 import { getIvyHost, getIvyBasePath, getMachineId } from "@/lib/utils";
 import { validateRedirectUrl, validateLinkUrl } from "@/lib/url";
 import { logger } from "@/lib/logger";
+import { copyToClipboard } from "@/lib/clipboard";
 import { applyPatch, Operation } from "fast-json-patch";
 import { ToastAction } from "@/components/ui/toast";
 import { setThemeGlobal } from "@/components/theme-provider";
@@ -849,7 +850,7 @@ export const useBackend = (
 
           connection.on("CopyToClipboard", (text: string) => {
             logger.debug(`[${connection.connectionId}] CopyToClipboard`);
-            navigator.clipboard.writeText(text);
+            copyToClipboard(text);
           });
 
           connection.on("OpenUrl", (url: string) => {

--- a/src/frontend/src/lib/clipboard.test.ts
+++ b/src/frontend/src/lib/clipboard.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { copyToClipboard } from "./clipboard";
+
+describe("copyToClipboard", () => {
+  let originalClipboard: Clipboard;
+  let originalExecCommand: typeof document.execCommand;
+
+  beforeEach(() => {
+    originalClipboard = navigator.clipboard;
+    originalExecCommand = document.execCommand;
+    // happy-dom doesn't define execCommand, so provide a stub
+    if (!document.execCommand) {
+      document.execCommand = vi.fn().mockReturnValue(true);
+    }
+  });
+
+  afterEach(() => {
+    Object.defineProperty(navigator, "clipboard", {
+      value: originalClipboard,
+      writable: true,
+      configurable: true,
+    });
+    document.execCommand = originalExecCommand;
+    vi.restoreAllMocks();
+  });
+
+  it("calls navigator.clipboard.writeText when available", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      writable: true,
+      configurable: true,
+    });
+
+    await copyToClipboard("hello");
+    expect(writeText).toHaveBeenCalledWith("hello");
+  });
+
+  it("falls back to execCommand when navigator.clipboard is undefined", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+
+    document.execCommand = vi.fn().mockReturnValue(true);
+    const appendChild = vi.spyOn(document.body, "appendChild");
+    const removeChild = vi.spyOn(document.body, "removeChild");
+
+    await copyToClipboard("fallback text");
+
+    expect(document.execCommand).toHaveBeenCalledWith("copy");
+    expect(appendChild).toHaveBeenCalled();
+    expect(removeChild).toHaveBeenCalled();
+
+    const textarea = appendChild.mock.calls[0][0] as HTMLTextAreaElement;
+    expect(textarea.value).toBe("fallback text");
+  });
+
+  it("falls back to execCommand when writeText rejects", async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error("Not allowed"));
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      writable: true,
+      configurable: true,
+    });
+
+    document.execCommand = vi.fn().mockReturnValue(true);
+
+    await copyToClipboard("rejected text");
+
+    expect(writeText).toHaveBeenCalledWith("rejected text");
+    expect(document.execCommand).toHaveBeenCalledWith("copy");
+  });
+});

--- a/src/frontend/src/lib/clipboard.ts
+++ b/src/frontend/src/lib/clipboard.ts
@@ -1,0 +1,17 @@
+export async function copyToClipboard(text: string): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch {
+    const textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.style.position = "fixed";
+    textarea.style.opacity = "0";
+    document.body.appendChild(textarea);
+    textarea.select();
+    try {
+      document.execCommand("copy");
+    } finally {
+      document.body.removeChild(textarea);
+    }
+  }
+}

--- a/src/frontend/src/widgets/article/DocumentTools.tsx
+++ b/src/frontend/src/widgets/article/DocumentTools.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { useToast } from "@/hooks/use-toast";
+import { copyToClipboard } from "@/lib/clipboard";
 import { Copy, Download, ChevronDown } from "lucide-react";
 import React from "react";
 
@@ -104,7 +105,7 @@ export const DocumentTools: React.FC<DocumentToolsProps> = ({
       }
 
       const content = stripMarkdownLinks(rawContent);
-      await navigator.clipboard.writeText(content);
+      await copyToClipboard(content);
       toast({
         title: "Copied!",
         description: "Markdown copied to clipboard",

--- a/src/frontend/src/widgets/inputs/code/CodeInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/code/CodeInputWidget.tsx
@@ -2,6 +2,7 @@ import React, { useState, useCallback, useMemo, Suspense, lazy, useEffect } from
 import { useOptimisticValue } from "../shared/useOptimisticValue";
 import { useEventHandler } from "@/components/event-handler";
 import { cn } from "@/lib/utils";
+import { copyToClipboard } from "@/lib/clipboard";
 import { getHeight, getWidth, inputStyles } from "@/lib/styles";
 import { InvalidIcon } from "@/components/InvalidIcon";
 import { Densities } from "@/types/density";
@@ -187,7 +188,7 @@ export const CodeInputWidget: React.FC<CodeInputWidgetProps> = ({
           {showCopy && (
             <button
               type="button"
-              onClick={() => navigator.clipboard.writeText(localValue)}
+              onClick={() => copyToClipboard(localValue)}
               aria-label="Copy to clipboard"
               className="p-1 rounded hover:bg-accent focus:outline-none cursor-pointer"
             >


### PR DESCRIPTION
## Summary

Created a shared `copyToClipboard` utility function with `navigator.clipboard.writeText` + `document.execCommand('copy')` fallback for non-secure contexts (plain HTTP). Updated all 4 unprotected call sites and refactored `CopyToClipboardButton` to use the shared helper, eliminating duplicated fallback logic. Added 3 unit tests covering the clipboard API path, undefined API fallback, and rejection fallback.

Closes https://github.com/Ivy-Interactive/Ivy-Framework/issues/4327

## API Changes

- New export: `copyToClipboard(text: string): Promise<void>` from `@/lib/clipboard`

## Files Modified

- **New:** `src/frontend/src/lib/clipboard.ts` — shared clipboard helper with execCommand fallback
- **New:** `src/frontend/src/lib/clipboard.test.ts` — 3 unit tests for the helper
- **Modified:** `src/frontend/src/components/CopyToClipboardButton.tsx` — replaced inline fallback with shared helper
- **Modified:** `src/frontend/src/components/ErrorDisplay.tsx` — use shared helper, renamed local function to avoid shadowing
- **Modified:** `src/frontend/src/hooks/use-backend.tsx` — use shared helper in CopyToClipboard SignalR handler
- **Modified:** `src/frontend/src/widgets/inputs/code/CodeInputWidget.tsx` — use shared helper for copy button
- **Modified:** `src/frontend/src/widgets/article/DocumentTools.tsx` — use shared helper for markdown copy

## Commits

- `a77189b1a` [00119] Add shared copyToClipboard helper with execCommand fallback and update all call sites
- `cbd2025fd` [00119] Add tests for copyToClipboard helper
- `fed14276f` [00119] Fix local function shadowing imported copyToClipboard in ErrorDisplay

## Verification

- ✅ DotnetBuild
- ✅ DotnetFormat
- ✅ DotnetTest
- ✅ FrameworkFrontendLint
- ✅ VitePlusCheck
- ✅ CheckResult