### PR TITLE
feat(ColorInput): add SwatchPicker variant

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/04_Inputs/09_ColorInput.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/04_Inputs/09_ColorInput.md
@@ -54,14 +54,15 @@ var colorInputFull = colorState.ToColorInput()
 
 ## Variants
 
-`ColorInput` has four variants:
+`ColorInput` has five variants:
 
-| Variant                           | Description                                  |
-| --------------------------------- | -------------------------------------------- |
-| `ColorInputVariant.Text`          | Text input for entering hex codes manually   |
-| `ColorInputVariant.Picker`        | Color picker only                            |
-| `ColorInputVariant.TextAndPicker` | Text input with color picker (default)       |
-| `ColorInputVariant.Swatch`        | Grid of predefined colors from `Colors` enum |
+| Variant                           | Description                                                          |
+| --------------------------------- | -------------------------------------------------------------------- |
+| `ColorInputVariant.Text`          | Text input for entering hex codes manually                           |
+| `ColorInputVariant.Picker`        | Color picker only (opens the native RGB picker)                      |
+| `ColorInputVariant.TextAndPicker` | Text input with color picker (default)                               |
+| `ColorInputVariant.Swatch`        | Inline grid of predefined colors from `Colors` enum                  |
+| `ColorInputVariant.SwatchPicker`  | Compact swatch — opens the `Colors` enum grid in a popover on click  |
 
 The following code shows all variants in action:
 
@@ -75,7 +76,8 @@ public class ColorVariantsDemo : ViewBase
             | Text.P("Just Text").Small() | colorState.ToColorInput().Variant(ColorInputVariant.Text)
             | Text.P("Just Picker").Small() | colorState.ToColorInput().Variant(ColorInputVariant.Picker)
             | Text.P("Text and Picker").Small() | colorState.ToColorInput().Variant(ColorInputVariant.TextAndPicker)
