### PR TITLE
[00036] Sheet title overlaps with X close button for long names

### DIFF
--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -91,6 +91,7 @@
     "react-icons": "5.5.0",
     "react-markdown": "10.1.0",
     "react-resizable-panels": "3.0.6",
+    "react-responsive-carousel": "^3.2.23",
     "react-syntax-highlighter": "16.1.0",
     "rehype-katex": "7.0.1",
     "rehype-raw": "7.0.0",

--- a/src/frontend/src/widgets/sheet/SheetWidget.tsx
+++ b/src/frontend/src/widgets/sheet/SheetWidget.tsx
@@ -273,7 +273,7 @@ export const SheetWidget: React.FC<SheetWidgetProps> = ({
           />
         )}
         <SheetHeader className={cn("p-4 pb-0", !title && !description && "sr-only")}>
-          <SheetTitle className={cn(!title && "sr-only")}>{title || "Sheet"}</SheetTitle>
+          <SheetTitle className={cn("pr-10", !title && "sr-only")}>{title || "Sheet"}</SheetTitle>
           <SheetDescription className={cn(!description && "sr-only")}>
             {description || "Sheet content"}
           </SheetDescription>


### PR DESCRIPTION
# Summary

## Changes

Added right padding (`pr-10` class) to SheetTitle component to prevent text overlap with the close button when sheet titles are long.

## API Changes

None.

## Files Modified

- **src/frontend/src/widgets/sheet/SheetWidget.tsx** — Added `pr-10` class to SheetTitle className to create ~40px right padding
- **src/frontend/package.json** — Added missing `react-responsive-carousel` dependency (discovered during build verification)

## Commits

- 2638570ae [00036] Add right padding to SheetTitle to prevent overlap with close button
- eacd8e452 [00036] Add missing react-responsive-carousel dependency