### PR TITLE
[00250] Increase minimum font size to 14px in AgentOutputView (12px for tool I/O content)

### DIFF
--- a/src/widgets/Ivy.Widgets.AgentOutputView/frontend/src/agent-output-view.css
+++ b/src/widgets/Ivy.Widgets.AgentOutputView/frontend/src/agent-output-view.css
@@ -19,7 +19,7 @@
     Consolas, monospace;
 
   color: var(--aov-fg);
-  font-size: 13px;
+  font-size: 14px;
   line-height: 1.55;
   position: relative;
   container-type: size;
@@ -68,7 +68,7 @@
   display: flex;
   align-items: center;
   padding: 8px 0;
-  font-size: 12px;
+  font-size: 14px;
   min-height: 32px;
 }
 
@@ -171,7 +171,7 @@
   border: 1px solid var(--aov-border);
   border-radius: 4px;
   padding: 1px 5px;
-  font-size: 12.5px;
+  font-size: 14px;
 }
 
 .aov-markdown pre {
@@ -181,7 +181,7 @@
   border-radius: 6px;
   padding: 10px 12px;
   overflow-x: auto;
-  font-size: 12.5px;
+  font-size: 14px;
 }
 
 .aov-markdown pre code {
@@ -207,7 +207,7 @@
 .aov-markdown h4 {
   margin: 0.75rem 0 0.375rem;
   font-weight: 600;
-  font-size: 13px;
+  font-size: 14px;
 }
 
 .aov-markdown blockquote {
@@ -230,7 +230,7 @@
   padding: 2px 0;
   cursor: pointer;
   user-select: none;
-  font-size: 12.5px;
+  font-size: 14px;
   outline: none;
 }
 
@@ -287,7 +287,7 @@
   border-radius: 4px;
   padding: 8px 10px;
   overflow-x: auto;
-  font-size: 12.5px;
+  font-size: 12px;
   color: var(--aov-fg);
   white-space: pre-wrap;
   word-break: break-word;
@@ -332,7 +332,7 @@
 
 .aov-result-meta {
   color: var(--aov-fg-muted);
-  font-size: 12px;
+  font-size: 14px;
 }
 
 .aov-result-body {
@@ -344,14 +344,14 @@
   flex-wrap: wrap;
   gap: 12px;
   color: var(--aov-fg-muted);
-  font-size: 12px;
+  font-size: 14px;
   margin-top: 4px;
 }
 
 /* ─── System & thinking blocks ──────────────────────────────────────────── */
 .aov-system {
   color: var(--aov-fg-faint);
-  font-size: 12px;
+  font-size: 14px;
   padding: 2px 0;
 }
 


### PR DESCRIPTION
Updated all font-size declarations in `agent-output-view.css` to enforce a minimum of 14px for readability, with a single exception: `.aov-tool-pre` (tool I/O expanded content) is set to 12px. Ten font-size values were updated across the AgentOutputView widget.

## Files Modified

- **src/widgets/Ivy.Widgets.AgentOutputView/frontend/src/agent-output-view.css** — Updated 10 font-size declarations (9 to 14px, 1 to 12px)

---

## Commits

- `7c127223d` [00250] Increase minimum font size to 14px in AgentOutputView (12px for tool I/O)