### PR TITLE
[00169] Fix white background overflow in CodeInput cm-editor

### DIFF
--- a/src/frontend/src/widgets/inputs/code/CodeInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/code/CodeInputWidget.tsx
@@ -228,8 +228,8 @@ export const CodeInputWidget: React.FC<CodeInputWidgetProps> = ({
           autoFocus={autoFocus}
           data-gramm="false"
           className={cn(
-            "h-full",
-            "[&_.cm-theme-light]:overflow-hidden [&_.cm-theme-light]:bg-transparent",
+            "h-full overflow-hidden",
+            "[&_.cm-editor]:bg-transparent",
             "border border-input shadow-sm rounded-field",
             "dark:bg-white/5 dark:border-white/10",
             invalid && inputStyles.invalid,


### PR DESCRIPTION
## Changes

Added `overflow-hidden` to the CodeMirror wrapper element in CodeInputWidget to clip the inner editor's white background at rounded corners. Replaced the `[&_.cm-theme-light]` selectors with a direct `[&_.cm-editor]:bg-transparent` selector that targets the actual element carrying the problematic background class.

## API Changes

None.

## Files Modified

- **src/frontend/src/widgets/inputs/code/CodeInputWidget.tsx** — Updated className to add overflow-hidden and fix the bg-transparent selector target

---

### Commits
- 27d6e1e3d [00169] Fix white background overflow in CodeInput cm-editor