### PR TITLE
(tendril docs): reset app host scroll on pages navigation

### DIFF
--- a/src/frontend/src/widgets/primitives/AppHostWidget.tsx
+++ b/src/frontend/src/widgets/primitives/AppHostWidget.tsx
@@ -21,26 +21,22 @@ export const AppHostWidget: React.FC<AppHostWidgetProps> = ({ appId, appArgs, pa
     false,
   );
   const containerRef = useRef<HTMLDivElement>(null);
-  const previousAppIdRef = useRef<string>(appId);
-  const hasResetForCurrentApp = useRef<boolean>(false);
+  const previousAppIdRef = useRef(appId);
 
   useEffect(() => {
-    // Reset scroll only once when navigating to a new app and content is loaded
-    if (
-      containerRef.current &&
-      widgetTree &&
-      previousAppIdRef.current !== appId &&
-      !hasResetForCurrentApp.current
-    ) {
-      containerRef.current.scrollTop = 0;
-      previousAppIdRef.current = appId;
-      hasResetForCurrentApp.current = true;
-    }
+    if (!containerRef.current || widgetTree == null) return;
+    if (previousAppIdRef.current === appId) return;
 
-    // Reset the flag when appId changes (for next navigation)
-    if (previousAppIdRef.current !== appId) {
-      hasResetForCurrentApp.current = false;
+    const el = containerRef.current;
+    el.scrollTop = 0;
+    const parent = el.parentElement;
+    if (parent) {
+      const { overflowY } = getComputedStyle(parent);
+      if (overflowY === "auto" || overflowY === "scroll") {
+        parent.scrollTop = 0;
+      }
     }
+    previousAppIdRef.current = appId;
   }, [widgetTree, appId]);
 
   return (


### PR DESCRIPTION
> Scroll position not reset when navigating between pages in tendril docs 
Reprosuced issue:

https://github.com/user-attachments/assets/ec77b3f2-8408-40a6-bb78-b7922155b43a

Fixed:

https://github.com/user-attachments/assets/57aa113f-d44d-4bfa-b3dc-9e511fcc124e

**Root cause**
AppHostWidget combined hasResetForCurrentApp and previousAppIdRef in one effect. When appId and widgetTree updated together, the scroll branch was skipped and the ref was never advanced, so scroll never reset.

Also verified Ivy Docs, everything works fine. 