### PR TITLE
[00035] Remove drag-to-change value feature from number input

### DIFF
--- a/src/frontend/src/components/NumberInput.tsx
+++ b/src/frontend/src/components/NumberInput.tsx
@@ -8,7 +8,6 @@ import React, {
   ChangeEvent,
   FocusEvent,
   WheelEvent,
-  MouseEvent as ReactMouseEvent,
 } from "react";
 import { formatBytes } from "@/lib/formatters";
 
@@ -29,13 +28,6 @@ interface NumberInputProps {
   className?: string;
   density?: Densities;
   "data-testid"?: string;
-}
-
-interface DragState {
-  isDragging: boolean;
-  startX: number;
-  startValue: number;
-  lastValue: number;
 }
 
 const NumberInput = React.forwardRef<HTMLInputElement, NumberInputProps>(
@@ -69,7 +61,6 @@ const NumberInput = React.forwardRef<HTMLInputElement, NumberInputProps>(
     const [displayValue, setDisplayValue] = useState<string>("");
     const [isFocused, setIsFocused] = useState(false);
     const [isValid, setIsValid] = useState(true);
-    const [dragState, setDragState] = useState<DragState | null>(null);
     const inputRef = React.useRef<HTMLInputElement | null>(null);
 
     const formatter = useMemo(() => new Intl.NumberFormat(undefined, format), [format]);
@@ -129,76 +120,6 @@ const NumberInput = React.forwardRef<HTMLInputElement, NumberInputProps>(
       },
       [value, step, parseValue, onChange, formatValue, disabled, min, max],
     );
-
-    const calculateDragValue = useCallback(
-      (currentX: number, startX: number, startValue: number) => {
-        const distance = currentX - startX;
-        const direction = distance >= 0 ? 1 : -1;
-        const absoluteDistance = Math.abs(distance);
-
-        let multiplier = 1;
-        if (absoluteDistance > 100) multiplier = 5;
-        if (absoluteDistance > 200) multiplier = 10;
-        if (absoluteDistance > 300) multiplier = 20;
-
-        const stepChange = Math.floor(absoluteDistance / 5) * direction * step * multiplier;
-        return parseValue((startValue + stepChange).toString(), true);
-      },
-      [parseValue, step],
-    );
-
-    const handleMouseDown = useCallback(
-      (e: ReactMouseEvent<HTMLInputElement>) => {
-        if (disabled || !inputRef.current) return;
-
-        const startValue = value ?? 0;
-        setDragState({
-          isDragging: true,
-          startX: e.clientX,
-          startValue,
-          lastValue: startValue,
-        });
-
-        e.preventDefault();
-
-        document.body.style.cursor = "ew-resize";
-
-        inputRef.current.focus();
-      },
-      [disabled, value],
-    );
-
-    useEffect(() => {
-      if (!dragState?.isDragging) return;
-
-      const handleMouseMove = (e: globalThis.MouseEvent) => {
-        if (!dragState) return;
-
-        const newValue = calculateDragValue(e.clientX, dragState.startX, dragState.startValue);
-
-        if (newValue !== null && newValue !== dragState.lastValue) {
-          setDisplayValue(formatValue(newValue));
-          setDragState((prev) => (prev ? { ...prev, lastValue: newValue } : null));
-        }
-      };
-
-      const handleMouseUp = () => {
-        // Call onChange only when mouse is released
-        if (dragState && dragState.lastValue !== dragState.startValue) {
-          onChange?.(dragState.lastValue);
-        }
-        setDragState(null);
-        document.body.style.cursor = "";
-      };
-
-      document.addEventListener("mousemove", handleMouseMove);
-      document.addEventListener("mouseup", handleMouseUp);
-
-      return () => {
-        document.removeEventListener("mousemove", handleMouseMove);
-        document.removeEventListener("mouseup", handleMouseUp);
-      };
-    }, [dragState, calculateDragValue, onChange, formatValue]);
 
     const handleKeyDown = useCallback(
       (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -301,7 +222,6 @@ const NumberInput = React.forwardRef<HTMLInputElement, NumberInputProps>(
           onBlur={handleBlur}
           onKeyDown={handleKeyDown}
           onWheel={handleWheel}
-          onMouseDown={handleMouseDown}
           min={min}
           max={max}
           step={step}
@@ -310,7 +230,7 @@ const NumberInput = React.forwardRef<HTMLInputElement, NumberInputProps>(
           density={density}
           className={`${className} ${
             !isValid ? "border-[var(--color-destructive)]" : ""
-          } ${dragState?.isDragging ? "select-none" : ""} cursor-pointer`}
+          }`}
           data-testid={dataTestId}
           {...props}
         />

--- a/src/frontend/src/components/NumberInput.tsx
+++ b/src/frontend/src/components/NumberInput.tsx
@@ -228,9 +228,7 @@ const NumberInput = React.forwardRef<HTMLInputElement, NumberInputProps>(
           disabled={disabled}
           placeholder={placeholder}
           density={density}
-          className={`${className} ${
-            !isValid ? "border-[var(--color-destructive)]" : ""
-          }`}
+          className={`${className} ${!isValid ? "border-[var(--color-destructive)]" : ""}`}
           data-testid={dataTestId}
           {...props}
         />


### PR DESCRIPTION
# Summary

## Changes

Removed the drag-to-change-value feature from the NumberInput component that was interfering with text selection. Users can now click and drag to select text in number inputs using standard browser behavior.

## API Changes

**NumberInput component:**
- Removed `DragState` interface (internal)
- Removed `dragState` state (internal)
- Removed `calculateDragValue` function (internal)
- Removed `handleMouseDown` handler (internal)
- Removed drag-related styling classes (`cursor-pointer`, `select-none`)
- Removed `MouseEvent` import

The public API (props) of NumberInput remains unchanged. Only internal implementation details were removed.

## Files Modified

**Components:**
- `src/frontend/src/components/NumberInput.tsx` - Removed drag-to-change-value feature (81 lines deleted) and applied formatting fixes

## Commits

- b56f9ef5b [00035] Remove drag-to-change value feature from NumberInput component
- 4af6da445 [00035] Fix formatting in NumberInput component