### PR TITLE
[00236] Add collapsible props to DiffView widget

### DIFF
--- a/src/widgets/Ivy.Widgets.DiffView/DiffView.cs
+++ b/src/widgets/Ivy.Widgets.DiffView/DiffView.cs
@@ -28,6 +28,12 @@ public record DiffView : WidgetBase<DiffView>
     /// <summary>Whether to wrap long lines instead of scrolling horizontally</summary>
     [Prop] public bool WordWrap { get; init; } = false;
 
+    /// <summary>Whether the file header is clickable to collapse/expand the diff content</summary>
+    [Prop] public bool Collapsible { get; init; } = false;
+
+    /// <summary>Whether the diff starts in a collapsed state (only applies when Collapsible is true)</summary>
+    [Prop] public bool DefaultCollapsed { get; init; } = false;
+
     [Event] public Func<Event<DiffView, int>, ValueTask>? OnLineClick { get; init; }
 }
 
@@ -53,6 +59,12 @@ public static class DiffViewExtensions
 
     public static DiffView WordWrap(this DiffView w, bool wordWrap = true) =>
         w with { WordWrap = wordWrap };
+
+    public static DiffView Collapsible(this DiffView w, bool collapsible = true) =>
+        w with { Collapsible = collapsible };
+
+    public static DiffView DefaultCollapsed(this DiffView w, bool collapsed = true) =>
+        w with { DefaultCollapsed = collapsed };
 
     public static DiffView OnLineClick(
         this DiffView w,

--- a/src/widgets/Ivy.Widgets.DiffView/frontend/src/DiffView.tsx
+++ b/src/widgets/Ivy.Widgets.DiffView/frontend/src/DiffView.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 import { parseDiff, Diff, Hunk, type ChangeData } from "react-diff-view";
 import "react-diff-view/style/index.css";
 import "./custom-diff.css";
@@ -17,6 +17,8 @@ interface DiffViewProps {
   oldRevision?: string;
   newRevision?: string;
   wordWrap?: boolean;
+  collapsible?: boolean;
+  defaultCollapsed?: boolean;
 }
 
 function getLineNumber(change: ChangeData | null): number {
@@ -36,6 +38,8 @@ export const DiffView: React.FC<DiffViewProps> = ({
   oldRevision,
   newRevision,
   wordWrap,
+  collapsible = false,
+  defaultCollapsed = false,
 }) => {
   const files = useMemo(() => {
     if (!diff) return [];
@@ -45,6 +49,8 @@ export const DiffView: React.FC<DiffViewProps> = ({
       return [];
     }
   }, [diff]);
+
+  const [collapsedState, setCollapsedState] = useState<Record<number, boolean>>({});
 
   const diffViewType = viewType === "Split" ? "split" : "unified";
 
@@ -78,10 +84,37 @@ export const DiffView: React.FC<DiffViewProps> = ({
           return parts[parts.length - 1] || path;
         };
 
+        const isCollapsed = collapsible
+          ? (collapsedState[fileIndex] ?? defaultCollapsed)
+          : false;
+
+        const toggleCollapsed = () => {
+          if (!collapsible) return;
+          setCollapsedState((prev) => ({
+            ...prev,
+            [fileIndex]: !isCollapsed,
+          }));
+        };
+
         return (
           <div key={fileIndex} id={fileId}>
             {hasHeader && (
-              <div className="flex items-center gap-2 px-3 py-1.5 text-[11px] bg-[var(--muted)] text-[var(--muted-foreground)] border-b border-[var(--border)] sticky top-0 z-10" style={{ fontFamily: 'var(--font-sans, sans-serif)' }}>
+              <div
+                className={`flex items-center gap-2 px-3 py-1.5 text-[11px] bg-[var(--muted)] text-[var(--muted-foreground)] border-b border-[var(--border)] sticky top-0 z-10${collapsible ? " cursor-pointer select-none" : ""}`}
+                style={{ fontFamily: 'var(--font-sans, sans-serif)' }}
+                onClick={collapsible ? toggleCollapsed : undefined}
+              >
+                {collapsible && (
+                  <svg
+                    width="12"
+                    height="12"
+                    viewBox="0 0 12 12"
+                    className="shrink-0 transition-transform duration-150"
+                    style={{ transform: isCollapsed ? "rotate(-90deg)" : "rotate(0deg)" }}
+                  >
+                    <path d="M3 4.5L6 7.5L9 4.5" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                )}
                 {isRename ? (
                   <>
                     <span className="font-semibold">{getBasename(oldName)}</span>
@@ -93,24 +126,26 @@ export const DiffView: React.FC<DiffViewProps> = ({
                 )}
               </div>
             )}
-            <Diff
-              viewType={diffViewType}
-              diffType={file.type}
-              hunks={file.hunks}
-              gutterEvents={{
-                onClick: ({ change }) => {
-                  if (events.includes("OnLineClick")) {
-                    onIvyEvent("OnLineClick", id, [getLineNumber(change)]);
-                  }
-                },
-              }}
-            >
-              {(hunks) =>
-                hunks.map((hunk) => (
-                  <Hunk key={hunk.content} hunk={hunk} />
-                ))
-              }
-            </Diff>
+            {!isCollapsed && (
+              <Diff
+                viewType={diffViewType}
+                diffType={file.type}
+                hunks={file.hunks}
+                gutterEvents={{
+                  onClick: ({ change }) => {
+                    if (events.includes("OnLineClick")) {
+                      onIvyEvent("OnLineClick", id, [getLineNumber(change)]);
+                    }
+                  },
+                }}
+              >
+                {(hunks) =>
+                  hunks.map((hunk) => (
+                    <Hunk key={hunk.content} hunk={hunk} />
+                  ))
+                }
+              </Diff>
+            )}
           </div>
         );
       })}


### PR DESCRIPTION
## Summary

Added native collapsible/expandable behavior to the DiffView widget. When `Collapsible` is true, the file header becomes clickable with a chevron indicator that toggles visibility of the diff content. `DefaultCollapsed` controls the initial state.

## API Changes

- `DiffView.Collapsible` (bool, default false) — makes file headers clickable to collapse/expand
- `DiffView.DefaultCollapsed` (bool, default false) — starts diffs in collapsed state
- `DiffViewExtensions.Collapsible(this DiffView w, bool collapsible = true)` — fluent extension
- `DiffViewExtensions.DefaultCollapsed(this DiffView w, bool collapsed = true)` — fluent extension

## Files Modified

- `src/widgets/Ivy.Widgets.DiffView/DiffView.cs` — Added two [Prop] properties and two extension methods
- `src/widgets/Ivy.Widgets.DiffView/frontend/src/DiffView.tsx` — Added props, per-file collapse state, chevron SVG, click handler, and conditional rendering

---

Commits:
- 35425e4e4 [00236] Add Collapsible and DefaultCollapsed props to DiffView widget