### PR TITLE
(text inputs) implement soften ghost

### DIFF
--- a/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/TextInputApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/TextInputApp.cs
@@ -9,7 +9,6 @@ public class TextInputApp : SampleBase
                | Text.H1("Text Input")
                | Layout.Tabs(
                    new Tab("Variants", new TextInputVariants()),
-                   new Tab("Ghost", new TextInputGhostDemo()),
                    new Tab("Sizes", new TextInputSizes()),
                    new Tab("Affixes", new TextInputAffixes()),
                    new Tab("Data Binding", new TextInputDataBinding()),
@@ -236,97 +235,6 @@ public class TextInputSizes : ViewBase
                | searchState.ToSearchInput().Small()
                | searchState.ToSearchInput()
                | searchState.ToSearchInput().Large();
-    }
-}
-
-/// <summary>Variants grid with <c>.Ghost()</c>, plus rows that combine suffix, <c>ShortcutKey</c> (kbd), and <c>Invalid</c>.</summary>
-public class TextInputGhostDemo : ViewBase
-{
-    private const string InvalidSample =
-        "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam nec purus nec eros";
-
-    public override object Build()
-    {
-        var withoutValue = UseState((string?)null);
-        var withValue = UseState("Hello");
-
-        var matrix = Layout.Grid().Columns(5)
-               | null!
-               | Text.Monospaced("Empty")
-               | Text.Monospaced("With Value")
-               | Text.Monospaced("Disabled")
-               | Text.Monospaced("Invalid")
-
-               | Text.Monospaced("TextInputVariant.Text")
-               | withoutValue.ToTextInput().Placeholder("Placeholder").Ghost()
-               | withValue.ToTextInput().Ghost()
-               | withValue.ToTextInput().Ghost().Disabled()
-               | withValue.ToTextInput().Ghost().Invalid(InvalidSample)
-
-               | Text.Monospaced("TextInputVariant.Password")
-               | withoutValue.ToPasswordInput().Placeholder("Placeholder").ShortcutKey("Ctrl+L").Ghost()
-               | withValue.ToPasswordInput().Ghost()
-               | withValue.ToPasswordInput().Ghost().Disabled()
-               | withValue.ToPasswordInput().Ghost().Invalid(InvalidSample)
-
-               | Text.Monospaced("TextInputVariant.Textarea")
-               | withoutValue.ToTextareaInput().Placeholder("Placeholder").ShortcutKey("Ctrl+T").Ghost()
-               | withValue.ToTextareaInput().Ghost()
-               | withValue.ToTextareaInput().Ghost().Disabled()
-               | withValue.ToTextareaInput().Ghost().Invalid(InvalidSample)
-
-               | Text.Monospaced("TextInputVariant.Search")
-               | withoutValue.ToSearchInput().Placeholder("Placeholder").ShortcutKey("Ctrl+K").Ghost()
-               | withValue.ToSearchInput().Ghost()
-               | withValue.ToSearchInput().Ghost().Disabled()
-               | withValue.ToSearchInput().Ghost().Invalid(InvalidSample)
-
-               | Text.Monospaced("Search + Suffix (Ghost)")
-               | withoutValue.ToSearchInput().Placeholder("Search").Ghost().Suffix(Icons.ChevronDown)
-               | withValue.ToSearchInput().Placeholder("Search").Ghost().Suffix(Icons.ChevronDown)
-               | withValue.ToSearchInput().Placeholder("Search").Ghost().Suffix(Icons.ChevronDown).Disabled()
-               | withValue.ToSearchInput().Placeholder("Search").Ghost().Suffix(Icons.ChevronDown).Invalid(InvalidSample)
-
-               | Text.Monospaced("Search + Suffix + ShortcutKey")
-               | withoutValue.ToSearchInput().Placeholder("Search").Ghost().Suffix(Icons.ChevronDown).ShortcutKey("Ctrl+H")
-               | withValue.ToSearchInput().Placeholder("Search").Ghost().Suffix(Icons.ChevronDown).ShortcutKey("Ctrl+H")
-               | withValue.ToSearchInput().Placeholder("Search").Ghost().Suffix(Icons.ChevronDown).ShortcutKey("Ctrl+H").Disabled()
-               | withValue.ToSearchInput().Placeholder("Search").Ghost().Suffix(Icons.ChevronDown).ShortcutKey("Ctrl+H").Invalid(InvalidSample)
-
-               | Text.Monospaced("Text + Suffix + ShortcutKey")
-               | withoutValue.ToTextInput().Placeholder("Query").Ghost().Suffix(Icons.ChevronDown).ShortcutKey("Ctrl+Y")
-               | withValue.ToTextInput().Ghost().Suffix(Icons.ChevronDown).ShortcutKey("Ctrl+Y")
-               | withValue.ToTextInput().Ghost().Suffix(Icons.ChevronDown).ShortcutKey("Ctrl+Y").Disabled()
-               | withValue.ToTextInput().Ghost().Suffix(Icons.ChevronDown).ShortcutKey("Ctrl+Y").Invalid(InvalidSample)
-
-               | Text.Monospaced("Text + Prefix + Suffix + ShortcutKey")
-               | withoutValue.ToTextInput().Placeholder("Token").Ghost().Prefix(Icons.Mail).Suffix(Icons.ChevronDown).ShortcutKey("Ctrl+Shift+Y")
-               | withValue.ToTextInput().Ghost().Prefix(Icons.Mail).Suffix(Icons.ChevronDown).ShortcutKey("Ctrl+Shift+Y")
-               | withValue.ToTextInput().Ghost().Prefix(Icons.Mail).Suffix(Icons.ChevronDown).ShortcutKey("Ctrl+Shift+Y").Disabled()
-               | withValue.ToTextInput().Ghost().Prefix(Icons.Mail).Suffix(Icons.ChevronDown).ShortcutKey("Ctrl+Shift+Y").Invalid(InvalidSample)
-
-               | Text.Monospaced("TextInputVariant.Email")
-               | withoutValue.ToEmailInput().Placeholder("Placeholder").ShortcutKey("Ctrl+E").Ghost()
-               | withValue.ToEmailInput().Ghost()
-               | withValue.ToEmailInput().Ghost().Disabled()
-               | withValue.ToEmailInput().Ghost().Invalid(InvalidSample)
-
-               | Text.Monospaced("TextInputVariant.Tel")
-               | withoutValue.ToTelInput().Placeholder("Placeholder").ShortcutKey("Ctrl+J").Ghost()
-               | withValue.ToTelInput().Ghost()
-               | withValue.ToTelInput().Ghost().Disabled()
-               | withValue.ToTelInput().Ghost().Invalid(InvalidSample)
-
-               | Text.Monospaced("TextInputVariant.Url")
-               | withoutValue.ToUrlInput().Placeholder("Placeholder").ShortcutKey("Ctrl+U").Ghost()
-               | withValue.ToUrlInput().Ghost()
-               | withValue.ToUrlInput().Ghost().Disabled()
-               | withValue.ToUrlInput().Ghost().Invalid(InvalidSample);
-
-        return Layout.Vertical().Gap(6)
-               | Text.P(
-                   "Ghost removes the default field border. Search with a suffix uses a tight trailing strip for clear (×), shortcut kbd, and invalid icon. Text inputs keep the overlay on the field; rows below mix suffix, ShortcutKey, and Invalid.")
-               | matrix;
     }
 }
 

