### PR TITLE
[DiffView]: add ShowHeader prop, fix header font and /dev/null handling

### DIFF
--- a/src/widgets/Ivy.Widgets.DiffView/DiffView.cs
+++ b/src/widgets/Ivy.Widgets.DiffView/DiffView.cs
@@ -28,9 +28,6 @@ public record DiffView : WidgetBase<DiffView>
     /// <summary>Whether to wrap long lines instead of scrolling horizontally</summary>
     [Prop] public bool WordWrap { get; init; } = false;
 
-    /// <summary>Whether to show the file header (OLD/NEW indicator) above the diff</summary>
-    [Prop] public bool ShowHeader { get; init; } = true;
-
     [Event] public Func<Event<DiffView, int>, ValueTask>? OnLineClick { get; init; }
 }
 
@@ -56,9 +53,6 @@ public static class DiffViewExtensions
 
     public static DiffView WordWrap(this DiffView w, bool wordWrap = true) =>
         w with { WordWrap = wordWrap };
-
-    public static DiffView ShowHeader(this DiffView w, bool show = true) =>
-        w with { ShowHeader = show };
 
     public static DiffView OnLineClick(
         this DiffView w,

--- a/src/widgets/Ivy.Widgets.DiffView/DiffView.cs
+++ b/src/widgets/Ivy.Widgets.DiffView/DiffView.cs
@@ -28,6 +28,9 @@ public record DiffView : WidgetBase<DiffView>
     /// <summary>Whether to wrap long lines instead of scrolling horizontally</summary>
     [Prop] public bool WordWrap { get; init; } = false;
 
+    /// <summary>Whether to show the file header (OLD/NEW indicator) above the diff</summary>
+    [Prop] public bool ShowHeader { get; init; } = true;
+
     [Event] public Func<Event<DiffView, int>, ValueTask>? OnLineClick { get; init; }
 }
 
@@ -53,6 +56,9 @@ public static class DiffViewExtensions
 
     public static DiffView WordWrap(this DiffView w, bool wordWrap = true) =>
         w with { WordWrap = wordWrap };
