### PR TITLE
[00125] Fix StackLayout ScrollTarget to use prod-safe data-anchor (not data-testid)

### DIFF
--- a/src/Ivy/Widgets/Primitives/TextBlock.cs
+++ b/src/Ivy/Widgets/Primitives/TextBlock.cs
@@ -78,6 +78,4 @@ public record TextBlock : WidgetBase<TextBlock>
 
     [Prop] public TextAlignment? TextAlignment { get; set; }
 
-    [Prop] public string? Anchor { get; set; }
-
 }

--- a/src/Ivy/Widgets/WidgetBase.cs
+++ b/src/Ivy/Widgets/WidgetBase.cs
@@ -21,6 +21,8 @@ public abstract record WidgetBase : AbstractWidget
 
     [Prop, ScaffoldColumn(false)] public string? TestId { get; set; }
 
+    [Prop, ScaffoldColumn(false)] public string? Anchor { get; set; }
+
     [Prop] public Responsive<bool?>? ResponsiveVisible { get; set; }
 }
 
@@ -61,6 +63,8 @@ public static class WidgetBaseExtensions
     public static T Large<T>(this T widget) where T : WidgetBase => widget.Density(Ivy.Density.Large);
 
     public static T TestId<T>(this T widget, string testId) where T : WidgetBase => widget with { TestId = testId };
+
+    public static T Anchor<T>(this T widget, string anchor) where T : WidgetBase => widget with { Anchor = anchor };
 
     public static T HideOn<T>(this T widget, params Breakpoint[] breakpoints) where T : WidgetBase
     {

--- a/src/frontend/src/widgets/layouts/StackLayoutWidget.tsx
+++ b/src/frontend/src/widgets/layouts/StackLayoutWidget.tsx
@@ -85,7 +85,7 @@ export const StackLayoutWidget: React.FC<StackLayoutWidgetProps> = ({
   React.useEffect(() => {
     if (!scrollTarget) return;
     const timer = setTimeout(() => {
-      const el = document.querySelector(`[data-testid="${CSS.escape(scrollTarget)}"]`);
+      const el = document.querySelector(`[data-anchor="${CSS.escape(scrollTarget)}"]`);
       if (el) {
         el.scrollIntoView({ behavior: "smooth", block: "start" });
       }

--- a/src/frontend/src/widgets/widgetRenderer.tsx
+++ b/src/frontend/src/widgets/widgetRenderer.tsx
@@ -121,8 +121,10 @@ export const MemoizedWidget = React.memo(
       ? (node.props.content as string) || (node.props.text as string) || ""
       : undefined;
 
+    const anchor = props.anchor as string | undefined;
+
     const content = (
-      <ivy-widget id={node.id} type={node.type} data-content={rawContent}>
+      <ivy-widget id={node.id} type={node.type} data-content={rawContent} data-anchor={anchor}>
         <Component {...props} slots={slots}>
           {slots.default}
         </Component>
@@ -227,8 +229,10 @@ const renderExternalWidget = (node: WidgetNode, inheritedScale?: Densities): Rea
 
   registerCallSite(node);
 
+  const anchor = props.anchor as string | undefined;
+
   const content = (
-    <ivy-widget key={node.id} id={node.id} type={node.type}>
+    <ivy-widget key={node.id} id={node.id} type={node.type} data-anchor={anchor}>
       <ExternalWidgetWrapper Component={Component} props={props}>
         {slots.default}
       </ExternalWidgetWrapper>


### PR DESCRIPTION
## Summary

Fixes the `ScrollTarget` feature added in #4348. The original implementation used `data-testid` as the scroll-target selector, but `data-testid` is stripped from production bundles, so `ScrollTarget` resolved to nothing in deployed environments.

## Approach

Reuse the existing `Anchor` concept (originally added to `TextBlock` for URL-fragment navigation in docs) and lift it to `WidgetBase` so any widget can declare a stable, prod-safe anchor name.

- `WidgetBase` gains an `Anchor` prop + `.Anchor(name)` extension (parallel to `TestId`).
- `TextBlock`'s duplicate `Anchor` prop is removed (now inherited from base; `TextBuilder.Anchor()` keeps working unchanged — it sets the inherited property).
- `widgetRenderer.tsx` emits `data-anchor` on the `<ivy-widget>` wrapper for all widgets, on both the memoized and external render paths. `TextBlockWidget` still consumes the `anchor` prop directly so `id={anchor}` on headings (used by article URL-fragment scrolling, #3817) is preserved.
- `StackLayoutWidget` queries `[data-anchor="..."]` instead of `[data-testid="..."]`.

## API

- `widget.Anchor("name")` on any `WidgetBase`-derived widget marks it as a scroll target.
- `Layout.Vertical().ScrollTarget("name")` (existing API from #4348) finds and scrolls to the matching anchor.

## Files Modified

- `src/Ivy/Widgets/WidgetBase.cs` — `Anchor` prop + extension
- `src/Ivy/Widgets/Primitives/TextBlock.cs` — remove duplicate `Anchor` declaration
- `src/frontend/src/widgets/widgetRenderer.tsx` — emit `data-anchor` on wrapper
- `src/frontend/src/widgets/layouts/StackLayoutWidget.tsx` — query `[data-anchor=...]`

## Companion PR

Ivy-Tendril must swap `.TestId(...)` for `.Anchor(...)` on file diff sections in `ChangesTabView` (used by both PlansApp and ReviewApp). PR: Ivy-Interactive/Ivy-Tendril#TBD — depends on this change shipping in a new Ivy NuGet release.

## Test plan

- [x] `dotnet build src/Ivy/Ivy.csproj -c Release` succeeds
- [x] `dotnet test src/Ivy.Test/Ivy.Test.csproj -c Release` — 1303 / 1303 passing
- [x] `tsc -b` clean
- [ ] Manual: open Tendril ChangesTab in production-built Tendril, click a file in the diff tree, verify content area scrolls to the right diff section
- [ ] Manual: confirm `Text.H1("Hello").Anchor("hello")` still produces `<h1 id="hello">` so `?#hello` URL fragment scrolling still works in articles

🤖 Generated with [Claude Code](https://claude.com/claude-code)