### PR TITLE
(datatable): add cell visual clickability indicator

### DIFF
--- a/src/Ivy.Samples.Shared/Apps/Widgets/DataTableApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/DataTableApp.cs
@@ -7,60 +7,12 @@ public class DataTableApp : SampleBase
     {
         return Layout.Tabs(
             new Tab("Overview", new DataTableMainSample()),
-            new Tab("Cell Actions", new DataTableCellActionsSample()),
             new Tab("Header Slots", new DataTableHeaderSlotsSample()),
             new Tab("Footer", new DataTableFooterSample()),
             new Tab("Multi Agg", new DataTableMultiAggSample()),
             new Tab("Density", new DataTableDensitySample()),
             new Tab("Million Rows", new DataTablesMillionRowsSample())
         ).Variant(TabsVariant.Content);
-    }
-}
-
-public class DataTableCellActionsSample : ViewBase
-{
-    public override object? Build()
-    {
-        var client = UseService<IClientProvider>();
-
-        var data = new[]
-        {
-            new { Name = "Ada Lovelace", Role = "Architect", Email = "ada@ivy.app", Team = "Compiler" },
-            new { Name = "Grace Hopper", Role = "Engineer", Email = "grace@ivy.app", Team = "Runtime" },
-            new { Name = "Barbara Liskov", Role = "Lead", Email = "barbara@ivy.app", Team = "Platform" },
-            new { Name = "Linus Torvalds", Role = "Maintainer", Email = "linus@ivy.app", Team = "Kernel" },
-        }.AsQueryable();
-
-        return Layout.Vertical()
-            | Text.P(
-                "Hover Name and Email cells to see the click indicator in the top-right corner. "
-                + "Those columns use OnCellAction handlers.")
-            | data.ToDataTable()
-                .Header(x => x.Name, "Name")
-                .Header(x => x.Role, "Role")
-                .Header(x => x.Email, "Email")
-                .Header(x => x.Team, "Team")
-                .Width(x => x.Name, Size.Px(180))
-                .Width(x => x.Role, Size.Px(140))
-                .Width(x => x.Email, Size.Px(220))
-                .Width(x => x.Team, Size.Px(160))
-                .OnCellAction(x => x.Name, (Func<object, ValueTask>)(e =>
-                {
-                    client.Toast($"Open profile: {e}");
-                    return ValueTask.CompletedTask;
-                }))
-                .OnCellAction(x => x.Email, (Func<object, ValueTask>)(e =>
-                {
-                    client.Toast($"Compose email: {e}");
-                    return ValueTask.CompletedTask;
-                }))
-                .Config(config =>
-                {
-                    config.AllowFiltering = true;
-                    config.AllowSorting = true;
-                    config.ShowSearch = true;
-                })
-                .Height(Size.Units(70));
     }
 }
 

--- a/src/Ivy.Samples.Shared/Apps/Widgets/DataTableApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/DataTableApp.cs
@@ -7,12 +7,60 @@ public class DataTableApp : SampleBase
     {
         return Layout.Tabs(
             new Tab("Overview", new DataTableMainSample()),
+            new Tab("Cell Actions", new DataTableCellActionsSample()),
             new Tab("Header Slots", new DataTableHeaderSlotsSample()),
             new Tab("Footer", new DataTableFooterSample()),
             new Tab("Multi Agg", new DataTableMultiAggSample()),
             new Tab("Density", new DataTableDensitySample()),
             new Tab("Million Rows", new DataTablesMillionRowsSample())
         ).Variant(TabsVariant.Content);
+    }
+}
+
+public class DataTableCellActionsSample : ViewBase
+{
+    public override object? Build()
+    {
+        var client = UseService<IClientProvider>();
+
+        var data = new[]
+        {
+            new { Name = "Ada Lovelace", Role = "Architect", Email = "ada@ivy.app", Team = "Compiler" },
+            new { Name = "Grace Hopper", Role = "Engineer", Email = "grace@ivy.app", Team = "Runtime" },
+            new { Name = "Barbara Liskov", Role = "Lead", Email = "barbara@ivy.app", Team = "Platform" },
+            new { Name = "Linus Torvalds", Role = "Maintainer", Email = "linus@ivy.app", Team = "Kernel" },
+        }.AsQueryable();
+
+        return Layout.Vertical()
+            | Text.P(
+                "Hover Name and Email cells to see the click indicator in the top-right corner. "
+                + "Those columns use OnCellAction handlers.")
+            | data.ToDataTable()
+                .Header(x => x.Name, "Name")
+                .Header(x => x.Role, "Role")
+                .Header(x => x.Email, "Email")
+                .Header(x => x.Team, "Team")
+                .Width(x => x.Name, Size.Px(180))
+                .Width(x => x.Role, Size.Px(140))
+                .Width(x => x.Email, Size.Px(220))
+                .Width(x => x.Team, Size.Px(160))
+                .OnCellAction(x => x.Name, (Func<object, ValueTask>)(e =>
+                {
+                    client.Toast($"Open profile: {e}");
+                    return ValueTask.CompletedTask;
+                }))
+                .OnCellAction(x => x.Email, (Func<object, ValueTask>)(e =>
+                {
+                    client.Toast($"Compose email: {e}");
+                    return ValueTask.CompletedTask;
+                }))
+                .Config(config =>
+                {
+                    config.AllowFiltering = true;
+                    config.AllowSorting = true;
+                    config.ShowSearch = true;
+                })
+                .Height(Size.Units(70));
     }
 }
 

