### PR TITLE
(Copy button): improve styling

### DIFF
--- a/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/CodeBlockApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/CodeBlockApp.cs
@@ -1,7 +1,7 @@
 
 namespace Ivy.Samples.Shared.Apps.Widgets.Primitives;
 
-[App(icon: Icons.Code, group: ["Widgets", "Primitives"], searchHints: ["syntax", "highlighting", "programming", "code-block", "snippet", "pre", "copy", "clipboard"])]
+[App(icon: Icons.Code, group: ["Widgets", "Primitives"], searchHints: ["syntax", "highlighting", "programming", "code-block", "snippet", "pre"])]
 public class CodeBlockApp : SampleBase
 {
     protected override object? BuildSample()
@@ -272,11 +272,6 @@ public class CodeBlockApp : SampleBase
             Layout.Vertical()
                 | Text.Monospaced("Wrap Lines")
                 | new CodeBlock("public class VeryLongClassName { public void VeryLongMethodName(string veryLongParameterName, int anotherVeryLongParameterName, bool yetAnotherParameter) { Console.WriteLine(\"This is a very long line that should wrap when WrapLines is enabled.\"); } }", Languages.Csharp).WrapLines().ShowLineNumbers(),
-            Layout.Vertical()
-                | Text.Monospaced("Repro: long one-liner + copy (CodeBlock widget, same UX as markdown fences)")
-                | new CodeBlock(
-                    """dotnet tool update -g Ivy.Tooling.EngineeringSuite --verbosity detailed --dry-run-previewdotnet tool update -g Ivy.Tooling.EngineeringSuite --verbosity detailed --dry-run-previewdotnet tool update -g Ivy.Tooling.EngineeringSuite --verbosity detailed --dry-run-preview""",
-                    Languages.Bash)
         };
 
         var variants = Layout.Grid().Columns(2).Gap(4) | optionBlocks;

--- a/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/CodeBlockApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/CodeBlockApp.cs
@@ -1,7 +1,7 @@
 
 namespace Ivy.Samples.Shared.Apps.Widgets.Primitives;
 
-[App(icon: Icons.Code, group: ["Widgets", "Primitives"], searchHints: ["syntax", "highlighting", "programming", "code-block", "snippet", "pre"])]
+[App(icon: Icons.Code, group: ["Widgets", "Primitives"], searchHints: ["syntax", "highlighting", "programming", "code-block", "snippet", "pre", "copy", "clipboard"])]
 public class CodeBlockApp : SampleBase
 {
     protected override object? BuildSample()
@@ -271,7 +271,12 @@ public class CodeBlockApp : SampleBase
                 | new CodeBlock(sampleCode, Languages.Csharp).ShowBorder(false),
             Layout.Vertical()
                 | Text.Monospaced("Wrap Lines")
-                | new CodeBlock("public class VeryLongClassName { public void VeryLongMethodName(string veryLongParameterName, int anotherVeryLongParameterName, bool yetAnotherParameter) { Console.WriteLine(\"This is a very long line that should wrap when WrapLines is enabled.\"); } }", Languages.Csharp).WrapLines().ShowLineNumbers()
+                | new CodeBlock("public class VeryLongClassName { public void VeryLongMethodName(string veryLongParameterName, int anotherVeryLongParameterName, bool yetAnotherParameter) { Console.WriteLine(\"This is a very long line that should wrap when WrapLines is enabled.\"); } }", Languages.Csharp).WrapLines().ShowLineNumbers(),
+            Layout.Vertical()
+                | Text.Monospaced("Repro: long one-liner + copy (CodeBlock widget, same UX as markdown fences)")
+                | new CodeBlock(
+                    """dotnet tool update -g Ivy.Tooling.EngineeringSuite --verbosity detailed --dry-run-previewdotnet tool update -g Ivy.Tooling.EngineeringSuite --verbosity detailed --dry-run-previewdotnet tool update -g Ivy.Tooling.EngineeringSuite --verbosity detailed --dry-run-preview""",
+                    Languages.Bash)
         };
 
         var variants = Layout.Grid().Columns(2).Gap(4) | optionBlocks;

