### PR TITLE
Fix Microsoft.Kiota.Abstractions vulnerability (GHSA-7j59-v9qr-6fq9)

### DIFF
--- a/src/auth/Ivy.Auth.MicrosoftEntra/Ivy.Auth.MicrosoftEntra.csproj
+++ b/src/auth/Ivy.Auth.MicrosoftEntra/Ivy.Auth.MicrosoftEntra.csproj
@@ -36,7 +36,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Identity.Client" Version="4.79.2" />
-    <PackageReference Include="Microsoft.Graph" Version="5.98.0" />
+    <PackageReference Include="Microsoft.Graph" Version="5.105.0" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.22.2" />
     <PackageReference Include="Azure.Identity" Version="1.17.1" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- Updated `Microsoft.Graph` from 5.98.0 to 5.105.0
- Added direct reference to `Microsoft.Kiota.Abstractions` 1.22.2 to override vulnerable transitive dependency (1.17.1/1.21.1)
- Resolves NU1903 build error caused by [GHSA-7j59-v9qr-6fq9](https://github.com/advisories/GHSA-7j59-v9qr-6fq9)