### PR TITLE
[00015] Combine failed plugins and unloaded plugins

### DIFF
--- a/src/Ivy.Plugin.Abstractions/IPluginManager.cs
+++ b/src/Ivy.Plugin.Abstractions/IPluginManager.cs
@@ -1,13 +1,15 @@
 namespace Ivy.Plugins;
 
-public record PluginCandidate(string Id, string Directory);
-public record FailedPlugin(string Directory, string Reason, DateTime FailedAt);
+public record PluginCandidate(
+    string Id,
+    string Directory,
+    string? FailureReason = null,
+    DateTime? FailedAt = null);
 
 public interface IPluginManager
 {
     IReadOnlyList<string> GetLoadedPluginIds();
     IReadOnlyList<PluginCandidate> GetUnloadedPlugins();
-    IReadOnlyList<FailedPlugin> GetFailedPlugins();
     bool UnloadPlugin(string pluginId);
     bool LoadPlugin(string pluginPath);
     bool ReloadPlugin(string pluginId);

--- a/src/Ivy.Test/PluginLoaderTests.cs
+++ b/src/Ivy.Test/PluginLoaderTests.cs
@@ -277,7 +277,7 @@ public class PluginLoaderTests
     }
 
     [Fact]
-    public void FailedPluginDirectoriesAreTracked()
+    public void FailedPluginsAppearInUnloadedList()
     {
         using var loggerFactory = LoggerFactory.Create(b => b.AddConsole());
         var logger = loggerFactory.CreateLogger<PluginLoader>();
@@ -297,14 +297,13 @@ public class PluginLoaderTests
             // Should have no loaded plugins
             Assert.Empty(loader.GetLoadedPluginIds());
 
-            // Should have one failed plugin
-            var failedPlugins = loader.GetFailedPlugins();
-            Assert.Single(failedPlugins);
-
-            var failed = failedPlugins[0];
-            Assert.Equal(emptyPluginDir, failed.Directory);
-            Assert.Contains("No valid plugin found", failed.Reason);
-            Assert.True((DateTime.UtcNow - failed.FailedAt).TotalSeconds < 5);
+            // Should have one unloaded plugin with failure info
+            var unloadedPlugins = loader.GetUnloadedPlugins();
+            var failedPlugin = unloadedPlugins.FirstOrDefault(p => p.FailureReason is not null);
+            Assert.NotNull(failedPlugin);
+            Assert.Equal(emptyPluginDir, failedPlugin.Directory);
+            Assert.Contains("No valid plugin found", failedPlugin.FailureReason);
+            Assert.True((DateTime.UtcNow - failedPlugin.FailedAt!.Value).TotalSeconds < 5);
         }
         finally
         {
@@ -313,7 +312,7 @@ public class PluginLoaderTests
     }
 
     [Fact]
-    public void MultipleFailureReasonsAreTracked()
+    public void MultipleFailedPluginsAppearInUnloadedList()
     {
         using var loggerFactory = LoggerFactory.Create(b => b.AddConsole());
         var logger = loggerFactory.CreateLogger<PluginLoader>();
@@ -335,12 +334,13 @@ public class PluginLoaderTests
             using var sp = new ServiceCollection().BuildServiceProvider();
             loader.DiscoverAndLoad(new Version(1, 0), sp);
 
-            // Should have two failed plugins
-            var failedPlugins = loader.GetFailedPlugins();
+            // Should have two unloaded plugins with failure info
+            var unloadedPlugins = loader.GetUnloadedPlugins();
+            var failedPlugins = unloadedPlugins.Where(p => p.FailureReason is not null).ToList();
             Assert.Equal(2, failedPlugins.Count);
 
             // Both should have the generic failure reason since they both return null from LoadPluginFromDirectory
-            Assert.All(failedPlugins, f => Assert.Contains("No valid plugin found", f.Reason));
+            Assert.All(failedPlugins, f => Assert.Contains("No valid plugin found", f.FailureReason));
         }
         finally
         {
@@ -349,7 +349,7 @@ public class PluginLoaderTests
     }
 
     [Fact]
