### PR TITLE
[SheetWidget]: prevent focus-outside from dismissing non-modal sheets

### DIFF
--- a/src/frontend/src/widgets/sheet/SheetWidget.tsx
+++ b/src/frontend/src/widgets/sheet/SheetWidget.tsx
@@ -210,6 +210,9 @@ export const SheetWidget: React.FC<SheetWidgetProps> = ({
         onPointerDownOutside={(e: Event) => {
           if (isResizingRef.current) e.preventDefault();
         }}
+        onFocusOutside={(e: Event) => {
+          e.preventDefault();
+        }}
         onOpenAutoFocus={(e: Event) => {
           const container = e.currentTarget as HTMLElement | null;
           const target = container?.querySelector<HTMLElement>("[autofocus]");


### PR DESCRIPTION
## Problem

Non-modal (resizable) sheets would auto-close immediately upon opening under certain conditions. Specifically, when a Sheet opened in response to a user action (e.g. clicking a DataTable cell) and the triggering element remained in the DOM, the Sheet would briefly appear and then close by itself on the first open after page reload.

### Root Cause

Resizable sheets use `modal={false}` in Radix UI, which enables `DismissableLayer` for outside-interaction detection. At the same time, `onOpenAutoFocus` prevents focus from moving into the Sheet:

```tsx
onOpenAutoFocus={(e: Event) => {
  e.preventDefault();  // Focus stays outside the Sheet
}}
```

This creates a conflict: the Sheet mounts → focus remains on the element that triggered it (outside the Sheet) → Radix's `DismissableLayer` detects **focus outside** → fires `onOpenChange(false)` → Sheet closes.

This bug was previously masked because the triggering element (DataTable) was being unmounted and remounted simultaneously (due to a separate flicker bug), which destroyed the focus target and prevented Radix from detecting "focus outside."

## Solution

Added an `onFocusOutside` handler to `SheetContent` that prevents focus-based dismissal:

```tsx
onFocusOutside={(e: Event) => {
  e.preventDefault();
}}
```

This preserves the desired **click outside → close sheet** behavior (handled by `onPointerDownOutside`) while preventing the unwanted **focus outside → close sheet** behavior. This is the correct semantic: a sheet should close when the user intentionally clicks outside of it, not simply because focus happens to be elsewhere.

## Changes

- **`SheetWidget.tsx`** — Added `onFocusOutside` handler with `e.preventDefault()` to `SheetContent` to prevent focus-based dismissal of non-modal sheets.

## Before

https://github.com/user-attachments/assets/b239f352-7714-4729-8474-aa3a8c6477a5

## After

https://github.com/user-attachments/assets/374203f8-ae42-40db-bb7d-db4df1695b05


