### PR TITLE
(docker): switch to alpine node for frontend builds

### DIFF
--- a/.github/docker/Dockerfile.docs
+++ b/.github/docker/Dockerfile.docs
@@ -9,12 +9,9 @@ ENV DOTNET_TieredPGO=1
 ENV DOTNET_TC_QuickJitForLoops=1
 
 # Build frontend (Ivy embeds frontend/dist)
-FROM node:24-bookworm-slim AS frontend
+FROM node:24-alpine AS frontend
 WORKDIR /src
-RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,id=apt-docs-frontend,target=/var/cache/apt \
-    --mount=type=cache,id=apt-docs-frontend-lib,target=/var/lib/apt \
-    apt-get update && apt-get install -y curl bash
+RUN apk add --no-cache curl bash
 RUN curl -fsSL https://vite.plus | bash
 ENV PATH="/root/.vite-plus/bin:${PATH}"
 COPY ["src/frontend/package.json", "src/frontend/pnpm-lock.yaml", "src/frontend/"]

--- a/.github/docker/Dockerfile.samples
+++ b/.github/docker/Dockerfile.samples
@@ -9,12 +9,9 @@ ENV DOTNET_TieredPGO=1
 ENV DOTNET_TC_QuickJitForLoops=1
 
 # Build frontend (Ivy embeds frontend/dist)
-FROM node:24-bookworm-slim AS frontend
+FROM node:24-alpine AS frontend
 WORKDIR /src
-RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,id=apt-samples-frontend,target=/var/cache/apt \
-    --mount=type=cache,id=apt-samples-frontend-lib,target=/var/lib/apt \
-    apt-get update && apt-get install -y curl bash
+RUN apk add --no-cache curl bash
 RUN curl -fsSL https://vite.plus | bash
 ENV PATH="/root/.vite-plus/bin:${PATH}"
 COPY ["src/frontend/package.json", "src/frontend/pnpm-lock.yaml", "src/frontend/"]


### PR DESCRIPTION
**Note: this is more research PR. Please verify it first on your machine first if you want to merge it. I can't verify docker builds since I don't have access.**

<img width="947" height="197" alt="Screenshot 2026-04-29 at 22 59 45" src="https://github.com/user-attachments/assets/d16ab4ad-1d28-477b-a164-65810a82938c" />

This image contains 1 high vulnerability.

<img width="900" height="212" alt="Screenshot 2026-04-29 at 23 00 09" src="https://github.com/user-attachments/assets/66357a41-264b-45df-866f-6d4cff505342" />

- Build the images end-to-end:
docker build -f .github/docker/Dockerfile.samples -t ivy-samples:test .
docker build -f .github/docker/Dockerfile.docs -t ivy-docs:test .
- Smoke-run containers:
docker run --rm -p 5010:5010 ivy-samples:test
docker run --rm -p 5011:5010 ivy-docs:test

- Confirm frontend build actually worked inside image:
In build logs, ensure vp install and vp build succeed (no musl/module-not-found errors).

On my machine running these commands continues for infinity
docker build -f .github/docker/Dockerfile.samples -t ivy-samples:test .
<img width="620" height="317" alt="Screenshot 2026-04-29 at 23 06 05" src="https://github.com/user-attachments/assets/0601dff1-51ab-48b4-a1a1-fc407faef0f0" />
Same for other command, docker build -f .github/docker/Dockerfile.docs -t ivy-docs:test .

