### PR TITLE
fix(ActivityHeatmap): normalize inverted date range; refresh sample and tests

### DIFF
--- a/src/Ivy.Test/ActivityHeatmapTests.cs
+++ b/src/Ivy.Test/ActivityHeatmapTests.cs
@@ -198,4 +198,38 @@ public class ActivityHeatmapTests
         Assert.True(weeks.Length <= 54);
         Assert.All(weeks, week => Assert.Equal(7, week.Length));
     }
+
+    [Fact]
+    public void BuildGrid_InvertedStartEnd_NormalizesToChronologicalRange()
+    {
+        var startDate = new DateOnly(2024, 3, 31);
+        var endDate = new DateOnly(2024, 3, 1);
+        var data = new[]
+        {
+            new Activity { Date = new DateOnly(2024, 3, 15), Count = 5 },
+        };
+
+        var weeks = ActivityHeatmapGrid.BuildGrid(data, startDate: startDate, endDate: endDate);
+
+        Assert.NotEmpty(weeks);
+        Assert.All(weeks, week => Assert.Equal(7, week.Length));
+        Assert.Equal(DayOfWeek.Sunday, weeks[0][0].Date.DayOfWeek);
+        Assert.Equal(DayOfWeek.Saturday, weeks[^1][6].Date.DayOfWeek);
+        Assert.True(weeks[0][0].Date <= endDate);
+        Assert.True(weeks[^1][6].Date >= startDate);
+        var midWeek = weeks.SelectMany(w => w).Single(d => d.Date == new DateOnly(2024, 3, 15));
+        Assert.Equal(5, midWeek.Count);
+    }
+
+    [Fact]
+    public void BuildGridFromRange_InvertedFirstLast_SwapsToOrderedRange()
+    {
+        var first = new DateOnly(2024, 3, 20);
+        var last = new DateOnly(2024, 3, 1);
+        var weeks = ActivityHeatmapGrid.BuildGridFromRange([], first, last);
+
+        Assert.NotEmpty(weeks);
+        Assert.True(weeks[0][0].Date <= last);
+        Assert.True(weeks[^1][6].Date >= first);
+    }
 }

--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/.samples/Program.cs
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/.samples/Program.cs
@@ -40,18 +40,24 @@ class ActivityHeatmapDemo : ViewBase
 
             | Text.H1("ActivityHeatmap")
             | Text.H2("Basic Usage")