--- a/src/Ivy.Samples.Shared/Apps/Widgets/DataTableApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/DataTableApp.cs
@@ -398,6 +398,7 @@ public class DataTableDensitySample : ViewBase
     public override object? Build()
     {
         var density = UseState(() => Density.Medium);
+        var client = UseService<IClientProvider>();
 
         var data = new[]
         {
@@ -418,6 +419,16 @@ public class DataTableDensitySample : ViewBase
             .Width(x => x.Category, Size.Px(100))
             .Width(x => x.Price, Size.Px(100))
             .AlignContent(x => x.Price, Align.Right)
+            .OnCellAction(x => x.Name, (Func<object, ValueTask>)(e =>
+            {
+                client.Toast($"Name clicked: {e}");
+                return ValueTask.CompletedTask;
+            }))
+            .OnCellAction(x => x.Price, (Func<object, ValueTask>)(e =>
+            {
+                client.Toast($"Price clicked: {e}");
+                return ValueTask.CompletedTask;
+            }))
             .Density(density.Value)
             .Height(Size.Units(60));
 

--- a/src/Ivy/Views/DataTables/DataTableBuilder.cs
+++ b/src/Ivy/Views/DataTables/DataTableBuilder.cs
@@ -459,7 +459,9 @@ public class DataTableBuilder<TModel>(
 
     public DataTableBuilder<TModel> OnCellAction(Expression<Func<TModel, object>> field, EventHandler<object> action)
     {
-        var columnName = TypeHelper.GetNameFromMemberExpression(field.Body);
+        var column = GetColumn(field);
+        var columnName = column.Column.Name;
+        column.Column.HasCellAction = true;
         _cellActions[columnName] = action;
         return this;
     }

--- a/src/Ivy/Widgets/DataTables/DataTableColumn.cs
+++ b/src/Ivy/Widgets/DataTables/DataTableColumn.cs
@@ -46,6 +46,12 @@ public class DataTableColumn
     /// Link type for LinkDisplayRenderer ("url", "email", "phone"). Sent to frontend for URL scheme handling.
     /// </summary>
     public string? LinkType { get; set; } = null;
+
+    /// <summary>
+    /// True when this column has a dedicated OnCellAction handler and should show
+    /// a visual affordance for clickability in the frontend.
+    /// </summary>
+    public bool HasCellAction { get; set; } = false;
 }
 
 public enum SortDirection

--- a/src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx
+++ b/src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx
@@ -34,6 +34,7 @@ import { DENSITY_CONFIG } from "./constants";
 import { useCellContent, useGridColumns, useHeaderMenu } from "./hooks";
 import { getOrderedVisibleDataColumns } from "../utils/columnHelpers";
 import type { SpriteMap } from "@glideapps/glide-data-grid";
+import { ExternalLink } from "lucide-react";
 
 interface TableEditorProps {
   widgetId: string;
@@ -166,15 +167,6 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
     visibleRows,
   });
 
-  // Compose onItemHovered: always call link hover, additionally call row hover when enabled
-  const handleItemHovered = useCallback(
-    (args: GridMouseEventArgs) => {
-      onLinkCellHovered(args);
-      onItemHovered(args);
-    },
-    [onLinkCellHovered, onItemHovered],
-  );
-
   // Table theme
   const { tableTheme, getRowThemeOverride, isDark } = useTableTheme({
     showVerticalBorders: showVerticalBorders ?? false,
@@ -245,6 +237,44 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
   const orderedDataColumns = useMemo(
     () => getOrderedVisibleDataColumns(columns, columnOrder),
     [columns, columnOrder],
+  );
+
+  const [cellActionIndicator, setCellActionIndicator] = React.useState<{
+    x: number;
+    y: number;
+    width: number;
+  } | null>(null);
+
+  // Compose onItemHovered: keep existing hover behavior and track actionable-cell affordance.
+  const handleItemHovered = useCallback(
+    (args: GridMouseEventArgs) => {
+      onLinkCellHovered(args);
+      onItemHovered(args);
+
+      if (args.kind !== "cell") {
+        setCellActionIndicator(null);
+        return;
+      }
+
+      const [col, row] = args.location;
+      if (row >= visibleRows) {
+        setCellActionIndicator(null);
+        return;
+      }
+
+      const hoveredColumn = orderedDataColumns[col];
+      if (!hoveredColumn?.hasCellAction) {
+        setCellActionIndicator(null);
+        return;
+      }
+
+      setCellActionIndicator({
+        x: args.bounds.x,
+        y: args.bounds.y,
+        width: args.bounds.width,
+      });
+    },
+    [onLinkCellHovered, onItemHovered, orderedDataColumns, visibleRows],
   );
 
   const wantAggregateFooter =
@@ -321,6 +351,22 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
     </TooltipProvider>
   );
 
+  const cellActionIndicatorNode = cellActionIndicator ? (
+    <div
+      style={{
+        position: "fixed",
+        left: cellActionIndicator.x + cellActionIndicator.width - 16,
+        top: cellActionIndicator.y + 2,
+        pointerEvents: "none",
+        zIndex: 20,
+        opacity: 0.7,
+      }}
+      aria-hidden
+    >
+      <ExternalLink size={12} />
+    </div>
+  ) : null;
+
   return (
     <>
       <GridContainer
@@ -375,6 +421,7 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
         hasEmptyRows={emptyRowsCount > 0}
       />
       {linkTooltipNode}
+      {cellActionIndicatorNode}
     </>
   );
 };

--- a/src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx
+++ b/src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx
@@ -77,6 +77,11 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
   } = useTable();
 
   const densityConfig = DENSITY_CONFIG[density];
