### PR TITLE
[00217] Fix duplicate final summary in ClaudeJsonRenderer

### DIFF
--- a/src/widgets/Ivy.Widgets.ClaudeJsonRenderer/frontend/src/ClaudeJsonRenderer.tsx
+++ b/src/widgets/Ivy.Widgets.ClaudeJsonRenderer/frontend/src/ClaudeJsonRenderer.tsx
@@ -166,10 +166,12 @@ function AssistantMessage({
   event,
   showThinking,
   toolResults,
+  skipTextBlocks = false,
 }: {
   event: AssistantEvent;
   showThinking: boolean;
   toolResults: Map<string, string>;
+  skipTextBlocks?: boolean;
 }) {
   const content = event.message?.content;
   if (!Array.isArray(content)) return null;
@@ -178,6 +180,7 @@ function AssistantMessage({
     <div className="my-3">
       {content.map((block: ContentBlock, i: number) => {
         if (block.type === "text" && block.text) {
+          if (skipTextBlocks) return null;
           return (
             <div key={i} className="claude-renderer">
               <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
@@ -301,12 +304,23 @@ export const ClaudeJsonRenderer: React.FC<ClaudeJsonRendererProps> = ({
         }
 
         if (event.type === "assistant") {
+          const nextEvent = parsedEvents[index + 1];
+          const isLastBeforeResult = nextEvent?.type === "result";
+          const assistantText = event.message?.content
+            ?.filter((b: ContentBlock) => b.type === "text")
+            .map((b: ContentBlock) => b.text)
+            .join("\n")
+            .trim();
+          const skipText = isLastBeforeResult && !!assistantText &&
+            (nextEvent as ResultEvent).result?.trim() === assistantText;
+
           return (
             <AssistantMessage
               key={index}
               event={event}
               showThinking={showThinking}
               toolResults={toolResults}
+              skipTextBlocks={skipText}
             />
           );
         }


### PR DESCRIPTION
Fixes Ivy-Interactive/Ivy-Tendril#538

## Summary

Fixed duplicate final summary rendering in `ClaudeJsonRenderer`. When a Claude Code stream ends, the last assistant event's text blocks are now suppressed if the immediately following result event contains identical text, preventing the summary from appearing twice (once as plain text, once in the green "Completed" box).

## API Changes

- `AssistantMessage` internal component: added optional `skipTextBlocks` prop (boolean, default `false`). This is not a public API — it's internal to the widget.

## Files Modified

- **src/widgets/Ivy.Widgets.ClaudeJsonRenderer/frontend/src/ClaudeJsonRenderer.tsx** — Added deduplication logic in the event rendering loop and `skipTextBlocks` prop to `AssistantMessage`

---

Commits: a27db8ff0