### PR TITLE
(datatable): dismiss row actions on scroll

### DIFF
--- a/src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx
+++ b/src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx
@@ -3,7 +3,9 @@ import {
   CompactSelection,
   CustomRenderer,
   DataEditorRef,
+  GridMouseCellEventArgs,
   GridMouseEventArgs,
+  Item,
 } from "@glideapps/glide-data-grid";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useTable } from "../dataTableContext";
@@ -115,6 +117,7 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
 
   // Grid ref
   const gridRef = useRef<DataEditorRef | null>(null);
+  const prevVisibleScrollOriginRef = useRef<{ x: number; y: number } | null>(null);
 
   // Cell content
   const { getCellContent } = useCellContent({
@@ -150,6 +153,8 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
     onItemHovered,
     handleRowActionClick,
     resolvedRowActions,
+    clearRowHover,
+    syncRowChromeFromCellArgs,
   } = useRowHover({
     widgetId,
     events,
@@ -167,6 +172,7 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
     virtualRef,
     onItemHovered: onLinkCellHovered,
     linkTooltipPos,
+    clearLinkCellHover,
   } = useLinkCellHover({
     getCellContent,
     visibleRows,
@@ -250,6 +256,20 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
     width: number;
   } | null>(null);
 
+  const handleVisibleRegionChangedForGrid = useCallback(
+    (range: { x: number; y: number; width: number; height: number }) => {
+      handleVisibleRegionChanged(range);
+      const prev = prevVisibleScrollOriginRef.current;
+      const originMoved = prev !== null && (prev.x !== range.x || prev.y !== range.y);
+      prevVisibleScrollOriginRef.current = { x: range.x, y: range.y };
+      if (!originMoved) return;
+      clearRowHover();
+      clearLinkCellHover();
+      setCellActionIndicator(null);
+    },
+    [handleVisibleRegionChanged, clearRowHover, clearLinkCellHover],
+  );
+
   // Compose onItemHovered: keep existing hover behavior and track actionable-cell affordance.
   const handleItemHovered = useCallback(
     (args: GridMouseEventArgs) => {
@@ -280,6 +300,19 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
       });
     },
     [onLinkCellHovered, onItemHovered, orderedDataColumns, visibleRows],
+  );
+
+  const handleCellClickedForGrid = useCallback(
+    (cell: Item, args: GridMouseEventArgs) => {
+      handleCellClicked(cell, args);
+      if ((enableRowHover ?? false) && args.kind === "cell") {
+        const [, row] = cell;
+        if (row < visibleRows) {
+          syncRowChromeFromCellArgs(args as GridMouseCellEventArgs);
+        }
+      }
+    },
+    [handleCellClicked, enableRowHover, visibleRows, syncRowChromeFromCellArgs],
   );
 
   const wantAggregateFooter =
@@ -394,7 +427,7 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
         }
         headerIcons={headerIcons}
         onColumnResize={allowColumnResizing ? handleColumnResize : undefined}
-        onVisibleRegionChanged={handleVisibleRegionChanged}
+        onVisibleRegionChanged={handleVisibleRegionChangedForGrid}
         onHeaderClicked={allowSorting ? handleHeaderMenuClick : undefined}
         theme={tableTheme}
         rowHeight={effectiveRowHeight}
@@ -412,7 +445,7 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
         rowMarkers={showIndexColumn ? "number" : "none"}
         onColumnMoved={allowColumnReordering ? handleColumnReorder : undefined}
         groupHeaderHeight={showGroups ? densityConfig.groupHeaderHeight : undefined}
-        onCellClicked={handleCellClicked}
+        onCellClicked={handleCellClickedForGrid}
         onCellActivated={handleCellActivated}
         onGroupHeaderClicked={shouldUseColumnGroups ? onGroupHeaderClicked : undefined}
         showSearch={showSearchConfig ? showSearch : false}

--- a/src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx
+++ b/src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx
@@ -260,9 +260,9 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
     (range: { x: number; y: number; width: number; height: number }) => {
       handleVisibleRegionChanged(range);
       const prev = prevVisibleScrollOriginRef.current;
-      const originMoved = prev !== null && (prev.x !== range.x || prev.y !== range.y);
+      const verticalScrolled = prev !== null && prev.y !== range.y;
       prevVisibleScrollOriginRef.current = { x: range.x, y: range.y };
-      if (!originMoved) return;
+      if (!verticalScrolled) return;
       clearRowHover();
       clearLinkCellHover();
       setCellActionIndicator(null);

--- a/src/frontend/src/widgets/dataTables/hooks/useLinkCellHover.test.ts
+++ b/src/frontend/src/widgets/dataTables/hooks/useLinkCellHover.test.ts
@@ -43,4 +43,8 @@ describe("useLinkCellHover", () => {
     expect(hookSource).toContain("args.bounds.x + args.bounds.width / 2");
     expect(hookSource).toContain("y: args.bounds.y");
   });
+
+  it("should expose clearLinkCellHover for scroll-driven dismissal", () => {
+    expect(hookSource).toContain("clearLinkCellHover");
+  });
 });