--- a/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/TextInputApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/TextInputApp.cs
@@ -239,7 +239,7 @@ public class TextInputSizes : ViewBase
     }
 }
 
-/// <summary>Variants grid with <c>.Ghost()</c> on every cell, including search + chevron suffix.</summary>
+/// <summary>Variants grid with <c>.Ghost()</c>, plus rows that combine suffix, <c>ShortcutKey</c> (kbd), and <c>Invalid</c>.</summary>
 public class TextInputGhostDemo : ViewBase
 {
     private const string InvalidSample =
@@ -250,7 +250,7 @@ public class TextInputGhostDemo : ViewBase
         var withoutValue = UseState((string?)null);
         var withValue = UseState("Hello");
 
-        return Layout.Grid().Columns(5)
+        var matrix = Layout.Grid().Columns(5)
                | null!
                | Text.Monospaced("Empty")
                | Text.Monospaced("With Value")
@@ -287,6 +287,24 @@ public class TextInputGhostDemo : ViewBase
                | withValue.ToSearchInput().Placeholder("Search").Ghost().Suffix(Icons.ChevronDown).Disabled()
                | withValue.ToSearchInput().Placeholder("Search").Ghost().Suffix(Icons.ChevronDown).Invalid(InvalidSample)
 
+               | Text.Monospaced("Search + Suffix + ShortcutKey")
+               | withoutValue.ToSearchInput().Placeholder("Search").Ghost().Suffix(Icons.ChevronDown).ShortcutKey("Ctrl+H")
+               | withValue.ToSearchInput().Placeholder("Search").Ghost().Suffix(Icons.ChevronDown).ShortcutKey("Ctrl+H")
+               | withValue.ToSearchInput().Placeholder("Search").Ghost().Suffix(Icons.ChevronDown).ShortcutKey("Ctrl+H").Disabled()
+               | withValue.ToSearchInput().Placeholder("Search").Ghost().Suffix(Icons.ChevronDown).ShortcutKey("Ctrl+H").Invalid(InvalidSample)
+
+               | Text.Monospaced("Text + Suffix + ShortcutKey")
+               | withoutValue.ToTextInput().Placeholder("Query").Ghost().Suffix(Icons.ChevronDown).ShortcutKey("Ctrl+Y")
+               | withValue.ToTextInput().Ghost().Suffix(Icons.ChevronDown).ShortcutKey("Ctrl+Y")
+               | withValue.ToTextInput().Ghost().Suffix(Icons.ChevronDown).ShortcutKey("Ctrl+Y").Disabled()
+               | withValue.ToTextInput().Ghost().Suffix(Icons.ChevronDown).ShortcutKey("Ctrl+Y").Invalid(InvalidSample)
+
+               | Text.Monospaced("Text + Prefix + Suffix + ShortcutKey")
+               | withoutValue.ToTextInput().Placeholder("Token").Ghost().Prefix(Icons.Mail).Suffix(Icons.ChevronDown).ShortcutKey("Ctrl+Shift+Y")
+               | withValue.ToTextInput().Ghost().Prefix(Icons.Mail).Suffix(Icons.ChevronDown).ShortcutKey("Ctrl+Shift+Y")
+               | withValue.ToTextInput().Ghost().Prefix(Icons.Mail).Suffix(Icons.ChevronDown).ShortcutKey("Ctrl+Shift+Y").Disabled()
+               | withValue.ToTextInput().Ghost().Prefix(Icons.Mail).Suffix(Icons.ChevronDown).ShortcutKey("Ctrl+Shift+Y").Invalid(InvalidSample)
+
                | Text.Monospaced("TextInputVariant.Email")
                | withoutValue.ToEmailInput().Placeholder("Placeholder").ShortcutKey("Ctrl+E").Ghost()
                | withValue.ToEmailInput().Ghost()
@@ -304,6 +322,11 @@ public class TextInputGhostDemo : ViewBase
                | withValue.ToUrlInput().Ghost()
                | withValue.ToUrlInput().Ghost().Disabled()
                | withValue.ToUrlInput().Ghost().Invalid(InvalidSample);
+
+        return Layout.Vertical().Gap(6)
+               | Text.P(
+                   "Ghost removes the default field border. Search with a suffix uses a tight trailing strip for clear (×), shortcut kbd, and invalid icon. Text inputs keep the overlay on the field; rows below mix suffix, ShortcutKey, and Invalid.")
+               | matrix;
     }
 }
 

