### PR TITLE
(auth): implement claude auth

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/04_Authentication/01_AuthenticationOverview.md
+++ b/src/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/04_Authentication/01_AuthenticationOverview.md
@@ -182,6 +182,8 @@ The `OAuthProviders` class provides constants for supported providers:
 - `OAuthProviders.Notion` - Notion
 - `OAuthProviders.GitLab` - GitLab
 - `OAuthProviders.Bitbucket` - Bitbucket
+- `OAuthProviders.Sliplane` - Sliplane
+- `OAuthProviders.Claude` - Claude (Anthropic, claude.ai OAuth)
 
 ### Registering Token Handlers
 
@@ -189,10 +191,11 @@ For an OAuth provider to appear in the brokered sessions dictionary, there must 
 
 **Built-in Handlers**
 
-Ivy provides pre-built token handlers for Google and GitHub. Simply add the NuGet package to your project:
+Ivy provides pre-built token handlers for common OAuth providers (for example Google, GitHub, and Claude). Add the corresponding NuGet package to your project:
 
 - `Ivy.Auth.Google` - Provides `GoogleAuthTokenHandler`
 - `Ivy.Auth.GitHub` - Provides `GitHubAuthTokenHandler`
+- `Ivy.Auth.Claude` - Provides `ClaudeAuthTokenHandler` (Anthropic claude.ai OAuth)
 
 **Configuration for Google Token Handler**
 
@@ -262,6 +265,7 @@ Ivy supports the following authentication providers. Click on any provider for d
 - **[Microsoft Entra](02_MicrosoftEntra.md)** - Enterprise SSO, conditional access, and Microsoft Graph integration
 - **[Authelia](02_Authelia.md)** - Self-hosted identity provider with LDAP and forward auth
 - **[Sliplane](02_Sliplane.md)** - OAuth 2.0 sign-in for apps deployed or integrated with Sliplane
+- **[Claude (Anthropic)](02_Claude.md)** - OAuth 2.0 sign-in with a Claude.ai account (PKCE)
 - **[Basic Auth](02_BasicAuth.md)** - Simple username/password authentication for development and internal tools
 
 ## Examples

