### PR TITLE
[00125] Add ScrollTarget prop to StackLayout widget

### DIFF
--- a/src/Ivy/Views/LayoutView.cs
+++ b/src/Ivy/Views/LayoutView.cs
@@ -33,6 +33,7 @@ public class LayoutView : ViewBase, IStateless
     private Ivy.BorderStyle _borderStyle = Ivy.BorderStyle.None;
     private Thickness _borderThickness = new(0);
     private string? _testId = null;
+    private string? _scrollTarget = null;
     private GridView? _activeGrid = null;
 
     public LayoutView Gap(bool gap)
@@ -440,6 +441,12 @@ public class LayoutView : ViewBase, IStateless
         return this;
     }
 
+    public LayoutView ScrollTarget(string? target)
+    {
+        _scrollTarget = target;
+        return this;
+    }
+
     public override object? Build()
     {
         var layout = new StackLayout(_elements.Select(e => e.Content).ToArray(), _orientation, _rowGap, _padding, _margin, _background,
@@ -456,6 +463,7 @@ public class LayoutView : ViewBase, IStateless
         };
 
         if (_testId != null) layout.TestId = _testId;
+        if (_scrollTarget != null) layout.ScrollTarget = _scrollTarget;
 
         return layout;
     }

--- a/src/Ivy/Widgets/Layouts/StackLayout.cs
+++ b/src/Ivy/Widgets/Layouts/StackLayout.cs
@@ -46,6 +46,8 @@ internal record StackLayout : WidgetBase<StackLayout>
 
     [Prop] public Scroll Scroll { get; set; } = Scroll.None;
 
+    [Prop] public string? ScrollTarget { get; set; }
+
     [Prop(attached: nameof(StackLayoutExtensions.AlignSelf))] public Align?[] ChildAlignSelf { get; set; } = null!;
 }
 

--- a/src/frontend/src/widgets/layouts/StackLayoutWidget.tsx
+++ b/src/frontend/src/widgets/layouts/StackLayoutWidget.tsx
@@ -50,6 +50,7 @@ interface StackLayoutWidgetProps {
   responsiveRowGap?: Responsive<number>;
   responsiveColumnGap?: Responsive<number>;
   responsivePadding?: Responsive<string>;
+  scrollTarget?: string | null;
 }
 
 export const StackLayoutWidget: React.FC<StackLayoutWidgetProps> = ({
@@ -77,8 +78,20 @@ export const StackLayoutWidget: React.FC<StackLayoutWidgetProps> = ({
   responsiveRowGap,
   responsiveColumnGap,
   responsivePadding,
+  scrollTarget,
 }) => {
   const bp = useCurrentBreakpoint();
+
+  React.useEffect(() => {
+    if (!scrollTarget) return;
+    const timer = setTimeout(() => {
+      const el = document.querySelector(`[data-testid="${CSS.escape(scrollTarget)}"]`);
+      if (el) {
+        el.scrollIntoView({ behavior: "smooth", block: "start" });
+      }
+    }, 50);
+    return () => clearTimeout(timer);
+  }, [scrollTarget]);
 
   // Resolve layout-specific responsive values with mobile-first cascading
   const resolvedOrientation = responsiveOrientation


### PR DESCRIPTION
## Summary

Added a `ScrollTarget` prop to the Ivy Framework's `StackLayout` widget that triggers a smooth scroll to a child element matching a `data-testid` value. Used this new prop in Tendril's `ChangesTabView` so that clicking a file in the diff tree sidebar scrolls the main content area to that file's diff section.

## API Changes

- `StackLayout` (record): Added `[Prop] public string? ScrollTarget { get; set; }`
- `LayoutView` (builder): Added `LayoutView ScrollTarget(string? target)` method
- `StackLayoutWidget` (React): Added `scrollTarget?: string | null` prop with `useEffect` scroll behavior

## Files Modified

**Ivy-Framework:**
- `src/Ivy/Widgets/Layouts/StackLayout.cs` — New `ScrollTarget` prop
- `src/Ivy/Views/LayoutView.cs` — Builder field, method, and Build() wiring
- `src/frontend/src/widgets/layouts/StackLayoutWidget.tsx` — Frontend prop and scrollIntoView effect

## Commits

- `b567819` [00125] Add ScrollTarget prop to StackLayout widget