-    public void SuccessfulLoadRemovesFromFailedList()
+    public void SuccessfulLoadRemovesFailureInformation()
     {
         using var loggerFactory = LoggerFactory.Create(b => b.AddConsole());
         var logger = loggerFactory.CreateLogger<PluginLoader>();
@@ -367,16 +367,18 @@ public class PluginLoaderTests
 
             // First discovery should fail (no DLLs)
             loader.DiscoverAndLoad(new Version(1, 0), sp);
-            Assert.Single(loader.GetFailedPlugins());
-            Assert.Equal(pluginDir, loader.GetFailedPlugins()[0].Directory);
+            var unloadedPlugins = loader.GetUnloadedPlugins();
+            var failedPlugin = unloadedPlugins.FirstOrDefault(p => p.FailureReason is not null);
+            Assert.NotNull(failedPlugin);
+            Assert.Equal(pluginDir, failedPlugin.Directory);
 
             // Now we can't easily simulate a successful LoadPlugin without a real plugin DLL,
             // but we can test that the remove mechanism exists in the code.
             // The implementation removes from _failedPlugins on successful load,
             // which we've verified by code inspection.
 
-            // For this test, we verify the failed list is populated correctly
-            Assert.Contains(loader.GetFailedPlugins(), f => f.Directory == pluginDir);
+            // For this test, we verify the failed plugin appears in unloaded list with failure info
+            Assert.Contains(unloadedPlugins, p => p.Directory == pluginDir && p.FailureReason is not null);
         }
         finally
         {

--- a/src/Ivy/Core/Plugins/PluginLoader.cs
+++ b/src/Ivy/Core/Plugins/PluginLoader.cs
@@ -31,7 +31,7 @@ public class PluginLoader : IPluginManager
     private readonly IReadOnlySet<string> _sharedAssemblyNames;
     private readonly List<LoadedPlugin> _plugins = [];
     private readonly Dictionary<string, string> _knownPlugins = new(); // id -> directory
-    private readonly Dictionary<string, FailedPlugin> _failedPlugins = new(); // directory -> failure info
+    private readonly Dictionary<string, (string Reason, DateTime FailedAt)> _failedPlugins = new(); // directory -> failure info
     private readonly ReaderWriterLockSlim _lock = new();
     private PluginContextBase? _pluginContext;
     private IConfiguration? _configuration;
@@ -81,8 +81,7 @@ public class PluginLoader : IPluginManager
                     _lock.EnterWriteLock();
                     try
                     {
-                        _failedPlugins[directory] = new FailedPlugin(
-                            directory,
+                        _failedPlugins[directory] = (
                             "No valid plugin found (no DLLs, no [IvyPlugin] attribute, or multiple attributes)",
                             DateTime.UtcNow);
                     }
@@ -113,8 +112,7 @@ public class PluginLoader : IPluginManager
                 _lock.EnterWriteLock();
                 try
                 {
-                    _failedPlugins[directory] = new FailedPlugin(
-                        directory,
+                    _failedPlugins[directory] = (
                         $"Exception during load: {ex.Message}",
                         DateTime.UtcNow);
                 }
@@ -334,8 +332,7 @@ public class PluginLoader : IPluginManager
                 foreach (var plugin in invalidPlugins)
                 {
                     _plugins.Remove(plugin);
-                    _failedPlugins[plugin.Directory] = new FailedPlugin(
-                        plugin.Directory,
+                    _failedPlugins[plugin.Directory] = (
                         $"Configuration invalid for '{plugin.Instance.Manifest.Id}'",
                         DateTime.UtcNow);
                 }
@@ -544,24 +541,26 @@ public class PluginLoader : IPluginManager
         try
         {
             var loadedIds = _plugins.Select(p => p.Instance.Manifest.Id).ToHashSet();
-            var failedDirs = _failedPlugins.Keys.ToHashSet();
-            return _knownPlugins
-                .Where(kv => !loadedIds.Contains(kv.Key) && !failedDirs.Contains(kv.Value))
-                .Select(kv => new PluginCandidate(kv.Key, kv.Value))
-                .ToList();
-        }
-        finally
-        {
-            _lock.ExitReadLock();
-        }
-    }
+            var result = new List<PluginCandidate>();
 
-    public IReadOnlyList<FailedPlugin> GetFailedPlugins()
-    {
-        _lock.EnterReadLock();
-        try
-        {
-            return _failedPlugins.Values.ToList();
+            // Add known plugins that aren't loaded
+            foreach (var (id, directory) in _knownPlugins)
+            {
+                if (!loadedIds.Contains(id))
+                {
+                    result.Add(new PluginCandidate(id, directory));
+                }
+            }
+
+            // Add failed plugins
+            foreach (var (directory, (reason, failedAt)) in _failedPlugins)
+            {
+                // Extract ID from directory name or use directory name as fallback
+                var id = Path.GetFileName(directory);
+                result.Add(new PluginCandidate(id, directory, reason, failedAt));
+            }
+
+            return result;
         }
         finally
         {

--- a/src/plugins/hosts/HelloWorldHost/HelloWorldApp.cs
+++ b/src/plugins/hosts/HelloWorldHost/HelloWorldApp.cs
@@ -16,7 +16,6 @@ public class HelloWorldApp : ViewBase
         var greeters = plugins.GetServices<IGreeter>().ToList();
         var loadedPlugins = pluginManager.GetLoadedPluginIds();
         var unloadedPlugins = pluginManager.GetUnloadedPlugins();
-        var failedPlugins = pluginManager.GetFailedPlugins();
         var nameState = UseState("World");
         var pluginStatus = UseState("");
         var refreshToken = UseRefreshToken();
@@ -53,28 +52,16 @@ public class HelloWorldApp : ViewBase
                 }, variant: ButtonVariant.Outline, icon: Icons.Power)
             )).ToArray()
             | unloadedPlugins.Select(p => (object)(Horizontal().Gap(4)
-                | new Badge(p.Id, BadgeVariant.Outline)
-                | Muted("unloaded")
-                | new Button("Load", onClick: _ =>
+                | new Badge(p.Id, p.FailureReason is not null ? BadgeVariant.Destructive : BadgeVariant.Outline)
+                | (p.FailureReason is not null ? Muted(p.FailureReason) : Muted("unloaded"))
+                | new Button(p.FailureReason is not null ? "Retry" : "Load", onClick: _ =>
                 {
                     pluginStatus.Set(pluginManager.LoadPlugin(p.Directory)
                         ? $"Loaded '{p.Id}'"
                         : $"Failed to load '{p.Id}'");
                     refreshToken.Refresh();
                     return ValueTask.CompletedTask;
-                }, variant: ButtonVariant.Outline, icon: Icons.Plus)
-            )).ToArray()
-            | failedPlugins.Select(f => (object)(Horizontal().Gap(4)
-                | new Badge(Path.GetFileName(f.Directory), BadgeVariant.Destructive)
-                | Muted(f.Reason)
-                | new Button("Retry", onClick: _ =>
-                {
-                    pluginStatus.Set(pluginManager.LoadPlugin(f.Directory)
-                        ? $"Loaded from '{Path.GetFileName(f.Directory)}'"
-                        : $"Failed to load '{Path.GetFileName(f.Directory)}'");
-                    refreshToken.Refresh();
-                    return ValueTask.CompletedTask;
-                }, variant: ButtonVariant.Outline, icon: Icons.RefreshCw)
+                }, variant: ButtonVariant.Outline, icon: p.FailureReason is not null ? Icons.RefreshCw : Icons.Plus)
             )).ToArray()
             | (string.IsNullOrEmpty(pluginStatus.Value) ? null
                 : pluginStatus.Value.StartsWith("Failed")

--- a/src/plugins/hosts/MessagingHost/MessagingTestApp.cs
+++ b/src/plugins/hosts/MessagingHost/MessagingTestApp.cs
@@ -30,6 +30,9 @@ public class MessagingTestApp : ViewBase
         var pluginStatus = UseState("");
         var refreshToken = UseRefreshToken();
 
+        if (channels.Count > 0 && !channels.Any(c => c.Platform == selectedPlatform.Value))
+            selectedPlatform.Set(channels.First().Platform);
+
         var activeChannel = channels.FirstOrDefault(c => c.Platform == selectedPlatform.Value);
 
         var uploadContext = this.UseUpload(async (file, stream, ct) =>

--- a/src/plugins/hosts/MessagingHost/MessagingTestApp.cs
+++ b/src/plugins/hosts/MessagingHost/MessagingTestApp.cs
@@ -18,7 +18,6 @@ public class MessagingTestApp : ViewBase
         var channels = plugins.GetServices<IMessagingChannel>().ToList();
         var loadedPlugins = pluginManager.GetLoadedPluginIds();
         var unloadedPlugins = pluginManager.GetUnloadedPlugins();
-        var failedPlugins = pluginManager.GetFailedPlugins();
 
         var selectedPlatform = UseState(channels.FirstOrDefault()?.Platform ?? "");
         var channelName = UseState(channels.FirstOrDefault()?.DefaultChannel ?? "#ivy-plugin-test");
@@ -150,28 +149,16 @@ public class MessagingTestApp : ViewBase
                 }, variant: ButtonVariant.Outline, icon: Icons.Power)
             )).ToArray()
             | unloadedPlugins.Select(p => (object)(Horizontal().Gap(4)
-                | new Badge(p.Id, BadgeVariant.Outline)
-                | Muted("unloaded")
-                | new Button("Load", onClick: _ =>
+                | new Badge(p.Id, p.FailureReason is not null ? BadgeVariant.Destructive : BadgeVariant.Outline)
+                | (p.FailureReason is not null ? Muted(p.FailureReason) : Muted("unloaded"))
+                | new Button(p.FailureReason is not null ? "Retry" : "Load", onClick: _ =>
                 {
                     pluginStatus.Set(pluginManager.LoadPlugin(p.Directory)
                         ? $"Loaded '{p.Id}'"
                         : $"Failed to load '{p.Id}'");
                     refreshToken.Refresh();
                     return ValueTask.CompletedTask;
-                }, variant: ButtonVariant.Outline, icon: Icons.Plus)
-            )).ToArray()
-            | failedPlugins.Select(f => (object)(Horizontal().Gap(4)
-                | new Badge(Path.GetFileName(f.Directory), BadgeVariant.Destructive)
-                | Muted(f.Reason)
-                | new Button("Retry", onClick: _ =>
-                {
-                    pluginStatus.Set(pluginManager.LoadPlugin(f.Directory)
-                        ? $"Loaded from '{Path.GetFileName(f.Directory)}'"
-                        : $"Failed to load '{Path.GetFileName(f.Directory)}'");
-                    refreshToken.Refresh();
-                    return ValueTask.CompletedTask;
-                }, variant: ButtonVariant.Outline, icon: Icons.RefreshCw)
+                }, variant: ButtonVariant.Outline, icon: p.FailureReason is not null ? Icons.RefreshCw : Icons.Plus)
             )).ToArray()
             | (string.IsNullOrEmpty(pluginStatus.Value) ? null : StatusBadge(pluginStatus.Value));
     }


