### PR TITLE
[SelectInput]: search threshold, long labels, and search UX

### DIFF
--- a/src/Ivy/Widgets/Inputs/SelectInput.cs
+++ b/src/Ivy/Widgets/Inputs/SelectInput.cs
@@ -51,7 +51,7 @@ public abstract record SelectInputBase : WidgetBase<SelectInputBase>, IAnySelect
 
     [Prop] public int? MinSelections { get; set; }
 
-    [Prop] public bool Searchable { get; set; }
+    [Prop] public bool? Searchable { get; set; }
 
     [Prop] public bool ShowActions { get; set; }
 
@@ -181,7 +181,7 @@ public static class SelectInputExtensions
 
     public static SelectInputBase MinSelections(this SelectInputBase widget, int min) => widget with { MinSelections = min };
 
-    public static SelectInputBase Searchable(this SelectInputBase widget, bool searchable = true) => widget with { Searchable = searchable };
+    public static SelectInputBase Searchable(this SelectInputBase widget, bool? searchable = true) => widget with { Searchable = searchable };
 
     public static SelectInputBase ShowActions(this SelectInputBase widget, bool showActions = true) => widget with { ShowActions = showActions };
 

--- a/src/frontend/src/components/ui/select.tsx
+++ b/src/frontend/src/components/ui/select.tsx
@@ -61,8 +61,8 @@ SelectScrollDownButton.displayName = SelectPrimitive.ScrollDownButton.displayNam
 const SelectContent = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content> &