--- a/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/MarkdownApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/MarkdownApp.cs
@@ -1,7 +1,7 @@
 
 namespace Ivy.Samples.Shared.Apps.Widgets.Primitives;
 
-[App(icon: Icons.FileText, searchHints: ["formatting", "markup", "markdown", "md", "text", "content"])]
+[App(icon: Icons.FileText, searchHints: ["formatting", "markup", "markdown", "md", "text", "content", "copy", "clipboard"])]
 public class MarkdownApp : SampleBase
 {
     protected override object? BuildSample()
@@ -15,7 +15,8 @@ public class MarkdownApp : SampleBase
             new Tab("Tables", new TablesTab()),
             new Tab("Math", new MathTab()),
             new Tab("Diagrams", new DiagramsTab()),
-            new Tab("Media", new MediaTab())
+            new Tab("Media", new MediaTab()),
+            new Tab("Copy overlays", new CopyOverlayTab())
         ).Variant(TabsVariant.Content);
     }
 }
@@ -459,6 +460,45 @@ public class MediaTab : ViewBase
                        > - Tables and more!
                        
                        [^note]: This is a footnote in a blockquote!
+                       """;
+
+        return new Markdown(markdown);
+    }
+}
+
+public class CopyOverlayTab : ViewBase
+{
+    public override object? Build()
+    {
+        var markdown = """
+                       # Copy chip + text (markdown reproduction)
+
+                       Fenced blocks use the floating copy control. Inline text uses backticks only, e.g. `dotnet --list`.Fenced blocks use the floating copy control. Inline text uses backticks only, e.g. `dotnet --list`.Fenced blocks use the floating copy control. Inline text uses backticks only, e.g. `dotnet --list`.
+
+                       ## Bash / long single line
+
+                       ```bash
+                       dotnet tool update -g Ivy.Tooling.EngineeringSuite --verbosity minimal --add-source https://api.nuget.org/v3/index.json --prerelease --version 9.9.9Fenced blocks use the floating copy control. Inline text uses backticks only, e.g. `dotnet --list`.Fenced blocks use the floating copy control. Inline text uses backticks only, e.g. `dotnet --list`.Fenced blocks use the floating copy control. Inline text uses backticks only, e.g. `dotnet --list`.
+                       ```
+
+                       ## Plain fenced (no language)
+
+                       ```
+                       dotnet tool install -g Corporate.Prefix.VeryLongPackageName.WithManySegments --global --framework net10.0Fenced blocks use the floating copy control. Inline text uses backticks only, e.g. `dotnet --list`.Fenced blocks use the floating copy control. Inline text uses backticks only, e.g. `dotnet --list`.Fenced blocks use the floating copy control. Inline text uses backticks only, e.g. `dotnet --list`.
+                       ```
+
+                       ## Terminal fence
+
+                       ```terminal
+                       > dotnet restore && dotnet build -c Release --no-incremental /p:TreatWarningsAsErrors=trueFenced blocks use the floating copy control. Inline text uses backticks only, e.g. `dotnet --list`.Fenced blocks use the floating copy control. Inline text uses backticks only, e.g. `dotnet --list`.Fenced blocks use the floating copy control. Inline text uses backticks only, e.g. `dotnet --list`.
+                       ```
+
+                       ## Highlighted multi-line C#
+
+                       ```csharp
+                       Console.WriteLine("Second line avoids comparing against a one-line-only glitch.");Fenced blocks use the floating copy control. Inline text uses backticks only, e.g. `dotnet --list`.Fenced blocks use the floating copy control. Inline text uses backticks only, e.g. `dotnet --list`.Fenced blocks use the floating copy control. Inline text uses backticks only, e.g. `dotnet --list`.
+                       await Task.CompletedTask;
+                       ```
                        """;
 
         return new Markdown(markdown);

--- a/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/MarkdownApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/MarkdownApp.cs
@@ -1,7 +1,7 @@
 
 namespace Ivy.Samples.Shared.Apps.Widgets.Primitives;
 
-[App(icon: Icons.FileText, searchHints: ["formatting", "markup", "markdown", "md", "text", "content", "copy", "clipboard"])]
+[App(icon: Icons.FileText, searchHints: ["formatting", "markup", "markdown", "md", "text", "content"])]
 public class MarkdownApp : SampleBase
 {
     protected override object? BuildSample()
@@ -15,8 +15,7 @@ public class MarkdownApp : SampleBase
             new Tab("Tables", new TablesTab()),
             new Tab("Math", new MathTab()),
             new Tab("Diagrams", new DiagramsTab()),
-            new Tab("Media", new MediaTab()),
-            new Tab("Copy overlays", new CopyOverlayTab())
+            new Tab("Media", new MediaTab())
         ).Variant(TabsVariant.Content);
     }
 }
@@ -460,45 +459,6 @@ public class MediaTab : ViewBase
                        > - Tables and more!
                        
                        [^note]: This is a footnote in a blockquote!
-                       """;
-
-        return new Markdown(markdown);
-    }
-}
-
-public class CopyOverlayTab : ViewBase
-{
-    public override object? Build()
-    {
-        var markdown = """
-                       # Copy chip + text (markdown reproduction)
-
-                       Fenced blocks use the floating copy control. Inline text uses backticks only, e.g. `dotnet --list`.Fenced blocks use the floating copy control. Inline text uses backticks only, e.g. `dotnet --list`.Fenced blocks use the floating copy control. Inline text uses backticks only, e.g. `dotnet --list`.
-
-                       ## Bash / long single line
-
-                       ```bash
-                       dotnet tool update -g Ivy.Tooling.EngineeringSuite --verbosity minimal --add-source https://api.nuget.org/v3/index.json --prerelease --version 9.9.9Fenced blocks use the floating copy control. Inline text uses backticks only, e.g. `dotnet --list`.Fenced blocks use the floating copy control. Inline text uses backticks only, e.g. `dotnet --list`.Fenced blocks use the floating copy control. Inline text uses backticks only, e.g. `dotnet --list`.
-                       ```
-
-                       ## Plain fenced (no language)
-
-                       ```
-                       dotnet tool install -g Corporate.Prefix.VeryLongPackageName.WithManySegments --global --framework net10.0Fenced blocks use the floating copy control. Inline text uses backticks only, e.g. `dotnet --list`.Fenced blocks use the floating copy control. Inline text uses backticks only, e.g. `dotnet --list`.Fenced blocks use the floating copy control. Inline text uses backticks only, e.g. `dotnet --list`.
-                       ```
-
-                       ## Terminal fence
-
-                       ```terminal
-                       > dotnet restore && dotnet build -c Release --no-incremental /p:TreatWarningsAsErrors=trueFenced blocks use the floating copy control. Inline text uses backticks only, e.g. `dotnet --list`.Fenced blocks use the floating copy control. Inline text uses backticks only, e.g. `dotnet --list`.Fenced blocks use the floating copy control. Inline text uses backticks only, e.g. `dotnet --list`.
-                       ```
-
-                       ## Highlighted multi-line C#
-
-                       ```csharp
-                       Console.WriteLine("Second line avoids comparing against a one-line-only glitch.");Fenced blocks use the floating copy control. Inline text uses backticks only, e.g. `dotnet --list`.Fenced blocks use the floating copy control. Inline text uses backticks only, e.g. `dotnet --list`.Fenced blocks use the floating copy control. Inline text uses backticks only, e.g. `dotnet --list`.
-                       await Task.CompletedTask;
-                       ```
                        """;
 
         return new Markdown(markdown);

--- a/src/frontend/src/components/CopyToClipboardButton.tsx
+++ b/src/frontend/src/components/CopyToClipboardButton.tsx
@@ -19,7 +19,7 @@ const copyIconVariant = cva("", {
 });
 
 const copyButtonSizeVariant = cva(
-  "p-2 rounded hover:bg-accent focus:outline-none cursor-pointer flex items-center",
+  "p-2 rounded bg-transparent hover:bg-accent focus:outline-none cursor-pointer flex items-center",
   {
     variants: {
       density: {
@@ -65,20 +65,22 @@ const CopyToClipboardButton: React.FC<CopyToClipboardButtonProps> = ({
 
   return (
     <button
+      type="button"
       onClick={handleCopy}
       aria-label={ariaLabel || "Copy to clipboard"}
       className={cn(
         isIconOnly
-          ? cn(copyButtonSizeVariant({ density }), copied && "bg-primary text-primary-foreground")
+          ? cn(
+              copyButtonSizeVariant({ density }),
+              !copied && "text-muted-foreground hover:text-foreground",
+              copied &&
+                "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus-visible:ring-primary",
+            )
           : "flex items-center gap-1 px-3 py-2 rounded-lg transition-all duration-200 ease-in-out cursor-pointer hover:bg-accent hover:shadow-sm border-0",
         !isIconOnly &&
           (copied
             ? "bg-primary text-primary-foreground"
             : "bg-transparent text-muted-foreground hover:text-foreground"),
-        isIconOnly && !copied && "bg-background hover:bg-accent",
-        copied &&
-          isIconOnly &&
-          "hover:bg-primary hover:text-primary-foreground focus-visible:ring-primary",
         className,
       )}
     >

--- a/src/frontend/src/components/markdown/CodeBlock.tsx
+++ b/src/frontend/src/components/markdown/CodeBlock.tsx
@@ -3,6 +3,11 @@ import { cn } from "@/lib/utils";
 import { createPrismTheme } from "@/lib/prismTheme";
 import { useTypography } from "@/contexts/TypographyContext";
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
+import {
+  codeCopyViewportInsetStyle,
+  markdownCodeCopyScrollPaddingClass,
+  markdownCodeCopyGutterLength,
+} from "@/components/ui/code-variant";
 import CopyToClipboardButton from "@/components/CopyToClipboardButton";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import { lazyWithRetry } from "@/lib/lazyWithRetry";
@@ -10,6 +15,35 @@ import { lazyWithRetry } from "@/lib/lazyWithRetry";
 const SyntaxHighlighter = lazyWithRetry(() =>
   import("react-syntax-highlighter").then((mod) => ({ default: mod.Prism })),
 );
+
+/** Copy stays transparent/floating; scroll content gets right inset so lines never run under the control. */
+function CodeBlockChromeWithCopy({
+  textToCopy,
+  outerClassName,
+  scrollAreaClassName,
+  children,
+}: {
+  textToCopy: string;
+  outerClassName: string;
+  scrollAreaClassName?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className={cn("relative w-full", outerClassName)}>
+      <div className="absolute top-2 right-2 z-30">
+        <CopyToClipboardButton textToCopy={textToCopy} />
+      </div>
+      <ScrollArea
+        className={cn("w-full", scrollAreaClassName)}
+        viewportClassName="min-w-0"
+        viewportStyle={codeCopyViewportInsetStyle(markdownCodeCopyGutterLength)}
+      >
+        <div className={markdownCodeCopyScrollPaddingClass}>{children}</div>
+        <ScrollBar orientation="horizontal" />
+      </ScrollArea>
+    </div>
+  );
+}
 
 const MermaidRenderer = lazyWithRetry(() => import("../MermaidRenderer"));
 const GraphvizRenderer = lazyWithRetry(() => import("../GraphvizRenderer"));
@@ -82,30 +116,25 @@ export const CodeBlock = memo(
         const cleanContent = lines.join("\n"); // Remove any empty lines
 
         return (
-          <div className="relative">
-            <div className="absolute top-2 right-2 z-30">
-              <CopyToClipboardButton textToCopy={cleanContent} />
-            </div>
-            <ScrollArea className="w-full">
-              <pre
-                className="p-4 bg-muted rounded-md font-mono text-sm"
-                style={{ overflowX: "auto" }}
-              >
-                {lines.map((line, i) => {
-                  const lineKey = `md-term-line-${i}`;
-                  return (
-                    <div key={lineKey} className="flex">
-                      <span className="text-muted-foreground select-none pointer-events-none mr-2">
-                        {"> "}
-                      </span>
-                      <span className="flex-1">{line}</span>
-                    </div>
-                  );
-                })}
-              </pre>
-              <ScrollBar orientation="horizontal" />
-            </ScrollArea>
-          </div>
+          <CodeBlockChromeWithCopy
+            textToCopy={cleanContent}
+            outerClassName="rounded-md bg-muted"
+            scrollAreaClassName="w-full"
+          >
+            <pre className="p-4 font-mono text-sm" style={{ overflowX: "auto" }}>
+              {lines.map((line, i) => {
+                const lineKey = `md-term-line-${i}`;
+                return (
+                  <div key={lineKey} className="flex">
+                    <span className="text-muted-foreground select-none pointer-events-none mr-2">
+                      {"> "}
+                    </span>
+                    <span className="flex-1">{line}</span>
+                  </div>
+                );
+              })}
+            </pre>
+          </CodeBlockChromeWithCopy>
         );
       }
 
@@ -114,57 +143,53 @@ export const CodeBlock = memo(
 
       if (!useHighlighter) {
         return (
-          <div className="relative">
-            <div className="absolute top-2 right-2 z-30">
-              <CopyToClipboardButton textToCopy={content} />
-            </div>
-            <ScrollArea className="w-full border border-border rounded-md">
-              <pre
-                className="p-4 rounded-md font-mono text-sm"
-                style={{ margin: 0, whiteSpace: "pre", overflowX: "auto" }}
-              >
-                {content}
-              </pre>
-              <ScrollBar orientation="horizontal" />
-            </ScrollArea>
-          </div>
+          <CodeBlockChromeWithCopy
+            textToCopy={content}
+            outerClassName="rounded-md border border-border"
+            scrollAreaClassName="w-full bg-muted"
+          >
+            <pre
+              className="p-4 font-mono text-sm"
+              style={{ margin: 0, whiteSpace: "pre", overflowX: "auto" }}
+            >
+              {content}
+            </pre>
+          </CodeBlockChromeWithCopy>
         );
       }
 
       return (
         <Suspense
           fallback={
-            <ScrollArea className="w-full border border-border rounded-md">
-              <pre
-                className="p-4 bg-muted rounded-md font-mono text-sm"
-                style={{ overflowX: "auto" }}
-              >
+            <CodeBlockChromeWithCopy
+              textToCopy={content}
+              outerClassName="rounded-md border border-border"
+              scrollAreaClassName="w-full bg-muted"
+            >
+              <pre className="p-4 font-mono text-sm" style={{ overflowX: "auto" }}>
                 {content}
               </pre>
-              <ScrollBar orientation="horizontal" />
-            </ScrollArea>
+            </CodeBlockChromeWithCopy>
           }
         >
-          <div className="relative">
-            <div className="absolute top-2 right-2 z-30">
-              <CopyToClipboardButton textToCopy={content} />
-            </div>
-            <ScrollArea className="w-full border border-border rounded-md">
-              <SyntaxHighlighter
-                language={language}
-                style={dynamicTheme}
-                customStyle={{
-                  margin: 0,
-                  wordBreak: "normal",
-                  overflowWrap: "break-word",
-                }}
-                wrapLongLines={false}
-              >
-                {content}
-              </SyntaxHighlighter>
-              <ScrollBar orientation="horizontal" />
-            </ScrollArea>
-          </div>
+          <CodeBlockChromeWithCopy
+            textToCopy={content}
+            outerClassName="rounded-md border border-border"
+            scrollAreaClassName="w-full bg-muted"
+          >
+            <SyntaxHighlighter
+              language={language}
+              style={dynamicTheme}
+              customStyle={{
+                margin: 0,
+                wordBreak: "normal",
+                overflowWrap: "break-word",
+              }}
+              wrapLongLines={false}
+            >
+              {content}
+            </SyntaxHighlighter>
+          </CodeBlockChromeWithCopy>
         </Suspense>
       );
     }

--- a/src/frontend/src/components/markdown/CodeBlock.tsx
+++ b/src/frontend/src/components/markdown/CodeBlock.tsx
@@ -31,7 +31,7 @@ export const CodeBlock = memo(
     const isMermaid = match && match[1] === "mermaid";
     const isGraphviz = match && (match[1] === "graphviz" || match[1] === "dot");
 
-    // Create dynamic theme that adapts to current CSS variables
+    // Create dynamic theme that uses CSS variables for dynamic theming
     const dynamicTheme = useMemo(() => createPrismTheme(), []);
     const typography = useTypography();
 

--- a/src/frontend/src/components/ui/code-variant.ts
+++ b/src/frontend/src/components/ui/code-variant.ts
@@ -1,4 +1,26 @@
+import type { CSSProperties } from "react";
 import { cva } from "class-variance-authority";
+import { Densities } from "@/types/density";
+
+/** Matches Tailwind widths used under `markdownCodeCopyScrollPaddingClass` / `codeScrollPaddingForDensity`. */
+export function codeCopyGutterLength(density: Densities): string {
+  switch (density) {
+    case Densities.Small:
+      return "2.5rem";
+    case Densities.Large:
+      return "3.5rem";
+    default:
+      return "3rem";
+  }
+}
+
+export const markdownCodeCopyGutterLength = codeCopyGutterLength(Densities.Medium);
+
+/** Clips scrolling paint so glyphs never occupy the viewport’s right gutter under a floating control. */
+export function codeCopyViewportInsetStyle(length: string): CSSProperties {
+  const clipPath = `inset(0 ${length} 0 0)`;
+  return { clipPath };
+}
 
 export const codeContainerVariant = cva("", {
   variants: {
@@ -12,6 +34,24 @@ export const codeContainerVariant = cva("", {
     density: "Medium",
   },
 });
+
+/**
+ * Extra inset on scrollable code so overlays never obscure text (matches positioned copy + gap).
+ * Tailwind Medium default for markdown `CodeBlock` (density not exposed there).
+ */
+export const markdownCodeCopyScrollPaddingClass = "pr-[3rem]";
+
+/** Same reserved band as `markdownCodeCopyScrollPaddingClass`, adjusted per widget density */
+export function codeScrollPaddingForDensity(density: Densities): string {
+  switch (density) {
+    case Densities.Small:
+      return "pr-10";
+    case Densities.Large:
+      return "pr-14";
+    default:
+      return markdownCodeCopyScrollPaddingClass;
+  }
+}
 
 export const codeCopyButtonVariant = cva("absolute z-50", {
   variants: {

--- a/src/frontend/src/widgets/primitives/CodeBlockWidget.tsx
+++ b/src/frontend/src/widgets/primitives/CodeBlockWidget.tsx
@@ -8,7 +8,12 @@ import { createPrismTheme } from "@/lib/prismTheme";
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
 import { Densities } from "@/types/density";
-import { codeCopyButtonVariant } from "@/components/ui/code-variant";
+import {
+  codeCopyButtonVariant,
+  codeCopyGutterLength,
+  codeCopyViewportInsetStyle,
+  codeScrollPaddingForDensity,
+} from "@/components/ui/code-variant";
 
 interface CodeWidgetProps {
   id: string;
@@ -165,6 +170,12 @@ const CodeWidget: React.FC<CodeWidgetProps> = memo(
         }
       : { ...getWidth(width) };
 
+    const copyViewportInset = useMemo(
+      () =>
+        showCopyButton ? codeCopyViewportInsetStyle(codeCopyGutterLength(density)) : undefined,
+      [density, showCopyButton],
+    );
+
     return (
       <div className="relative" style={containerStyles}>
         {showCopyButton && <MemoizedCopyButton textToCopy={content} density={density} />}
@@ -172,47 +183,51 @@ const CodeWidget: React.FC<CodeWidgetProps> = memo(
           className={cn(
             "w-full",
             isFull ? "flex-1 min-h-0" : "h-full",
-            showBorder && "border border-border rounded-md",
+            showBorder && "rounded-md border border-border",
           )}
+          viewportClassName="min-w-0"
+          viewportStyle={copyViewportInset}
         >
-          <Suspense
-            fallback={
-              <pre
-                className={cn("p-4 bg-muted rounded-md font-mono text-sm")}
-                style={isFull ? { ...preStyle, height: "auto" } : preStyle}
-              >
-                {content}
-              </pre>
-            }
-          >
-            <SyntaxHighlighter
-              language={mapLanguageToPrism(language)}
-              customStyle={isFull ? { ...preStyle, height: "auto" } : preStyle}
-              style={dynamicTheme}
-              showLineNumbers={showLineNumbers}
-              startingLineNumber={startingLineNumber}
-              wrapLines={true}
-              wrapLongLines={wrapLines}
-              key={highlighterKey}
-              codeTagProps={{ style: codeTagStyle }}
-              lineProps={showLineNumbers ? { style: { display: "table-row" } } : undefined}
-              lineNumberStyle={
-                showLineNumbers
-                  ? {
-                      display: "table-cell",
-                      paddingRight: currentScale.lineNumberPaddingRight,
-                      minWidth: currentScale.lineNumberMinWidth,
-                      textAlign: "right",
-                      userSelect: "none",
-                      color: "var(--muted-foreground)",
-                      opacity: 0.5,
-                    }
-                  : undefined
+          <div className={showCopyButton ? codeScrollPaddingForDensity(density) : undefined}>
+            <Suspense
+              fallback={
+                <pre
+                  className={cn("rounded-md bg-muted p-4 font-mono text-sm")}
+                  style={isFull ? { ...preStyle, height: "auto" } : preStyle}
+                >
+                  {content}
+                </pre>
               }
             >
-              {content}
-            </SyntaxHighlighter>
-          </Suspense>
+              <SyntaxHighlighter
+                language={mapLanguageToPrism(language)}
+                customStyle={isFull ? { ...preStyle, height: "auto" } : preStyle}
+                style={dynamicTheme}
+                showLineNumbers={showLineNumbers}
+                startingLineNumber={startingLineNumber}
+                wrapLines={true}
+                wrapLongLines={wrapLines}
+                key={highlighterKey}
+                codeTagProps={{ style: codeTagStyle }}
+                lineProps={showLineNumbers ? { style: { display: "table-row" } } : undefined}
+                lineNumberStyle={
+                  showLineNumbers
+                    ? {
+                        display: "table-cell",
+                        paddingRight: currentScale.lineNumberPaddingRight,
+                        minWidth: currentScale.lineNumberMinWidth,
+                        textAlign: "right",
+                        userSelect: "none",
+                        color: "var(--muted-foreground)",
+                        opacity: 0.5,
+                      }
+                    : undefined
+                }
+              >
+                {content}
+              </SyntaxHighlighter>
+            </Suspense>
+          </div>
           <ScrollBar orientation="horizontal" />
         </ScrollArea>
       </div>


### PR DESCRIPTION
Had an issue:
<img width="624" height="395" alt="image" src="https://github.com/user-attachments/assets/d1ffd15e-dd70-462e-b68f-31a7245eca4a" />

## Summary
- Made background for copy button transperent;
- Fix case when copy button overlays text

Current implementation:

Code Blocks:

https://github.com/user-attachments/assets/4e55b195-d0a9-48ec-9446-a67a866065f1

Markdown:

https://github.com/user-attachments/assets/b64060c5-6a23-48eb-97eb-65af6f86e549

My main goal was to safe copy button styling, but make it responsive to different designs and avoid issues like overlaying etc. So in basic use cases it stays as it was before, but now looks cleaner when placed in elements with different background colors and when text block contains long strings. 

Note:
Also verified for light theme.

Code block:

https://github.com/user-attachments/assets/b6d8d1a8-7d93-455e-9b96-5686f19c3df2

MarkDown:

https://github.com/user-attachments/assets/d736e26a-8e65-4ebf-9e9d-ba4bf2371c5a