--- a/src/frontend/src/widgets/dataTables/hooks/useLinkCellHover.ts
+++ b/src/frontend/src/widgets/dataTables/hooks/useLinkCellHover.ts
@@ -51,5 +51,15 @@ export const useLinkCellHover = ({ getCellContent, visibleRows }: UseLinkCellHov
     [],
   );
 
-  return { isLinkHovered: linkTooltipPos !== null, virtualRef, onItemHovered, linkTooltipPos };
+  const clearLinkCellHover = useCallback(() => {
+    setLinkTooltipPos(null);
+  }, []);
+
+  return {
+    isLinkHovered: linkTooltipPos !== null,
+    virtualRef,
+    onItemHovered,
+    linkTooltipPos,
+    clearLinkCellHover,
+  };
 };

--- a/src/frontend/src/widgets/dataTables/hooks/useRowHover.ts
+++ b/src/frontend/src/widgets/dataTables/hooks/useRowHover.ts
@@ -1,9 +1,23 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useState, useSyncExternalStore } from "react";
 import { GridMouseCellEventArgs, GridMouseEventArgs } from "@glideapps/glide-data-grid";
 import { useEventHandler } from "@/components/event-handler";
 import { MenuItem } from "@/types/widgets";
 import { getHiddenKeyValue } from "../utils/arrowUtils";
 import * as arrow from "apache-arrow";
