### PR TITLE
[DataTableBuilder]: Add Responsive<Density?> support for per-breakpoint density control

### DIFF
--- a/src/Ivy.Test/Views/DataTables/DataTableScaffoldTests.cs
+++ b/src/Ivy.Test/Views/DataTables/DataTableScaffoldTests.cs
@@ -101,7 +101,8 @@ public class DataTableScaffoldTests
     {
         var flags = System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance;
         var field = builder.GetType().GetField("_density", flags)!;
-        return (Density)field.GetValue(builder)!;
+        var responsive = (Responsive<Density?>)field.GetValue(builder)!;
+        return responsive.Default ?? Density.Medium;
     }
 
     [Fact]

--- a/src/Ivy/Views/DataTables/DataTableBuilder.cs
+++ b/src/Ivy/Views/DataTables/DataTableBuilder.cs
@@ -28,7 +28,7 @@ public class DataTableBuilder<TModel>(
     private FuncViewBuilder? _headerLeftFactory;
     private FuncViewBuilder? _headerRightFactory;
     private Dictionary<string, object>? _footerValuesByColumn;
-    private Density _density = Ivy.Density.Medium;
+    private Responsive<Density?> _density = (Responsive<Density?>)(Density?)Ivy.Density.Medium;
     private IWriteStream<DataTableCellUpdate>? _updateStream;
 
     private readonly string? _idColumnName =
@@ -496,27 +496,33 @@ public class DataTableBuilder<TModel>(
         return this;
     }
 
-    public DataTableBuilder<TModel> Density(Ivy.Density density)
+    public DataTableBuilder<TModel> Density(Responsive<Density?> density)
     {
         _density = density;
         return this;
     }
 
+    public DataTableBuilder<TModel> Density(Ivy.Density density)
+    {
+        _density = (Responsive<Density?>)(Density?)density;
+        return this;
+    }
+
     public DataTableBuilder<TModel> Small()
     {
-        _density = Ivy.Density.Small;
+        _density = (Responsive<Density?>)(Density?)Ivy.Density.Small;
         return this;
     }
 
     public DataTableBuilder<TModel> Medium()
     {
-        _density = Ivy.Density.Medium;
+        _density = (Responsive<Density?>)(Density?)Ivy.Density.Medium;
         return this;
     }
 
     public DataTableBuilder<TModel> Large()
     {
-        _density = Ivy.Density.Large;
+        _density = (Responsive<Density?>)(Density?)Ivy.Density.Large;
         return this;
     }
 

--- a/src/Ivy/Views/DataTables/DataTableView.cs
+++ b/src/Ivy/Views/DataTables/DataTableView.cs
@@ -9,7 +9,7 @@ public class DataTableView(
     Size? height,
     DataTableColumn[] columns,
     DataTableConfig config,
-    Density density = Density.Medium,
+    Responsive<Density?>? density = null,
     Func<Event<DataTable, CellClickEventArgs>, ValueTask>? onCellClick = null,
     Func<Event<DataTable, CellClickEventArgs>, ValueTask>? onCellActivated = null,
     MenuItem[]? rowActions = null,
@@ -61,6 +61,6 @@ public class DataTableView(
         // Memoize based on queryable and configuration
         // Don't include the queryable itself as it might change reference
         // Only memoize if all inputs are stable
-        return [(object?)width!, (object?)height!, columns, config, refreshToken?.Token!, density];
+        return [(object?)width!, (object?)height!, columns, config, refreshToken?.Token!, (object?)density!];
     }
 }


### PR DESCRIPTION
# Add Responsive Density Support to DataTableBuilder

## Related

- **Issue:** https://github.com/Ivy-Interactive/Ivy-Tendril/issues/256

## Problem

The `DataTableBuilder` only accepted a plain `Density` enum value, making it impossible to set different density levels per breakpoint. This meant you couldn't have `Large` density on mobile/tablet (for better touch usability) while keeping `Medium` on desktop.

The underlying `WidgetBase` already supports `Responsive<Density?>`, so the framework's frontend already handles responsive density — but the `DataTableBuilder` and `DataTableView` intermediaries were bottlenecking the type to a plain `Density`.

## Solution

Updated `DataTableBuilder` and `DataTableView` to pass `Responsive<Density?>` instead of plain `Density`:

### `DataTableBuilder.cs`
- Changed the `_density` field type from `Density` to `Responsive<Density?>`
- Added a new `Density(Responsive<Density?>)` overload for responsive density
- Kept the existing `Density(Density)` overload for backwards compatibility
- Updated `Small()`, `Medium()`, `Large()` convenience methods to use the new type

### `DataTableView.cs`
- Changed the `density` constructor parameter from `Density` to `Responsive<Density?>?`
- Fixed nullable reference in `GetMemoValues()`

## Usage

```csharp
// Responsive — Large on tablet and below, Medium on desktop and above
.Density(Density.Large.At(Breakpoint.Tablet).And(Breakpoint.Desktop, Density.Medium))

// Plain density still works (backwards compatible)
.Small()
.Medium()
.Large()
.Density(Density.Small)
```

## Breaking Changes

None. All existing code using `.Small()`, `.Medium()`, `.Large()`, or `.Density(Density.X)` continues to work without modification.

https://github.com/user-attachments/assets/2f28f453-6a01-4296-90fd-336b039b2e7a