-    VariantProps<typeof selectContentVariant>
->(({ className, density, children, position = "popper", ...props }, ref) => (
+    VariantProps<typeof selectContentVariant> & { header?: React.ReactNode }
+>(({ className, density, children, header, position = "popper", ...props }, ref) => (
   <SelectPrimitive.Portal>
     <SelectPrimitive.Content
       ref={ref}
@@ -75,6 +75,7 @@ const SelectContent = React.forwardRef<
       position={position}
       {...props}
     >
+      {header}
       <SelectScrollUpButton />
       <SelectPrimitive.Viewport
         className={cn(

--- a/src/frontend/src/widgets/inputs/SelectInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/SelectInputWidget.tsx
@@ -23,7 +23,7 @@ export const SelectInputWidget: React.FC<SelectInputWidgetProps> = (props) => {
     selectMany: props.selectMany ?? false,
     maxSelections: props.maxSelections,
     minSelections: props.minSelections,
-    searchable: props.searchable ?? false,
+    searchable: props.searchable,
     searchMode: props.searchMode ?? "CaseInsensitive",
     emptyMessage: props.emptyMessage,
     loading: props.loading ?? false,

--- a/src/frontend/src/widgets/inputs/SelectSingleVariant.tsx
+++ b/src/frontend/src/widgets/inputs/SelectSingleVariant.tsx
@@ -73,6 +73,9 @@ export const SelectSingleVariant: React.FC<SelectInputWidgetProps> = ({
 
   const selectedLabel = selectedOption?.label;
   const triggerRef = useRef<HTMLButtonElement>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  /** True after the user edits the panel search field; reset when the dropdown closes. */
+  const userFilteringRef = useRef(false);
   const [isEllipsed, setIsEllipsed] = useState(false);
 
   const [isOpen, setIsOpen] = useState(false);
@@ -119,6 +122,26 @@ export const SelectSingleVariant: React.FC<SelectInputWidgetProps> = ({
     });
   }, [validOptions, isSearchEnabled, searchTerm, searchMode]);
 
+  // Radix Select runs focusSelectedItem in a child useEffect: it focuses the selected item, or the
+  // listbox when there are no items — which steals focus from the header search field whenever the
+  // filtered item set changes (0 matches, 1 match, after clearing text, etc.). Parent useEffect runs
+  // after the child's; a macrotask catches deferred focus work inside Radix.
+  useEffect(() => {
+    if (!isOpen || !isSearchEnabled || !userFilteringRef.current) return;
+    const input = searchInputRef.current;
+    if (!input) return;
+
+    const restore = () => {
+      const active = document.activeElement;
+      if (active === input || active === triggerRef.current) return;
+      input.focus({ preventScroll: true });
+    };
+
+    restore();
+    const t = window.setTimeout(restore, 0);
+    return () => clearTimeout(t);
+  }, [filteredOptions.length, isOpen, isSearchEnabled, searchTerm]);
+
   const groupedOptions = filteredOptions.reduce<Record<string, typeof validOptions>>(
     (acc, option) => {
       const key = option.group || "default";
@@ -140,6 +163,9 @@ export const SelectSingleVariant: React.FC<SelectInputWidgetProps> = ({
 
   const handleOpenChange = (newOpen: boolean) => {
     setIsOpen(newOpen);
+    if (!newOpen) {
+      userFilteringRef.current = false;
+    }
     if (newOpen) {
       if (events.includes("OnFocus")) eventHandler("OnFocus", id, []);
     } else {
@@ -253,10 +279,14 @@ export const SelectSingleVariant: React.FC<SelectInputWidgetProps> = ({
               <div className="relative">
                 <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
                 <Input
+                  ref={searchInputRef}
                   type="text"
                   placeholder="Search..."
                   value={searchTerm}
-                  onChange={(e) => setSearchTerm(e.target.value)}
+                  onChange={(e) => {
+                    userFilteringRef.current = true;
+                    setSearchTerm(e.target.value);
+                  }}
                   onKeyDown={(e) => e.stopPropagation()}
                   onClick={(e) => e.stopPropagation()}
                   className="pl-9 h-9"

--- a/src/frontend/src/widgets/inputs/SelectSingleVariant.tsx
+++ b/src/frontend/src/widgets/inputs/SelectSingleVariant.tsx
@@ -8,7 +8,6 @@ import {
   SelectLabel,
   SelectSeparator,
   SelectTrigger,
-  SelectValue,
 } from "@/components/ui/select";
 import { Tooltip, TooltipProvider, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { Input } from "@/components/ui/input";
@@ -173,7 +172,14 @@ export const SelectSingleVariant: React.FC<SelectInputWidgetProps> = ({
       onBlur={handleTriggerBlur}
       onFocus={handleTriggerFocus}
     >
-      <SelectValue placeholder={placeholder} />
+      <span
+        className={cn(
+          "flex-1 truncate text-left pointer-events-none",
+          !hasValue && "text-muted-foreground",
+        )}
+      >
+        {hasValue ? (selectedLabel ?? stringValue) : placeholder}
+      </span>
       {((nullable && hasValue && !disabled) || invalid || loading) && (
         <div className="flex items-center gap-1 px-1 ml-auto shrink-0 pointer-events-none">
           {loading && (

--- a/src/frontend/src/widgets/inputs/SelectSingleVariant.tsx
+++ b/src/frontend/src/widgets/inputs/SelectSingleVariant.tsx
@@ -239,24 +239,28 @@ export const SelectSingleVariant: React.FC<SelectInputWidgetProps> = ({
       ) : (
         selectTriggerElement
       )}
-      <SelectContent density={density}>
-        {isSearchEnabled && (
-          <div className="p-2 border-b">
-            <div className="relative">
-              <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
-              <Input
-                type="text"
-                placeholder="Search..."
-                value={searchTerm}
-                onChange={(e) => setSearchTerm(e.target.value)}
-                onKeyDown={(e) => e.stopPropagation()}
-                onClick={(e) => e.stopPropagation()}
-                className="pl-9 h-9"
-                disabled={disabled || loading}
-              />
+      <SelectContent
+        density={density}
+        header={
+          isSearchEnabled ? (
+            <div className="p-2 border-b">
+              <div className="relative">
+                <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+                <Input
+                  type="text"
+                  placeholder="Search..."
+                  value={searchTerm}
+                  onChange={(e) => setSearchTerm(e.target.value)}
+                  onKeyDown={(e) => e.stopPropagation()}
+                  onClick={(e) => e.stopPropagation()}
+                  className="pl-9 h-9"
+                  disabled={disabled || loading}
+                />
+              </div>
             </div>
-          </div>
-        )}
+          ) : undefined
+        }
+      >
         {loading ? (
           <div className="flex justify-center p-4">
             <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />

--- a/src/frontend/src/widgets/inputs/SelectSingleVariant.tsx
+++ b/src/frontend/src/widgets/inputs/SelectSingleVariant.tsx
@@ -142,6 +142,17 @@ export const SelectSingleVariant: React.FC<SelectInputWidgetProps> = ({
     return () => clearTimeout(t);
   }, [filteredOptions.length, isOpen, isSearchEnabled, searchTerm]);
 
+  useEffect(() => {
+    if (!isOpen || !isSearchEnabled) return;
+    requestAnimationFrame(() => {
+      const viewport = document.querySelector<HTMLElement>("[data-radix-select-viewport]");
+      if (viewport) {
+        viewport.scrollTop = 0;
+        viewport.dispatchEvent(new Event("scroll"));
+      }
+    });
+  }, [searchTerm, isOpen, isSearchEnabled]);
+
   const groupedOptions = filteredOptions.reduce<Record<string, typeof validOptions>>(
     (acc, option) => {
       const key = option.group || "default";

--- a/src/frontend/src/widgets/inputs/SelectSingleVariant.tsx
+++ b/src/frontend/src/widgets/inputs/SelectSingleVariant.tsx
@@ -30,7 +30,7 @@ export const SelectSingleVariant: React.FC<SelectInputWidgetProps> = ({
   options = EMPTY_ARRAY,
   eventHandler,
   nullable = false,
-  searchable = false,
+  searchable,
   searchMode = "CaseInsensitive",
   emptyMessage,
   loading = false,
@@ -95,8 +95,15 @@ export const SelectSingleVariant: React.FC<SelectInputWidgetProps> = ({
     return () => window.removeEventListener("resize", handleResize);
   }, [selectedLabel]);
 
+  const SEARCH_THRESHOLD = 7;
+  // null/undefined = auto (show search when options >= threshold)
+  // true  = always show search
+  // false = never show search
+  const isSearchEnabled =
+    searchable === true || (searchable !== false && validOptions.length >= SEARCH_THRESHOLD);
+
   const filteredOptions = useMemo(() => {
-    if (!searchable || !searchTerm) return validOptions;
+    if (!isSearchEnabled || !searchTerm) return validOptions;
     return validOptions.filter((option) => {
       const term = searchMode === "CaseInsensitive" ? searchTerm.toLowerCase() : searchTerm;
       const label = (option.label || "").toLowerCase();
@@ -111,7 +118,7 @@ export const SelectSingleVariant: React.FC<SelectInputWidgetProps> = ({
       }
       return label.includes(term);
     });
-  }, [validOptions, searchable, searchTerm, searchMode]);
+  }, [validOptions, isSearchEnabled, searchTerm, searchMode]);
 
   const groupedOptions = filteredOptions.reduce<Record<string, typeof validOptions>>(
     (acc, option) => {
@@ -233,7 +240,7 @@ export const SelectSingleVariant: React.FC<SelectInputWidgetProps> = ({
         selectTriggerElement
       )}
       <SelectContent density={density}>
-        {searchable && (
+        {isSearchEnabled && (
           <div className="p-2 border-b">
             <div className="relative">
               <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />

--- a/src/frontend/src/widgets/inputs/select-types.ts
+++ b/src/frontend/src/widgets/inputs/select-types.ts
@@ -27,7 +27,7 @@ export interface SelectInputWidgetProps {
   separator: string;
   maxSelections?: number;
   minSelections?: number;
-  searchable?: boolean;
+  searchable?: boolean | null;
   showActions?: boolean;
   searchMode?: "CaseInsensitive" | "CaseSensitive" | "Fuzzy";
   emptyMessage?: string;


### PR DESCRIPTION

## Summary

Improves the single-select experience when lists grow, when selected labels are long, and when users filter options via the inline search field.

## Changes

- **Search when the list is large** — Search is enabled by default when there are **7 or more** options (unless search is explicitly disabled). `Searchable` on the select input is **nullable** so callers can force on, force off, or use the default threshold behavior.
- **Long selected text** — Replaces `SelectValue` with a conditional label/placeholder render so long option text displays more reliably on the trigger.
- **Search field UX** — Search lives in a `SelectContent` **header** slot; focus stays in the search input while the dropdown is open and the user is filtering; after the search term changes, a scroll event is dispatched on the Radix viewport so the scroll-down control state stays correct.

## Technical notes

- `SelectContent`: new `header` prop for embedding the search UI.
- `SelectSingleVariant`: `SEARCH_THRESHOLD = 7`, client-side filtering, refs/effects for focus and scroll synchronization.

## How to test

1. **≤ 6 options** — No search bar (unless `Searchable(true)`).
2. **≥ 7 options** — Search appears; typing filters options; focus remains in search while filtering; list scroll affordances update after filtering.
3. **Long option label** — Select a long label and confirm the trigger/placeholder still reads clearly.


https://github.com/user-attachments/assets/12f20ad7-3de9-454a-96d7-72282a59bf98