-            | Text.P("Swatch").Small() | colorState.ToColorInput().Variant(ColorInputVariant.Swatch);
+            | Text.P("Swatch").Small() | colorState.ToColorInput().Variant(ColorInputVariant.Swatch)
+            | Text.P("Swatch Picker").Small() | colorState.ToColorInput().Variant(ColorInputVariant.SwatchPicker);
     }
 }
 ```
@@ -92,6 +94,23 @@ public class ColorSwatchDemo : ViewBase
         var colorState = UseState(Colors.Blue);
         return Layout.Vertical()
             | colorState.ToColorInput().Variant(ColorInputVariant.Swatch)
+            | Text.P($"Selected: {colorState.Value}");
+    }
+}
+```
+
+### SwatchPicker Variant
+
+The `SwatchPicker` variant has the same compact footprint as `Picker` — a single colored square — but clicking it opens a popover containing the `Colors` enum grid instead of the native RGB picker. Use this when you want the space efficiency of `Picker` together with the constrained palette of `Swatch`.
+
+```csharp demo-below
+public class ColorSwatchPickerDemo : ViewBase
+{
+    public override object? Build()
+    {
+        var colorState = UseState(Colors.Green);
+        return Layout.Horizontal().Gap(2)
+            | colorState.ToColorInput().Variant(ColorInputVariant.SwatchPicker)
             | Text.P($"Selected: {colorState.Value}");
     }
 }

--- a/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/ColorInputApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Inputs/ColorInputApp.cs
@@ -65,11 +65,13 @@ public class ColorInputVariantTests : ViewBase
         var pickerState = UseState("#dd5860");
         var bothState = UseState("#6637d1");
         var swatchState = UseState("blue");
+        var swatchPickerState = UseState("green");
         var ghostState = UseState("#9b59b6");
         var nullTextState = UseState((string?)null);
         var nullPickerState = UseState((string?)null);
         var nullBothState = UseState((string?)null);
         var nullSwatchState = UseState((string?)null);
+        var nullSwatchPickerState = UseState((string?)null);
 
         return Layout.Grid().Columns(6)
             | Text.Monospaced("")
@@ -106,6 +108,13 @@ public class ColorInputVariantTests : ViewBase
             | swatchState.ToColorInput().Variant(ColorInputVariant.Swatch).Disabled()
             | nullSwatchState.ToColorInput().Variant(ColorInputVariant.Swatch)
             | nullSwatchState.ToColorInput().Variant(ColorInputVariant.Swatch).Invalid("Invalid color")
+
+            | Text.Monospaced("Swatch Picker")
+            | swatchPickerState.ToColorInput().Variant(ColorInputVariant.SwatchPicker)
+            | swatchPickerState.ToColorInput().Variant(ColorInputVariant.SwatchPicker).Invalid("Invalid color")
+            | swatchPickerState.ToColorInput().Variant(ColorInputVariant.SwatchPicker).Disabled()
+            | nullSwatchPickerState.ToColorInput().Variant(ColorInputVariant.SwatchPicker)
+            | nullSwatchPickerState.ToColorInput().Variant(ColorInputVariant.SwatchPicker).Invalid("Invalid color")
             | Text.Monospaced("Ghost")
             | ghostState.ToColorInput().Variant(ColorInputVariant.TextAndPicker).Ghost()
             | ghostState.ToColorInput().Variant(ColorInputVariant.TextAndPicker).Ghost().Invalid("Invalid color")

--- a/src/Ivy/Widgets/Inputs/ColorInput.cs
+++ b/src/Ivy/Widgets/Inputs/ColorInput.cs
@@ -12,7 +12,8 @@ public enum ColorInputVariant
     Text,
     Picker,
     TextAndPicker,
-    Swatch
+    Swatch,
+    SwatchPicker
 }
 
 public interface IAnyColorInput : IAnyInput

--- a/src/frontend/src/widgets/inputs/ColorInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/ColorInputWidget.tsx
@@ -20,6 +20,7 @@ import {
 import { Densities } from "@/types/density";
 import { xIconVariant } from "@/components/ui/input/text-input-variant";
 import { EMPTY_ARRAY } from "@/lib/constants";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 
 interface ColorInputWidgetProps {
   id: string;
@@ -30,7 +31,7 @@ interface ColorInputWidgetProps {
   placeholder?: string;
   nullable?: boolean;
   events?: string[];
-  variant?: "Text" | "Picker" | "TextAndPicker" | "Swatch";
+  variant?: "Text" | "Picker" | "TextAndPicker" | "Swatch" | "SwatchPicker";
   density?: Densities;
   foreground?: boolean;
   ghost?: boolean;
@@ -411,6 +412,54 @@ export const ColorInputWidget: React.FC<ColorInputWidgetProps> = ({
           onColorSelect={handleSwatchSelect}
           disabled={disabled}
         />
+        {invalid && <InvalidIcon message={invalid} />}
+      </div>
+    );
+  }
+
+  if (variant === "SwatchPicker") {
+    const handleSwatchSelect = (colorName: string) => {
+      fireColorChange(colorName);
+    };
+
+    return (
+      <div className="flex items-center space-x-2">
+        <Popover>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              disabled={disabled}
+              aria-label="Choose color"
+              title="Choose color"
+              className={cn(
+                colorInputPickerVariant({ density }),
+                "relative shrink-0 rounded-md overflow-hidden bg-transparent border",
+                disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer",
+                invalid ? inputStyles.invalidInput : "border-input shadow-sm",
+              )}
+            >
+              <div
+                className="absolute inset-0 pointer-events-none"
+                style={{
+                  backgroundImage:
+                    "repeating-conic-gradient(hsl(var(--muted)) 0% 25%, transparent 0% 50%)",
+                  backgroundSize: "12px 12px",
+                }}
+              />
+              <div
+                className="absolute inset-0 pointer-events-none"
+                style={{ backgroundColor: convertToHex(displayValue) || "transparent" }}
+              />
+            </button>
+          </PopoverTrigger>
+          <PopoverContent className="w-auto p-0" align="start">
+            <ColorSwatchGrid
+              selectedColor={localValue}
+              onColorSelect={handleSwatchSelect}
+              disabled={disabled}
+            />
+          </PopoverContent>
+        </Popover>
         {invalid && <InvalidIcon message={invalid} />}
       </div>
     );


### PR DESCRIPTION
## Summary

- Adds a fifth `ColorInputVariant`: `SwatchPicker`. It renders the same compact colored-square trigger as `Picker`, but clicking it opens a popover containing the `Colors`-enum swatch grid instead of the browser's native RGB picker.
- Use when you want the small footprint of `Picker` combined with the constrained palette of `Swatch`.
- Existing variants and the `Colors`-typed default in `ToColorInput` (still `Swatch` inline) are unchanged — purely additive.

### Files

- `src/Ivy/Widgets/Inputs/ColorInput.cs` — enum value
- `src/frontend/src/widgets/inputs/ColorInputWidget.tsx` — prop union, `Popover` import, new render branch reusing the existing `ColorSwatchGrid`
- `src/Ivy.Samples.Shared/Apps/Widgets/Inputs/ColorInputApp.cs` — row in the variants test grid (Default / Invalid / Disabled / Nullable / Nullable + Invalid)
- `src/Ivy.Docs.Shared/Docs/02_Widgets/04_Inputs/09_ColorInput.md` — variants table updated to 5 rows, added to variants demo, new dedicated section with its own demo

## Test plan

- [ ] Open the **Color Input** sample → **Variants** tab and verify the new "Swatch Picker" row renders the trigger square and the 5 column states (Default / Invalid / Disabled / Nullable / Nullable + Invalid).
- [ ] Click the trigger and confirm a popover opens with the Colors-enum grid; selecting a color closes the popover and updates state.
- [ ] Verify Disabled blocks the popover from opening; Invalid shows the invalid-icon affordance.
- [ ] Verify the existing `Picker`, `Swatch`, `Text`, `TextAndPicker` variants are unchanged.
- [ ] Spot-check the docs page (`/widgets/inputs/color-input`) for the new variants table row, demo, and dedicated section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)