### PR TITLE
[00124] Add colored border to tooltip

### DIFF
--- a/src/frontend/src/components/ui/tooltip.tsx
+++ b/src/frontend/src/components/ui/tooltip.tsx
@@ -80,7 +80,7 @@ const TooltipContent = React.forwardRef<
         ref={ref}
         sideOffset={sideOffset}
         className={cn(
-          "z-50 overflow-hidden rounded-selector bg-popover px-3 py-1.5 text-xs text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 max-w-sm",
+          "z-50 overflow-hidden rounded-selector border border-border bg-popover px-3 py-1.5 text-xs text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 max-w-sm",
           className,
         )}
         {...props}


### PR DESCRIPTION
# Summary

Added `border border-border` Tailwind classes to the `TooltipContent` component in `tooltip.tsx`. This gives all tooltips a subtle themed border that adapts to light/dark mode via the `--border` CSS variable.

## API Changes

None.

## Files Modified

- **src/frontend/src/components/ui/tooltip.tsx** — Added border classes to TooltipContent className

## Commits

- 340dcbd03 — [00124] Add border border-border to TooltipContent for visible edge distinction

---
Source: https://github.com/Ivy-Interactive/Ivy-Tendril/issues/413