### PR TITLE
[00240] Increase spacing between assistant text and tool groups in AgentOutputView

### DIFF
--- a/src/widgets/Ivy.Widgets.AgentOutputView/frontend/src/agent-output-view.css
+++ b/src/widgets/Ivy.Widgets.AgentOutputView/frontend/src/agent-output-view.css
@@ -166,7 +166,7 @@
 
 /* ─── Assistant text (markdown) ─────────────────────────────────────────── */
 .aov-assistant {
-  margin: 8px 0;
+  margin: 16px 0;
 }
 
 .aov-markdown {
@@ -243,7 +243,7 @@
   border: 1px solid var(--aov-border);
   background: var(--aov-bg-elev);
   border-radius: 6px;
-  margin: 6px 0;
+  margin: 14px 0;
   overflow: hidden;
 }
 


### PR DESCRIPTION
Increases the visual gap between assistant text output and tool call group cards in AgentOutputView.

- `.aov-assistant` margin: `8px 0` → `16px 0`
- `.aov-tool` margin: `6px 0` → `14px 0`

This doubles the effective gap (~14px → ~30px), making content sections clearly delineated.

---

**Commits:**
- bdeedc908 [00240] Increase spacing between assistant text and tool groups