### PR TITLE
[00252] Add line separator between input and output in expanded tool calls

### DIFF
--- a/src/widgets/Ivy.Widgets.AgentOutputView/frontend/src/agent-output-view.css
+++ b/src/widgets/Ivy.Widgets.AgentOutputView/frontend/src/agent-output-view.css
@@ -300,6 +300,12 @@
   padding: 0;
 }
 
+.aov-tool-separator {
+  border: none;
+  border-top: 1px solid var(--aov-border);
+  margin: 8px 0 4px;
+}
+
 /* ─── Result summary ────────────────────────────────────────────────────── */
 .aov-result {
   border: 1px solid var(--aov-border);

--- a/src/widgets/Ivy.Widgets.AgentOutputView/frontend/src/tool-use-card.tsx
+++ b/src/widgets/Ivy.Widgets.AgentOutputView/frontend/src/tool-use-card.tsx
@@ -91,9 +91,12 @@ export const ToolUseCard: React.FC<ToolUseCardProps> = ({ tool }) => {
             <code>{displayInput(tool.name, tool.input)}</code>
           </pre>
           {tool.result != null && (
-            <pre className="aov-tool-pre">
-              <code>{tool.result}</code>
-            </pre>
+            <>
+              <hr className="aov-tool-separator" />
+              <pre className="aov-tool-pre">
+                <code>{tool.result}</code>
+              </pre>
+            </>
           )}
         </div>
       )}


### PR DESCRIPTION
## Changes

Added a visual line separator (`<hr>`) between the input and output sections in expanded tool call cards in the AgentOutputView widget. The separator uses the existing `--aov-border` CSS variable for consistent styling.

## Files Modified

- `src/widgets/Ivy.Widgets.AgentOutputView/frontend/src/tool-use-card.tsx` — Added `<hr className="aov-tool-separator" />` between input and output pre blocks
- `src/widgets/Ivy.Widgets.AgentOutputView/frontend/src/agent-output-view.css` — Added `.aov-tool-separator` CSS rule

---

**Commit:** 0ce889114 — [00252] Add line separator between input and output in expanded tool calls