### PR TITLE
[00239] Add max-height 50% constraint to tool calls group in AgentOutputView

### DIFF
--- a/src/widgets/Ivy.Widgets.AgentOutputView/frontend/src/agent-output-view.css
+++ b/src/widgets/Ivy.Widgets.AgentOutputView/frontend/src/agent-output-view.css
@@ -26,6 +26,7 @@
   border: 1px solid var(--aov-border);
   border-radius: 8px;
   position: relative;
+  container-type: size;
 }
 
 .light .aov-shell {
@@ -245,6 +246,9 @@
   border-radius: 6px;
   margin: 6px 0;
   overflow: hidden;
+  max-height: 50cqh;
+  display: flex;
+  flex-direction: column;
 }
 
 .aov-tool-header {
@@ -340,6 +344,8 @@
 .aov-tool-body {
   border-top: 1px solid var(--aov-border);
   padding: 8px 10px 10px;
+  overflow-y: auto;
+  min-height: 0;
 }
 
 .aov-tool-section-label {


### PR DESCRIPTION
## Changes

Added a max-height constraint (50% of container) to the `.aov-tool` card in AgentOutputView using CSS container queries. The `.aov-shell` is now a size container, `.aov-tool` uses flex column layout with `max-height: 50cqh`, and `.aov-tool-body` scrolls internally when content overflows.

## API Changes

None.

## Files Modified

- **src/widgets/Ivy.Widgets.AgentOutputView/frontend/src/agent-output-view.css** — Added `container-type: size` to `.aov-shell`, `max-height: 50cqh` + flex layout to `.aov-tool`, and `overflow-y: auto` to `.aov-tool-body`

---

**Commit:** c394915be