+  const actionIndicatorStyle = useMemo(() => {
+    if (density === "Small") return { iconSize: 10, top: 1, right: 2 };
+    if (density === "Large") return { iconSize: 14, top: 3, right: 4 };
+    return { iconSize: 12, top: 2, right: 3 };
+  }, [density]);
 
   const hasWrappingColumns = columns.some((c) => c.wrapText && !c.hidden);
   const effectiveRowHeight = hasWrappingColumns
@@ -355,15 +360,19 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
     <div
       style={{
         position: "fixed",
-        left: cellActionIndicator.x + cellActionIndicator.width - 16,
-        top: cellActionIndicator.y + 2,
+        left:
+          cellActionIndicator.x +
+          cellActionIndicator.width -
+          actionIndicatorStyle.iconSize -
+          actionIndicatorStyle.right,
+        top: cellActionIndicator.y + actionIndicatorStyle.top,
         pointerEvents: "none",
         zIndex: 20,
         opacity: 0.7,
       }}
       aria-hidden
     >
-      <ExternalLink size={12} />
+      <ExternalLink size={actionIndicatorStyle.iconSize} />
     </div>
   ) : null;
 

--- a/src/frontend/src/widgets/dataTables/types/types.ts
+++ b/src/frontend/src/widgets/dataTables/types/types.ts
@@ -45,6 +45,7 @@ export interface DataColumn {
   badgeColorMapping?: Record<string, string> | null;
   linkType?: string | null; // Link type for LinkDisplayRenderer ("url", "email", "phone")
   wrapText?: boolean;
+  hasCellAction?: boolean;
 }
 
 export interface DataTableConnection {


### PR DESCRIPTION
Added icon onHover to datatable cell when it has cell events:

<img width="1988" height="419" alt="Screenshot 2026-04-29 at 14 11 44" src="https://github.com/user-attachments/assets/36aadefc-00cf-4690-84ae-24172a3c3293" />

How it looks when elements aligned to the right:

<img width="2001" height="339" alt="Screenshot 2026-04-29 at 14 11 20" src="https://github.com/user-attachments/assets/f82fdfab-7fd7-4514-99c1-f3a2712b4e66" />

<img width="716" height="210" alt="Screenshot 2026-04-29 at 14 11 27" src="https://github.com/user-attachments/assets/6d6adefc-020a-4e9e-991e-5e8ed20f7c01" />

Same "flowing" appearing approach as toolbar has:

https://github.com/user-attachments/assets/c78ba999-faf9-46db-9d3b-acdf605308e4

Respects different densities:

https://github.com/user-attachments/assets/36d50af6-a017-40f6-8c8b-e8b55cad572a