--- a/src/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/04_Authentication/02_Claude.md
+++ b/src/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/04_Authentication/02_Claude.md
@@ -1,0 +1,106 @@
+---
+title: Claude (Anthropic)
+searchHints:
+  - claude
+  - anthropic
+  - authentication
+  - oauth
+  - pkce
+  - claude.ai
+---
+# Claude (Anthropic) authentication provider
+
+<Ingress>
+Sign in to your Ivy application with Anthropic Claude using OAuth 2.0 and PKCE—the same style of browser login used by Claude Code and Claude on the web.
+</Ingress>
+
+## Overview
+
+The Claude provider uses Anthropic’s OAuth endpoints to authenticate users with a **Claude.ai** account. The flow is an **authorization code** grant with **PKCE** (no static client secret required for public clients). Ivy exchanges the authorization code at the token endpoint and stores access (and optional refresh) tokens in the Ivy auth session.
+
+> **Note:** You must register an OAuth client in the [Anthropic Console](https://console.anthropic.com/) and add your Ivy app’s callback URL. Exact console steps may change; follow Anthropic’s current documentation for creating an OAuth application and allowed redirect URIs.
+
+## Configuration
+
+### 1. Register your OAuth client
+
+In the Anthropic Console, create an OAuth application and set the **redirect URI** to your Ivy auth callback, for example:
+
+`https://localhost:5010/ivy/auth/callback`
+
+Use the same scheme, host, port, and path that your app serves (HTTPS in production).
+
+### 2. Install the package
+
+```terminal
+dotnet add package Ivy.Auth.Claude
+```
+
+### 3. Enable the provider
+
+```csharp
+using Ivy.Auth.Claude;
+
+var server = new Server();
+
+server.UseAuth<ClaudeAuthProvider>();
+
+await server.RunAsync();
+```
+
+### 4. Secrets or environment variables
+
+Configure these keys via [.NET user secrets](../../02_Concepts/14_Secrets.md) or environment variables.
+
+| Key | Required | Description |
+|-----|----------|-------------|
+| **Claude:ClientId** | Yes | OAuth client ID from the Anthropic Console |
+| **Claude:RedirectUri** | Yes | Must match the registered redirect URI (for example `https://localhost:5010/ivy/auth/callback`) |
+| **Claude:ClientSecret** | No | Use if Anthropic issued a confidential client secret |
+| **Claude:AuthorizationUrl** | No | Default: `https://claude.ai/oauth/authorize` |
+| **Claude:TokenUrl** | No | Default: `https://console.anthropic.com/v1/oauth/token` |
+| **Claude:Scope** | No | Default: `user:profile user:inference` |
+| **Claude:UserInfoUrl** | No | Default: `https://api.anthropic.com/api/oauth/claude_cli/client_data` (profile JSON for `GetUserInfoAsync`; Anthropic may change this API) |
+| **Claude:UserAgent** | Optional | Overrides the `User-Agent` header on HTTP calls (defaults to Ivy’s version string) |
+
+**User secrets (development):**
+
+```terminal
+dotnet user-secrets set "Claude:ClientId" "your_client_id"
+dotnet user-secrets set "Claude:RedirectUri" "https://localhost:5010/ivy/auth/callback"
+```
+
+If your client has a secret:
+
+```terminal
+dotnet user-secrets set "Claude:ClientSecret" "your_client_secret"
+```
+
+**Environment variables (production):** use double underscores, for example `Claude__ClientId`, `Claude__RedirectUri`.
+
+As elsewhere in Ivy, values in user secrets take precedence over environment variables when both are set.
+
+## Authentication flow
+
+1. The user chooses **Claude** on the Ivy login screen.
+2. Ivy opens the authorize URL with PKCE (`code_challenge` / `code_verifier`).
+3. The user signs in on Anthropic and approves the app.
+4. Anthropic redirects to `/ivy/auth/callback` with an authorization `code`.
+5. Ivy exchanges the code at the token endpoint (JSON body, PKCE verifier).
+6. Ivy resolves the user profile for `IAuthService` using the configured user-info URL where possible.
+
+## Brokered sessions and token handler
+
+The package includes `ClaudeAuthTokenHandler` registered for `OAuthProviders.Claude`, so brokered account tooling can refresh and validate Claude OAuth tokens when a refresh token is present.
+
+## Troubleshooting
+
+- **Redirect URI mismatch:** The value of **Claude:RedirectUri** must exactly match a redirect URI allowed for your OAuth client (including trailing slashes, `http` vs `https`, and port).
+- **PKCE errors:** The code verifier is kept in memory for the login request. If the server restarts between starting OAuth and completing the callback, start sign-in again.
+- **Profile or user info:** If `Claude:UserInfoUrl` returns 404 or a new JSON shape, set **Claude:UserInfoUrl** to the URL Anthropic documents for profile access, or rely on Ivy’s fallback identity until you adjust the URL.
+
+## Related documentation
+
+- [Authentication overview](01_AuthenticationOverview.md)
+- [GitHub authentication](02_GitHub.md) (similar manual OAuth setup)
+- [Sliplane authentication](02_Sliplane.md) (OAuth code flow reference)

--- a/src/Ivy.Test/Auth/ConnectedAccountButtonTests.cs
+++ b/src/Ivy.Test/Auth/ConnectedAccountButtonTests.cs
@@ -34,6 +34,7 @@ public class ConnectedAccountButtonTests
     [InlineData(OAuthProviders.Twitter, Icons.XTwitter)]
     [InlineData(OAuthProviders.Figma, Icons.Figma)]
     [InlineData(OAuthProviders.Notion, Icons.Notion)]
+    [InlineData(OAuthProviders.Claude, Icons.ClaudeCode)]
     public void GetProviderIcon_ReturnsCorrectIcon(string provider, Icons expected)
     {
         Assert.Equal(expected, ConnectedAccountButton.GetProviderIcon(provider));

--- a/src/Ivy/Auth/ConnectedAccountButton.cs
+++ b/src/Ivy/Auth/ConnectedAccountButton.cs
@@ -54,6 +54,7 @@ public class ConnectedAccountButton(string provider, string? displayName = null,
         OAuthProviders.Twitter => Icons.XTwitter,
         OAuthProviders.Figma => Icons.Figma,
         OAuthProviders.Notion => Icons.Notion,
+        OAuthProviders.Claude => Icons.ClaudeCode,
         _ => Icons.Link,
     };
 }

--- a/src/Ivy/Auth/OAuthProviders.cs
+++ b/src/Ivy/Auth/OAuthProviders.cs
@@ -17,4 +17,7 @@ public static class OAuthProviders
     public const string GitLab = "gitlab";
     public const string Bitbucket = "bitbucket";
     public const string Sliplane = "sliplane";
+
+    /// <summary>Anthropic Claude (claude.ai) OAuth</summary>
+    public const string Claude = "claude";
 }

