### PR TITLE
Add `QRCode` external widget

### DIFF
--- a/src/Ivy.Test/Ivy.Test.csproj
+++ b/src/Ivy.Test/Ivy.Test.csproj
@@ -33,6 +33,7 @@
   <ItemGroup>
     <ProjectReference Include="../Ivy/Ivy.csproj" />
     <ProjectReference Include="../widgets/Ivy.Widgets.ActivityHeatmap/Ivy.Widgets.ActivityHeatmap.csproj" />
+    <ProjectReference Include="../widgets/Ivy.Widgets.QRCode/Ivy.Widgets.QRCode.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Ivy.Test/QRCodeTests.cs
+++ b/src/Ivy.Test/QRCodeTests.cs
@@ -1,0 +1,147 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Ivy;
+using Ivy.Core;
+using Ivy.Widgets.QRCode;
+using Xunit.Abstractions;
+
+namespace Ivy.Test;
+
+public class QRCodeTests(ITestOutputHelper output)
+{
+    private static JsonNode SerializeQr(QRCode qr)
+    {
+        qr.Id = Guid.NewGuid().ToString();
+        return WidgetSerializer.Serialize(qr);
+    }
+
+    [Fact]
+    public void Defaults_ValueEmpty_LowCorrection_IncludeMarginTrue_OptionalNull()
+    {
+        var qr = new QRCode();
+
+        Assert.Equal("", qr.Value);
+        Assert.Null(qr.PixelSize);
+        Assert.Equal(QrErrorCorrectionLevel.Low, qr.ErrorCorrectionLevel);
+        Assert.True(qr.IncludeMargin);
+        Assert.Null(qr.Background);
+        Assert.Null(qr.Foreground);
+    }
+
+    [Fact]
+    public void Value_Extension_SetsValue()
+    {
+        var qr = new QRCode().Value("https://ivy.app");
+
+        Assert.Equal("https://ivy.app", qr.Value);
+    }
+
+    [Fact]
+    public void PixelSize_Extension_SetsPixelSize()
+    {
+        var qr = new QRCode().PixelSize(128);
+
+        Assert.Equal(128, qr.PixelSize);
+    }
+
+    [Fact]
+    public void ErrorCorrectionLevel_Extension_SetsLevel()
+    {
+        var qr = new QRCode().ErrorCorrectionLevel(QrErrorCorrectionLevel.High);
+
+        Assert.Equal(QrErrorCorrectionLevel.High, qr.ErrorCorrectionLevel);
+    }
+
+    [Fact]
+    public void IncludeMargin_Extension_SetsIncludeMargin()
+    {
+        var qr = new QRCode().IncludeMargin(false);
+
+        Assert.False(qr.IncludeMargin);
+    }
+
+    [Fact]
+    public void Background_Foreground_Extensions_SetColors()
+    {
+        var qr = new QRCode()
+            .Background(Colors.White)
+            .Foreground(Colors.Black);
+
+        Assert.Equal(Colors.White, qr.Background);
+        Assert.Equal(Colors.Black, qr.Foreground);
+    }
+
+    [Fact]
+    public void Extensions_ReturnNewInstance_PreservesOriginal()
+    {
+        var original = new QRCode();
+        var chained = original
+            .Value("x")
+            .PixelSize(64)
+            .ErrorCorrectionLevel(QrErrorCorrectionLevel.Medium)
+            .IncludeMargin(false);
+
+        Assert.Equal("", original.Value);
+        Assert.Null(original.PixelSize);
+        Assert.Equal(QrErrorCorrectionLevel.Low, original.ErrorCorrectionLevel);
+        Assert.True(original.IncludeMargin);
+
+        Assert.Equal("x", chained.Value);
+        Assert.Equal(64, chained.PixelSize);
+        Assert.Equal(QrErrorCorrectionLevel.Medium, chained.ErrorCorrectionLevel);
+        Assert.False(chained.IncludeMargin);
+        Assert.NotSame(original, chained);
+    }
+
+    [Fact]
+    public void Serialize_TypeName_IsFullWidgetName()
+    {
+        var qr = new QRCode();
+        var result = SerializeQr(qr);
+
+        output.WriteLine(result.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
+
+        Assert.Equal("Ivy.Widgets.QRCode.QRCode", result["type"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void Serialize_DefaultProps_OmitRedundantValues()
+    {
+        var qr = new QRCode();
+        var result = SerializeQr(qr);
+        var props = result["props"]!.AsObject();
+
+        output.WriteLine(result.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
+
+        Assert.Null(props["value"]);
+        Assert.Null(props["pixelSize"]);
+        Assert.Null(props["errorCorrectionLevel"]);
+        Assert.Null(props["includeMargin"]);
+        Assert.Null(props["background"]);
+        Assert.Null(props["foreground"]);
+    }
+
+    [Fact]
+    public void Serialize_NonDefaultProps_ArePresent()
+    {
+        var qr = new QRCode()
+            .Value("https://example.com")
+            .PixelSize(96)
+            .ErrorCorrectionLevel(QrErrorCorrectionLevel.Quartile)
+            .IncludeMargin(false)
+            .Background(Colors.Slate)
+            .Foreground(Colors.Rose);
+
+        var result = SerializeQr(qr);
+        var props = result["props"]!.AsObject();
+
+        output.WriteLine(result.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
+
+        Assert.Equal("https://example.com", props["value"]!.GetValue<string>());
+        Assert.Equal(96, props["pixelSize"]!.GetValue<int>());
+        Assert.Equal("Quartile", props["errorCorrectionLevel"]!.GetValue<string>());
+        Assert.False(props["includeMargin"]!.GetValue<bool>());
+        Assert.Equal("Slate", props["background"]!.GetValue<string>());
+        Assert.Equal("Rose", props["foreground"]!.GetValue<string>());
+    }
+}

--- a/src/widgets/Ivy.Widgets.QRCode/.samples/.samples.sln
+++ b/src/widgets/Ivy.Widgets.QRCode/.samples/.samples.sln
@@ -1,0 +1,90 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Program", "Program.csproj", "{90139C66-1797-44F1-8EA9-6B6CB948A0DE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ivy.Widgets.QRCode", "..\Ivy.Widgets.QRCode.csproj", "{6163F6D5-A1B5-44A5-AFDB-2C47D501749F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ivy", "..\..\..\Ivy\Ivy.csproj", "{F987ABD0-187D-46E8-9142-FE92FCD67538}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ivy.Agent.Filter", "..\..\..\Ivy.Agent.Filter\Ivy.Agent.Filter.csproj", "{A4C1E587-1B6D-4504-B756-1A30AC864AA1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ivy.Plugin.Abstractions", "..\..\..\Ivy.Plugin.Abstractions\Ivy.Plugin.Abstractions.csproj", "{97FD7EDD-E8CC-4FC7-AECA-BD6008123614}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{90139C66-1797-44F1-8EA9-6B6CB948A0DE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{90139C66-1797-44F1-8EA9-6B6CB948A0DE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{90139C66-1797-44F1-8EA9-6B6CB948A0DE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{90139C66-1797-44F1-8EA9-6B6CB948A0DE}.Debug|x64.Build.0 = Debug|Any CPU
+		{90139C66-1797-44F1-8EA9-6B6CB948A0DE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{90139C66-1797-44F1-8EA9-6B6CB948A0DE}.Debug|x86.Build.0 = Debug|Any CPU
+		{90139C66-1797-44F1-8EA9-6B6CB948A0DE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{90139C66-1797-44F1-8EA9-6B6CB948A0DE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{90139C66-1797-44F1-8EA9-6B6CB948A0DE}.Release|x64.ActiveCfg = Release|Any CPU
+		{90139C66-1797-44F1-8EA9-6B6CB948A0DE}.Release|x64.Build.0 = Release|Any CPU
+		{90139C66-1797-44F1-8EA9-6B6CB948A0DE}.Release|x86.ActiveCfg = Release|Any CPU
+		{90139C66-1797-44F1-8EA9-6B6CB948A0DE}.Release|x86.Build.0 = Release|Any CPU
+		{6163F6D5-A1B5-44A5-AFDB-2C47D501749F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6163F6D5-A1B5-44A5-AFDB-2C47D501749F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6163F6D5-A1B5-44A5-AFDB-2C47D501749F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6163F6D5-A1B5-44A5-AFDB-2C47D501749F}.Debug|x64.Build.0 = Debug|Any CPU
+		{6163F6D5-A1B5-44A5-AFDB-2C47D501749F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6163F6D5-A1B5-44A5-AFDB-2C47D501749F}.Debug|x86.Build.0 = Debug|Any CPU
+		{6163F6D5-A1B5-44A5-AFDB-2C47D501749F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6163F6D5-A1B5-44A5-AFDB-2C47D501749F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6163F6D5-A1B5-44A5-AFDB-2C47D501749F}.Release|x64.ActiveCfg = Release|Any CPU
+		{6163F6D5-A1B5-44A5-AFDB-2C47D501749F}.Release|x64.Build.0 = Release|Any CPU
+		{6163F6D5-A1B5-44A5-AFDB-2C47D501749F}.Release|x86.ActiveCfg = Release|Any CPU
+		{6163F6D5-A1B5-44A5-AFDB-2C47D501749F}.Release|x86.Build.0 = Release|Any CPU
+		{F987ABD0-187D-46E8-9142-FE92FCD67538}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F987ABD0-187D-46E8-9142-FE92FCD67538}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F987ABD0-187D-46E8-9142-FE92FCD67538}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F987ABD0-187D-46E8-9142-FE92FCD67538}.Debug|x64.Build.0 = Debug|Any CPU
+		{F987ABD0-187D-46E8-9142-FE92FCD67538}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F987ABD0-187D-46E8-9142-FE92FCD67538}.Debug|x86.Build.0 = Debug|Any CPU
+		{F987ABD0-187D-46E8-9142-FE92FCD67538}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F987ABD0-187D-46E8-9142-FE92FCD67538}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F987ABD0-187D-46E8-9142-FE92FCD67538}.Release|x64.ActiveCfg = Release|Any CPU
+		{F987ABD0-187D-46E8-9142-FE92FCD67538}.Release|x64.Build.0 = Release|Any CPU
+		{F987ABD0-187D-46E8-9142-FE92FCD67538}.Release|x86.ActiveCfg = Release|Any CPU
+		{F987ABD0-187D-46E8-9142-FE92FCD67538}.Release|x86.Build.0 = Release|Any CPU
+		{A4C1E587-1B6D-4504-B756-1A30AC864AA1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A4C1E587-1B6D-4504-B756-1A30AC864AA1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A4C1E587-1B6D-4504-B756-1A30AC864AA1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A4C1E587-1B6D-4504-B756-1A30AC864AA1}.Debug|x64.Build.0 = Debug|Any CPU
+		{A4C1E587-1B6D-4504-B756-1A30AC864AA1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A4C1E587-1B6D-4504-B756-1A30AC864AA1}.Debug|x86.Build.0 = Debug|Any CPU
+		{A4C1E587-1B6D-4504-B756-1A30AC864AA1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A4C1E587-1B6D-4504-B756-1A30AC864AA1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A4C1E587-1B6D-4504-B756-1A30AC864AA1}.Release|x64.ActiveCfg = Release|Any CPU
+		{A4C1E587-1B6D-4504-B756-1A30AC864AA1}.Release|x64.Build.0 = Release|Any CPU
+		{A4C1E587-1B6D-4504-B756-1A30AC864AA1}.Release|x86.ActiveCfg = Release|Any CPU
+		{A4C1E587-1B6D-4504-B756-1A30AC864AA1}.Release|x86.Build.0 = Release|Any CPU
+		{97FD7EDD-E8CC-4FC7-AECA-BD6008123614}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{97FD7EDD-E8CC-4FC7-AECA-BD6008123614}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{97FD7EDD-E8CC-4FC7-AECA-BD6008123614}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{97FD7EDD-E8CC-4FC7-AECA-BD6008123614}.Debug|x64.Build.0 = Debug|Any CPU
+		{97FD7EDD-E8CC-4FC7-AECA-BD6008123614}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{97FD7EDD-E8CC-4FC7-AECA-BD6008123614}.Debug|x86.Build.0 = Debug|Any CPU
+		{97FD7EDD-E8CC-4FC7-AECA-BD6008123614}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{97FD7EDD-E8CC-4FC7-AECA-BD6008123614}.Release|Any CPU.Build.0 = Release|Any CPU
+		{97FD7EDD-E8CC-4FC7-AECA-BD6008123614}.Release|x64.ActiveCfg = Release|Any CPU
+		{97FD7EDD-E8CC-4FC7-AECA-BD6008123614}.Release|x64.Build.0 = Release|Any CPU
+		{97FD7EDD-E8CC-4FC7-AECA-BD6008123614}.Release|x86.ActiveCfg = Release|Any CPU
+		{97FD7EDD-E8CC-4FC7-AECA-BD6008123614}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/widgets/Ivy.Widgets.QRCode/.samples/Program.cs
+++ b/src/widgets/Ivy.Widgets.QRCode/.samples/Program.cs
@@ -10,10 +10,9 @@ class QRCodeApp : ViewBase
 {
     public override object Build()
     {
-        var state = UseState("https://ivy-interactive.com");
-        return Layout.Vertical().Children(
-            new QRCode().Value(state.Value).PixelSize(256),
-            Input.Text(state, "URL")
-        );
+        var state = UseState("https://tendril.ivy.app/");
+        return Layout.Vertical()
+            | new QRCode().Value(state.Value).PixelSize(256)
+            | state.ToTextInput();
     }
 }

--- a/src/widgets/Ivy.Widgets.QRCode/.samples/Program.cs
+++ b/src/widgets/Ivy.Widgets.QRCode/.samples/Program.cs
@@ -1,0 +1,19 @@
+using Ivy;
+using Ivy.Widgets.QRCode;
+
+var server = new Server();
+server.AddApp<QRCodeApp>();
+await server.RunAsync();
+
+[App]
+class QRCodeApp : ViewBase
+{
+    public override object Build()
+    {
+        var state = UseState("https://ivy-interactive.com");
+        return Layout.Vertical().Children(
+            new QRCode().Value(state.Value).PixelSize(256),
+            Input.Text(state, "URL")
+        );
+    }
+}

--- a/src/widgets/Ivy.Widgets.QRCode/.samples/Program.cs
+++ b/src/widgets/Ivy.Widgets.QRCode/.samples/Program.cs
@@ -11,7 +11,7 @@ class QRCodeApp : ViewBase
     public override object Build()
     {
         var state = UseState("https://tendril.ivy.app/");
-        return Layout.Vertical()
+        return Layout.Vertical().Width(Size.Fit())
             | new QRCode()
                 .Value(state.Value)
                 .PixelSize(256)

--- a/src/widgets/Ivy.Widgets.QRCode/.samples/Program.cs
+++ b/src/widgets/Ivy.Widgets.QRCode/.samples/Program.cs
@@ -11,26 +11,70 @@ class QRCodeDemo : ViewBase
     public override object Build()
     {
         var client = UseService<IClientProvider>();
-        var state = UseState("https://tendril.ivy.app/");
-        return Layout.Vertical().Width(Size.Fit())
-            | Text.H1("QRCode")
-            | Text.H2("Basic Usage")
-            | new CodeBlock(@$"class QRCodeDemo : ViewBase
+        var basicExampleQrContent = UseState("https://tendril.ivy.app/");
+        var fullExampleContent = UseState("https://tendril.ivy.app/");
+        var pixelSize = UseState(300);
+        var foregroundColor = UseState(Colors.Emerald);
+        var backgroundColor = UseState(Colors.White);
+        var includeMargin = UseState(false);
+        var errorCorrectionLevel = UseState(QrErrorCorrectionLevel.Low);
+
+        var fullExampleToolbar = Layout.Horizontal().Gap(2).Width(Size.Fit())
+            | foregroundColor.ToColorInput().Variant(ColorInputVariant.SwatchPicker).WithLabel("Foreground")
+            | backgroundColor.ToColorInput().Variant(ColorInputVariant.SwatchPicker).WithLabel("Background")
+            | pixelSize.ToNumberInput().Min(100).Max(1000).WithLabel("PixelSize")
+            | includeMargin.ToBoolInput().WithLabel("IncludeMargin")
+            | errorCorrectionLevel.ToSelectInput().WithLabel("ErrorCorrectionLevel");
+
+        return Layout.Vertical().Gap(16).Width(Size.Auto())
+            | (Layout.Vertical()
+                | Text.H1("QRCode")
+                | Text.H2("Basic Usage")
+                | new CodeBlock(@$"class QRCodeBasicDemo : ViewBase
 {{
     public override object Build()
     {{
-        var state = UseState({"\"https://tendril.ivy.app/\""});
+        var basicExampleQrContent = UseState({"\"https://tendril.ivy.app/\""});
+
         return Layout.Vertical()
-            | new QRCode().Value(state.Value)
-            | state.ToTextInput();
+            | new QRCode().Value(basicExampleQrContent.Value)
+            | basicExampleQrContent.ToTextInput();
     }}
 }}")
+                | (Layout.Vertical()
+                    | new QRCode()
+                        .Value(basicExampleQrContent.Value)
+                        .AlignSelf(Align.Center)
+                    | basicExampleQrContent.ToTextInput())
+                .WithBox())
+
             | (Layout.Vertical()
-                | new QRCode()
-                    .Value(state.Value)
-                    .AlignSelf(Align.Center)
-                | state.ToTextInput())
-            .WithBox()
+                | Text.H2("Full Props Usage")
+                | new CodeBlock(@$"class QRCodeFullDemo : ViewBase
+{{
+    public override object Build()
+    {{
+        return new QRCode()
+            .Value({$"\"{fullExampleContent.Value}\""})
+            .PixelSize({pixelSize.Value})
+            .Foreground(Colors.{foregroundColor.Value})
+            .Background(Colors.{backgroundColor.Value})
+            .IncludeMargin({includeMargin.Value.ToString().ToLower()})
+            .ErrorCorrectionLevel(QrErrorCorrectionLevel.{errorCorrectionLevel.Value});
+    }}
+}}")
+                | (Layout.Vertical()
+                    | new QRCode()
+                        .Value(fullExampleContent.Value)
+                        .PixelSize(pixelSize.Value)
+                        .Foreground(foregroundColor.Value)
+                        .Background(backgroundColor.Value)
+                        .IncludeMargin(includeMargin.Value)
+                        .ErrorCorrectionLevel(errorCorrectionLevel.Value)
+                        .AlignSelf(Align.Center)
+                    | fullExampleContent.ToTextInput()
+                    | fullExampleToolbar)
+                .WithBox())
 
             | new DropDownMenu(@evt =>
                 {

--- a/src/widgets/Ivy.Widgets.QRCode/.samples/Program.cs
+++ b/src/widgets/Ivy.Widgets.QRCode/.samples/Program.cs
@@ -12,7 +12,11 @@ class QRCodeApp : ViewBase
     {
         var state = UseState("https://tendril.ivy.app/");
         return Layout.Vertical()
-            | new QRCode().Value(state.Value).PixelSize(256)
+            | new QRCode()
+                .Value(state.Value)
+                .PixelSize(256)
+                .Foreground(Colors.Primary)
+                .Background(Colors.White)
             | state.ToTextInput();
     }
 }

--- a/src/widgets/Ivy.Widgets.QRCode/.samples/Program.cs
+++ b/src/widgets/Ivy.Widgets.QRCode/.samples/Program.cs
@@ -10,6 +10,7 @@ class QRCodeDemo : ViewBase
 {
     public override object Build()
     {
+        var client = UseService<IClientProvider>();
         var state = UseState("https://tendril.ivy.app/");
         return Layout.Vertical().Width(Size.Fit())
             | Text.H1("QRCode")
@@ -20,22 +21,30 @@ class QRCodeDemo : ViewBase
     {{
         var state = UseState({"\"https://tendril.ivy.app/\""});
         return Layout.Vertical()
-            | new QRCode()
-                .Value(state.Value)
-                .PixelSize(256)
-                .Foreground(Colors.Primary)
-                .Background(Colors.White)
+            | new QRCode().Value(state.Value)
             | state.ToTextInput();
     }}
 }}")
             | (Layout.Vertical()
                 | new QRCode()
                     .Value(state.Value)
-                    .PixelSize(256)
-                    .Foreground(Colors.Primary)
-                    .Background(Colors.White)
                     .AlignSelf(Align.Center)
                 | state.ToTextInput())
-            .WithBox();
+            .WithBox()
+
+            | new DropDownMenu(@evt =>
+                {
+                    ThemeMode selectedTheme = @evt.Value switch
+                    {
+                        "Light" => ThemeMode.Light,
+                        "Dark" => ThemeMode.Dark,
+                        _ => ThemeMode.System,
+                    };
+                    client.SetThemeMode(selectedTheme);
+                },
+                new Button("Theme").Variant(ButtonVariant.Link).Icon(Icons.SunMoon),
+                MenuItem.Default("Light").Icon(Icons.Sun),
+                MenuItem.Default("Dark").Icon(Icons.Moon),
+                MenuItem.Default("System").Icon(Icons.Computer));
     }
 }

--- a/src/widgets/Ivy.Widgets.QRCode/.samples/Program.cs
+++ b/src/widgets/Ivy.Widgets.QRCode/.samples/Program.cs
@@ -2,21 +2,40 @@ using Ivy;
 using Ivy.Widgets.QRCode;
 
 var server = new Server();
-server.AddApp<QRCodeApp>();
+server.AddApp<QRCodeDemo>();
 await server.RunAsync();
 
 [App]
-class QRCodeApp : ViewBase
+class QRCodeDemo : ViewBase
 {
     public override object Build()
     {
         var state = UseState("https://tendril.ivy.app/");
         return Layout.Vertical().Width(Size.Fit())
+            | Text.H1("QRCode")
+            | Text.H2("Basic Usage")
+            | new CodeBlock(@$"class QRCodeDemo : ViewBase
+{{
+    public override object Build()
+    {{
+        var state = UseState({"\"https://tendril.ivy.app/\""});
+        return Layout.Vertical()
             | new QRCode()
                 .Value(state.Value)
                 .PixelSize(256)
                 .Foreground(Colors.Primary)
                 .Background(Colors.White)
             | state.ToTextInput();
+    }}
+}}")
+            | (Layout.Vertical()
+                | new QRCode()
+                    .Value(state.Value)
+                    .PixelSize(256)
+                    .Foreground(Colors.Primary)
+                    .Background(Colors.White)
+                    .AlignSelf(Align.Center)
+                | state.ToTextInput())
+            .WithBox();
     }
 }

--- a/src/widgets/Ivy.Widgets.QRCode/.samples/Program.csproj
+++ b/src/widgets/Ivy.Widgets.QRCode/.samples/Program.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Ivy.Widgets.QRCode.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/widgets/Ivy.Widgets.QRCode/Ivy.Widgets.QRCode.csproj
+++ b/src/widgets/Ivy.Widgets.QRCode/Ivy.Widgets.QRCode.csproj
@@ -1,0 +1,49 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <NoWarn>CS1591;CS1573</NoWarn>
+    <PackageId>Ivy.Widgets.QRCode</PackageId>
+    <Description>QR code widget for Ivy Framework</Description>
+    <Authors>Ivy Interactive</Authors>
+    <Company>Ivy Interactive</Company>
+    <PackageTags>ivy;widget;qrcode;qr</PackageTags>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/Ivy-Interactive/Ivy-Framework/</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/Ivy-Interactive/Ivy-Framework/</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <CI Condition="'$(GITHUB_ACTIONS)' == 'true'">true</CI>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(CI)' == 'true'">
+    <DebugType>none</DebugType>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(CI)' != 'true'">
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Ivy\Ivy.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove=".samples\**\*.cs" />
+    <None Include=".samples\**\*" CopyToOutputDirectory="Never" />
+  </ItemGroup>
+
+  <Import Project="..\..\Ivy\Build\Ivy.ExternalWidget.targets" />
+
+</Project>

--- a/src/widgets/Ivy.Widgets.QRCode/QRCode.cs
+++ b/src/widgets/Ivy.Widgets.QRCode/QRCode.cs
@@ -5,10 +5,10 @@ public record QRCode : WidgetBase<QRCode>
 {
     [Prop] public string Value { get; init; } = "";
     [Prop] public int? PixelSize { get; init; }
-    [Prop] public string Level { get; init; } = "L";
+    [Prop] public QrErrorCorrectionLevel ErrorCorrectionLevel { get; init; } = QrErrorCorrectionLevel.Low;
     [Prop] public bool IncludeMargin { get; init; } = true;
-    [Prop] public string? BgColor { get; init; }
-    [Prop] public string? FgColor { get; init; }
+    [Prop] public Colors? Background { get; init; }
+    [Prop] public Colors? Foreground { get; init; }
 }
 
 public static class QRCodeExtensions
@@ -19,15 +19,23 @@ public static class QRCodeExtensions
     public static QRCode PixelSize(this QRCode w, int size) =>
         w with { PixelSize = size };
 
-    public static QRCode Level(this QRCode w, string level) =>
-        w with { Level = level };
+    public static QRCode ErrorCorrectionLevel(this QRCode w, QrErrorCorrectionLevel level) =>
+        w with { ErrorCorrectionLevel = level };
 
     public static QRCode IncludeMargin(this QRCode w, bool includeMargin = true) =>
         w with { IncludeMargin = includeMargin };
 
-    public static QRCode BgColor(this QRCode w, string bgColor) =>
-        w with { BgColor = bgColor };
+    public static QRCode Background(this QRCode w, Colors color) =>
+        w with { Background = color };
 
-    public static QRCode FgColor(this QRCode w, string fgColor) =>
-        w with { FgColor = fgColor };
+    public static QRCode Foreground(this QRCode w, Colors color) =>
+        w with { Foreground = color };
+}
+
+public enum QrErrorCorrectionLevel
+{
+    Low,
+    Medium,
+    Quartile,
+    High
 }

--- a/src/widgets/Ivy.Widgets.QRCode/QRCode.cs
+++ b/src/widgets/Ivy.Widgets.QRCode/QRCode.cs
@@ -1,0 +1,35 @@
+namespace Ivy.Widgets.QRCode;
+
+[ExternalWidget("frontend/dist/Ivy_Widgets_QRCode.js", ExportName = "QRCode")]
+public record QRCode : WidgetBase<QRCode>
+{
+    internal QRCode() { }
+
+    [Prop] public string Value { get; init; } = "";
+    [Prop] public int? PixelSize { get; init; }
+    [Prop] public string Level { get; init; } = "L";
+    [Prop] public bool IncludeMargin { get; init; } = true;
+    [Prop] public string? BgColor { get; init; }
+    [Prop] public string? FgColor { get; init; }
+}
+
+public static class QRCodeExtensions
+{
+    public static QRCode Value(this QRCode w, string value) =>
+        w with { Value = value };
+
+    public static QRCode PixelSize(this QRCode w, int size) =>
+        w with { PixelSize = size };
+
+    public static QRCode Level(this QRCode w, string level) =>
+        w with { Level = level };
+
+    public static QRCode IncludeMargin(this QRCode w, bool includeMargin = true) =>
+        w with { IncludeMargin = includeMargin };
+
+    public static QRCode BgColor(this QRCode w, string bgColor) =>
+        w with { BgColor = bgColor };
+
+    public static QRCode FgColor(this QRCode w, string fgColor) =>
+        w with { FgColor = fgColor };
+}

--- a/src/widgets/Ivy.Widgets.QRCode/QRCode.cs
+++ b/src/widgets/Ivy.Widgets.QRCode/QRCode.cs
@@ -3,8 +3,6 @@ namespace Ivy.Widgets.QRCode;
 [ExternalWidget("frontend/dist/Ivy_Widgets_QRCode.js", ExportName = "QRCode")]
 public record QRCode : WidgetBase<QRCode>
 {
-    internal QRCode() { }
-
     [Prop] public string Value { get; init; } = "";
     [Prop] public int? PixelSize { get; init; }
     [Prop] public string Level { get; init; } = "L";

--- a/src/widgets/Ivy.Widgets.QRCode/README.md
+++ b/src/widgets/Ivy.Widgets.QRCode/README.md
@@ -7,11 +7,11 @@ A QR code widget for the Ivy Framework, powered by [`qrcode.react`](https://gith
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
 | `Value` | `string` | `""` | The data to encode as a QR code |
-| `PixelSize` | `int?` | `256` | Size of the QR code in pixels |
-| `Level` | `string` | `"L"` | Error correction level: `"L"`, `"M"`, `"Q"`, or `"H"` |
+| `PixelSize` | `int?` | *(client default 256)* | Size of the QR code in pixels |
+| `ErrorCorrectionLevel` | `QrErrorCorrectionLevel` | `Low` | Error correction: `Low` (L), `Medium` (M), `Quartile` (Q), `High` (H) |
 | `IncludeMargin` | `bool` | `true` | Whether to include a quiet zone margin |
-| `BgColor` | `string?` | `null` | Background color (CSS color string) |
-| `FgColor` | `string?` | `null` | Foreground color (CSS color string) |
+| `Background` | `Colors?` | `null` | Module background (resolved from the active Ivy theme) |
+| `Foreground` | `Colors?` | `null` | Module foreground (resolved from the active Ivy theme) |
 
 ## Usage
 
@@ -26,7 +26,7 @@ new QRCode().Value("https://ivy-interactive.com")
 new QRCode()
     .Value("https://ivy-interactive.com")
     .PixelSize(300)
-    .Level("H")
-    .FgColor("#1a1a2e")
-    .BgColor("#ffffff")
+    .ErrorCorrectionLevel(QrErrorCorrectionLevel.High)
+    .Foreground(Colors.Primary)
+    .Background(Colors.White)
 ```

--- a/src/widgets/Ivy.Widgets.QRCode/README.md
+++ b/src/widgets/Ivy.Widgets.QRCode/README.md
@@ -1,0 +1,32 @@
+# Ivy.Widgets.QRCode
+
+A QR code widget for the Ivy Framework, powered by [`qrcode.react`](https://github.com/zpao/qrcode.react).
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `Value` | `string` | `""` | The data to encode as a QR code |
+| `PixelSize` | `int?` | `256` | Size of the QR code in pixels |
+| `Level` | `string` | `"L"` | Error correction level: `"L"`, `"M"`, `"Q"`, or `"H"` |
+| `IncludeMargin` | `bool` | `true` | Whether to include a quiet zone margin |
+| `BgColor` | `string?` | `null` | Background color (CSS color string) |
+| `FgColor` | `string?` | `null` | Foreground color (CSS color string) |
+
+## Usage
+
+```csharp
+using Ivy;
+using Ivy.Widgets.QRCode;
+
+// Basic usage
+new QRCode().Value("https://ivy-interactive.com")
+
+// With options
+new QRCode()
+    .Value("https://ivy-interactive.com")
+    .PixelSize(300)
+    .Level("H")
+    .FgColor("#1a1a2e")
+    .BgColor("#ffffff")
+```

--- a/src/widgets/Ivy.Widgets.QRCode/frontend/package.json
+++ b/src/widgets/Ivy.Widgets.QRCode/frontend/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "ivy-widgets-qrcode",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vp dev",
+    "build": "tsc && vp build",
+    "preview": "vp preview"
+  },
+  "dependencies": {
+    "qrcode.react": "4.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "19.2.8",
+    "@types/react-dom": "19.2.3",
+    "@vitejs/plugin-react": "6.0.1",
+    "autoprefixer": "10.4.23",
+    "postcss": "8.5.10",
+    "tailwindcss": "3.4.19",
+    "typescript": "5.9.3",
+    "vite": "npm:@voidzero-dev/vite-plus-core@0.1.20",
+    "vite-plus": "0.1.20"
+  },
+  "peerDependencies": {
+    "react": "19.2.3",
+    "react-dom": "19.2.3"
+  },
+  "packageManager": "pnpm@10.33.0",
+  "pnpm": {
+    "overrides": {
+      "jiti": "^2.0.0",
+      "lodash": "4.18.1",
+      "lodash-es": "4.18.1",
+      "vite": "npm:@voidzero-dev/vite-plus-core@0.1.20",
+      "vitest": "npm:@voidzero-dev/vite-plus-test@0.1.20"
+    }
+  }
+}

--- a/src/widgets/Ivy.Widgets.QRCode/frontend/pnpm-lock.yaml
+++ b/src/widgets/Ivy.Widgets.QRCode/frontend/pnpm-lock.yaml
@@ -1,0 +1,1797 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+overrides:
+  jiti: ^2.0.0
+  lodash: 4.18.1
+  lodash-es: 4.18.1
+  vite: npm:@voidzero-dev/vite-plus-core@0.1.20
+  vitest: npm:@voidzero-dev/vite-plus-test@0.1.20
+
+importers:
+
+  .:
+    dependencies:
+      qrcode.react:
+        specifier: 4.2.0
+        version: 4.2.0(react@19.2.3)
+      react:
+        specifier: 19.2.3
+        version: 19.2.3
+      react-dom:
+        specifier: 19.2.3
+        version: 19.2.3(react@19.2.3)
+    devDependencies:
+      '@types/react':
+        specifier: 19.2.8
+        version: 19.2.8
+      '@types/react-dom':
+        specifier: 19.2.3
+        version: 19.2.3(@types/react@19.2.8)
+      '@vitejs/plugin-react':
+        specifier: 6.0.1
+        version: 6.0.1(@voidzero-dev/vite-plus-core@0.1.20(jiti@2.7.0)(typescript@5.9.3))
+      autoprefixer:
+        specifier: 10.4.23
+        version: 10.4.23(postcss@8.5.10)
+      postcss:
+        specifier: 8.5.10
+        version: 8.5.10
+      tailwindcss:
+        specifier: 3.4.19
+        version: 3.4.19
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vite:
+        specifier: npm:@voidzero-dev/vite-plus-core@0.1.20
+        version: '@voidzero-dev/vite-plus-core@0.1.20(jiti@2.7.0)(typescript@5.9.3)'
+      vite-plus:
+        specifier: 0.1.20
+        version: 0.1.20(@voidzero-dev/vite-plus-core@0.1.20(jiti@2.7.0)(typescript@5.9.3))(jiti@2.7.0)(typescript@5.9.3)
+
+packages:
+
+  '@alloc/quick-lru@5.2.0':
+    resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
+    engines: {node: '>=10'}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
+
+  '@oxc-project/runtime@0.127.0':
+    resolution: {integrity: sha512-UQYLxAhDDPHm++szfa4z0RTdcPq5vaywrAoEA2n1YaAKeanXQdjHsoT6x1gP3U97RN8LZ7yHsSOrKPCcA6mCqw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  '@oxc-project/types@0.127.0':
+    resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
+
+  '@oxfmt/binding-android-arm-eabi@0.46.0':
+    resolution: {integrity: sha512-b1doV4WRcJU+BESSlCvCjV+5CEr/T6h0frArAdV26Nir+gGNFNaylvDiiMPfF1pxeV0txZEs38ojzJaxBYg+ng==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxfmt/binding-android-arm64@0.46.0':
+    resolution: {integrity: sha512-v6+HhjsoV3GO0u2u9jLSAZrvWfTraDxKofUIQ7/ktS7tzS+epVsxdHmeM+XxuNcAY/nWxxU1Sg4JcGTNRXraBA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxfmt/binding-darwin-arm64@0.46.0':
+    resolution: {integrity: sha512-3eeooJGrqGIlI5MyryDZsAcKXSmKIgAD4yYtfRrRJzXZ0UTFZtiSveIur56YPrGMYZwT4XyVhHsMqrNwr1XeFA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxfmt/binding-darwin-x64@0.46.0':
+    resolution: {integrity: sha512-QG8BDM0CXWbu84k2SKmCqfEddPQPFiBicwtYnLqHRWZZl57HbtOLRMac/KTq2NO4AEc4ICCBpFxJIV9zcqYfkQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxfmt/binding-freebsd-x64@0.46.0':
+    resolution: {integrity: sha512-9DdCqS/n2ncu/Chazvt3cpgAjAmIGQDz7hFKSrNItMApyV/Ja9mz3hD4JakIE3nS8PW9smEbPWnb389QLBY4nw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.46.0':
+    resolution: {integrity: sha512-Dgs7VeE2jT0LHMhw6tPEt0xQYe54kBqHEovmWsv4FVQlegCOvlIJNx0S8n4vj8WUtpT+Z6BD2HhKJPLglLxvZg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.46.0':
+    resolution: {integrity: sha512-Zxn3adhTH13JKnU4xXJj8FeEfF680XjXh3gSShKl57HCMBRde2tUJTgogV/1MSHA80PJEVrDa7r66TLVq3Ia7Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm64-gnu@0.46.0':
+    resolution: {integrity: sha512-+TWipjrgVM8D7aIdDD0tlr3teLTTvQTn7QTE5BpT10H1Fj82gfdn9X6nn2sDgx/MepuSCfSnzFNJq2paLL0OiA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-arm64-musl@0.46.0':
+    resolution: {integrity: sha512-aAUPBWJ1lGwwnxZUEDLJ94+Iy6MuwJwPxUgO4sCA5mEEyDk7b+cDQ+JpX1VR150Zoyd+D49gsrUzpUK5h587Eg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.46.0':
+    resolution: {integrity: sha512-ufBCJukyFX/UDrokP/r6BGDoTInnsDs7bxyzKAgMiZlt2Qu8GPJSJ6Zm6whIiJzKk0naxA8ilwmbO1LMw6Htxw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.46.0':
+    resolution: {integrity: sha512-eqtlC2YmPqjun76R1gVfGLuKWx7NuEnLEAudZ7n6ipSKbCZTqIKSs1b5Y8K/JHZsRpLkeSmAAjig5HOIg8fQzQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-riscv64-musl@0.46.0':
+    resolution: {integrity: sha512-yccVOO2nMXkQLGgy0He3EQEwKD7NF0zEk+/OWmroznkqXyJdN6bfK0LtNnr6/14Bh3FjpYq7bP33l/VloCnxpA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-linux-s390x-gnu@0.46.0':
+    resolution: {integrity: sha512-aAf7fG23OQCey6VRPj9IeCraoYtpgtx0ZyJ1CXkPyT1wjzBE7c3xtuxHe/AdHaJfVVb/SXpSk8Gl1LzyQupSqw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-x64-gnu@0.46.0':
+    resolution: {integrity: sha512-q0JPsTMyJNjYrBvYFDz4WbVsafNZaPCZv4RnFypRotLqpKROtBZcEaXQW4eb9YmvLU3NckVemLJnzkSZSdmOxw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-x64-musl@0.46.0':
+    resolution: {integrity: sha512-7LsLY9Cw57GPkhSR+duI3mt9baRczK/DtHYSldQ4BEU92da9igBQNl4z7Vq5U9NNPsh1FmpKvv1q9WDtiUQR1A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-openharmony-arm64@0.46.0':
+    resolution: {integrity: sha512-lHiBOz8Duaku7JtRNLlps3j++eOaICPZSd8FCVmTDM4DFOPT71Bjn7g6iar1z7StXlKRweUKxWUs4sA+zWGDXg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxfmt/binding-win32-arm64-msvc@0.46.0':
+    resolution: {integrity: sha512-/5ktYUliP89RhgC37DBH1x20U5zPSZMy3cMEcO0j3793rbHP9MWsknBwQB6eozRzWmYrh0IFM/p20EbPvDlYlg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxfmt/binding-win32-ia32-msvc@0.46.0':
+    resolution: {integrity: sha512-3WTnoiuIr8XvV0DIY7SN+1uJSwKf4sPpcbHfobcRT9JutGcLaef/miyBB87jxd3aqH+mS0+G5lsgHuXLUwjjpQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxfmt/binding-win32-x64-msvc@0.46.0':
+    resolution: {integrity: sha512-IXxiQpkYnOwNfP23vzwSfhdpxJzyiPTY7eTn6dn3DsriKddESzM8i6kfq9R7CD/PUJwCvQT22NgtygBeug3KoA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxlint-tsgolint/darwin-arm64@0.22.0':
+    resolution: {integrity: sha512-/exgXceakHbQrzaHTtKOe7MuDATaWMCCWpsCDQCZKeYhLGXzComipTrCYnHzAXrdnNBb5r5K+RRf5A6ormrhMA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint-tsgolint/darwin-x64@0.22.0':
+    resolution: {integrity: sha512-xFGdIahlmUbK+/MpZ5y08D0ewMGLDbd2Vki5wxVFYg50lSrtgPAtdDl+kqKZLNaFu0zpMar8n9wv1le05sL/jw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint-tsgolint/linux-arm64@0.22.0':
+    resolution: {integrity: sha512-53RvC9f77eUo+V1dfQNwGVnsIfPJFMibRR0ee128EUpYNDOZe/ojmCfuXJeU7cY91V7r7fZSm42KPJocXUX8og==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxlint-tsgolint/linux-x64@0.22.0':
+    resolution: {integrity: sha512-evZcJAZ9hjNyuN69RnXwbt+U2pAOcYt+yvqukgugiCkRm4iBZ0R0CvpY1tgfG2XcGUhEPh8dljO+nPZTEVGpCQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxlint-tsgolint/win32-arm64@0.22.0':
+    resolution: {integrity: sha512-7jTO+k1mr5BxRAI2fxc1NRcE3MAbHNZ0Vef9SD1yAR6d1E6qEv5D/D7yuHpQpw6AO3qoecSVo2Jzr+JirN61+w==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxlint-tsgolint/win32-x64@0.22.0':
+    resolution: {integrity: sha512-7lbl9XFcqO+scsynxMzTQdl0XUe6sBUCyY/oGWvCB+JmV4U+70vzSyZJdTEzzxtkZiNnUVFFh9RJLmoiQSne+w==}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxlint/binding-android-arm-eabi@1.61.0':
+    resolution: {integrity: sha512-6eZBPgiigK5txqoVgRqxbaxiom4lM8AP8CyKPPvpzKnQ3iFRFOIDc+0AapF+qsUSwjOzr5SGk4SxQDpQhkSJMQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxlint/binding-android-arm64@1.61.0':
+    resolution: {integrity: sha512-CkwLR69MUnyv5wjzebvbbtTSUwqLxM35CXE79bHqDIK+NtKmPEUpStTcLQRZMCo4MP0qRT6TXIQVpK0ZVScnMA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxlint/binding-darwin-arm64@1.61.0':
+    resolution: {integrity: sha512-8JbefTkbmvqkqWjmQrHke+MdpgT2UghhD/ktM4FOQSpGeCgbMToJEKdl9zwhr/YWTl92i4QI1KiTwVExpcUN8A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint/binding-darwin-x64@1.61.0':
+    resolution: {integrity: sha512-uWpoxDT47hTnDLcdEh5jVbso8rlTTu5o0zuqa9J8E0JAKmIWn7kGFEIB03Pycn2hd2vKxybPGLhjURy/9We5FQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint/binding-freebsd-x64@1.61.0':
+    resolution: {integrity: sha512-K/o4hEyW7flfMel0iBVznmMBt7VIMHGdjADocHKpK1DUF9erpWnJ+BSSWd2W0c8K3mPtpph+CuHzRU6CI3l9jQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.61.0':
+    resolution: {integrity: sha512-P6040ZkcyweJ0Po9yEFqJCdvZnf3VNCGs1SIHgXDf8AAQNC6ID/heXQs9iSgo2FH7gKaKq32VWc59XZwL34C5Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm-musleabihf@1.61.0':
+    resolution: {integrity: sha512-bwxrGCzTZkuB+THv2TQ1aTkVEfv5oz8sl+0XZZCpoYzErJD8OhPQOTA0ENPd1zJz8QsVdSzSrS2umKtPq4/JXg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm64-gnu@1.61.0':
+    resolution: {integrity: sha512-vkhb9/wKguMkLlrm3FoJW/Xmdv31GgYAE+x8lxxQ+7HeOxXUySI0q36a3NTVIuQUdLzxCI1zzMGsk1o37FOe3w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-arm64-musl@1.61.0':
+    resolution: {integrity: sha512-bl1dQh8LnVqsj6oOQAcxwbuOmNJkwc4p6o//HTBZhNTzJy21TLDwAviMqUFNUxDHkPGpmdKTSN4tWTjLryP8xg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-linux-ppc64-gnu@1.61.0':
+    resolution: {integrity: sha512-QoOX6KB2IiEpyOj/HKqaxi+NQHPnOgNgnr22n9N4ANJCzXkUlj1UmeAbFb4PpqdlHIzvGDM5xZ0OKtcLq9RhiQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-riscv64-gnu@1.61.0':
+    resolution: {integrity: sha512-1TGcTerjY6p152wCof3oKElccq3xHljS/Mucp04gV/4ATpP6nO7YNnp7opEg6SHkv2a57/b4b8Ndm9znJ1/qAw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-riscv64-musl@1.61.0':
+    resolution: {integrity: sha512-65wXEmZIrX2ADwC8i/qFL4EWLSbeuBpAm3suuX1vu4IQkKd+wLT/HU/BOl84kp91u2SxPkPDyQgu4yrqp8vwVA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-linux-s390x-gnu@1.61.0':
+    resolution: {integrity: sha512-TVvhgMvor7Qa6COeXxCJ7ENOM+lcAOGsQ0iUdPSCv2hxb9qSHLQ4XF1h50S6RE1gBOJ0WV3rNukg4JJJP1LWRA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-x64-gnu@1.61.0':
+    resolution: {integrity: sha512-SjpS5uYuFoDnDdZPwZE59ndF95AsY47R5MliuneTWR1pDm2CxGJaYXbKULI71t5TVfLQUWmrHEGRL9xvuq6dnA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-x64-musl@1.61.0':
+    resolution: {integrity: sha512-gGfAeGD4sNJGILZbc/yKcIimO9wQnPMoYp9swAaKeEtwsSQAbU+rsdQze5SBtIP6j0QDzeYd4XSSUCRCF+LIeQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-openharmony-arm64@1.61.0':
+    resolution: {integrity: sha512-OlVT0LrG/ct33EVtWRyR+B/othwmDWeRxfi13wUdPeb3lAT5TgTcFDcfLfarZtzB4W1nWF/zICMgYdkggX2WmQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxlint/binding-win32-arm64-msvc@1.61.0':
+    resolution: {integrity: sha512-vI//NZPJk6DToiovPtaiwD4iQ7kO1r5ReWQD0sOOyKRtP3E2f6jxin4uvwi3OvDzHA2EFfd7DcZl5dtkQh7g1w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxlint/binding-win32-ia32-msvc@1.61.0':
+    resolution: {integrity: sha512-0ySj4/4zd2XjePs3XAQq7IigIstN4LPQZgCyigX5/ERMLjdWAJfnxcTsrtxZxuij8guJW8foXuHmhGxW0H4dDA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxlint/binding-win32-x64-msvc@1.61.0':
+    resolution: {integrity: sha512-0xgSiyeqDLDZxXoe9CVJrOx3TUVsfyoOY7cNi03JbItNcC9WCZqrSNdrAbHONxhSPaVh/lzfnDcON1RqSUMhHw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@polka/url@1.0.0-next.29':
+    resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
+  '@rolldown/pluginutils@1.0.0-rc.7':
+    resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.8':
+    resolution: {integrity: sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==}
+
+  '@vitejs/plugin-react@6.0.1':
+    resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
+      babel-plugin-react-compiler: ^1.0.0
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      '@rolldown/plugin-babel':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+
+  '@voidzero-dev/vite-plus-core@0.1.20':
+    resolution: {integrity: sha512-4KmzRfzwTeG3JuvDijrdqWusSgRvLMKDPrVsDdtbDVVjEMq0VnM8lSH+Nvepd6Pg+SuSVUP212OIfH/3Yn1bfA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@arethetypeswrong/core': ^0.18.1
+      '@tsdown/css': 0.21.10
+      '@tsdown/exe': 0.21.10
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: ^2.0.0
+      less: ^4.0.0
+      publint: ^0.3.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      typescript: ^5.0.0 || ^6.0.0
+      unplugin-unused: ^0.5.0
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@arethetypeswrong/core':
+        optional: true
+      '@tsdown/css':
+        optional: true
+      '@tsdown/exe':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      publint:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      typescript:
+        optional: true
+      unplugin-unused:
+        optional: true
+      yaml:
+        optional: true
+
+  '@voidzero-dev/vite-plus-darwin-arm64@0.1.20':
+    resolution: {integrity: sha512-ykCOJk91h0IEMvljYGTauI4Svxr/CatZAitofvtEFqaTCLE3n06QCHD8qWphMM784VnPz1G/J2xuewxbQduNlg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@voidzero-dev/vite-plus-darwin-x64@0.1.20':
+    resolution: {integrity: sha512-5XxNW9cYEh85Z4BErALyWh/tLP/NZmxNXzUQ0FanhHreI2Zq7FfgbSqQNvC7/sYsPYTWf74RlxmIjzV7R/Lb5Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@voidzero-dev/vite-plus-linux-arm64-gnu@0.1.20':
+    resolution: {integrity: sha512-Mc7npPBd9t/h0haURVCZGae+TfB0Yx2Ex8HbPKOVA4hnN9ynlMhMpLRFfTQAicDKYbEGDhfBcbCIX0vVv4vacA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@voidzero-dev/vite-plus-linux-arm64-musl@0.1.20':
+    resolution: {integrity: sha512-Oh/pxMdTLR/wsDl/OONjItjLOeTewFBLuKkH5RQmcI9g3AVqKzLj1/uawujgysBI5E25tonRRK7I2q/zu8Uqvg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@voidzero-dev/vite-plus-linux-x64-gnu@0.1.20':
+    resolution: {integrity: sha512-msO1ZoUX5aSK8L6kN1C3XQO4CcH9aFsNPRSNcO1cjk1kTnaLyVYzkVxgvbh3vk7nzZAAMkmyZ4SlMpqJrdahrg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@voidzero-dev/vite-plus-linux-x64-musl@0.1.20':
+    resolution: {integrity: sha512-U93urREvg23ZFDkxKkkfWWIOI4GI9erhbWAZpXG+GeYqygWKrVC6PUTXiuexVg3/CFg2sSMTdm1W6V7TFG5hYA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@voidzero-dev/vite-plus-test@0.1.20':
+    resolution: {integrity: sha512-vy2dJYw1bhgQ/+BrQrfwPlSKzQ2mm3YLJ9kGF7Yo0UJ2P3XKpshtgFIWLjSg/IASnC93OAx0c/7j3NM0I1RMuA==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/coverage-istanbul': 4.1.5
+      '@vitest/coverage-v8': 4.1.5
+      '@vitest/ui': 4.1.5
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  '@voidzero-dev/vite-plus-win32-arm64-msvc@0.1.20':
+    resolution: {integrity: sha512-deXfe3h2OpzKV88s1PMUgVOJfN9LlnDDpIEVH6y2+YAXwlTSO7YeKBj2QmyS6ALZCI4Rfp4HOsB0OKMVBfEqww==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@voidzero-dev/vite-plus-win32-x64-msvc@0.1.20':
+    resolution: {integrity: sha512-ygdgQgo0N9oUI1Q2IdYBcvr+KLY6riaqLY/bkWNYtvHS4uk8a4GuEd0F08znWt2E8sFm29i35bYIzI6fFY2EBg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  anymatch@3.1.3:
+    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
+    engines: {node: '>= 8'}
+
+  arg@5.0.2:
+    resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  autoprefixer@10.4.23:
+    resolution: {integrity: sha512-YYTXSFulfwytnjAPlw8QHncHJmlvFKtczb8InXaAx9Q0LbfDnfEYDE55omerIJKihhmU61Ft+cAOSzQVaBUmeA==}
+    engines: {node: ^10 || ^12 || >=14}
+    hasBin: true
+    peerDependencies:
+      postcss: ^8.1.0
+
+  baseline-browser-mapping@2.10.29:
+    resolution: {integrity: sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  binary-extensions@2.3.0:
+    resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
+    engines: {node: '>=8'}
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  camelcase-css@2.0.1:
+    resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
+    engines: {node: '>= 6'}
+
+  caniuse-lite@1.0.30001792:
+    resolution: {integrity: sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==}
+
+  chokidar@3.6.0:
+    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
+    engines: {node: '>= 8.10.0'}
+
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
+  cssesc@3.0.0:
+    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  didyoumean@1.2.2:
+    resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
+
+  dlv@1.1.3:
+    resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
+
+  electron-to-chromium@1.5.354:
+    resolution: {integrity: sha512-JaBHwWcfIdmSAfWM5l3uwjGd431j8YEMikZ+K/2nXVuBqJKyZ0f+2h4n4JY5AyNiZmnY9qQr2RU3v9DxDmHMNg==}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
+  fraction.js@5.3.4:
+    resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
+  is-binary-path@2.1.0:
+    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
+    engines: {node: '>=8'}
+
+  is-core-module@2.16.2:
+    resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
+    engines: {node: '>= 0.4'}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
+    hasBin: true
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
+  mrmime@2.0.1:
+    resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
+    engines: {node: '>=10'}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  node-releases@2.0.44:
+    resolution: {integrity: sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==}
+
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-hash@3.0.0:
+    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
+    engines: {node: '>= 6'}
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  oxfmt@0.46.0:
+    resolution: {integrity: sha512-CopwJOwPAjZ9p76fCvz+mSOJTw9/NY3cSksZK3VO/bUQ8UoEcketNgUuYS0UB3p+R9XnXe7wGGXUmyFxc7QxJA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  oxlint-tsgolint@0.22.0:
+    resolution: {integrity: sha512-ku4MecLmCQIj1ScCtzNAqTuyl0BJQ02B36fJT+c5XQihHpYSFak+FC3GYO5fPyYk4oDwi0w0S7hTvrpNzuZhig==}
+    hasBin: true
+
+  oxlint@1.61.0:
+    resolution: {integrity: sha512-ZC0ALuhDZ6ivOFG+sy0D0pEDN49EvsId98zVlmYdkcXHsEM14m/qTNUEsUpiFiCVbpIxYtVBmmLE87nsbUHohQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      oxlint-tsgolint: '>=0.18.0'
+    peerDependenciesMeta:
+      oxlint-tsgolint:
+        optional: true
+
+  path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  pify@2.3.0:
+    resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
+    engines: {node: '>=0.10.0'}
+
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
+  pixelmatch@7.2.0:
+    resolution: {integrity: sha512-xhcb4yHu9sM/G7foGzoLtXYcC0zHEaOXXjRKhGup0fw78Nf2Tkiapv4EQyMzrbcmQPsllAI7DbFY2UT7PlI9Pg==}
+    hasBin: true
+
+  pngjs@7.0.0:
+    resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
+    engines: {node: '>=14.19.0'}
+
+  postcss-import@15.1.0:
+    resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      postcss: ^8.0.0
+
+  postcss-js@4.1.0:
+    resolution: {integrity: sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==}
+    engines: {node: ^12 || ^14 || >= 16}
+    peerDependencies:
+      postcss: ^8.4.21
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: ^2.0.0
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  postcss-nested@6.2.0:
+    resolution: {integrity: sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==}
+    engines: {node: '>=12.0'}
+    peerDependencies:
+      postcss: ^8.2.14
+
+  postcss-selector-parser@6.1.2:
+    resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
+    engines: {node: '>=4'}
+
+  postcss-value-parser@4.2.0:
+    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
+
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  qrcode.react@4.2.0:
+    resolution: {integrity: sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  react-dom@19.2.3:
+    resolution: {integrity: sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==}
+    peerDependencies:
+      react: ^19.2.3
+
+  react@19.2.3:
+    resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
+    engines: {node: '>=0.10.0'}
+
+  read-cache@1.0.0:
+    resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
+
+  readdirp@3.6.0:
+    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
+    engines: {node: '>=8.10.0'}
+
+  resolve@1.22.12:
+    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
+
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  sirv@3.0.2:
+    resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
+    engines: {node: '>=18'}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
+
+  tailwindcss@3.4.19:
+    resolution: {integrity: sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.1.2:
+    resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@2.1.0:
+    resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
+    engines: {node: ^20.0.0 || >=22.0.0}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
+  totalist@3.0.1:
+    resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
+    engines: {node: '>=6'}
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  vite-plus@0.1.20:
+    resolution: {integrity: sha512-hxJqXTxiiFhszwAeD0MvKlztVuXE4TztTdJ64BPxGqgY67F0PDa5eZkUsrN91Ae8aYUMfweW6V/J57OUO9/0zw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+snapshots:
+
+  '@alloc/quick-lru@5.2.0': {}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.20.1
+
+  '@oxc-project/runtime@0.127.0': {}
+
+  '@oxc-project/types@0.127.0': {}
+
+  '@oxfmt/binding-android-arm-eabi@0.46.0':
+    optional: true
+
+  '@oxfmt/binding-android-arm64@0.46.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-arm64@0.46.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-x64@0.46.0':
+    optional: true
+
+  '@oxfmt/binding-freebsd-x64@0.46.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.46.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.46.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-gnu@0.46.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-musl@0.46.0':
+    optional: true
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.46.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.46.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-musl@0.46.0':
+    optional: true
+
+  '@oxfmt/binding-linux-s390x-gnu@0.46.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-gnu@0.46.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-musl@0.46.0':
+    optional: true
+
+  '@oxfmt/binding-openharmony-arm64@0.46.0':
+    optional: true
+
+  '@oxfmt/binding-win32-arm64-msvc@0.46.0':
+    optional: true
+
+  '@oxfmt/binding-win32-ia32-msvc@0.46.0':
+    optional: true
+
+  '@oxfmt/binding-win32-x64-msvc@0.46.0':
+    optional: true
+
+  '@oxlint-tsgolint/darwin-arm64@0.22.0':
+    optional: true
+
+  '@oxlint-tsgolint/darwin-x64@0.22.0':
+    optional: true
+
+  '@oxlint-tsgolint/linux-arm64@0.22.0':
+    optional: true
+
+  '@oxlint-tsgolint/linux-x64@0.22.0':
+    optional: true
+
+  '@oxlint-tsgolint/win32-arm64@0.22.0':
+    optional: true
+
+  '@oxlint-tsgolint/win32-x64@0.22.0':
+    optional: true
+
+  '@oxlint/binding-android-arm-eabi@1.61.0':
+    optional: true
+
+  '@oxlint/binding-android-arm64@1.61.0':
+    optional: true
+
+  '@oxlint/binding-darwin-arm64@1.61.0':
+    optional: true
+
+  '@oxlint/binding-darwin-x64@1.61.0':
+    optional: true
+
+  '@oxlint/binding-freebsd-x64@1.61.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.61.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-musleabihf@1.61.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-gnu@1.61.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-musl@1.61.0':
+    optional: true
+
+  '@oxlint/binding-linux-ppc64-gnu@1.61.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-gnu@1.61.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-musl@1.61.0':
+    optional: true
+
+  '@oxlint/binding-linux-s390x-gnu@1.61.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-gnu@1.61.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-musl@1.61.0':
+    optional: true
+
+  '@oxlint/binding-openharmony-arm64@1.61.0':
+    optional: true
+
+  '@oxlint/binding-win32-arm64-msvc@1.61.0':
+    optional: true
+
+  '@oxlint/binding-win32-ia32-msvc@1.61.0':
+    optional: true
+
+  '@oxlint/binding-win32-x64-msvc@1.61.0':
+    optional: true
+
+  '@polka/url@1.0.0-next.29': {}
+
+  '@rolldown/pluginutils@1.0.0-rc.7': {}
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/react-dom@19.2.3(@types/react@19.2.8)':
+    dependencies:
+      '@types/react': 19.2.8
+
+  '@types/react@19.2.8':
+    dependencies:
+      csstype: 3.2.3
+
+  '@vitejs/plugin-react@6.0.1(@voidzero-dev/vite-plus-core@0.1.20(jiti@2.7.0)(typescript@5.9.3))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.0-rc.7
+      vite: '@voidzero-dev/vite-plus-core@0.1.20(jiti@2.7.0)(typescript@5.9.3)'
+
+  '@voidzero-dev/vite-plus-core@0.1.20(jiti@2.7.0)(typescript@5.9.3)':
+    dependencies:
+      '@oxc-project/runtime': 0.127.0
+      '@oxc-project/types': 0.127.0
+      lightningcss: 1.32.0
+      postcss: 8.5.10
+    optionalDependencies:
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      typescript: 5.9.3
+
+  '@voidzero-dev/vite-plus-darwin-arm64@0.1.20':
+    optional: true
+
+  '@voidzero-dev/vite-plus-darwin-x64@0.1.20':
+    optional: true
+
+  '@voidzero-dev/vite-plus-linux-arm64-gnu@0.1.20':
+    optional: true
+
+  '@voidzero-dev/vite-plus-linux-arm64-musl@0.1.20':
+    optional: true
+
+  '@voidzero-dev/vite-plus-linux-x64-gnu@0.1.20':
+    optional: true
+
+  '@voidzero-dev/vite-plus-linux-x64-musl@0.1.20':
+    optional: true
+
+  '@voidzero-dev/vite-plus-test@0.1.20(@voidzero-dev/vite-plus-core@0.1.20(jiti@2.7.0)(typescript@5.9.3))(jiti@2.7.0)(typescript@5.9.3)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@voidzero-dev/vite-plus-core': 0.1.20(jiti@2.7.0)(typescript@5.9.3)
+      es-module-lexer: 1.7.0
+      obug: 2.1.1
+      pixelmatch: 7.2.0
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
+      vite: '@voidzero-dev/vite-plus-core@0.1.20(jiti@2.7.0)(typescript@5.9.3)'
+      ws: 8.20.1
+    transitivePeerDependencies:
+      - '@arethetypeswrong/core'
+      - '@tsdown/css'
+      - '@tsdown/exe'
+      - '@vitejs/devtools'
+      - bufferutil
+      - esbuild
+      - jiti
+      - less
+      - publint
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - typescript
+      - unplugin-unused
+      - utf-8-validate
+      - yaml
+
+  '@voidzero-dev/vite-plus-win32-arm64-msvc@0.1.20':
+    optional: true
+
+  '@voidzero-dev/vite-plus-win32-x64-msvc@0.1.20':
+    optional: true
+
+  any-promise@1.3.0: {}
+
+  anymatch@3.1.3:
+    dependencies:
+      normalize-path: 3.0.0
+      picomatch: 2.3.2
+
+  arg@5.0.2: {}
+
+  assertion-error@2.0.1: {}
+
+  autoprefixer@10.4.23(postcss@8.5.10):
+    dependencies:
+      browserslist: 4.28.2
+      caniuse-lite: 1.0.30001792
+      fraction.js: 5.3.4
+      picocolors: 1.1.1
+      postcss: 8.5.10
+      postcss-value-parser: 4.2.0
+
+  baseline-browser-mapping@2.10.29: {}
+
+  binary-extensions@2.3.0: {}
+
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.29
+      caniuse-lite: 1.0.30001792
+      electron-to-chromium: 1.5.354
+      node-releases: 2.0.44
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  camelcase-css@2.0.1: {}
+
+  caniuse-lite@1.0.30001792: {}
+
+  chokidar@3.6.0:
+    dependencies:
+      anymatch: 3.1.3
+      braces: 3.0.3
+      glob-parent: 5.1.2
+      is-binary-path: 2.1.0
+      is-glob: 4.0.3
+      normalize-path: 3.0.0
+      readdirp: 3.6.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  commander@4.1.1: {}
+
+  cssesc@3.0.0: {}
+
+  csstype@3.2.3: {}
+
+  detect-libc@2.1.2: {}
+
+  didyoumean@1.2.2: {}
+
+  dlv@1.1.3: {}
+
+  electron-to-chromium@1.5.354: {}
+
+  es-errors@1.3.0: {}
+
+  es-module-lexer@1.7.0: {}
+
+  escalade@3.2.0: {}
+
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
+  fraction.js@5.3.4: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  function-bind@1.1.2: {}
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
+
+  is-binary-path@2.1.0:
+    dependencies:
+      binary-extensions: 2.3.0
+
+  is-core-module@2.16.2:
+    dependencies:
+      hasown: 2.0.3
+
+  is-extglob@2.1.1: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-number@7.0.0: {}
+
+  jiti@2.7.0: {}
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
+  lilconfig@3.1.3: {}
+
+  lines-and-columns@1.2.4: {}
+
+  merge2@1.4.1: {}
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.2
+
+  mrmime@2.0.1: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
+  nanoid@3.3.12: {}
+
+  node-releases@2.0.44: {}
+
+  normalize-path@3.0.0: {}
+
+  object-assign@4.1.1: {}
+
+  object-hash@3.0.0: {}
+
+  obug@2.1.1: {}
+
+  oxfmt@0.46.0:
+    dependencies:
+      tinypool: 2.1.0
+    optionalDependencies:
+      '@oxfmt/binding-android-arm-eabi': 0.46.0
+      '@oxfmt/binding-android-arm64': 0.46.0
+      '@oxfmt/binding-darwin-arm64': 0.46.0
+      '@oxfmt/binding-darwin-x64': 0.46.0
+      '@oxfmt/binding-freebsd-x64': 0.46.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.46.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.46.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.46.0
+      '@oxfmt/binding-linux-arm64-musl': 0.46.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.46.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.46.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.46.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.46.0
+      '@oxfmt/binding-linux-x64-gnu': 0.46.0
+      '@oxfmt/binding-linux-x64-musl': 0.46.0
+      '@oxfmt/binding-openharmony-arm64': 0.46.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.46.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.46.0
+      '@oxfmt/binding-win32-x64-msvc': 0.46.0
+
+  oxlint-tsgolint@0.22.0:
+    optionalDependencies:
+      '@oxlint-tsgolint/darwin-arm64': 0.22.0
+      '@oxlint-tsgolint/darwin-x64': 0.22.0
+      '@oxlint-tsgolint/linux-arm64': 0.22.0
+      '@oxlint-tsgolint/linux-x64': 0.22.0
+      '@oxlint-tsgolint/win32-arm64': 0.22.0
+      '@oxlint-tsgolint/win32-x64': 0.22.0
+
+  oxlint@1.61.0(oxlint-tsgolint@0.22.0):
+    optionalDependencies:
+      '@oxlint/binding-android-arm-eabi': 1.61.0
+      '@oxlint/binding-android-arm64': 1.61.0
+      '@oxlint/binding-darwin-arm64': 1.61.0
+      '@oxlint/binding-darwin-x64': 1.61.0
+      '@oxlint/binding-freebsd-x64': 1.61.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.61.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.61.0
+      '@oxlint/binding-linux-arm64-gnu': 1.61.0
+      '@oxlint/binding-linux-arm64-musl': 1.61.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.61.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.61.0
+      '@oxlint/binding-linux-riscv64-musl': 1.61.0
+      '@oxlint/binding-linux-s390x-gnu': 1.61.0
+      '@oxlint/binding-linux-x64-gnu': 1.61.0
+      '@oxlint/binding-linux-x64-musl': 1.61.0
+      '@oxlint/binding-openharmony-arm64': 1.61.0
+      '@oxlint/binding-win32-arm64-msvc': 1.61.0
+      '@oxlint/binding-win32-ia32-msvc': 1.61.0
+      '@oxlint/binding-win32-x64-msvc': 1.61.0
+      oxlint-tsgolint: 0.22.0
+
+  path-parse@1.0.7: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@2.3.2: {}
+
+  picomatch@4.0.4: {}
+
+  pify@2.3.0: {}
+
+  pirates@4.0.7: {}
+
+  pixelmatch@7.2.0:
+    dependencies:
+      pngjs: 7.0.0
+
+  pngjs@7.0.0: {}
+
+  postcss-import@15.1.0(postcss@8.5.10):
+    dependencies:
+      postcss: 8.5.10
+      postcss-value-parser: 4.2.0
+      read-cache: 1.0.0
+      resolve: 1.22.12
+
+  postcss-js@4.1.0(postcss@8.5.10):
+    dependencies:
+      camelcase-css: 2.0.1
+      postcss: 8.5.10
+
+  postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.10):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      jiti: 2.7.0
+      postcss: 8.5.10
+
+  postcss-nested@6.2.0(postcss@8.5.10):
+    dependencies:
+      postcss: 8.5.10
+      postcss-selector-parser: 6.1.2
+
+  postcss-selector-parser@6.1.2:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+
+  postcss-value-parser@4.2.0: {}
+
+  postcss@8.5.10:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  qrcode.react@4.2.0(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+
+  queue-microtask@1.2.3: {}
+
+  react-dom@19.2.3(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+      scheduler: 0.27.0
+
+  react@19.2.3: {}
+
+  read-cache@1.0.0:
+    dependencies:
+      pify: 2.3.0
+
+  readdirp@3.6.0:
+    dependencies:
+      picomatch: 2.3.2
+
+  resolve@1.22.12:
+    dependencies:
+      es-errors: 1.3.0
+      is-core-module: 2.16.2
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+
+  reusify@1.1.0: {}
+
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
+
+  scheduler@0.27.0: {}
+
+  sirv@3.0.2:
+    dependencies:
+      '@polka/url': 1.0.0-next.29
+      mrmime: 2.0.1
+      totalist: 3.0.1
+
+  source-map-js@1.2.1: {}
+
+  std-env@4.1.0: {}
+
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.16
+      ts-interface-checker: 0.1.13
+
+  supports-preserve-symlinks-flag@1.0.0: {}
+
+  tailwindcss@3.4.19:
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      arg: 5.0.2
+      chokidar: 3.6.0
+      didyoumean: 1.2.2
+      dlv: 1.1.3
+      fast-glob: 3.3.3
+      glob-parent: 6.0.2
+      is-glob: 4.0.3
+      jiti: 2.7.0
+      lilconfig: 3.1.3
+      micromatch: 4.0.8
+      normalize-path: 3.0.0
+      object-hash: 3.0.0
+      picocolors: 1.1.1
+      postcss: 8.5.10
+      postcss-import: 15.1.0(postcss@8.5.10)
+      postcss-js: 4.1.0(postcss@8.5.10)
+      postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.10)
+      postcss-nested: 6.2.0(postcss@8.5.10)
+      postcss-selector-parser: 6.1.2
+      resolve: 1.22.12
+      sucrase: 3.35.1
+    transitivePeerDependencies:
+      - tsx
+      - yaml
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.1.2: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinypool@2.1.0: {}
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
+  totalist@3.0.1: {}
+
+  ts-interface-checker@0.1.13: {}
+
+  typescript@5.9.3: {}
+
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  util-deprecate@1.0.2: {}
+
+  vite-plus@0.1.20(@voidzero-dev/vite-plus-core@0.1.20(jiti@2.7.0)(typescript@5.9.3))(jiti@2.7.0)(typescript@5.9.3):
+    dependencies:
+      '@oxc-project/types': 0.127.0
+      '@voidzero-dev/vite-plus-core': 0.1.20(jiti@2.7.0)(typescript@5.9.3)
+      '@voidzero-dev/vite-plus-test': 0.1.20(@voidzero-dev/vite-plus-core@0.1.20(jiti@2.7.0)(typescript@5.9.3))(jiti@2.7.0)(typescript@5.9.3)
+      oxfmt: 0.46.0
+      oxlint: 1.61.0(oxlint-tsgolint@0.22.0)
+      oxlint-tsgolint: 0.22.0
+    optionalDependencies:
+      '@voidzero-dev/vite-plus-darwin-arm64': 0.1.20
+      '@voidzero-dev/vite-plus-darwin-x64': 0.1.20
+      '@voidzero-dev/vite-plus-linux-arm64-gnu': 0.1.20
+      '@voidzero-dev/vite-plus-linux-arm64-musl': 0.1.20
+      '@voidzero-dev/vite-plus-linux-x64-gnu': 0.1.20
+      '@voidzero-dev/vite-plus-linux-x64-musl': 0.1.20
+      '@voidzero-dev/vite-plus-win32-arm64-msvc': 0.1.20
+      '@voidzero-dev/vite-plus-win32-x64-msvc': 0.1.20
+    transitivePeerDependencies:
+      - '@arethetypeswrong/core'
+      - '@edge-runtime/vm'
+      - '@opentelemetry/api'
+      - '@tsdown/css'
+      - '@tsdown/exe'
+      - '@types/node'
+      - '@vitejs/devtools'
+      - '@vitest/coverage-istanbul'
+      - '@vitest/coverage-v8'
+      - '@vitest/ui'
+      - bufferutil
+      - esbuild
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - publint
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - typescript
+      - unplugin-unused
+      - utf-8-validate
+      - vite
+      - yaml
+
+  ws@8.20.1: {}

--- a/src/widgets/Ivy.Widgets.QRCode/frontend/postcss.config.js
+++ b/src/widgets/Ivy.Widgets.QRCode/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/widgets/Ivy.Widgets.QRCode/frontend/src/QRCode.tsx
+++ b/src/widgets/Ivy.Widgets.QRCode/frontend/src/QRCode.tsx
@@ -1,16 +1,26 @@
 import React from "react";
 import { QRCodeSVG } from "qrcode.react";
+import { resolveIvyColorForSvg } from "./ivyColor";
 
 type EventHandler = (eventName: string, widgetId: string, args: unknown[]) => void;
+
+type QrErrorCorrectionLevel = "Low" | "Medium" | "Quartile" | "High";
+
+const correctionToLibraryLevel: Record<QrErrorCorrectionLevel, "L" | "M" | "Q" | "H"> = {
+  Low: "L",
+  Medium: "M",
+  Quartile: "Q",
+  High: "H",
+};
 
 interface QRCodeProps {
   id: string;
   value?: string;
   pixelSize?: number;
-  level?: "L" | "M" | "Q" | "H";
+  errorCorrectionLevel?: QrErrorCorrectionLevel;
   includeMargin?: boolean;
-  bgColor?: string;
-  fgColor?: string;
+  background?: string;
+  foreground?: string;
   eventHandler?: EventHandler;
   onIvyEvent?: EventHandler;
   events?: string[];
@@ -19,19 +29,23 @@ interface QRCodeProps {
 export const QRCode: React.FC<QRCodeProps> = ({
   value = "",
   pixelSize = 256,
-  level = "L",
+  errorCorrectionLevel = "Low",
   includeMargin = true,
-  bgColor,
-  fgColor,
+  background,
+  foreground,
 }) => {
+  const level = correctionToLibraryLevel[errorCorrectionLevel] ?? "L";
+  const bgColor = resolveIvyColorForSvg(background);
+  const fgColor = resolveIvyColorForSvg(foreground);
+
   return (
     <QRCodeSVG
       value={value || " "}
       size={pixelSize}
       level={level}
       marginSize={includeMargin ? 4 : 0}
-      bgColor={bgColor}
-      fgColor={fgColor}
+      {...(bgColor !== undefined ? { bgColor } : {})}
+      {...(fgColor !== undefined ? { fgColor } : {})}
     />
   );
 };

--- a/src/widgets/Ivy.Widgets.QRCode/frontend/src/QRCode.tsx
+++ b/src/widgets/Ivy.Widgets.QRCode/frontend/src/QRCode.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { QRCodeSVG } from "qrcode.react";
+
+type EventHandler = (eventName: string, widgetId: string, args: unknown[]) => void;
+
+interface QRCodeProps {
+  id: string;
+  value?: string;
+  pixelSize?: number;
+  level?: "L" | "M" | "Q" | "H";
+  includeMargin?: boolean;
+  bgColor?: string;
+  fgColor?: string;
+  eventHandler?: EventHandler;
+  onIvyEvent?: EventHandler;
+  events?: string[];
+}
+
+export const QRCode: React.FC<QRCodeProps> = ({
+  value = "",
+  pixelSize = 256,
+  level = "L",
+  includeMargin = true,
+  bgColor,
+  fgColor,
+}) => {
+  return (
+    <QRCodeSVG
+      value={value || " "}
+      size={pixelSize}
+      level={level}
+      marginSize={includeMargin ? 4 : 0}
+      bgColor={bgColor}
+      fgColor={fgColor}
+    />
+  );
+};

--- a/src/widgets/Ivy.Widgets.QRCode/frontend/src/index.ts
+++ b/src/widgets/Ivy.Widgets.QRCode/frontend/src/index.ts
@@ -1,0 +1,9 @@
+import { QRCode } from "./QRCode";
+
+if (typeof window !== "undefined") {
+  (window as unknown as Record<string, unknown>).Ivy_Widgets_QRCode = {
+    QRCode,
+  };
+}
+
+export { QRCode };

--- a/src/widgets/Ivy.Widgets.QRCode/frontend/src/ivyColor.ts
+++ b/src/widgets/Ivy.Widgets.QRCode/frontend/src/ivyColor.ts
@@ -1,0 +1,23 @@
+function ivyColorNameToToken(name: string): string {
+  return name.replace(/([a-z0-9])([A-Z])/g, "$1-$2").toLowerCase();
+}
+
+/** Resolves an Ivy `Colors` enum name (JSON) to a concrete color for SVG fill/stroke. */
+export function resolveIvyColorForSvg(name: string | undefined): string | undefined {
+  if (!name?.trim() || typeof document === "undefined") return undefined;
+
+  const cssVar = `var(--color-${ivyColorNameToToken(name.trim())})`;
+  const probe = document.createElement("span");
+  probe.style.position = "absolute";
+  probe.style.visibility = "hidden";
+  probe.style.pointerEvents = "none";
+  probe.style.color = cssVar;
+  document.documentElement.appendChild(probe);
+  const resolved = getComputedStyle(probe).color.trim();
+  document.documentElement.removeChild(probe);
+
+  if (!resolved || resolved === "rgba(0, 0, 0, 0)" || resolved === "transparent") {
+    return undefined;
+  }
+  return resolved;
+}

--- a/src/widgets/Ivy.Widgets.QRCode/frontend/src/vite-env.d.ts
+++ b/src/widgets/Ivy.Widgets.QRCode/frontend/src/vite-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="vite/client" />
+
+declare module "*.css" {
+  const content: string;
+  export default content;
+}

--- a/src/widgets/Ivy.Widgets.QRCode/frontend/tailwind.config.js
+++ b/src/widgets/Ivy.Widgets.QRCode/frontend/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ["./src/**/*.{js,ts,jsx,tsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/src/widgets/Ivy.Widgets.QRCode/frontend/tsconfig.json
+++ b/src/widgets/Ivy.Widgets.QRCode/frontend/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["src"]
+}

--- a/src/widgets/Ivy.Widgets.QRCode/frontend/vite.config.ts
+++ b/src/widgets/Ivy.Widgets.QRCode/frontend/vite.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig } from "vite-plus";
+import react from "@vitejs/plugin-react";
+import { resolve } from "path";
+import { fileURLToPath } from "url";
+import { dirname } from "path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export default defineConfig({
+  plugins: [react()],
+  define: {
+    "process.env.NODE_ENV": JSON.stringify("production"),
+  },
+  build: {
+    lib: {
+      entry: resolve(__dirname, "src/index.ts"),
+      formats: ["iife"],
+      fileName: () => "Ivy_Widgets_QRCode.js",
+      name: "Ivy_Widgets_QRCode",
+    },
+    rolldownOptions: {
+      external: ["react", "react-dom", "react/jsx-runtime"],
+      output: {
+        globals: {
+          react: "React",
+          "react-dom": "ReactDOM",
+          "react/jsx-runtime": "ReactJsxRuntime",
+        },
+        extend: false,
+      },
+    },
+    outDir: "dist",
+    emptyOutDir: true,
+    sourcemap: true,
+    cssCodeSplit: false,
+  },
+});


### PR DESCRIPTION
# Summary
Addresses https://github.com/Ivy-Interactive/Ivy-Framework/issues/4412

I asked claude for a comparison between [qrcode.react](https://www.npmjs.com/package/qrcode.react) and [react-qr-code](https://www.npmjs.com/package/react-qr-code) with bundle size and security being high priorities:

> Here's a side-by-side comparison based on the npm registry data for each package:
> 
> | | `qrcode.react` 4.2.0 | `react-qr-code` 2.0.21 |
> |---|---|---|
> | Last publish | Dec 2024 | Apr 2026 |
> | Weekly downloads | 5.2M | 1.8M |
> | Unpacked size | 112 KB | 14 KB |
> | Runtime deps | **0** | 2 (`prop-types`, `qr.js@0.0.0`) |
> | React peer range | `^16.8 \|\| ^17 \|\| ^18 \|\| ^19` | `*` (unpinned) |
> | Render targets | SVG **and** Canvas | SVG only |
> | TypeScript types | Built-in | `types/index.d.ts` (552 B) |
> | License | ISC | MIT |
> | Encoder | Bundled Nayuki QR generator (MIT, well-known) | `qr.js@0.0.0` (unmaintained since ~2014) |
> 
>
> ### My recommendation: `qrcode.react`
> 
> Despite the larger unpacked footprint, it's the better choice for an Ivy external widget on both axes you care about:
> 
> **Security / supply chain**
> - **0 runtime dependencies.** `react-qr-code` pulls in `qr.js@0.0.0`, an essentially unmaintained encoder pinned at the literal version `0.0.0` (last touched around 2014), plus `prop-types` (legacy in modern React).
> - `qrcode.react` bundles Paul O'Shannessy's port of Nayuki's QR Code Generator — that encoder is widely audited, MIT, and is the de-facto reference implementation. The wrapper itself is also actively maintained.
> - `qrcode.react` declares proper React peer-dep ranges. `react-qr-code` declares `react: "*"`, which is a code smell and means nothing prevents resolution against future incompatible majors.
> 
> **Bundle size**
> - The "112 KB vs 14 KB unpacked" gap is misleading — most of `qrcode.react`'s package is source maps, both ESM and CJS builds, and TS declarations. After tree-shaking and gzip you typically end up with **~10–12 KB gzipped** for `qrcode.react` vs **~5–6 KB gzipped** for `react-qr-code`. A ~5 KB difference is rarely meaningful, especially since each Ivy external widget already ships its own React-free bundle.
> - `qrcode.react` exports `QRCodeSVG` and `QRCodeCanvas` as separate entry points — import only `QRCodeSVG` and Vite will drop the canvas path entirely.
> 
> **Fit for the Ivy widget pattern**
> - Your widgets target React 19.2 (`Ivy.Widgets.ActivityHeatmap/frontend/package.json`), and `qrcode.react` lists React 19 explicitly in its peer range, plus its dev deps are on React 19 — so it's tested against your exact runtime.
> - The richer API (`marginSize`, `level`, `imageSettings` for an embedded logo, `minVersion`, `boostLevel`) gives you more headroom if the C# `QrCode` widget grows props later, without swapping libraries.
> 
> Only consider `react-qr-code` if you specifically need the few extra KB shaved off and you're comfortable with an unmaintained transitive encoder.

**Screenshot from sample app showing minimal usage example:**
<img width="586" height="755" alt="QRCode sample app showing minimal usage example" src="https://github.com/user-attachments/assets/9bea45da-33ab-4283-a692-822d1c5fad1f" />

## API Changes

Created `Ivy.Widgets.QRCode`, a new external widget that renders QR codes using the `qrcode.react`npm package (MIT licensed). The widget provides a `QRCode` C# record with fluent extension methods, a React frontend component wrapping `QRCodeSVG`, and a sample app demonstrating live QR code generation from a text input.

**New class: `Ivy.Widgets.QRCode.QRCode`**

```csharp
[ExternalWidget("frontend/dist/Ivy_Widgets_QRCode.js", ExportName = "QRCode")]
public record QRCode : WidgetBase<QRCode>
{
    [Prop] public string Value { get; init; } = "";
    [Prop] public int? PixelSize { get; init; }
    [Prop] public QrErrorCorrectionLevel ErrorCorrectionLevel { get; init; } = QrErrorCorrectionLevel.Low;
    [Prop] public bool IncludeMargin { get; init; } = true;
    [Prop] public Colors? Background { get; init; }
    [Prop] public Colors? Foreground { get; init; }
}
```

**New class: `Ivy.Widgets.QRCode.QRCodeExtensions`**

- `.Value(string)`, `.PixelSize(int)`, `.Level(string)`, `.IncludeMargin(bool)`, `.BgColor(string)`, `.FgColor(string)`

## Files Modified

**New widget project:**

- `src/widgets/Ivy.Widgets.QRCode/QRCode.cs` — C# record + extension methods
- `src/widgets/Ivy.Widgets.QRCode/Ivy.Widgets.QRCode.csproj`
- `src/widgets/Ivy.Widgets.QRCode/README.md`

**Frontend:**

- `src/widgets/Ivy.Widgets.QRCode/frontend/src/QRCode.tsx` — React component
- `src/widgets/Ivy.Widgets.QRCode/frontend/src/ivyColor.ts` — Resolves an Ivy `Colors` enum name to a concrete color for SVG fill/stroke.
- `src/widgets/Ivy.Widgets.QRCode/frontend/src/index.ts` — window registration + export
- `src/widgets/Ivy.Widgets.QRCode/frontend/package.json`, `pnpm-lock.yaml`, `vite.config.ts`, `tsconfig.json`, `postcss.config.js`, `tailwind.config.js`, `src/vite-env.d.ts`

**Sample app:**

- `src/widgets/Ivy.Widgets.QRCode/.samples/Program.cs`
- `src/widgets/Ivy.Widgets.QRCode/.samples/Program.csproj`
- `src/widgets/Ivy.Widgets.QRCode/.samples/.samples.sln`

**Tests:**

- `src/Ivy.Test/QRCodeTests.cs`
- `src/Ivy.Test/Ivy.Test.csproj`