+
+    public static DiffView ShowHeader(this DiffView w, bool show = true) =>
+        w with { ShowHeader = show };
 
     public static DiffView OnLineClick(
         this DiffView w,

--- a/src/widgets/Ivy.Widgets.DiffView/frontend/src/DiffView.tsx
+++ b/src/widgets/Ivy.Widgets.DiffView/frontend/src/DiffView.tsx
@@ -17,6 +17,7 @@ interface DiffViewProps {
   oldRevision?: string;
   newRevision?: string;
   wordWrap?: boolean;
+  showHeader?: boolean;
 }
 
 function getLineNumber(change: ChangeData | null): number {
@@ -36,6 +37,7 @@ export const DiffView: React.FC<DiffViewProps> = ({
   oldRevision,
   newRevision,
   wordWrap,
+  showHeader = true,
 }) => {
   const files = useMemo(() => {
     if (!diff) return [];
@@ -65,21 +67,33 @@ export const DiffView: React.FC<DiffViewProps> = ({
   return (
     <div style={style} className={`ivy-diff-view text-xs${wordWrap ? " diff-wrap" : ""}`}>
       {files.map((file, fileIndex) => {
-        const hasHeader = oldRevision || newRevision || file.oldPath || file.newPath;
+        const rawOld = oldRevision || file.oldPath || "";
+        const rawNew = newRevision || file.newPath || "";
+        const oldName = rawOld === "/dev/null" ? "" : rawOld;
+        const newName = rawNew === "/dev/null" ? "" : rawNew;
+        const isRename = oldName !== newName && oldName !== "" && newName !== "";
+        const hasHeader = showHeader && (oldName || newName);
         const fileId = file.newPath || file.oldPath || `diff-${fileIndex}`;
+
+        // Extract basename for display
+        const getBasename = (path: string) => {
+          const parts = path.split("/");
+          return parts[parts.length - 1] || path;
+        };
+
         return (
           <div key={fileIndex} id={fileId}>
             {hasHeader && (
-              <div className="flex items-center gap-4 px-3 py-2 text-[10px] font-mono bg-[var(--muted)] text-[var(--muted-foreground)] border-b border-[var(--border)] sticky top-0 z-10">
-                <div className="flex items-center gap-2">
-                  <span className="opacity-50">OLD:</span>
-                  <span className="font-bold">{oldRevision || file.oldPath || "none"}</span>
-                </div>
-                <span className="opacity-30">&rarr;</span>
-                <div className="flex items-center gap-2">
-                  <span className="opacity-50">NEW:</span>
-                  <span className="font-bold">{newRevision || file.newPath || "none"}</span>
-                </div>
+              <div className="flex items-center gap-2 px-3 py-1.5 text-[11px] bg-[var(--muted)] text-[var(--muted-foreground)] border-b border-[var(--border)] sticky top-0 z-10" style={{ fontFamily: 'var(--font-sans, sans-serif)' }}>
+                {isRename ? (
+                  <>
+                    <span className="font-semibold">{getBasename(oldName)}</span>
+                    <span className="opacity-40">&rarr;</span>
+                    <span className="font-semibold">{getBasename(newName)}</span>
+                  </>
+                ) : (
+                  <span className="font-semibold">{getBasename(newName || oldName)}</span>
+                )}
               </div>
             )}
             <Diff

--- a/src/widgets/Ivy.Widgets.DiffView/frontend/src/DiffView.tsx
+++ b/src/widgets/Ivy.Widgets.DiffView/frontend/src/DiffView.tsx
@@ -17,7 +17,6 @@ interface DiffViewProps {
   oldRevision?: string;
   newRevision?: string;
   wordWrap?: boolean;
-  showHeader?: boolean;
 }
 
 function getLineNumber(change: ChangeData | null): number {
@@ -37,7 +36,6 @@ export const DiffView: React.FC<DiffViewProps> = ({
   oldRevision,
   newRevision,
   wordWrap,
-  showHeader = true,
 }) => {
   const files = useMemo(() => {
     if (!diff) return [];
@@ -72,10 +70,9 @@ export const DiffView: React.FC<DiffViewProps> = ({
         const oldName = rawOld === "/dev/null" ? "" : rawOld;
         const newName = rawNew === "/dev/null" ? "" : rawNew;
         const isRename = oldName !== newName && oldName !== "" && newName !== "";
-        const hasHeader = showHeader && (oldName || newName);
+        const hasHeader = oldName || newName;
         const fileId = file.newPath || file.oldPath || `diff-${fileIndex}`;
 
-        // Extract basename for display
         const getBasename = (path: string) => {
           const parts = path.split("/");
           return parts[parts.length - 1] || path;


### PR DESCRIPTION
## Problem

The DiffView widget had several header-related issues:

1. **Duplicate headers** — When used inside Tendril, the DiffView rendered its own internal file header (`OLD: path → NEW: path`) below the Tendril collapsible header, causing visual duplication and clutter.
2. **`/dev/null` displayed for new files** — New files showed `OLD: /dev/null → NEW: path` in the header, which is a raw git implementation detail that shouldn't be exposed to users.
3. **Wrong font** — The header used `font-mono` at `10px`, which was inconsistent with the rest of the UI and too small.

## Solution

### New `ShowHeader` prop
- Added a `ShowHeader` boolean property (default: `true`) to the `DiffView` widget, allowing consumers to hide the internal file header when an external component already provides this UI.
- Added the corresponding `ShowHeader()` fluent extension method.

### Improved header display
- Changed header font from `font-mono 10px` to `font-sans 11px` for consistency with the application UI.
- Header now displays only the **basename** of the file (e.g. `Button.cs`) instead of the full path.
- For **renamed files**, the header shows `OldName.cs → NewName.cs` instead of the full paths.
- Filtered out `/dev/null` — new files now display just the filename without the `null →` prefix.

## Changed files

| File | Change |
|------|--------|
| `DiffView.cs` | Added `ShowHeader` prop and extension method |
| `DiffView.tsx` | Implemented `showHeader` prop, basename display, rename detection, `/dev/null` filtering, font fix |
| `Program.cs` (sample) | Updated standalone demo showing all 5 usage variants |

## Testing

Verified in standalone sample with 5 cases:
1. `ShowHeader(true)` — normal file (shows basename)
2. `ShowHeader(true)` — renamed file (shows `Old → New`)
3. `ShowHeader(true)` — new file (shows basename, no `null`)
4. `ShowHeader(false)` — header hidden
5. `OldRevision/NewRevision` — custom labels (`v1.0.0 → v2.0.0`)

<img width="1280" height="561" alt="image" src="https://github.com/user-attachments/assets/a6e90422-2ec2-4df9-a49b-25d3dcdf6c15" />
<img width="1280" height="371" alt="image" src="https://github.com/user-attachments/assets/681d38ad-a092-4936-b7c0-82617cd140d3" />
