### PR TITLE
fix: remove indentation on leaf nodes in Tree widget

### DIFF
--- a/src/frontend/src/widgets/tree/TreeItem.tsx
+++ b/src/frontend/src/widgets/tree/TreeItem.tsx
@@ -53,8 +53,6 @@ interface TreeItemWidgetProps {
   item: MenuItem;
   density?: Densities;
   rowActions?: MenuItem[];
-  hasSiblingWithChildren?: boolean;
-  isNested?: boolean;
   onItemClick: (item: MenuItem) => void;
   onRowActionClick?: (item: MenuItem, action: MenuItem) => void;
 }
@@ -63,8 +61,6 @@ export const TreeItem: React.FC<TreeItemWidgetProps> = ({
   item,
   density,
   rowActions,
-  hasSiblingWithChildren,
-  isNested,
   onItemClick,
   onRowActionClick,
 }) => {
@@ -204,10 +200,6 @@ export const TreeItem: React.FC<TreeItemWidgetProps> = ({
                 density={density}
                 onItemClick={onItemClick}
                 rowActions={rowActions}
-                hasSiblingWithChildren={item.children!.some(
-                  (c) => c.children && c.children.length > 0,
-                )}
-                isNested
                 onRowActionClick={onRowActionClick}
               />
             ))}
@@ -230,7 +222,6 @@ export const TreeItem: React.FC<TreeItemWidgetProps> = ({
       onKeyDown={handleKeyDown}
       onClick={handleClick}
     >
-      {hasSiblingWithChildren && isNested && <span className="h-5 w-5 shrink-0" />}
       {item.icon && item.icon !== "None" && (
         <Icon className="h-4 w-4 shrink-0 text-muted-foreground" name={item.icon} />
       )}

--- a/src/frontend/src/widgets/tree/TreeItem.tsx
+++ b/src/frontend/src/widgets/tree/TreeItem.tsx
@@ -230,7 +230,7 @@ export const TreeItem: React.FC<TreeItemWidgetProps> = ({
       onKeyDown={handleKeyDown}
       onClick={handleClick}
     >
-      {hasSiblingWithChildren && !isNested && <span className="h-5 w-5 shrink-0" />}
+      {hasSiblingWithChildren && isNested && <span className="h-5 w-5 shrink-0" />}
       {item.icon && item.icon !== "None" && (
         <Icon className="h-4 w-4 shrink-0 text-muted-foreground" name={item.icon} />
       )}

--- a/src/frontend/src/widgets/tree/TreeWidget.tsx
+++ b/src/frontend/src/widgets/tree/TreeWidget.tsx
@@ -59,7 +59,6 @@ export const TreeWidget: React.FC<TreeWidgetProps> = ({
           density={density}
           onItemClick={onItemClick}
           rowActions={rowActions}
-          hasSiblingWithChildren={items.some((i) => i.children && i.children.length > 0)}
           onRowActionClick={onRowActionClick}
         />
       ))}


### PR DESCRIPTION
Addresses https://github.com/Ivy-Interactive/Ivy-Framework/issues/4371

## Problem
A span was rendered to the left of leaf nodes that had siblings with children which made the leaf nodes appear to be on the same level as their siblings' children. 

## Solution
Removed `hasSiblingWithChildren` and `isNested` props from `TreeItem`.

### Before:
<img width="300" alt="ivy-framework-tree- widget-indentation_before" src="https://github.com/user-attachments/assets/c567938f-e7d9-4cf9-b6f4-1ca4eabcf4bd" />

### After:
<img width="300" alt="ivy-framework-tree- widget-indentation_after" src="https://github.com/user-attachments/assets/fccd4248-089c-43d6-a73b-c43f9771eca4" />