--- a/src/auth/Ivy.Auth.Claude/ClaudeAuthProvider.cs
+++ b/src/auth/Ivy.Auth.Claude/ClaudeAuthProvider.cs
@@ -1,0 +1,210 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Ivy.Core;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Ivy.Auth.Claude;
+
+/// <summary>Anthropic Claude.ai OAuth 2.0 with PKCE (authorization code flow)</summary>
+public class ClaudeAuthProvider : ClaudeAuthTokenHandler, IAuthProvider
+{
+    private readonly string _redirectUri;
+    private readonly string _authorizationUrl;
+    private readonly string _scope;
+    private string? _codeVerifier;
+
+    /// <summary>Initialize Claude auth provider</summary>
+    public ClaudeAuthProvider(IConfiguration configuration, ILogger<ClaudeAuthTokenHandler>? logger = null)
+        : base(configuration, logger)
+    {
+        _redirectUri = configuration.GetValue<string>("Claude:RedirectUri")
+            ?? throw new InvalidOperationException(
+                "Missing required configuration: 'Claude:RedirectUri'. Must match the callback URL registered for your OAuth client (for example https://localhost:5010/ivy/auth/callback).");
+
+        _authorizationUrl = configuration.GetValue<string>("Claude:AuthorizationUrl")
+            ?? "https://claude.ai/oauth/authorize";
+
+        _scope = configuration.GetValue<string>("Claude:Scope")
+            ?? "user:profile user:inference";
+    }
+
+    /// <inheritdoc />
+    public Task<LoginResult> LoginAsync(
+        IAuthSession authSession,
+        string email,
+        string password,
+        CancellationToken cancellationToken = default)
+    {
+        throw new NotSupportedException(
+            "Claude authentication only supports OAuth. Use GetOAuthUriAsync and HandleOAuthCallbackAsync instead.");
+    }
+
+    /// <inheritdoc />
+    public Task<Uri> GetOAuthUriAsync(
+        IAuthSession authSession,
+        AuthOption option,
+        WebhookEndpoint callback,
+        CancellationToken cancellationToken = default)
+    {
+        _codeVerifier = GenerateCodeVerifier();
+        var codeChallenge = GenerateCodeChallenge(_codeVerifier);
+
+        var query = string.Join("&", new[]
+        {
+            $"code=true",
+            $"client_id={Uri.EscapeDataString(ClientId)}",
+            "response_type=code",
+            $"redirect_uri={Uri.EscapeDataString(_redirectUri)}",
+            $"scope={Uri.EscapeDataString(_scope)}",
+            $"code_challenge={Uri.EscapeDataString(codeChallenge)}",
+            "code_challenge_method=S256",
+            $"state={Uri.EscapeDataString(callback.Id)}",
+        });
+
+        var uri = new UriBuilder(_authorizationUrl) { Query = query }.Uri;
+        return Task.FromResult(uri);
+    }
+
+    /// <inheritdoc />
+    public async Task<AuthToken?> HandleOAuthCallbackAsync(
+        IAuthSession authSession,
+        HttpRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var code = request.Query["code"].ToString();
+        var error = request.Query["error"].ToString();
+        var errorDescription = request.Query["error_description"].ToString();
+
+        if (error.Length > 0 || errorDescription.Length > 0)
+            throw new ClaudeOAuthException(error, errorDescription);
+
+        if (string.IsNullOrEmpty(code))
+        {
+            throw new InvalidOperationException(
+                "No authorization code in the OAuth callback. The user may have denied access or the redirect URI may be misconfigured.");
+        }
+
+        if (string.IsNullOrEmpty(_codeVerifier))
+        {
+            throw new InvalidOperationException(
+                "PKCE verifier is missing. Start sign-in again from your app (the OAuth flow was not initiated in this process).");
+        }
+
+        try
+        {
+            var state = request.Query["state"].ToString();
+            var exchange = new AuthorizationCodeTokenRequest
+            {
+                GrantType = "authorization_code",
+                ClientId = ClientId,
+                ClientSecret = ClientSecret,
+                Code = code,
+                RedirectUri = _redirectUri,
+                CodeVerifier = _codeVerifier,
+                State = string.IsNullOrEmpty(state) ? null : state
+            };
+
+            using var response = await PostJsonTokenRequestAsync(exchange, cancellationToken).ConfigureAwait(false);
+            var responseContent = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new HttpRequestException(
+                    $"Claude token exchange failed: {(int)response.StatusCode} {response.ReasonPhrase}. {responseContent}",
+                    null,
+                    response.StatusCode);
+            }
+
+            var tokenResponse = JsonSerializer.Deserialize<ClaudeTokenResponse>(responseContent);
+            if (tokenResponse?.Error != null)
+            {
+                throw new ClaudeOAuthException(tokenResponse.Error, tokenResponse.ErrorDescription);
+            }
+
+            if (string.IsNullOrWhiteSpace(tokenResponse?.AccessToken))
+                return null;
+
+            _codeVerifier = null;
+
+            return new AuthToken(
+                tokenResponse.AccessToken,
+                tokenResponse.RefreshToken
+            );
+        }
+        catch (HttpRequestException)
+        {
+            throw;
+        }
+        catch (ClaudeOAuthException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"Claude OAuth token exchange failed: {ex.Message}", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public Task LogoutAsync(IAuthSession authSession, CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+
+    /// <inheritdoc />
+    public AuthOption[] GetAuthOptions() =>
+        [new AuthOption(AuthFlow.OAuth, "Claude", OAuthProviders.Claude, Icons.ClaudeCode)];
+
+    /// <inheritdoc />
+    public Task<BrokeredSessionsResult> GetBrokeredSessionsAsync(
+        IAuthSession authSession,
+        bool skipCache = false,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult(BrokeredSessionsResult.Success([]));
+
+    private static string GenerateCodeVerifier()
+    {
+        var bytes = new byte[32];
+        System.Security.Cryptography.RandomNumberGenerator.Fill(bytes);
+        return Convert.ToBase64String(bytes)
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+    }
+
+    private static string GenerateCodeChallenge(string codeVerifier)
+    {
+        var bytes = System.Text.Encoding.UTF8.GetBytes(codeVerifier);
+        var hash = System.Security.Cryptography.SHA256.HashData(bytes);
+        return Convert.ToBase64String(hash)
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+    }
+
+    private sealed class AuthorizationCodeTokenRequest
+    {
+        [JsonPropertyName("grant_type")]
+        public string GrantType { get; init; } = "";
+
+        [JsonPropertyName("client_id")]
+        public string ClientId { get; init; } = "";
+
+        [JsonPropertyName("client_secret")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? ClientSecret { get; init; }
+
+        [JsonPropertyName("code")]
+        public string Code { get; init; } = "";
+
+        [JsonPropertyName("redirect_uri")]
+        public string RedirectUri { get; init; } = "";
+
+        [JsonPropertyName("code_verifier")]
+        public string CodeVerifier { get; init; } = "";
+
+        [JsonPropertyName("state")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? State { get; init; }
+    }
+}

--- a/src/auth/Ivy.Auth.Claude/ClaudeAuthTokenHandler.cs
+++ b/src/auth/Ivy.Auth.Claude/ClaudeAuthTokenHandler.cs
@@ -1,0 +1,239 @@
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Ivy.Auth.Claude;
+
+/// <summary>OAuth access token / refresh token response from Anthropic</summary>
+internal sealed class ClaudeTokenResponse
+{
+    [JsonPropertyName("access_token")]
+    public string? AccessToken { get; init; }
+
+    [JsonPropertyName("refresh_token")]
+    public string? RefreshToken { get; init; }
+
+    [JsonPropertyName("expires_in")]
+    public int? ExpiresIn { get; init; }
+
+    [JsonPropertyName("error")]
+    public string? Error { get; init; }
+
+    [JsonPropertyName("error_description")]
+    public string? ErrorDescription { get; init; }
+}
+
+/// <summary>Claude (Anthropic) OAuth token handler for brokered sessions and user info</summary>
+[OAuthTokenHandler(OAuthProviders.Claude)]
+public class ClaudeAuthTokenHandler : IAuthTokenHandler
+{
+    protected readonly HttpClient HttpClient;
+    protected readonly string ClientId;
+    protected readonly string? ClientSecret;
+    protected readonly string TokenUrl;
+    protected readonly string? UserInfoUrl;
+    private readonly ILogger<ClaudeAuthTokenHandler>? _logger;
+
+    /// <summary>Initialize Claude auth token handler</summary>
+    public ClaudeAuthTokenHandler(IConfiguration configuration, ILogger<ClaudeAuthTokenHandler>? logger = null)
+    {
+        ClientId = configuration.GetValue<string>("Claude:ClientId")
+            ?? throw new InvalidOperationException(
+                "Missing required configuration: 'Claude:ClientId'. Set user secrets or environment variables. See Ivy docs for Claude authentication.");
+
+        var secret = configuration.GetValue<string>("Claude:ClientSecret");
+        ClientSecret = string.IsNullOrWhiteSpace(secret) ? null : secret;
+
+        TokenUrl = configuration.GetValue<string>("Claude:TokenUrl")
+            ?? "https://console.anthropic.com/v1/oauth/token";
+
+        UserInfoUrl = configuration.GetValue<string>("Claude:UserInfoUrl")
+            ?? "https://api.anthropic.com/api/oauth/claude_cli/client_data";
+
+        var userAgent = AuthProviderHelpers.GetUserAgent(configuration, "Claude:UserAgent");
+        HttpClient = new HttpClient();
+        HttpClient.DefaultRequestHeaders.UserAgent.ParseAdd(userAgent);
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<AuthToken?> RefreshAccessTokenAsync(
+        IAuthTokenHandlerSession authSession,
+        CancellationToken cancellationToken = default)
+    {
+        var refresh = authSession.AuthToken?.RefreshToken;
+        if (string.IsNullOrWhiteSpace(refresh))
+            return null;
+
+        try
+        {
+            var requestBody = new RefreshTokenRequest
+            {
+                GrantType = "refresh_token",
+                ClientId = ClientId,
+                ClientSecret = ClientSecret,
+                RefreshToken = refresh
+            };
+
+            using var response = await PostJsonTokenRequestAsync(requestBody, cancellationToken).ConfigureAwait(false);
+            var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            var tokenResponse = JsonSerializer.Deserialize<ClaudeTokenResponse>(json);
+
+            if (tokenResponse?.Error != null)
+            {
+                throw new ClaudeOAuthException(tokenResponse.Error, tokenResponse.ErrorDescription);
+            }
+
+            if (string.IsNullOrWhiteSpace(tokenResponse?.AccessToken))
+                return null;
+
+            return new AuthToken(
+                tokenResponse.AccessToken,
+                tokenResponse.RefreshToken ?? refresh
+            );
+        }
+        catch (Exception ex) when (ex is not ClaudeOAuthException)
+        {
+            _logger?.LogError(ex, "Claude OAuth token refresh failed");
+            return null;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> ValidateAccessTokenAsync(
+        IAuthTokenHandlerSession authSession,
+        CancellationToken cancellationToken = default)
+    {
+        var info = await GetUserInfoAsync(authSession, cancellationToken).ConfigureAwait(false);
+        return info != null;
+    }
+
+    /// <inheritdoc />
+    public async Task<UserInfo?> GetUserInfoAsync(
+        IAuthTokenHandlerSession authSession,
+        CancellationToken cancellationToken = default)
+    {
+        var token = authSession.AuthToken?.AccessToken;
+        if (string.IsNullOrWhiteSpace(token) || string.IsNullOrWhiteSpace(UserInfoUrl))
+            return null;
+
+        try
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, UserInfoUrl);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+            var response = await HttpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger?.LogWarning(
+                    "Claude user info request failed with {Status}. Response may change when Anthropic updates OAuth APIs.",
+                    response.StatusCode);
+                return FallbackUserInfoFromToken(token);
+            }
+
+            var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            return ParseUserInfo(json, token);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+        {
+            if (!cancellationToken.IsCancellationRequested)
+                _logger?.LogError(ex, "Exception during Claude user info request");
+            return FallbackUserInfoFromToken(token);
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<TokenLifetime?> GetAccessTokenLifetimeAsync(
+        IAuthTokenHandlerSession authSession,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult<TokenLifetime?>(null);
+
+    internal static UserInfo? ParseUserInfo(string json, string accessTokenFallback)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            string? email = TryGetString(root, "email")
+                ?? TryNestedString(root, "account", "email")
+                ?? TryNestedString(root, "user", "email")
+                ?? TryNestedString(root, "profile", "email");
+
+            string? id = TryGetString(root, "account_uuid")
+                ?? TryGetString(root, "user_id")
+                ?? TryGetString(root, "id")
+                ?? TryNestedString(root, "user", "id");
+
+            string? name = TryGetString(root, "name")
+                ?? TryNestedString(root, "profile", "name")
+                ?? TryNestedString(root, "user", "name");
+
+            string? avatar = TryGetString(root, "avatar_url")
+                ?? TryNestedString(root, "profile", "avatar_url");
+
+            if (string.IsNullOrEmpty(id) && string.IsNullOrEmpty(email))
+                return FallbackUserInfoFromToken(accessTokenFallback);
+
+            id ??= email ?? "claude-oauth";
+            email ??= id;
+
+            return new UserInfo(id, email, name, avatar);
+        }
+        catch (JsonException)
+        {
+            return FallbackUserInfoFromToken(accessTokenFallback);
+        }
+    }
+
+    private static string? TryGetString(JsonElement root, string name) =>
+        root.TryGetProperty(name, out var p) && p.ValueKind == JsonValueKind.String ? p.GetString() : null;
+
+    private static string? TryNestedString(JsonElement root, string obj, string prop)
+    {
+        if (!root.TryGetProperty(obj, out var inner) || inner.ValueKind != JsonValueKind.Object)
+            return null;
+        return TryGetString(inner, prop);
+    }
+
+    private static UserInfo? FallbackUserInfoFromToken(string token)
+    {
+        var id = token.Length >= 16 ? token[..16] : token;
+        return new UserInfo(id, "claude-oauth@local.invalid", null, null);
+    }
+
+    internal async Task<HttpResponseMessage> PostJsonTokenRequestAsync(
+        object body,
+        CancellationToken cancellationToken)
+    {
+        var json = JsonSerializer.Serialize(body);
+        using var request = new HttpRequestMessage(HttpMethod.Post, TokenUrl)
+        {
+            Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json")
+        };
+        request.Headers.TryAddWithoutValidation("Origin", "https://claude.ai");
+        request.Headers.TryAddWithoutValidation("Referer", "https://claude.ai/");
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+        return await HttpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+    }
+
+    private sealed class RefreshTokenRequest
+    {
+        [JsonPropertyName("grant_type")]
+        public string GrantType { get; init; } = "";
+
+        [JsonPropertyName("client_id")]
+        public string ClientId { get; init; } = "";
+
+        [JsonPropertyName("client_secret")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? ClientSecret { get; init; }
+
+        [JsonPropertyName("refresh_token")]
+        public string RefreshToken { get; init; } = "";
+    }
+}

--- a/src/auth/Ivy.Auth.Claude/ClaudeOAuthException.cs
+++ b/src/auth/Ivy.Auth.Claude/ClaudeOAuthException.cs
@@ -1,0 +1,12 @@
+namespace Ivy.Auth.Claude;
+
+/// <summary>Anthropic Claude OAuth error returned from the authorization or token endpoints</summary>
+public class ClaudeOAuthException(string? error, string? errorDescription)
+    : Exception($"Claude OAuth error: '{error}' - {errorDescription}")
+{
+    /// <summary>Error code from the OAuth provider</summary>
+    public string? Error { get; } = error;
+
+    /// <summary>Human-readable description</summary>
+    public string? ErrorDescription { get; } = errorDescription;
+}

--- a/src/auth/Ivy.Auth.Claude/Ivy.Auth.Claude.csproj
+++ b/src/auth/Ivy.Auth.Claude/Ivy.Auth.Claude.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="../../../../Ivy/Directory.Build.props" Condition="Exists('../../../../Ivy/Directory.Build.props')" />
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <NoWarn>CS1591</NoWarn>
+    <PackageId>Ivy.Auth.Claude</PackageId>
+    <Company>Ivy Interactive</Company>
+    <Description>Build Internal Applications with AI and Pure C#</Description>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/Ivy-Interactive/Ivy</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/Ivy-Interactive/Ivy</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../Ivy/Ivy.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <CI Condition="'$(GITHUB_ACTIONS)' == 'true'">true</CI>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(CI)' == 'true'">
+    <DebugType>none</DebugType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+</Project>

--- a/src/auth/Ivy.Auth.Claude/README.md
+++ b/src/auth/Ivy.Auth.Claude/README.md
@@ -1,0 +1,19 @@
+<div align="center">
+  <img src="https://raw.githubusercontent.com/Ivy-Interactive/Ivy-Framework/main/src/assets/logo_green_w200.png" alt="Ivy Logo" width="100"/>
+</div>
+
+# Ivy.Auth.Claude
+
+[![NuGet](https://img.shields.io/nuget/v/Ivy.Auth.Claude?style=flat)](https://www.nuget.org/packages/Ivy.Auth.Claude)
+[![License](https://img.shields.io/github/license/Ivy-Interactive/Ivy-Framework?style=flat)](https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/LICENSE)
+
+Sign-in with **Anthropic Claude** (claude.ai OAuth 2.0 authorization code flow with PKCE) for [Ivy](https://ivy.app) applications.
+
+## Documentation
+
+See the [Claude authentication guide](https://docs.ivy.app/onboarding/cli/authentication/claude) on docs.ivy.app.
+
+## Links
+
+- [Ivy documentation](https://docs.ivy.app)
+- [Ivy Framework repository](https://github.com/Ivy-Interactive/Ivy-Framework)

--- a/src/auth/examples/ClaudeExample/ClaudeExample.csproj
+++ b/src/auth/examples/ClaudeExample/ClaudeExample.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>ClaudeExample</RootNamespace>
+    <UserSecretsId>ivy-auth-claude-example</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Ivy\Ivy.csproj" />
+    <ProjectReference Include="..\..\..\Ivy.Desktop\Ivy.Desktop.csproj" />
+    <ProjectReference Include="..\..\..\Ivy.Analyser\Ivy.Analyser.csproj">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <OutputItemType>Analyzer</OutputItemType>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Ivy.Auth.Claude\Ivy.Auth.Claude.csproj" />
+    <ProjectReference Include="..\Ivy.Auth.Examples.Shared\Ivy.Auth.Examples.Shared.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/auth/examples/ClaudeExample/Connections/Auth/ClaudeAuthConnection.cs
+++ b/src/auth/examples/ClaudeExample/Connections/Auth/ClaudeAuthConnection.cs
@@ -1,0 +1,36 @@
+using Ivy;
+using Ivy.Auth.Claude;
+using Microsoft.Extensions.Configuration;
+
+namespace ClaudeExample.Connections.Auth;
+
+public class ClaudeAuthConnection : IConnection, IHaveSecrets
+{
+    public string GetContext(string connectionPath) => string.Empty;
+
+    public string GetName() => "ClaudeAuth";
+
+    public string GetNamespace() => typeof(ClaudeAuthConnection).Namespace ?? "";
+
+    public string GetConnectionType() => "Auth";
+
+    public ConnectionEntity[] GetEntities() => [];
+
+    public void RegisterServices(Server server)
+    {
+        server.UseAuth<ClaudeAuthProvider>();
+    }
+
+    public Secret[] GetSecrets() =>
+    [
+        new("Claude:ClientId"),
+        new("Claude:ClientSecret"),
+        new("Claude:RedirectUri")
+    ];
+
+    public async Task<(bool ok, string? message)> TestConnection(IConfiguration config)
+    {
+        await Task.CompletedTask;
+        return (true, "Claude OAuth configured");
+    }
+}

--- a/src/auth/examples/ClaudeExample/MainApp.cs
+++ b/src/auth/examples/ClaudeExample/MainApp.cs
@@ -1,0 +1,41 @@
+using Ivy;
+using Ivy.Auth.Examples.Shared;
+
+namespace ClaudeExample;
+
+[App(id: "auth-test", title: "Auth Test")]
+public class MainApp : ViewBase
+{
+    public override object? Build()
+    {
+        var auth = UseService<IAuthService>();
+        var userInfo = UseState<UserInfo?>();
+
+        UseEffect(async () =>
+        {
+            var info = await auth.GetUserInfoAsync();
+            userInfo.Set(info);
+        });
+
+        if (userInfo.Value is null)
+        {
+            return Text.P("Loading user data...");
+        }
+
+        var user = userInfo.Value;
+
+        return Layout.Vertical(
+            Text.H2("Authentication successful").Color(Colors.Success),
+
+            Layout.Horizontal(
+                new Image(user.AvatarUrl ?? "").Size(Size.Units(64)),
+                Layout.Vertical(
+                    Text.H3(user.FullName ?? "User"),
+                    Text.Muted(user.Email)
+                ).Gap(4).AlignContent(Align.Center)
+            ).Gap(20).AlignContent(Align.Center),
+
+            new OAuthProviderTestView(OAuthProviders.Claude, auth.GetAuthSession())
+        ).Gap(40).Padding(50).AlignContent(Align.Center).Height(Size.Full());
+    }
+}

--- a/src/auth/examples/ClaudeExample/Program.cs
+++ b/src/auth/examples/ClaudeExample/Program.cs
@@ -1,0 +1,36 @@
+using Ivy;
+using Ivy.Desktop;
+
+var server = new Server();
+
+server.UseHotReload();
+
+server.AddConnectionsFromAssembly();
+server.AddAppsFromAssembly();
+
+var settings = new AppShellSettings()
+    .UseTabs(preventDuplicates: true)
+    .DefaultApp<ClaudeExample.MainApp>();
+
+server.UseAppShell(settings);
+
+server.SetMetaTitle("Claude Example");
+
+Server.AuthCookiePrefix = "claude";
+
+var launchDesktop = args.Contains("--desktop") || args.Contains("-d");
+
+if (launchDesktop)
+{
+    var window = new DesktopWindow(server)
+        .Title("Claude Example")
+        .AppId("ClaudeExample")
+        .Size(1200, 800)
+        .MinSize(800, 600)
+        .UseDevTools();
+
+    return window.Run();
+}
+
+await server.RunAsync();
+return 0;

--- a/src/auth/examples/Ivy.Auth.Examples.Shared/ClaudeOAuthTestView.cs
+++ b/src/auth/examples/Ivy.Auth.Examples.Shared/ClaudeOAuthTestView.cs
@@ -1,0 +1,62 @@
+using System.Net.Http.Headers;
+using System.Text.Json;
+
+namespace Ivy.Auth.Examples.Shared;
+
+/// <summary>Sample view: call Anthropic OAuth client_data with the brokered access token.</summary>
+public class ClaudeOAuthTestView : ViewBase
+{
+    private const string DefaultProfileUrl = "https://api.anthropic.com/api/oauth/claude_cli/client_data";
+
+    private readonly IAuthTokenHandlerSession _session;
+
+    public ClaudeOAuthTestView(IAuthTokenHandlerSession session)
+    {
+        _session = session;
+    }
+
+    public override object? Build()
+    {
+        var rawJson = UseState<string?>();
+        var error = UseState<string?>();
+
+        return Layout.Vertical(
+            Text.H4("Claude OAuth test"),
+            new Button("Fetch OAuth profile (client_data)", async () =>
+            {
+                error.Set(null);
+                rawJson.Set(null);
+                var token = _session.AuthToken?.AccessToken;
+                if (string.IsNullOrEmpty(token))
+                {
+                    error.Set("No access token in session.");
+                    return;
+                }
+
+                try
+                {
+                    using var http = new HttpClient();
+                    using var request = new HttpRequestMessage(HttpMethod.Get, DefaultProfileUrl);
+                    request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+                    request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+                    var response = await http.SendAsync(request);
+                    var body = await response.Content.ReadAsStringAsync();
+                    if (!response.IsSuccessStatusCode)
+                    {
+                        error.Set($"HTTP {(int)response.StatusCode}: {body}");
+                        return;
+                    }
+
+                    rawJson.Set(JsonSerializer.Serialize(JsonDocument.Parse(body), new JsonSerializerOptions { WriteIndented = true }));
+                }
+                catch (Exception ex)
+                {
+                    error.Set(ex.Message);
+                }
+            }, variant: ButtonVariant.Primary),
+            error.Value != null ? Callout.Error(error.Value) : null,
+            rawJson.Value != null ? Text.Monospaced(rawJson.Value) : null
+        ).Gap(10);
+    }
+}

--- a/src/auth/examples/Ivy.Auth.Examples.Shared/OAuthProviderTestView.cs
+++ b/src/auth/examples/Ivy.Auth.Examples.Shared/OAuthProviderTestView.cs
@@ -21,6 +21,7 @@ public class OAuthProviderTestView : ViewBase
         {
             OAuthProviders.Google => new GoogleOAuthTestView(_session),
             OAuthProviders.GitHub => new GitHubOAuthTestView(_session),
+            OAuthProviders.Claude => new ClaudeOAuthTestView(_session),
             OAuthProviders.Microsoft => new MicrosoftGraphOAuthTestView(_session),
             OAuthProviders.Apple => UnsupportedProviderView("Apple"),
             OAuthProviders.Twitter => UnsupportedProviderView("Twitter"),


### PR DESCRIPTION
QAuth requieres client ID which I can't get from claude. I compared creating of auth with git hub,  and it's clear how do to it with git, because creating QAuth app in git is availible in browser, but not for claude. 

I've researched about it:
It’s not just a Pro/Max personal subscription toggle.

Most likely cases:

OAuth app registration is org-level / enterprise-gated / allowlisted.
It may require contacting Anthropic support/sales to enable.

It supposed to work this way:
- creating QAuth app using cluade https://platform.claude.com/
- adding client id and trusted url for ivy app
- in the ivy app it should appear like "sign in with claude", on clicking it redirects to claude auth page