--- a/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/TextInputApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/TextInputApp.cs
@@ -9,6 +9,7 @@ public class TextInputApp : SampleBase
                | Text.H1("Text Input")
                | Layout.Tabs(
                    new Tab("Variants", new TextInputVariants()),
+                   new Tab("Ghost", new TextInputGhostDemo()),
                    new Tab("Sizes", new TextInputSizes()),
                    new Tab("Affixes", new TextInputAffixes()),
                    new Tab("Data Binding", new TextInputDataBinding()),
@@ -235,6 +236,74 @@ public class TextInputSizes : ViewBase
                | searchState.ToSearchInput().Small()
                | searchState.ToSearchInput()
                | searchState.ToSearchInput().Large();
+    }
+}
+
+/// <summary>Variants grid with <c>.Ghost()</c> on every cell, including search + chevron suffix.</summary>
+public class TextInputGhostDemo : ViewBase
+{
+    private const string InvalidSample =
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam nec purus nec eros";
+
+    public override object Build()
+    {
+        var withoutValue = UseState((string?)null);
+        var withValue = UseState("Hello");
+
+        return Layout.Grid().Columns(5)
+               | null!
+               | Text.Monospaced("Empty")
+               | Text.Monospaced("With Value")
+               | Text.Monospaced("Disabled")
+               | Text.Monospaced("Invalid")
+
+               | Text.Monospaced("TextInputVariant.Text")
+               | withoutValue.ToTextInput().Placeholder("Placeholder").Ghost()
+               | withValue.ToTextInput().Ghost()
+               | withValue.ToTextInput().Ghost().Disabled()
+               | withValue.ToTextInput().Ghost().Invalid(InvalidSample)
+
+               | Text.Monospaced("TextInputVariant.Password")
+               | withoutValue.ToPasswordInput().Placeholder("Placeholder").ShortcutKey("Ctrl+L").Ghost()
+               | withValue.ToPasswordInput().Ghost()
+               | withValue.ToPasswordInput().Ghost().Disabled()
+               | withValue.ToPasswordInput().Ghost().Invalid(InvalidSample)
+
+               | Text.Monospaced("TextInputVariant.Textarea")
+               | withoutValue.ToTextareaInput().Placeholder("Placeholder").ShortcutKey("Ctrl+T").Ghost()
+               | withValue.ToTextareaInput().Ghost()
+               | withValue.ToTextareaInput().Ghost().Disabled()
+               | withValue.ToTextareaInput().Ghost().Invalid(InvalidSample)
+
+               | Text.Monospaced("TextInputVariant.Search")
+               | withoutValue.ToSearchInput().Placeholder("Placeholder").ShortcutKey("Ctrl+K").Ghost()
+               | withValue.ToSearchInput().Ghost()
+               | withValue.ToSearchInput().Ghost().Disabled()
+               | withValue.ToSearchInput().Ghost().Invalid(InvalidSample)
+
+               | Text.Monospaced("Search + Suffix (Ghost)")
+               | withoutValue.ToSearchInput().Placeholder("Search").Ghost().Suffix(Icons.ChevronDown)
+               | withValue.ToSearchInput().Placeholder("Search").Ghost().Suffix(Icons.ChevronDown)
+               | withValue.ToSearchInput().Placeholder("Search").Ghost().Suffix(Icons.ChevronDown).Disabled()
+               | withValue.ToSearchInput().Placeholder("Search").Ghost().Suffix(Icons.ChevronDown).Invalid(InvalidSample)
+
+               | Text.Monospaced("TextInputVariant.Email")
+               | withoutValue.ToEmailInput().Placeholder("Placeholder").ShortcutKey("Ctrl+E").Ghost()
+               | withValue.ToEmailInput().Ghost()
+               | withValue.ToEmailInput().Ghost().Disabled()
+               | withValue.ToEmailInput().Ghost().Invalid(InvalidSample)
+
+               | Text.Monospaced("TextInputVariant.Tel")
+               | withoutValue.ToTelInput().Placeholder("Placeholder").ShortcutKey("Ctrl+J").Ghost()
+               | withValue.ToTelInput().Ghost()
+               | withValue.ToTelInput().Ghost().Disabled()
+               | withValue.ToTelInput().Ghost().Invalid(InvalidSample)
+
+               | Text.Monospaced("TextInputVariant.Url")
+               | withoutValue.ToUrlInput().Placeholder("Placeholder").ShortcutKey("Ctrl+U").Ghost()
+               | withValue.ToUrlInput().Ghost()
+               | withValue.ToUrlInput().Ghost().Disabled()
+               | withValue.ToUrlInput().Ghost().Invalid(InvalidSample);
     }
 }
 