### PR DESCRIPTION
# Summary

## Changes

Consolidated the plugin system's two separate concepts for unloaded plugins (`PluginCandidate`) and failed plugins (`FailedPlugin`) into a single `PluginCandidate` record with optional failure information. This simplifies the API and eliminates duplication across the codebase.

## API Changes

- **Modified**: `PluginCandidate` record now includes optional `FailureReason` and `FailedAt` parameters
- **Removed**: `FailedPlugin` record
- **Removed**: `IPluginManager.GetFailedPlugins()` method
- **Modified**: `IPluginManager.GetUnloadedPlugins()` now returns all unloaded plugins (including those with failure information)

## Files Modified

**Core abstractions:**
- `src/Ivy.Plugin.Abstractions/IPluginManager.cs` - Updated interface and records

**Implementation:**
- `src/Ivy/Core/Plugins/PluginLoader.cs` - Changed internal tracking and combined GetUnloadedPlugins logic

**UI apps:**
- `src/plugins/hosts/MessagingHost/MessagingTestApp.cs` - Unified plugin display with conditional styling
- `src/plugins/hosts/HelloWorldHost/HelloWorldApp.cs` - Unified plugin display with conditional styling

**Tests:**
- `src/Ivy.Test/PluginLoaderTests.cs` - Updated three tests to check unloaded list instead of failed list

## Commits

- [00015] Fix messaging buttons not enabling after plugin retry (5d24a00ce)
- [00015] Combine failed plugins and unloaded plugins (ad411e2e4)