### PR TITLE
[Inputs]: restore clear button visibility in SearchVariant

### DIFF
--- a/src/frontend/src/widgets/inputs/TextInputWidget/variants/SearchVariant.tsx
+++ b/src/frontend/src/widgets/inputs/TextInputWidget/variants/SearchVariant.tsx
@@ -91,9 +91,7 @@ export const SearchVariant: React.FC<SearchVariantProps> = ({
   const hasAffixes = hasPrefix || hasSuffix;
   const ghostAffixChrome = Boolean(props.ghost && hasAffixes);
   const ghostSuffixLayout = Boolean(props.ghost && hasSuffix);
-  const showClear = ghostSuffixLayout
-    ? !props.disabled && hasValue
-    : props.nullable && !props.disabled && hasValue;
+  const showClear = !props.disabled && hasValue;
   const showShortcut =
     Boolean(props.shortcutKey) && !isFocused && !hasValue && !showClear && !props.invalid;
   const showTrailing = showClear || showShortcut || Boolean(props.invalid);


### PR DESCRIPTION
## Problem

The X (clear) button in **search** inputs stopped appearing after the ghost/affix layout refactor in `2bf207004`.

The refactor introduced a `showClear` variable that tied button visibility to `props.nullable`, but `nullable` defaults to **false** for non-nullable string types — so the button was silently hidden for most search inputs.

## Root cause

Before the refactor, the clear button rendered directly in JSX with a simple `hasValue && !disabled` check.

The refactor unified the trailing cluster logic into a `showClear` flag, but incorrectly applied the **nullable** guard (which is appropriate for text/default inputs) to the **search** variant as well.

Search inputs should **always** show a clear button when they have a value — that is standard UX for search fields. Whether the underlying state type is nullable is an implementation detail and should not control button visibility here.

## Fix

Simplified `showClear` in `SearchVariant` to `!props.disabled && hasValue`, restoring the pre-refactor behavior.
<img width="1333" height="843" alt="Знімок екрана 2026-05-13 о 02 43 39" src="https://github.com/user-attachments/assets/be0f964a-e4fe-46a1-8b64-1722043b6f12" />
