### PR TITLE
[00251] Add hover and expanded bg color to tool call cards in AgentOutputView

### DIFF
--- a/src/widgets/Ivy.Widgets.AgentOutputView/frontend/src/agent-output-view.css
+++ b/src/widgets/Ivy.Widgets.AgentOutputView/frontend/src/agent-output-view.css
@@ -221,6 +221,16 @@
 .aov-tool {
   font-family: var(--aov-mono);
   margin: 4px 0;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.aov-tool:hover {
+  background: color-mix(in srgb, var(--muted-foreground) 4%, var(--aov-bg-elev));
+}
+
+.aov-tool.open {
+  background: color-mix(in srgb, var(--muted-foreground) 4%, var(--aov-bg-elev));
 }
 
 .aov-tool-header {

--- a/src/widgets/Ivy.Widgets.AgentOutputView/frontend/src/tool-use-card.tsx
+++ b/src/widgets/Ivy.Widgets.AgentOutputView/frontend/src/tool-use-card.tsx
@@ -64,7 +64,7 @@ export const ToolUseCard: React.FC<ToolUseCardProps> = ({ tool }) => {
   const headerPreview = summary ? basename(summary) : "";
 
   return (
-    <div className="aov-tool">
+    <div className={`aov-tool ${open ? "open" : ""}`}>
       <div
         className="aov-tool-header"
         onClick={handleToggle}


### PR DESCRIPTION
Added hover and expanded background color feedback to tool call cards in AgentOutputView. When hovering a `.aov-tool` card, a subtle muted background appears. When expanded (open), the same background persists to indicate state.

## Changes

- **agent-output-view.css** — Added `.aov-tool:hover` and `.aov-tool.open` rules with `color-mix` background, plus padding/border-radius on `.aov-tool` for visual containment
- **tool-use-card.tsx** — Added dynamic `open` class to the `.aov-tool` container div based on expanded state

---

### Commits

- 86f7c717f [00251] Add hover and expanded background color to tool call cards in AgentOutputView