--- a/src/frontend/src/components/ui/input/text-input-variant.ts
+++ b/src/frontend/src/components/ui/input/text-input-variant.ts
@@ -1,5 +1,29 @@
 import { cva } from "class-variance-authority";
 
+import { cn } from "@/lib/utils";
+
+/** Prefix/suffix regions: boxed chrome by default; with ghost they blend into the parent. */
+export function textInputAffixCellClasses(
+  side: "prefix" | "suffix",
+  isFocused: boolean,
+  ghostWithAffixes: boolean,
+): string {
+  return cn(
+    "flex items-center text-muted-foreground [&_button]:rounded [&_button]:px-1 [&_button]:hover:bg-accent [&_button]:cursor-pointer [&_button]:transition-colors",
+    ghostWithAffixes
+      ? "px-2 shrink-0 bg-transparent"
+      : cn(
+          "px-3 bg-muted",
+          side === "prefix"
+            ? "rounded-tl-fields rounded-bl-fields"
+            : "rounded-tr-fields rounded-br-fields",
+        ),
+    side === "prefix"
+      ? !ghostWithAffixes && !isFocused && "border-r border-input"
+      : !ghostWithAffixes && !isFocused && "border-l border-input",
+  );
+}
+
 // Size variants for TextInputWidget
 export const textInputSizeVariant = cva("w-full", {
   variants: {

--- a/src/frontend/src/components/ui/input/text-input-variant.ts
+++ b/src/frontend/src/components/ui/input/text-input-variant.ts
@@ -2,7 +2,7 @@ import { cva } from "class-variance-authority";
 
 import { cn } from "@/lib/utils";
 
-/** Affix cells: muted box by default; ghost + affixes uses transparent chrome (suffix leading padding tight to clear). */
+/** Affix cells: muted box by default; ghost uses transparent chrome with tight padding toward the input. */
 export function textInputAffixCellClasses(
   side: "prefix" | "suffix",
   isFocused: boolean,
@@ -12,8 +12,8 @@ export function textInputAffixCellClasses(
     "flex items-center text-muted-foreground [&_button]:rounded [&_button]:px-1 [&_button]:hover:bg-accent [&_button]:cursor-pointer [&_button]:transition-colors",
     ghostWithAffixes
       ? side === "suffix"
-        ? "shrink-0 bg-transparent pl-0 pr-2"
-        : "shrink-0 bg-transparent px-2"
+        ? "shrink-0 bg-transparent pl-0 pr-1.5"
+        : "shrink-0 bg-transparent pl-2 pr-0.5"
       : cn(
           "px-3 bg-muted",
           side === "prefix"

--- a/src/frontend/src/components/ui/input/text-input-variant.ts
+++ b/src/frontend/src/components/ui/input/text-input-variant.ts
@@ -2,7 +2,7 @@ import { cva } from "class-variance-authority";
 
 import { cn } from "@/lib/utils";
 
-/** Prefix/suffix regions: boxed chrome by default; with ghost they blend into the parent. */
+/** Affix cells: muted box by default; ghost + affixes uses transparent chrome (suffix leading padding tight to clear). */
 export function textInputAffixCellClasses(
   side: "prefix" | "suffix",
   isFocused: boolean,
@@ -11,7 +11,9 @@ export function textInputAffixCellClasses(
   return cn(
     "flex items-center text-muted-foreground [&_button]:rounded [&_button]:px-1 [&_button]:hover:bg-accent [&_button]:cursor-pointer [&_button]:transition-colors",
     ghostWithAffixes
-      ? "px-2 shrink-0 bg-transparent"
+      ? side === "suffix"
+        ? "shrink-0 bg-transparent pl-0 pr-2"
+        : "shrink-0 bg-transparent px-2"
       : cn(
           "px-3 bg-muted",
           side === "prefix"

--- a/src/frontend/src/widgets/inputs/TextInputWidget/__tests__/TextInputWidget.test.ts
+++ b/src/frontend/src/widgets/inputs/TextInputWidget/__tests__/TextInputWidget.test.ts
@@ -38,6 +38,7 @@ vi.mock("@/components/ui/input", () => {
 
 vi.mock("@/components/ui/input/text-input-variant", () => ({
   textInputSizeVariant: () => "",
+  textInputAffixCellClasses: () => "",
   searchIconVariant: () => "",
   xIconVariant: () => "",
 }));

--- a/src/frontend/src/widgets/inputs/TextInputWidget/variants/DefaultVariant.tsx
+++ b/src/frontend/src/widgets/inputs/TextInputWidget/variants/DefaultVariant.tsx
@@ -4,7 +4,11 @@ import { cn } from "@/lib/utils";
 import { getWidth, inputStyles } from "@/lib/styles";
 import { InvalidIcon } from "@/components/InvalidIcon";
 import { Densities } from "@/types/density";
-import { textInputSizeVariant, xIconVariant } from "@/components/ui/input/text-input-variant";
+import {
+  textInputAffixCellClasses,
+  textInputSizeVariant,
+  xIconVariant,
+} from "@/components/ui/input/text-input-variant";
 import { TextInputWidgetProps } from "../types";
 import {
   useCursorPosition,
@@ -69,6 +73,7 @@ export const DefaultVariant: React.FC<DefaultVariantProps> = ({
   const hasPrefix = (prefixContent?.length ?? 0) > 0;
   const hasSuffix = (suffixContent?.length ?? 0) > 0;
   const hasAffixes = hasPrefix || hasSuffix;
+  const ghostAffixChrome = Boolean(props.ghost && hasAffixes);
   const showClear = props.nullable && !props.disabled && hasValue;
 
   return (
@@ -87,12 +92,7 @@ export const DefaultVariant: React.FC<DefaultVariantProps> = ({
       >
         {/* Prefix with background and separator */}
         {hasPrefix && (
-          <div
-            className={cn(
-              "flex items-center px-3 bg-muted text-muted-foreground rounded-tl-[var(--radius-fields)] rounded-bl-[var(--radius-fields)] [&_button]:rounded [&_button]:px-1 [&_button]:hover:bg-accent [&_button]:cursor-pointer [&_button]:transition-colors",
-              !isFocused && "border-r border-input",
-            )}
-          >
+          <div className={textInputAffixCellClasses("prefix", isFocused, ghostAffixChrome)}>
             {prefixContent}
           </div>
         )}
@@ -176,7 +176,8 @@ export const DefaultVariant: React.FC<DefaultVariantProps> = ({
               props.onDictationToggle?.();
             }}
             className={cn(
-              "flex items-center justify-center px-2 border-l border-input hover:bg-accent focus:outline-none cursor-pointer transition-colors",
+              "flex items-center justify-center px-2 border-l hover:bg-accent focus:outline-none cursor-pointer transition-colors",
+              props.ghost ? "border-border/30" : "border-input",
               props.isRecording && "bg-destructive/10 text-destructive",
             )}
           >
@@ -186,12 +187,7 @@ export const DefaultVariant: React.FC<DefaultVariantProps> = ({
 
         {/* Suffix with background and separator */}
         {hasSuffix && (
-          <div
-            className={cn(
-              "flex items-center px-3 bg-muted text-muted-foreground rounded-tr-[var(--radius-fields)] rounded-br-[var(--radius-fields)] [&_button]:rounded [&_button]:px-1 [&_button]:hover:bg-accent [&_button]:cursor-pointer [&_button]:transition-colors",
-              !isFocused && "border-l border-input",
-            )}
-          >
+          <div className={textInputAffixCellClasses("suffix", isFocused, ghostAffixChrome)}>
             {suffixContent}
           </div>
         )}

--- a/src/frontend/src/widgets/inputs/TextInputWidget/variants/DefaultVariant.tsx
+++ b/src/frontend/src/widgets/inputs/TextInputWidget/variants/DefaultVariant.tsx
@@ -75,6 +75,7 @@ export const DefaultVariant: React.FC<DefaultVariantProps> = ({
   const hasAffixes = hasPrefix || hasSuffix;
   const ghostAffixChrome = Boolean(props.ghost && hasAffixes);
   const showClear = props.nullable && !props.disabled && hasValue;
+  const ghostTrailingTight = Boolean(props.ghost && hasSuffix);
 
   return (
     <div className="relative w-full select-none" style={styles}>
@@ -135,7 +136,12 @@ export const DefaultVariant: React.FC<DefaultVariantProps> = ({
 
           {/* Right side container: shortcut (if any), clear (if nullable), then invalid (if any) */}
           {(props.shortcutKey || showClear || props.invalid) && (
-            <div className="absolute right-2 top-1/2 -translate-y-1/2 flex flex-row items-center gap-1 pointer-events-none">
+            <div
+              className={cn(
+                "pointer-events-none absolute top-1/2 flex -translate-y-1/2 flex-row items-center",
+                ghostTrailingTight ? "right-0 gap-0 pr-0" : "right-2 gap-1",
+              )}
+            >
               {props.shortcutKey && !isFocused && !hasValue && !showClear && !props.invalid && (
                 <div className="pointer-events-auto flex items-center h-6">
                   <kbd className="px-1 py-0.5 text-xs font-medium text-foreground bg-muted border border-border rounded-selector">

--- a/src/frontend/src/widgets/inputs/TextInputWidget/variants/PasswordVariant.tsx
+++ b/src/frontend/src/widgets/inputs/TextInputWidget/variants/PasswordVariant.tsx
@@ -82,6 +82,7 @@ export const PasswordVariant: React.FC<PasswordVariantProps> = ({
   const shortcutDisplay = formatShortcutForDisplay(props.shortcutKey);
   const hasValue = props.value && props.value.toString().trim() !== "";
   const showClear = props.nullable && !props.disabled && hasValue;
+  const ghostTight = Boolean(props.ghost);
 
   return (
     <div className="relative w-full select-none" style={styles} ref={containerRef}>
@@ -127,11 +128,19 @@ export const PasswordVariant: React.FC<PasswordVariantProps> = ({
         />
       </div>
       {!hasLastPass && (
-        <div className="absolute right-2 top-1/2 -translate-y-1/2 flex flex-row items-center gap-1 pointer-events-none h-6">
+        <div
+          className={cn(
+            "pointer-events-none absolute top-1/2 flex h-6 -translate-y-1/2 flex-row items-center",
+            ghostTight ? "right-0 gap-1 pr-0.5" : "right-2 gap-1",
+          )}
+        >
           <div className="pointer-events-auto flex items-center h-6">
             <button
               type="button"
-              className="p-1 rounded hover:bg-accent focus:outline-none cursor-pointer flex items-center"
+              className={cn(
+                "flex items-center rounded hover:bg-accent focus:outline-none cursor-pointer",
+                ghostTight ? "p-0.5" : "p-1",
+              )}
               onClick={togglePassword}
               aria-label={showPassword ? "Hide password" : "Show password"}
             >
@@ -154,15 +163,19 @@ export const PasswordVariant: React.FC<PasswordVariantProps> = ({
             </button>
           )}
           {props.shortcutKey && !hasValue && !showClear && !props.invalid && (
-            <div className="pointer-events-auto flex items-center h-6">
-              <kbd className="ml-2 px-1 py-0.5 text-xs font-medium text-foreground bg-muted border border-border rounded-field">
+            <div className="pointer-events-auto flex h-6 items-center">
+              <kbd
+                className={cn(
+                  "rounded-field border border-border bg-muted px-1 py-0.5 text-xs font-medium text-foreground",
+                  !ghostTight && "ml-2",
+                )}
+              >
                 {shortcutDisplay}
               </kbd>
             </div>
           )}
-          {/* Invalid icon - rightmost */}
           {props.invalid && (
-            <div className="flex items-center h-6 ml-2">
+            <div className={cn("flex h-6 items-center", !ghostTight && "ml-2")}>
               <InvalidIcon message={props.invalid} />
             </div>
           )}

--- a/src/frontend/src/widgets/inputs/TextInputWidget/variants/SearchVariant.tsx
+++ b/src/frontend/src/widgets/inputs/TextInputWidget/variants/SearchVariant.tsx
@@ -8,6 +8,7 @@ import { useFocusable } from "@/hooks/use-focus-management";
 import { sidebarMenuRef } from "@/widgets/layouts/sidebar";
 import { Densities } from "@/types/density";
 import {
+  textInputAffixCellClasses,
   textInputSizeVariant,
   searchIconVariant,
   xIconVariant,
@@ -90,6 +91,7 @@ export const SearchVariant: React.FC<SearchVariantProps> = ({
   const hasPrefix = (prefixContent?.length ?? 0) > 0;
   const hasSuffix = (suffixContent?.length ?? 0) > 0;
   const hasAffixes = hasPrefix || hasSuffix;
+  const ghostAffixChrome = Boolean(props.ghost && hasAffixes);
 
   // Merge focusRef and inputRef
   const mergedRef = useCallback(
@@ -121,12 +123,7 @@ export const SearchVariant: React.FC<SearchVariantProps> = ({
         )}
       >
         {hasPrefix && (
-          <div
-            className={cn(
-              "flex items-center px-3 bg-muted text-muted-foreground rounded-tl-[var(--radius-fields)] rounded-bl-[var(--radius-fields)] [&_button]:rounded [&_button]:px-1 [&_button]:hover:bg-accent [&_button]:cursor-pointer [&_button]:transition-colors",
-              !isFocused && "border-r border-input",
-            )}
-          >
+          <div className={textInputAffixCellClasses("prefix", isFocused, ghostAffixChrome)}>
             {prefixContent}
           </div>
         )}
@@ -198,12 +195,7 @@ export const SearchVariant: React.FC<SearchVariantProps> = ({
         </div>
 
         {hasSuffix && (
-          <div
-            className={cn(
-              "flex items-center px-3 bg-muted text-muted-foreground rounded-tr-[var(--radius-fields)] rounded-br-[var(--radius-fields)] [&_button]:rounded [&_button]:px-1 [&_button]:hover:bg-accent [&_button]:cursor-pointer [&_button]:transition-colors",
-              !isFocused && "border-l border-input",
-            )}
-          >
+          <div className={textInputAffixCellClasses("suffix", isFocused, ghostAffixChrome)}>
             {suffixContent}
           </div>
         )}

--- a/src/frontend/src/widgets/inputs/TextInputWidget/variants/SearchVariant.tsx
+++ b/src/frontend/src/widgets/inputs/TextInputWidget/variants/SearchVariant.tsx
@@ -83,29 +83,64 @@ export const SearchVariant: React.FC<SearchVariantProps> = ({
   };
 
   const shortcutDisplay = formatShortcutForDisplay(props.shortcutKey);
-  const hasValue = props.value && props.value.trim() !== "";
-  const showClear = props.nullable && !props.disabled && hasValue;
-
+  const hasValue = Boolean(props.value && String(props.value).trim() !== "");
   const prefixContent = props.slots?.Prefix;
   const suffixContent = props.slots?.Suffix;
   const hasPrefix = (prefixContent?.length ?? 0) > 0;
   const hasSuffix = (suffixContent?.length ?? 0) > 0;
   const hasAffixes = hasPrefix || hasSuffix;
   const ghostAffixChrome = Boolean(props.ghost && hasAffixes);
+  const ghostSuffixLayout = Boolean(props.ghost && hasSuffix);
+  const showClear = ghostSuffixLayout
+    ? !props.disabled && hasValue
+    : props.nullable && !props.disabled && hasValue;
+  const showShortcut =
+    Boolean(props.shortcutKey) && !isFocused && !hasValue && !showClear && !props.invalid;
+  const showTrailing = showClear || showShortcut || Boolean(props.invalid);
 
-  // Merge focusRef and inputRef
   const mergedRef = useCallback(
     (element: HTMLInputElement | null) => {
-      // Set focusRef for focus management
       focusRef(element);
-      // Set inputRef for keyboard shortcut handler
-      // Refs are mutable objects by design, so this assignment is safe
       if (inputRef && "current" in inputRef) {
-        // Use Reflect.set to bypass linter
         Reflect.set(inputRef, "current", element);
       }
     },
     [focusRef, inputRef],
+  );
+
+  const kbd = (
+    <kbd className="rounded-selector border border-border bg-muted px-1 py-0.25 text-xs text-foreground">
+      {shortcutDisplay}
+    </kbd>
+  );
+
+  const trailingCluster = (overlay: boolean) => (
+    <>
+      {showClear && (
+        <button
+          type="button"
+          tabIndex={-1}
+          aria-label="Clear search"
+          onClick={onClear}
+          className={cn(
+            "flex h-6 shrink-0 items-center rounded hover:bg-accent focus:outline-none cursor-pointer",
+            overlay ? "p-1 pointer-events-auto" : "p-0.5",
+          )}
+        >
+          <X className={xIconVariant({ density })} />
+        </button>
+      )}
+      {showShortcut && (
+        <div className={cn("flex h-4 shrink-0 items-center", overlay && "pointer-events-auto")}>
+          {kbd}
+        </div>
+      )}
+      {props.invalid && (
+        <div className={cn("flex h-6 shrink-0 items-center", overlay && "pointer-events-auto")}>
+          <InvalidIcon message={props.invalid} />
+        </div>
+      )}
+    </>
   );
 
   return (
@@ -128,7 +163,7 @@ export const SearchVariant: React.FC<SearchVariantProps> = ({
           </div>
         )}
 
-        <div className="relative flex-1">
+        <div className={cn("relative flex-1", ghostSuffixLayout && "min-w-0")}>
           <Search className={searchIconVariant({ density })} />
           <Input
             ref={mergedRef}
@@ -150,14 +185,16 @@ export const SearchVariant: React.FC<SearchVariantProps> = ({
               textInputSizeVariant({ density }),
               "pl-8 cursor-pointer border-0 shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 dark:bg-transparent",
               props.invalid && inputStyles.invalidInput,
-              (props.invalid || showClear) && "pr-8",
-              props.shortcutKey &&
+              ghostSuffixLayout && showTrailing && "pr-2",
+              !ghostSuffixLayout && (props.invalid || showClear) && "pr-8",
+              !ghostSuffixLayout &&
+                props.shortcutKey &&
                 !isFocused &&
                 !hasValue &&
                 !showClear &&
                 !props.invalid &&
                 "pr-16",
-              showClear && props.invalid && "pr-16",
+              !ghostSuffixLayout && showClear && props.invalid && "pr-16",
               !hasValue && props.nullable && "placeholder:text-muted-foreground",
               "[&::-webkit-search-cancel-button]:appearance-none [&::-webkit-search-cancel-button]:hidden",
               hasPrefix && "rounded-l-none",
@@ -166,33 +203,18 @@ export const SearchVariant: React.FC<SearchVariantProps> = ({
             )}
             data-testid={props["data-testid"]}
           />
-          <div className="absolute right-2.5 top-1/2 -translate-y-1/2 flex items-center gap-2 pointer-events-none z-10 h-6">
-            {hasValue && !props.disabled && (
-              <button
-                type="button"
-                tabIndex={-1}
-                aria-label="Clear search"
-                onClick={onClear}
-                className="p-1 rounded hover:bg-accent focus:outline-none cursor-pointer pointer-events-auto flex items-center h-6"
-                style={{ pointerEvents: "auto" }}
-              >
-                <X className={xIconVariant({ density })} />
-              </button>
-            )}
-            {props.shortcutKey && !isFocused && !hasValue && (
-              <div className="pointer-events-auto flex items-center h-4">
-                <kbd className="text-xs text-foreground bg-muted border border-border rounded-selector px-1 py-0.25">
-                  {shortcutDisplay}
-                </kbd>
-              </div>
-            )}
-            {props.invalid && (
-              <div className="flex items-center h-6">
-                <InvalidIcon message={props.invalid} />
-              </div>
-            )}
-          </div>
+          {!ghostSuffixLayout && showTrailing && (
+            <div className="pointer-events-none absolute inset-y-0 left-0 right-0 z-10 flex items-center justify-end gap-2 pr-2.5">
+              {trailingCluster(true)}
+            </div>
+          )}
         </div>
+
+        {ghostSuffixLayout && showTrailing && (
+          <div className="relative z-10 flex shrink-0 items-center gap-0 self-stretch bg-transparent px-0 text-muted-foreground">
+            {trailingCluster(false)}
+          </div>
+        )}
 
         {hasSuffix && (
           <div className={textInputAffixCellClasses("suffix", isFocused, ghostAffixChrome)}>


### PR DESCRIPTION
Had an issue:

> Add a slot for SearchInput component that removes the extra UI/border styling to make it stand out less visually.

<img width="1158" height="303" alt="image" src="https://github.com/user-attachments/assets/99a7b6ed-42a1-438f-9293-4d117c1b9b4a" />

We already had ghost prop for text inputs, but while verifying its appearance, I found an issue that when suffix/affix is enabled, only text's input part has corrected border styling, while suffix/affix borders stay standard.
Fixed. Created a small demo with text inputs in ghost variants, the main goal is still a search input:

https://github.com/user-attachments/assets/73b7c4a4-85e4-4b7e-abc9-89dfc66a8ffb

<img width="637" height="80" alt="image" src="https://github.com/user-attachments/assets/4fee9938-a0d1-4ea2-981c-a2faf519ced3" />

<img width="639" height="77" alt="image" src="https://github.com/user-attachments/assets/869819c7-d80c-4f91-aae9-9e2e0c6767ef" />

<img width="319" height="67" alt="image" src="https://github.com/user-attachments/assets/54cc91f8-d0f6-4045-b8dc-475cb85226b9" />

<img width="327" height="68" alt="image" src="https://github.com/user-attachments/assets/e7253506-65a5-460d-a11f-3b9f50de9ee0" />

