### PR TITLE
[00232] Add Disabled property to Stepper widget

### DIFF
--- a/src/Ivy/Widgets/Primitives/Stepper.cs
+++ b/src/Ivy/Widgets/Primitives/Stepper.cs
@@ -29,6 +29,8 @@ public record Stepper : WidgetBase<Stepper>
 
     [Prop] public bool AllowSelectForward { get; set; } = false;
 
+    [Prop] public bool Disabled { get; set; }
+
     [Event] public EventHandler<Event<Stepper, int>>? OnSelect { get; set; }
 }
 
@@ -36,6 +38,7 @@ public static class StepperExtensions
 {
     public static Stepper OnSelect(this Stepper stepper, Func<Event<Stepper, int>, ValueTask> onSelect) => stepper with { OnSelect = new(onSelect) };
     public static Stepper AllowSelectForward(this Stepper stepper, bool allowSelectForward = true) => stepper with { AllowSelectForward = allowSelectForward };
+    public static Stepper Disabled(this Stepper stepper, bool disabled = true) => stepper with { Disabled = disabled };
 }
 
 

--- a/src/frontend/src/widgets/primitives/StepperWidget.tsx
+++ b/src/frontend/src/widgets/primitives/StepperWidget.tsx
@@ -21,6 +21,7 @@ interface StepperWidgetProps {
   items: StepperItem[];
   width?: string;
   allowSelectForward?: boolean;
+  disabled?: boolean;
   events?: string[];
   density?: Densities;
 }
@@ -31,6 +32,7 @@ export const StepperWidget: React.FC<StepperWidgetProps> = ({
   items = EMPTY_ARRAY,
   width,
   allowSelectForward = false,
+  disabled = false,
   events = EMPTY_ARRAY,
   density = Densities.Medium,
 }) => {
@@ -70,7 +72,7 @@ export const StepperWidget: React.FC<StepperWidgetProps> = ({
   };
 
   return (
-    <div key={id} style={styles} className="flex flex-col w-full">
+    <div key={id} style={styles} className={cn("flex flex-col w-full", disabled && "opacity-50 pointer-events-none")}>
       {/* Row 1: Circles and lines */}
       <div className="flex items-center w-full">
         {items.map((item, index) => {
@@ -78,6 +80,7 @@ export const StepperWidget: React.FC<StepperWidgetProps> = ({
           const isLast = index === items.length - 1;
           const isLineCompleted = index < selectedIndex;
           const isClickable =
+            !disabled &&
             hasSelectHandler &&
             (state === "completed" || (state === "upcoming" && allowSelectForward));
 

--- a/src/frontend/src/widgets/primitives/StepperWidget.tsx
+++ b/src/frontend/src/widgets/primitives/StepperWidget.tsx
@@ -72,7 +72,11 @@ export const StepperWidget: React.FC<StepperWidgetProps> = ({
   };
 
   return (
-    <div key={id} style={styles} className={cn("flex flex-col w-full", disabled && "opacity-50 pointer-events-none")}>
+    <div
+      key={id}
+      style={styles}
+      className={cn("flex flex-col w-full", disabled && "opacity-50 pointer-events-none")}
+    >
       {/* Row 1: Circles and lines */}
       <div className="flex items-center w-full">
         {items.map((item, index) => {


### PR DESCRIPTION
Fixes https://github.com/Ivy-Interactive/Ivy-Tendril/issues/585

## Summary

Added a `Disabled` property to the Stepper widget. When enabled, it prevents all step button interactions and applies a visual disabled state (reduced opacity, no pointer events).

## API Changes

- **New property:** `[Prop] public bool Disabled { get; set; }` on `Stepper` record
- **New extension method:** `public static Stepper Disabled(this Stepper stepper, bool disabled = true)`
- **New frontend prop:** `disabled?: boolean` on `StepperWidgetProps` interface

## Files Modified

- `src/Ivy/Widgets/Primitives/Stepper.cs` — Added Disabled prop and extension method
- `src/frontend/src/widgets/primitives/StepperWidget.tsx` — Added disabled prop handling, clickability override, and disabled styling

---

## Commits

- `2d5809609` [00232] Add Disabled property to Stepper widget
- `dbe16627c` [00232] Fix formatting in StepperWidget.tsx