### PR TITLE
[00242] Replace clickable cell icon with hover highlight styling

### DIFF
--- a/src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx
+++ b/src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx
@@ -408,9 +408,7 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
         height: cellActionIndicator.height,
         pointerEvents: "none",
         zIndex: 20,
-        backgroundColor: isDark
-          ? "rgba(59, 130, 246, 0.08)"
-          : "rgba(59, 130, 246, 0.06)",
+        backgroundColor: isDark ? "rgba(59, 130, 246, 0.08)" : "rgba(59, 130, 246, 0.06)",
         border: `1px solid ${isDark ? "rgba(59, 130, 246, 0.3)" : "rgba(59, 130, 246, 0.2)"}`,
         borderRadius: "2px",
         boxSizing: "border-box",

--- a/src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx
+++ b/src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx
@@ -37,7 +37,6 @@ import { DENSITY_CONFIG } from "./constants";
 import { useCellContent, useGridColumns, useHeaderMenu } from "./hooks";
 import { getOrderedVisibleDataColumns } from "../utils/columnHelpers";
 import type { SpriteMap } from "@glideapps/glide-data-grid";
-import { ExternalLink } from "lucide-react";
 
 interface TableEditorProps {
   widgetId: string;
@@ -80,11 +79,6 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
   } = useTable();
 
   const densityConfig = DENSITY_CONFIG[density];
-  const actionIndicatorStyle = useMemo(() => {
-    if (density === "Small") return { iconSize: 10, top: 1, right: 2 };
-    if (density === "Large") return { iconSize: 14, top: 3, right: 4 };
-    return { iconSize: 12, top: 2, right: 3 };
-  }, [density]);
 
   const hasWrappingColumns = columns.some((c) => c.wrapText && !c.hidden);
   const effectiveRowHeight = hasWrappingColumns
@@ -267,6 +261,7 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
     x: number;
     y: number;
     width: number;
+    height: number;
   } | null>(null);
 
   const handleVisibleRegionChangedForGrid = useCallback(
@@ -310,6 +305,7 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
         x: args.bounds.x,
         y: args.bounds.y,
         width: args.bounds.width,
+        height: args.bounds.height,
       });
     },
     [onLinkCellHovered, onItemHovered, orderedDataColumns, visibleRows],
@@ -406,20 +402,21 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
     <div
       style={{
         position: "fixed",
-        left:
-          cellActionIndicator.x +
-          cellActionIndicator.width -
-          actionIndicatorStyle.iconSize -
-          actionIndicatorStyle.right,
-        top: cellActionIndicator.y + actionIndicatorStyle.top,
+        left: cellActionIndicator.x,
+        top: cellActionIndicator.y,
+        width: cellActionIndicator.width,
+        height: cellActionIndicator.height,
         pointerEvents: "none",
         zIndex: 20,
-        opacity: 0.7,
+        backgroundColor: isDark
+          ? "rgba(59, 130, 246, 0.08)"
+          : "rgba(59, 130, 246, 0.06)",
+        border: `1px solid ${isDark ? "rgba(59, 130, 246, 0.3)" : "rgba(59, 130, 246, 0.2)"}`,
+        borderRadius: "2px",
+        boxSizing: "border-box",
       }}
       aria-hidden
-    >
-      <ExternalLink size={actionIndicatorStyle.iconSize} />
-    </div>
+    />
   ) : null;
 
   return (


### PR DESCRIPTION
When a DataTable cell is clickable, the previous affordance was a small ExternalLink icon in the top-right corner on hover. This replaces it with a full-cell highlight overlay (blue-tinted background + border) that clearly communicates clickability and visually separates from the row hover effect.

**Changes:**
- Removed ExternalLink icon overlay and its import
- Added full-cell highlight overlay with theme-aware colors (blue tint that differs from gray row hover)
- Updated cellActionIndicator state to include cell height for proper overlay sizing
- Removed unused `actionIndicatorStyle` useMemo

---

**Commits:**
- `83f7ff48e` [00242] Replace clickable cell icon with hover highlight styling
- `6bb1ff9d0` [00242] Fix formatting