-            | new CodeBlock(@$"var rng = new Random(42);
-var today = DateOnly.FromDateTime(DateTime.Today);
-var start = today.AddDays(-364);
+            | new CodeBlock(@$"public class ActivityHeatmapDemo : ViewBase
+{{
+    public override object Build()
+    {{
+        var rng = new Random(42);
+        var today = DateOnly.FromDateTime(DateTime.Today);
+        var start = today.AddDays(-364);
 
-Activity[] data = Enumerable
-    .Range(0, 365)
-    .Select(start.AddDays)
-    .Where(_ => rng.NextDouble() > 0.4)
-    .Select(d => new Activity {{ Date = d, Count = rng.Next(1, 20) }})
-    .ToArray();
+        Activity[] data = Enumerable
+            .Range(0, 365)
+            .Select(start.AddDays)
+            .Where(_ => rng.NextDouble() > 0.4)
+            .Select(d => new Activity {{ Date = d, Count = rng.Next(1, 20) }})
+            .ToArray();
 
-new ActivityHeatmap().Data(data);", Languages.Csharp)
+        return new ActivityHeatmap().Data(data);
+    }}
+}}", Languages.Csharp)
             | (Layout
                 .Vertical()
                 .Gap(2)

--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/.samples/Program.cs
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/.samples/Program.cs
@@ -14,9 +14,9 @@ class ActivityHeatmapDemo : ViewBase
     {
         var client = UseService<IClientProvider>();
 
-        var selectedColor = UseState(Colors.Primary);
-        var showDayLabels = UseState(true);
-        var showMonthLabels = UseState(true);
+        var selectedColor = UseState(Colors.Emerald);
+        var showDayLabels = UseState(false);
+        var showMonthLabels = UseState(false);
         var nullableRange = UseState<(DateOnly?, DateOnly?)>(() =>
             (DateOnly.FromDateTime(DateTime.Today.AddDays(-364)),
              DateOnly.FromDateTime(DateTime.Today)));
@@ -40,28 +40,38 @@ class ActivityHeatmapDemo : ViewBase
 
             | Text.H1("ActivityHeatmap")
             | Text.H2("Basic Usage")
-            | new CodeBlock(@$"
-Activity[] data = 
-[
-    {{
-        Date = DateOnly.FromDateTime(DateTime.Today),
-        Count = 16
-    }}
-];
+            | new CodeBlock(@$"var rng = new Random(42);
+var today = DateOnly.FromDateTime(DateTime.Today);
+var start = today.AddDays(-364);
 
-new ActivityHeatmap()
-    .Data(data)
-    .ColorScheme(Colors.{selectedColor.Value})
-    .OnDayClick(day => Console.WriteLine(...));", Languages.Csharp)
+Activity[] data = Enumerable
+    .Range(0, 365)
+    .Select(start.AddDays)
+    .Where(_ => rng.NextDouble() > 0.4)
+    .Select(d => new Activity {{ Date = d, Count = rng.Next(1, 20) }})
+    .ToArray();
 
+new ActivityHeatmap().Data(data);", Languages.Csharp)
             | (Layout
                 .Vertical()
                 .Gap(2)
                 .Padding(4)
+                .BottomMargin(16)
                 .BorderThickness(1)
                 .BorderRadius(BorderRadius.Rounded)
+                | new ActivityHeatmap().Data(data))
 
-                | (Layout
+            | Text.H2("With Optional Properties:")
+            | new CodeBlock(@$"new ActivityHeatmap()
+    .Data(data)
+    .ShowDayLabels({showDayLabels.Value.ToString().ToLower()})
+    .ShowMonthLabels({showMonthLabels.Value.ToString().ToLower()})
+    .StartDate(DateOnly.Parse({$"\"{startDate}\""}))
+    .EndDate(DateOnly.Parse({$"\"{endDate}\""}))
+    .ColorScheme(Colors.{selectedColor.Value})
+    .OnDayClick(day => Console.WriteLine(...));", Languages.Csharp)
+
+            | (Layout
                     .Horizontal()
                     .Gap(2)
                     | (Layout.Horizontal().Gap(2).Width(Size.Fit())
@@ -72,6 +82,12 @@ new ActivityHeatmap()
                         | showMonthLabels.ToBoolInput().Label("Show month labels"))
                     | nullableRange.ToDateRangeInput())
 
+            | (Layout
+                .Vertical()
+                .Gap(2)
+                .Padding(4)
+                .BorderThickness(1)
+                .BorderRadius(BorderRadius.Rounded)
                 | new ActivityHeatmap()
                     .Data(data)
                     .StartDate(startDate)
@@ -79,7 +95,8 @@ new ActivityHeatmap()
                     .ColorScheme(selectedColor.Value)
                     .ShowDayLabels(showDayLabels.Value)
                     .ShowMonthLabels(showMonthLabels.Value)
-                    .OnDayClick(day => Console.WriteLine($"Clicked {day.Date}: {day.Count}")))
+                    .OnDayClick(day => Console.WriteLine($"Clicked {day.Date}: {day.Count}"))
+                    )
 
                 | new DropDownMenu(@evt =>
                     {

--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/.samples/Program.cs
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/.samples/Program.cs
@@ -17,8 +17,11 @@ class ActivityHeatmapDemo : ViewBase
         var selectedColor = UseState(Colors.Primary);
         var showDayLabels = UseState(true);
         var showMonthLabels = UseState(true);
-        var startDate = UseState(DateOnly.FromDateTime(DateTime.Today).AddDays(-364));
-        var endDate = UseState(DateOnly.FromDateTime(DateTime.Today));
+        var nullableRange = UseState<(DateOnly?, DateOnly?)>(() =>
+            (DateOnly.FromDateTime(DateTime.Today.AddDays(-364)),
+             DateOnly.FromDateTime(DateTime.Today)));
+        var startDate = nullableRange.Value.Item1;
+        var endDate = nullableRange.Value.Item2;
 
         var rng = new Random(42);
         var today = DateOnly.FromDateTime(DateTime.Today);
@@ -61,17 +64,18 @@ new ActivityHeatmap()
                 | (Layout
                     .Horizontal()
                     .Gap(2)
-                    | selectedColor.ToColorInput().Variant(ColorInputVariant.SwatchPicker)
-                    | Text.P(selectedColor.Value.ToString())
-                    | showDayLabels.ToBoolInput().Label("Show day labels")
-                    | showMonthLabels.ToBoolInput().Label("Show month labels")
-                    | startDate.ToDateInput().WithLabel("Start date")
-                    | endDate.ToDateInput().WithLabel("End date"))
+                    | (Layout.Horizontal().Gap(2).Width(Size.Fit())
+                        | selectedColor.ToColorInput().Variant(ColorInputVariant.SwatchPicker)
+                        | Text.P(selectedColor.Value.ToString()))
+                    | (Layout.Horizontal().Gap(2).Width(Size.Grow())
+                        | showDayLabels.ToBoolInput().Label("Show day labels")
+                        | showMonthLabels.ToBoolInput().Label("Show month labels"))
+                    | nullableRange.ToDateRangeInput())
 
                 | new ActivityHeatmap()
                     .Data(data)
-                    .StartDate(startDate.Value)
-                    .EndDate(endDate.Value)
+                    .StartDate(startDate)
+                    .EndDate(endDate)
                     .ColorScheme(selectedColor.Value)
                     .ShowDayLabels(showDayLabels.Value)
                     .ShowMonthLabels(showMonthLabels.Value)

--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/.samples/Program.cs
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/.samples/Program.cs
@@ -17,8 +17,8 @@ class ActivityHeatmapDemo : ViewBase
         var selectedColor = UseState(Colors.Primary);
         var showDayLabels = UseState(true);
         var showMonthLabels = UseState(true);
+        var startDate = UseState(DateOnly.FromDateTime(DateTime.Today).AddDays(-364));
         var endDate = UseState(DateOnly.FromDateTime(DateTime.Today));
-        var startDate = UseState(endDate.Value.AddDays(-364));
 
         var rng = new Random(42);
         var today = DateOnly.FromDateTime(DateTime.Today);

--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/.samples/Program.cs
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/.samples/Program.cs
@@ -48,11 +48,7 @@ Activity[] data =
 
 new ActivityHeatmap()
     .Data(data)
-    .StartDate({startDate.Value})
-    .EndDate({endDate.Value})
     .ColorScheme(Colors.{selectedColor.Value})
-    .ShowDayLabels({showDayLabels.Value.ToString().ToLower()})
-    .ShowMonthLabels({showMonthLabels.Value.ToString().ToLower()})
     .OnDayClick(day => Console.WriteLine(...));", Languages.Csharp)
 
             | (Layout

--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/ActivityHeatmap.cs
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/ActivityHeatmap.cs
@@ -23,10 +23,10 @@ public record ActivityHeatmap : WidgetBase<ActivityHeatmap>
     /// <summary>Show weekday labels on the left (Mon, Wed, Fri).</summary>
     [Prop] public bool ShowDayLabels { get; init; } = true;
 
-    /// <summary>Pins the start of the visible range, overriding the data-derived minimum date.</summary>
+    /// <summary>Pins the start of the visible range, overriding the data-derived minimum date. If <see cref="EndDate"/> is earlier, bounds are treated in chronological order (same as swapping).</summary>
     [Prop] public DateOnly? StartDate { get; init; }
 
-    /// <summary>Pins the end of the visible range, overriding the data-derived maximum date.</summary>
+    /// <summary>Pins the end of the visible range, overriding the data-derived maximum date. If earlier than <see cref="StartDate"/>, bounds are normalized to chronological order.</summary>
     [Prop] public DateOnly? EndDate { get; init; }
 
     /// <summary>Fired when the user clicks a day cell.</summary>
@@ -81,6 +81,7 @@ public static class ActivityHeatmapGrid
     /// Builds a weeks × 7-days matrix. Pads left to the preceding Sunday of the earliest date,
     /// pads right to the following Saturday of the latest date. Empty days get Count = 0.
     /// When startDate or endDate is provided, they override the data-derived bounds.
+    /// If both are set and endDate is before startDate, the range is normalized to chronological order.
     /// </summary>
     public static Activity[][] BuildGrid(Activity[] data, DateOnly? startDate = null, DateOnly? endDate = null)
     {
@@ -98,9 +99,13 @@ public static class ActivityHeatmapGrid
 
     /// <summary>
     /// Builds a grid between two dates (inclusive), padded to week boundaries.
+    /// If <paramref name="first"/> is after <paramref name="last"/>, the arguments are treated as reversed.
     /// </summary>
     public static Activity[][] BuildGridFromRange(Activity[] data, DateOnly first, DateOnly last)
     {
+        if (first > last)
+            (first, last) = (last, first);
+
         // Pad left to Sunday (DayOfWeek.Sunday == 0)
         var start = first.AddDays(-(int)first.DayOfWeek);
         // Pad right to Saturday (DayOfWeek.Saturday == 6)

--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/README.md
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/README.md
@@ -30,6 +30,8 @@ new ActivityHeatmap()
 | `StartDate` | `DateOnly?` | `null` | Pins the start of the visible range; when set, overrides the minimum date derived from `Data` |
 | `EndDate` | `DateOnly?` | `null` | Pins the end of the visible range; when set, overrides the maximum date derived from `Data` |
 
+If both `StartDate` and `EndDate` are set and `EndDate` is before `StartDate`, the widget treats the range in chronological order (same as swapping the two values), so the grid still renders instead of collapsing to zero weeks.
+
 ## Data Constraints
 
 - Duplicate dates in `Data` are not supported.

--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/ActivityHeatmap.tsx
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/ActivityHeatmap.tsx
@@ -67,12 +67,24 @@ function buildGridFromRange(
   firstDate: Date,
   lastDate: Date
 ): (Activity | null)[][] {
+  let rangeStart = firstDate;
+  let rangeEnd = lastDate;
+  if (
+    !Number.isNaN(rangeStart.getTime()) &&
+    !Number.isNaN(rangeEnd.getTime()) &&
+    rangeStart > rangeEnd
+  ) {
+    const t = rangeStart;
+    rangeStart = rangeEnd;
+    rangeEnd = t;
+  }
+
   // Pad left to preceding Sunday
-  const start = new Date(firstDate);
+  const start = new Date(rangeStart);
   start.setDate(start.getDate() - start.getDay());
 
   // Pad right to following Saturday
-  const end = new Date(lastDate);
+  const end = new Date(rangeEnd);
   end.setDate(end.getDate() + (6 - end.getDay()));
 
   const dataMap = new Map<string, Activity>();

--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/ActivityHeatmap.tsx
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/ActivityHeatmap.tsx
@@ -57,7 +57,7 @@ function buildGrid(
 
   const today = new Date();
   const firstDate = firstStr ? new Date(firstStr + "T00:00:00") : new Date(new Date().setDate(today.getDate() - 364));
-  const lastDate = lastStr ? new Date(lastStr + "T00:00:00") : new Date();
+  const lastDate = lastStr ? new Date(lastStr + "T00:00:00") : today;
 
   return buildGridFromRange(data, firstDate, lastDate);
 }


### PR DESCRIPTION
## Summary

Improves **ActivityHeatmap** when pinned `StartDate` / `EndDate` are reversed or inconsistent with the derived range, keeps **C# and TS** grid building aligned, and refreshes the **widget sample** so the UI and `CodeBlock` snippets match real usage.

## Changes

- **Grid behavior:** `ActivityHeatmapGrid.BuildGridFromRange` (and the TS `buildGridFromRange` helper) **swap bounds** when the logical start is after the end, so padding + iteration never yield **zero weeks** and an empty heatmap.
- **Documentation:** README / XML comments describe that **end before start** is normalized (chronological order), not rejected.
- **Tests:** New coverage for inverted `BuildGrid` / `BuildGridFromRange` inputs (`Ivy.Test`).
- **Sample app:** `DateRangeInput` for the range, **Basic usage** vs **With optional properties** sections, expanded data-generation snippet aligned with the sample’s `Enumerable` pipeline, optional-properties `CodeBlock` driven by live state (including **quoted** `DateOnly.Parse(...)` for dates), layout cleanup, and small TS fix so the default **end** fallback does not rely on a **mutated** “today” date.

## How to test

- `dotnet test` (at least `ActivityHeatmapTests`).
- Run **ActivityHeatmap** sample: toggle range (including reversed dates), optional props, and theme menu; confirm heatmap always shows a sensible grid and snippets stay readable.