+
+function subscribeHoverNone(onStoreChange: () => void) {
+  const mq = window.matchMedia("(hover: none)");
+  mq.addEventListener("change", onStoreChange);
+  return () => mq.removeEventListener("change", onStoreChange);
+}
+
+function getHoverNoneSnapshot() {
+  return window.matchMedia("(hover: none)").matches;
+}
+
+function getServerHoverNoneSnapshot() {
+  return false;
+}
 
 interface UseRowHoverProps {
   widgetId: string;
@@ -17,7 +31,8 @@ interface UseRowHoverProps {
 }
 
 /**
- * Hook to manage row hover state and action button positioning
+ * Row hover + RowActions overlay. On touch / `(hover: none)` UIs, pointer "hover" is
+ * sticky and must not drive the bar — use `syncRowChromeFromCellArgs` from `onCellClicked`.
  */
 export const useRowHover = ({
   widgetId,
@@ -34,57 +49,92 @@ export const useRowHover = ({
   const [actionButtonsHeight, setActionButtonsHeight] = useState<number>(0);
   const eventHandler = useEventHandler();
 
-  // Handle row hover
+  const primaryInputCannotHover = useSyncExternalStore(
+    subscribeHoverNone,
+    getHoverNoneSnapshot,
+    getServerHoverNoneSnapshot,
+  );
+
+  const layoutActionButtonsFromCellArgs = useCallback(
+    (args: GridMouseCellEventArgs) => {
+      if (!(rowActions?.length || perRowActions) || !containerRef.current) {
+        setActionButtonsTop(0);
+        setActionButtonsHeight(0);
+        return;
+      }
+      const { bounds } = args;
+      const container = containerRef.current;
+      const containerRect = container.getBoundingClientRect();
+      const style = window.getComputedStyle(container);
+      const borderTop = parseFloat(style.borderTopWidth) || 0;
+      const overlayTop = bounds.y - containerRect.top - borderTop;
+      const overlayHeight = bounds.height;
+      const dpr = window.devicePixelRatio;
+      const snap = (val: number) => Math.round(val * dpr) / dpr;
+      setActionButtonsTop(snap(overlayTop));
+      setActionButtonsHeight(snap(overlayHeight));
+    },
+    [rowActions, perRowActions, containerRef],
+  );
+
+  const syncRowChromeFromCellArgs = useCallback(
+    (args: GridMouseCellEventArgs) => {
+      if (!(enableRowHover ?? false)) return;
+      const [, row] = args.location;
+      if (row >= visibleRows) {
+        setHoverRow(undefined);
+        setActionButtonsTop(0);
+        setActionButtonsHeight(0);
+        return;
+      }
+      setHoverRow(row);
+      layoutActionButtonsFromCellArgs(args);
+    },
+    [enableRowHover, visibleRows, layoutActionButtonsFromCellArgs],
+  );
+
+  const clearRowHover = useCallback(() => {
+    setHoverRow(undefined);
+    setActionButtonsTop(0);
+    setActionButtonsHeight(0);
+  }, []);
+
   const onItemHovered = useCallback(
     (args: GridMouseEventArgs) => {
       if (!(enableRowHover ?? false)) return;
+
       const [, row] = args.location;
-      // Don't allow hover on empty filler rows
+
       if (args.kind === "cell" && row >= visibleRows) {
         setHoverRow(undefined);
+        setActionButtonsTop(0);
+        setActionButtonsHeight(0);
         return;
       }
-      const newHoverRow = args.kind !== "cell" ? undefined : row;
-      setHoverRow(newHoverRow);
 
-      if (
-        (rowActions?.length || perRowActions) &&
-        newHoverRow !== undefined &&
-        containerRef.current
-      ) {
-        const { bounds } = args as GridMouseCellEventArgs;
-        const container = containerRef.current;
-        const containerRect = container.getBoundingClientRect();
-
-        // Get precision border width (clientTop is always an integer, which is inaccurate at zoom)
-        const style = window.getComputedStyle(container);
-        const borderTop = parseFloat(style.borderTopWidth) || 0;
-
-        // Convert grid viewport coords -> overlay container padding-box coords.
-        const overlayTop = bounds.y - containerRect.top - borderTop;
-        const overlayHeight = bounds.height;
-
-        // Pixel-perfect snapping using devicePixelRatio.
-        // This ensures the overlay aligns perfectly with physical pixels even at non-standard zoom levels.
-        const dpr = window.devicePixelRatio;
-        const snap = (val: number) => Math.round(val * dpr) / dpr;
-
-        setActionButtonsTop(snap(overlayTop));
-        setActionButtonsHeight(snap(overlayHeight));
+      if (args.kind !== "cell") {
+        setHoverRow(undefined);
+        setActionButtonsTop(0);
+        setActionButtonsHeight(0);
+        return;
       }
+
+      if (args.isTouch || primaryInputCannotHover) {
+        return;
+      }
+
+      setHoverRow(row);
+      layoutActionButtonsFromCellArgs(args as GridMouseCellEventArgs);
     },
-    [enableRowHover, rowActions, perRowActions, visibleRows, containerRef],
+    [enableRowHover, primaryInputCannotHover, layoutActionButtonsFromCellArgs, visibleRows],
   );
 
-  // Handle row action button click
   const handleRowActionClick = useCallback(
     (action: MenuItem) => {
       if (hoverRow === undefined) return;
 
-      // Extract _hiddenKey directly from Arrow table
       const rowId = getHiddenKeyValue(arrowTableRef.current, hoverRow);
 
-      // Send event to backend's OnRowAction event with row ID and menu item tag
       if (events.includes("OnRowAction"))
         eventHandler("OnRowAction", widgetId, [
           {
@@ -96,7 +146,6 @@ export const useRowHover = ({
     [hoverRow, events, eventHandler, widgetId, arrowTableRef],
   );
 
-  // Resolve per-row actions for the currently hovered row
   const resolvedRowActions = useMemo(() => {
     if (!perRowActions || hoverRow === undefined) return rowActions;
     const rowId = getHiddenKeyValue(arrowTableRef.current, hoverRow);
@@ -113,5 +162,7 @@ export const useRowHover = ({
     onItemHovered,
     handleRowActionClick,
     resolvedRowActions,
+    clearRowHover,
+    syncRowChromeFromCellArgs,
   };
 };


### PR DESCRIPTION
### Summary
Row actions and row highlight were driven by Glide onItemHovered, which behaves like sticky hover on touch: scrolling kept the last row “active” and the action bar used stale coordinates so it looked like it drifted with the scroll.

Garants better UX for touch devices and looks cleaner on PC:

For touch devices:
https://github.com/user-attachments/assets/9abb5b49-4774-43c3-bb87-f76a728d008a

For PC:

https://github.com/user-attachments/assets/7f5f9844-405e-412e-b7a3-fddf7b27aab8

Before bar was on screen permanently which caused visual trash feeling:

https://github.com/user-attachments/assets/799a8ed5-e90c-4288-a531-d4afe93274a3

What changed

- On visible region / scroll (when the grid’s visible origin (x, y) changes), we clear row hover, link tooltip state, and the cell link affordance overlay so floating UI doesn’t survive a scroll.
- On touch / (hover: none) environments, we do not apply row chrome from onItemHovered for data cells (avoids WebKit-style sticky hover). Leaving headers / non-cells / filler still clears state.
onCellClicked pins row chrome (row + action bar layout) so tap shows RowActions() on phones/tablets and in device emulation.
