### PR TITLE
Add unconfigured plugin state

### DIFF
--- a/src/Ivy.Plugin.Abstractions/IIvyPlugin.cs
+++ b/src/Ivy.Plugin.Abstractions/IIvyPlugin.cs
@@ -1,12 +1,8 @@
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-
 namespace Ivy.Plugins;
 
 public interface IIvyPlugin
 {
     PluginManifest Manifest { get; }
     PluginConfigurationSchema? ConfigurationSchema { get; }
-    void ConfigureServices(IServiceCollection services, IConfiguration configuration);
     void Configure(IIvyPluginContext context);
 }

--- a/src/Ivy.Plugin.Abstractions/IPluginManager.cs
+++ b/src/Ivy.Plugin.Abstractions/IPluginManager.cs
@@ -8,13 +8,17 @@ public record PluginCandidate(
 
 public interface IPluginManager
 {
-    IReadOnlyList<string> GetLoadedPluginIds();
+    IReadOnlyList<string> GetActivePluginIds();
     IReadOnlyList<PluginCandidate> GetUnloadedPlugins();
+    IReadOnlyList<UnconfiguredPlugin> GetUnconfiguredPlugins();
     bool UnloadPlugin(string pluginId);
     bool LoadPlugin(string pluginPath);
     bool ReloadPlugin(string pluginId);
+    bool ReconfigurePlugin(string pluginId);
 
     event Action<string>? PluginLoaded;
     event Action<string>? PluginUnloaded;
     event Action<string>? PluginReloaded;
+    event Action<string>? PluginActivated;
+    event Action<string>? PluginDeactivated;
 }

--- a/src/Ivy.Plugin.Abstractions/PluginStatus.cs
+++ b/src/Ivy.Plugin.Abstractions/PluginStatus.cs
@@ -1,0 +1,7 @@
+namespace Ivy.Plugins;
+
+public enum PluginStatus
+{
+    Active,
+    Unconfigured
+}

--- a/src/Ivy.Plugin.Abstractions/UnconfiguredPlugin.cs
+++ b/src/Ivy.Plugin.Abstractions/UnconfiguredPlugin.cs
@@ -1,0 +1,8 @@
+namespace Ivy.Plugins;
+
+public record UnconfiguredPlugin(
+    string Id,
+    string Name,
+    string Directory,
+    PluginConfigurationSchema Schema,
+    IReadOnlyList<string> ValidationErrors);

--- a/src/Ivy.Test/Hooks/UsePluginStateTests.cs
+++ b/src/Ivy.Test/Hooks/UsePluginStateTests.cs
@@ -105,7 +105,7 @@ public class UsePluginStateTests
     {
         public event Action? PluginStateChanged;
 
-        public IReadOnlyList<string> GetLoadedPluginIds() => [];
+        public IReadOnlyList<string> GetActivePluginIds() => [];
 
         public void RaisePluginStateChanged() => PluginStateChanged?.Invoke();
     }

--- a/src/Ivy.Test/PluginConfigurationValidationTests.cs
+++ b/src/Ivy.Test/PluginConfigurationValidationTests.cs
@@ -344,8 +344,6 @@ public class PluginConfigurationValidationTests
 
         public PluginConfigurationSchema? ConfigurationSchema { get; }
 
-        public void ConfigureServices(IServiceCollection services, IConfiguration configuration) { }
-
         public void Configure(IIvyPluginContext context) => _onConfigure?.Invoke(context);
     }
 }

--- a/src/Ivy.Test/PluginConfigurationValidationTests.cs
+++ b/src/Ivy.Test/PluginConfigurationValidationTests.cs
@@ -3,7 +3,6 @@ using Ivy.Core.Plugins;
 using Ivy.Plugins;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Ivy.Test.Plugins;

--- a/src/Ivy.Test/PluginLoaderTests.cs
+++ b/src/Ivy.Test/PluginLoaderTests.cs
@@ -165,11 +165,11 @@ public class PluginLoaderTests
             var loader = new PluginLoader(tempDir, logger);
 
             // We can't easily test this through the full PluginLoader without real DLLs,
-            // but we can verify GetLoadedPluginIds returns empty for a directory with no plugins
+            // but we can verify GetActivePluginIds returns empty for a directory with no plugins
             using var sp = new ServiceCollection().BuildServiceProvider();
             loader.DiscoverAndLoad(new Version(1, 0), sp);
 
-            Assert.Empty(loader.GetLoadedPluginIds());
+            Assert.Empty(loader.GetActivePluginIds());
             Assert.False(loader.UnloadPlugin("nonexistent"));
         }
         finally
@@ -288,7 +288,7 @@ public class PluginLoaderTests
             loader.DiscoverAndLoad(new Version(1, 0), sp);
 
             // Should have no loaded plugins
-            Assert.Empty(loader.GetLoadedPluginIds());
+            Assert.Empty(loader.GetActivePluginIds());
 
             // Should have one unloaded plugin with failure info
             var unloadedPlugins = loader.GetUnloadedPlugins();
@@ -438,7 +438,7 @@ public class PluginLoaderTests
             var testPlugin = new TestPlugin { Id = "test-plugin-id" };
             loader.AddTestPlugin(testPlugin, pluginDir);
 
-            var loadedIdsBefore = loader.GetLoadedPluginIds();
+            var loadedIdsBefore = loader.GetActivePluginIds();
             Assert.Contains("test-plugin-id", loadedIdsBefore);
 
             var watcher = new PluginWatcher(tempDir, loader, watcherLogger);
@@ -451,7 +451,7 @@ public class PluginLoaderTests
             await Task.Delay(500);
 
             // Verify the plugin was unloaded
-            var loadedIdsAfter = loader.GetLoadedPluginIds();
+            var loadedIdsAfter = loader.GetActivePluginIds();
             Assert.DoesNotContain("test-plugin-id", loadedIdsAfter);
 
             watcher.Dispose();
@@ -541,7 +541,7 @@ public class PluginLoaderTests
             await Task.Delay(400);
 
             // Plugin should still be loaded (not reloaded/unloaded)
-            var loadedIds = loader.GetLoadedPluginIds();
+            var loadedIds = loader.GetActivePluginIds();
             Assert.Contains("test-plugin-id", loadedIds);
 
             watcher.Dispose();
@@ -565,8 +565,6 @@ public class PluginLoaderTests
         };
 
         public Ivy.Plugins.PluginConfigurationSchema? ConfigurationSchema => null;
-
-        public void ConfigureServices(Microsoft.Extensions.DependencyInjection.IServiceCollection services, Microsoft.Extensions.Configuration.IConfiguration configuration) { }
 
         public void Configure(Ivy.Plugins.IIvyPluginContext context) { }
     }

--- a/src/Ivy.Test/Plugins/PluginStateServiceTests.cs
+++ b/src/Ivy.Test/Plugins/PluginStateServiceTests.cs
@@ -48,14 +48,42 @@ public class PluginStateServiceTests
     }
 
     [Fact]
-    public void GetLoadedPluginIds_ReturnsPluginManagerList()
+    public void PluginStateChanged_FiresWhenPluginActivated()
     {
         var fakeManager = new FakePluginManager();
-        fakeManager.LoadedPluginIds = new List<string> { "plugin1", "plugin2" };
+        var service = new PluginStateService(fakeManager);
+
+        var eventFired = false;
+        service.PluginStateChanged += () => eventFired = true;
+
+        fakeManager.RaisePluginActivated("test-plugin");
+
+        Assert.True(eventFired);
+    }
+
+    [Fact]
+    public void PluginStateChanged_FiresWhenPluginDeactivated()
+    {
+        var fakeManager = new FakePluginManager();
+        var service = new PluginStateService(fakeManager);
+
+        var eventFired = false;
+        service.PluginStateChanged += () => eventFired = true;
+
+        fakeManager.RaisePluginDeactivated("test-plugin");
+
+        Assert.True(eventFired);
+    }
+
+    [Fact]
+    public void GetActivePluginIds_ReturnsPluginManagerList()
+    {
+        var fakeManager = new FakePluginManager();
+        fakeManager.ActivePluginIds = new List<string> { "plugin1", "plugin2" };
 
         var service = new PluginStateService(fakeManager);
 
-        var result = service.GetLoadedPluginIds();
+        var result = service.GetActivePluginIds();
 
         Assert.Equal(2, result.Count);
         Assert.Contains("plugin1", result);
@@ -64,13 +92,17 @@ public class PluginStateServiceTests
 
     private class FakePluginManager : IPluginManager
     {
-        public List<string> LoadedPluginIds { get; set; } = [];
+        public List<string> ActivePluginIds { get; set; } = [];
 
         public event Action<string>? PluginLoaded;
         public event Action<string>? PluginUnloaded;
         public event Action<string>? PluginReloaded;
+        public event Action<string>? PluginActivated;
+        public event Action<string>? PluginDeactivated;
 
-        public IReadOnlyList<string> GetLoadedPluginIds() => LoadedPluginIds;
+        public IReadOnlyList<string> GetActivePluginIds() => ActivePluginIds;
+
+        public IReadOnlyList<UnconfiguredPlugin> GetUnconfiguredPlugins() => [];
 
         public IReadOnlyList<PluginCandidate> GetUnloadedPlugins() => [];
 
@@ -80,8 +112,12 @@ public class PluginStateServiceTests
 
         public bool ReloadPlugin(string pluginId) => throw new NotImplementedException();
 
+        public bool ReconfigurePlugin(string pluginId) => throw new NotImplementedException();
+
         public void RaisePluginLoaded(string pluginId) => PluginLoaded?.Invoke(pluginId);
         public void RaisePluginUnloaded(string pluginId) => PluginUnloaded?.Invoke(pluginId);
         public void RaisePluginReloaded(string pluginId) => PluginReloaded?.Invoke(pluginId);
+        public void RaisePluginActivated(string pluginId) => PluginActivated?.Invoke(pluginId);
+        public void RaisePluginDeactivated(string pluginId) => PluginDeactivated?.Invoke(pluginId);
     }
 }

--- a/src/Ivy/Apps/PluginManagerApp.cs
+++ b/src/Ivy/Apps/PluginManagerApp.cs
@@ -14,19 +14,20 @@ public class PluginManagerApp : ViewBase
     public override object? Build()
     {
         var pluginManager = this.UseService<IPluginManager>();
-        var loadedPlugins = pluginManager.GetLoadedPluginIds();
+        var activePlugins = pluginManager.GetActivePluginIds();
+        var unconfiguredPlugins = pluginManager.GetUnconfiguredPlugins();
         var unloadedPlugins = pluginManager.GetUnloadedPlugins();
         var pluginStatus = UseState("");
         UsePluginState();
 
         return Vertical().Gap(6).Padding(4)
             | H1("Plugin Manager")
-            | new Badge($"{loadedPlugins.Count} loaded, {unloadedPlugins.Count} unloaded", BadgeVariant.Info)
+            | new Badge($"{activePlugins.Count} active, {unconfiguredPlugins.Count} unconfigured, {unloadedPlugins.Count} unloaded", BadgeVariant.Info)
             | new Separator()
-            | H2("Loaded Plugins")
-            | (loadedPlugins.Count == 0
-                ? Muted("No plugins currently loaded")
-                : loadedPlugins.Select(id => (object)(Horizontal().Gap(4)
+            | H2("Active Plugins")
+            | (activePlugins.Count == 0
+                ? Muted("No plugins currently active")
+                : activePlugins.Select(id => (object)(Horizontal().Gap(4)
                     | new Badge(id, BadgeVariant.Secondary)
                     | new Button("Reload", onClick: _ =>
                     {
@@ -42,6 +43,22 @@ public class PluginManagerApp : ViewBase
                             : $"Failed to unload '{id}'");
                         return ValueTask.CompletedTask;
                     }, variant: ButtonVariant.Outline, icon: Icons.Power)
+                )).ToArray())
+            | new Separator()
+            | H2("Unconfigured Plugins")
+            | (unconfiguredPlugins.Count == 0
+                ? Muted("No unconfigured plugins")
+                : unconfiguredPlugins.Select(p => (object)(Vertical().Gap(2)
+                    | (Horizontal().Gap(4)
+                        | new Badge(p.Id, BadgeVariant.Warning)
+                        | Muted(string.Join(", ", p.ValidationErrors)))
+                    | new Button("Reconfigure", onClick: _ =>
+                    {
+                        pluginStatus.Set(pluginManager.ReconfigurePlugin(p.Id)
+                            ? $"Activated '{p.Id}'"
+                            : $"Configuration still invalid for '{p.Id}'");
+                        return ValueTask.CompletedTask;
+                    }, variant: ButtonVariant.Outline, icon: Icons.Settings)
                 )).ToArray())
             | new Separator()
             | H2("Unloaded Plugins")
@@ -60,7 +77,7 @@ public class PluginManagerApp : ViewBase
                 )).ToArray())
             | (string.IsNullOrEmpty(pluginStatus.Value)
                 ? null
-                : pluginStatus.Value.StartsWith("Failed") || pluginStatus.Value.Contains("Error")
+                : pluginStatus.Value.StartsWith("Failed") || pluginStatus.Value.Contains("Error") || pluginStatus.Value.Contains("invalid")
                     ? new Badge(pluginStatus.Value, BadgeVariant.Destructive)
                     : new Badge(pluginStatus.Value, BadgeVariant.Success));
     }

--- a/src/Ivy/Core/Plugins/IPluginStateService.cs
+++ b/src/Ivy/Core/Plugins/IPluginStateService.cs
@@ -2,6 +2,6 @@ namespace Ivy.Core.Plugins;
 
 public interface IPluginStateService
 {
-    IReadOnlyList<string> GetLoadedPluginIds();
+    IReadOnlyList<string> GetActivePluginIds();
     event Action? PluginStateChanged;
 }

--- a/src/Ivy/Core/Plugins/PluginLoader.cs
+++ b/src/Ivy/Core/Plugins/PluginLoader.cs
@@ -25,6 +25,8 @@ public class PluginLoader : IPluginManager
     public event Action<string>? PluginLoaded;
     public event Action<string>? PluginUnloaded;
     public event Action<string>? PluginReloaded;
+    public event Action<string>? PluginActivated;
+    public event Action<string>? PluginDeactivated;
 
     internal bool BuildSourcePlugins { get; }
 
@@ -366,19 +368,9 @@ public class PluginLoader : IPluginManager
         }
     }
 
-    public void ConfigureServices(IServiceCollection hostServices, IConfiguration configuration)
+    public void SetConfiguration(IConfiguration configuration)
     {
         _configuration = configuration;
-        _lock.EnterReadLock();
-        try
-        {
-            foreach (var plugin in _plugins)
-                plugin.Instance.ConfigureServices(plugin.Services, configuration);
-        }
-        finally
-        {
-            _lock.ExitReadLock();
-        }
     }
 
     internal void SetServiceProviderFactory(Func<IServiceProvider> factory)
@@ -389,7 +381,6 @@ public class PluginLoader : IPluginManager
     public void Configure(PluginContextBase context)
     {
         _pluginContext = context;
-        var invalidPlugins = new List<LoadedPlugin>();
 
         _lock.EnterReadLock();
         try
@@ -405,11 +396,11 @@ public class PluginLoader : IPluginManager
 
                     if (errors.Count > 0)
                     {
-                        _logger.LogError(
-                            "Plugin '{Id}' configuration is invalid: {Errors}",
+                        _logger.LogWarning(
+                            "Plugin '{Id}' configuration is incomplete: {Errors}. Plugin loaded as unconfigured.",
                             plugin.Instance.Manifest.Id,
                             string.Join(", ", errors));
-                        invalidPlugins.Add(plugin);
+                        plugin.Status = PluginStatus.Unconfigured;
                         continue;
                     }
 
@@ -426,30 +417,12 @@ public class PluginLoader : IPluginManager
                 plugin.Instance.Configure(context);
                 context.ClearCurrentPlugin();
                 context.PopConfiguration();
+                plugin.Status = PluginStatus.Active;
             }
         }
         finally
         {
             _lock.ExitReadLock();
-        }
-
-        if (invalidPlugins.Count > 0)
-        {
-            _lock.EnterWriteLock();
-            try
-            {
-                foreach (var plugin in invalidPlugins)
-                {
-                    _plugins.Remove(plugin);
-                    _failedPlugins[plugin.Directory] = (
-                        $"Configuration invalid for '{plugin.Instance.Manifest.Id}'",
-                        DateTime.UtcNow);
-                }
-            }
-            finally
-            {
-                _lock.ExitWriteLock();
-            }
         }
     }
 
@@ -480,8 +453,9 @@ public class PluginLoader : IPluginManager
                 return false;
             }
 
-            // Remove contributions from context
-            _pluginContext?.RemovePluginContributions(pluginId);
+            // Remove contributions from context (only if it was active)
+            if (plugin.Status == PluginStatus.Active)
+                _pluginContext?.RemovePluginContributions(pluginId);
 
             // Dispose the plugin's service provider
             (plugin.ServiceProvider as IDisposable)?.Dispose();
@@ -498,7 +472,7 @@ public class PluginLoader : IPluginManager
         }
 
         // Fire event outside the lock to avoid deadlocks — subscribers may call
-        // GetLoadedPluginIds() which needs a read lock.
+        // GetActivePluginIds() which needs a read lock.
         PluginUnloaded?.Invoke(pluginId);
 
         return true;
@@ -516,6 +490,7 @@ public class PluginLoader : IPluginManager
             SourcePluginBuilder.BuildSync(pluginPath, _logger);
 
         string? loadedPluginId = null;
+        PluginStatus loadedStatus = PluginStatus.Active;
         _lock.EnterWriteLock();
         try
         {
@@ -554,11 +529,7 @@ public class PluginLoader : IPluginManager
 
             var plugin = new LoadedPlugin(loaded.Value.Instance, loaded.Value.Assembly, loaded.Value.Context, loaded.Value.Directory);
 
-            // Configure services
-            if (_configuration is not null)
-                plugin.Instance.ConfigureServices(plugin.Services, _configuration);
-
-            // Validate configuration before Configure
+            // Validate configuration
             if (plugin.Instance.ConfigurationSchema is { } schema && _configuration is not null)
             {
                 var errors = ValidatePluginConfiguration(
@@ -568,21 +539,27 @@ public class PluginLoader : IPluginManager
 
                 if (errors.Count > 0)
                 {
-                    _logger.LogError(
-                        "Plugin '{Id}' configuration is invalid: {Errors}. Plugin load failed.",
+                    _logger.LogWarning(
+                        "Plugin '{Id}' configuration is incomplete: {Errors}. Plugin loaded as unconfigured.",
                         manifest.Id,
                         string.Join(", ", errors));
+                    plugin.Status = PluginStatus.Unconfigured;
+                    loadedStatus = PluginStatus.Unconfigured;
 
-                    (plugin.ServiceProvider as IDisposable)?.Dispose();
-                    plugin.LoadContext.Unload();
-                    return false;
+                    _knownPlugins[manifest.Id] = pluginPath;
+                    _plugins.Add(plugin);
+                    _failedPlugins.Remove(pluginPath);
+
+                    _logger.LogInformation("Loaded plugin (unconfigured): {Id} v{Version}", manifest.Id, manifest.Version);
+                    loadedPluginId = manifest.Id;
+
+                    return true;
                 }
             }
 
-            // Configure context
+            // Configure context — plugin has valid config
             if (_pluginContext is not null)
             {
-                // Apply defaults if schema exists
                 if (plugin.Instance.ConfigurationSchema is { } configSchema && _configuration is not null)
                 {
                     var configWithDefaults = ApplyConfigurationDefaults(
@@ -601,6 +578,7 @@ public class PluginLoader : IPluginManager
                 plugin.ServiceProvider = _pluginContext.GetPluginServiceProvider(manifest.Id);
             }
 
+            plugin.Status = PluginStatus.Active;
             _knownPlugins[manifest.Id] = pluginPath;
             _plugins.Add(plugin);
 
@@ -617,7 +595,7 @@ public class PluginLoader : IPluginManager
         }
 
         // Reload app repository so newly added apps appear in the UI
-        if (loadedPluginId is not null)
+        if (loadedPluginId is not null && loadedStatus == PluginStatus.Active)
         {
             _pluginContext?.ReloadApps();
             // Refresh any open tabs showing apps from this plugin (e.g. after reload)
@@ -627,7 +605,7 @@ public class PluginLoader : IPluginManager
         }
 
         // Fire event outside the lock to avoid deadlocks — subscribers may call
-        // GetLoadedPluginIds() which needs a read lock.
+        // GetActivePluginIds() which needs a read lock.
         if (loadedPluginId is not null)
             PluginLoaded?.Invoke(loadedPluginId);
 
@@ -643,6 +621,7 @@ public class PluginLoader : IPluginManager
         }
 
         string? directory;
+        PluginStatus oldStatus;
         _lock.EnterReadLock();
         try
         {
@@ -653,6 +632,7 @@ public class PluginLoader : IPluginManager
                 return false;
             }
             directory = plugin.Directory;
+            oldStatus = plugin.Status;
         }
         finally
         {
@@ -680,6 +660,8 @@ public class PluginLoader : IPluginManager
             return false;
         }
 
+        PluginStatus newStatus;
+
         // Now atomically swap: unload old, insert new
         _lock.EnterWriteLock();
         try
@@ -687,7 +669,8 @@ public class PluginLoader : IPluginManager
             var oldPlugin = _plugins.FirstOrDefault(p => p.Instance.Manifest.Id == pluginId);
             if (oldPlugin is not null)
             {
-                _pluginContext?.RemovePluginContributions(pluginId);
+                if (oldPlugin.Status == PluginStatus.Active)
+                    _pluginContext?.RemovePluginContributions(pluginId);
                 (oldPlugin.ServiceProvider as IDisposable)?.Dispose();
                 oldPlugin.LoadContext.Unload();
                 _plugins.Remove(oldPlugin);
@@ -695,15 +678,36 @@ public class PluginLoader : IPluginManager
 
             var newPlugin = new LoadedPlugin(loaded.Value.Instance, loaded.Value.Assembly, loaded.Value.Context, loaded.Value.Directory);
 
-            if (_configuration is not null)
-                newPlugin.Instance.ConfigureServices(newPlugin.Services, _configuration);
+            // Validate configuration
+            if (newPlugin.Instance.ConfigurationSchema is { } schema && _configuration is not null)
+            {
+                var errors = ValidatePluginConfiguration(
+                    manifest.ConfigSectionName, schema, _configuration);
+
+                if (errors.Count > 0)
+                {
+                    _logger.LogWarning(
+                        "Plugin '{Id}' configuration is incomplete after reload: {Errors}. Plugin loaded as unconfigured.",
+                        manifest.Id, string.Join(", ", errors));
+                    newPlugin.Status = PluginStatus.Unconfigured;
+                    newStatus = PluginStatus.Unconfigured;
+
+                    _knownPlugins[manifest.Id] = directory;
+                    _plugins.Add(newPlugin);
+                    _failedPlugins.Remove(directory);
+
+                    _logger.LogInformation("Reloaded plugin (unconfigured): {Id} v{Version}", manifest.Id, manifest.Version);
+
+                    return true;
+                }
+            }
 
             if (_pluginContext is not null)
             {
-                if (newPlugin.Instance.ConfigurationSchema is { } schema && _configuration is not null)
+                if (newPlugin.Instance.ConfigurationSchema is { } configSchema && _configuration is not null)
                 {
                     var configWithDefaults = ApplyConfigurationDefaults(
-                        manifest.ConfigSectionName, schema, _configuration);
+                        manifest.ConfigSectionName, configSchema, _configuration);
                     _pluginContext.PushConfiguration(configWithDefaults);
                 }
 
@@ -715,6 +719,8 @@ public class PluginLoader : IPluginManager
                 newPlugin.ServiceProvider = _pluginContext.GetPluginServiceProvider(manifest.Id);
             }
 
+            newPlugin.Status = PluginStatus.Active;
+            newStatus = PluginStatus.Active;
             _knownPlugins[manifest.Id] = directory;
             _plugins.Add(newPlugin);
             _failedPlugins.Remove(directory);
@@ -727,21 +733,177 @@ public class PluginLoader : IPluginManager
         }
 
         // Refresh UI after the swap is complete
-        _pluginContext?.ReloadApps();
-        var appIds = _pluginContext?.GetPluginAppIds(pluginId);
-        if (appIds is { Count: > 0 })
-            _pluginContext!.RefreshApps(appIds);
+        if (newStatus == PluginStatus.Active)
+        {
+            _pluginContext?.ReloadApps();
+            var appIds = _pluginContext?.GetPluginAppIds(pluginId);
+            if (appIds is { Count: > 0 })
+                _pluginContext!.RefreshApps(appIds);
+        }
 
         PluginReloaded?.Invoke(pluginId);
+
+        // Fire activation/deactivation events based on state transitions
+        if (oldStatus == PluginStatus.Unconfigured && newStatus == PluginStatus.Active)
+            PluginActivated?.Invoke(pluginId);
+        else if (oldStatus == PluginStatus.Active && newStatus == PluginStatus.Unconfigured)
+            PluginDeactivated?.Invoke(pluginId);
+
         return true;
     }
 
-    public IReadOnlyList<string> GetLoadedPluginIds()
+    public bool ReconfigurePlugin(string pluginId)
+    {
+        if (_configuration is null || _pluginContext is null)
+        {
+            _logger.LogError("Cannot reconfigure plugin: PluginLoader has not been initialized.");
+            return false;
+        }
+
+        LoadedPlugin? plugin;
+        _lock.EnterReadLock();
+        try
+        {
+            plugin = _plugins.FirstOrDefault(p => p.Instance.Manifest.Id == pluginId);
+            if (plugin is null)
+            {
+                _logger.LogWarning("Plugin '{Id}' not found for reconfiguration.", pluginId);
+                return false;
+            }
+        }
+        finally
+        {
+            _lock.ExitReadLock();
+        }
+
+        var manifest = plugin.Instance.Manifest;
+        var oldStatus = plugin.Status;
+
+        // Validate the current configuration
+        List<string> errors = [];
+        if (plugin.Instance.ConfigurationSchema is { } schema)
+        {
+            errors = ValidatePluginConfiguration(
+                manifest.ConfigSectionName,
+                schema,
+                _configuration);
+        }
+
+        if (errors.Count > 0)
+        {
+            // Configuration is invalid
+            if (oldStatus == PluginStatus.Active)
+            {
+                // Deactivate: remove contributions
+                _lock.EnterWriteLock();
+                try
+                {
+                    _pluginContext.RemovePluginContributions(pluginId);
+                    (plugin.ServiceProvider as IDisposable)?.Dispose();
+                    plugin.ServiceProvider = null;
+                    plugin.Status = PluginStatus.Unconfigured;
+                }
+                finally
+                {
+                    _lock.ExitWriteLock();
+                }
+
+                _logger.LogWarning(
+                    "Plugin '{Id}' deactivated due to invalid configuration: {Errors}",
+                    pluginId, string.Join(", ", errors));
+
+                _pluginContext.ReloadApps();
+                PluginDeactivated?.Invoke(pluginId);
+            }
+            return false;
+        }
+
+        // Configuration is valid — activate or reconfigure
+        _lock.EnterWriteLock();
+        try
+        {
+            // If already active, remove old contributions first
+            if (oldStatus == PluginStatus.Active)
+            {
+                _pluginContext.RemovePluginContributions(pluginId);
+                (plugin.ServiceProvider as IDisposable)?.Dispose();
+                plugin.ServiceProvider = null;
+            }
+
+            // Apply defaults and call Configure
+            if (plugin.Instance.ConfigurationSchema is { } configSchema)
+            {
+                var configWithDefaults = ApplyConfigurationDefaults(
+                    manifest.ConfigSectionName, configSchema, _configuration);
+                _pluginContext.PushConfiguration(configWithDefaults);
+            }
+
+            _pluginContext.SetCurrentPlugin(manifest.Id, plugin.Directory);
+            plugin.Instance.Configure(_pluginContext);
+            _pluginContext.ClearCurrentPlugin();
+            _pluginContext.PopConfiguration();
+            _pluginContext.BuildPluginServiceProvider(manifest.Id, plugin.Services);
+            plugin.ServiceProvider = _pluginContext.GetPluginServiceProvider(manifest.Id);
+            plugin.Status = PluginStatus.Active;
+        }
+        finally
+        {
+            _lock.ExitWriteLock();
+        }
+
+        _logger.LogInformation("Reconfigured plugin: {Id}", pluginId);
+
+        _pluginContext.ReloadApps();
+        var appIds = _pluginContext.GetPluginAppIds(pluginId);
+        if (appIds is { Count: > 0 })
+            _pluginContext.RefreshApps(appIds);
+
+        if (oldStatus == PluginStatus.Unconfigured)
+            PluginActivated?.Invoke(pluginId);
+
+        return true;
+    }
+
+    public IReadOnlyList<string> GetActivePluginIds()
     {
         _lock.EnterReadLock();
         try
         {
-            return _plugins.Select(p => p.Instance.Manifest.Id).ToList();
+            return _plugins
+                .Where(p => p.Status == PluginStatus.Active)
+                .Select(p => p.Instance.Manifest.Id)
+                .ToList();
+        }
+        finally
+        {
+            _lock.ExitReadLock();
+        }
+    }
+
+    public IReadOnlyList<UnconfiguredPlugin> GetUnconfiguredPlugins()
+    {
+        _lock.EnterReadLock();
+        try
+        {
+            var result = new List<UnconfiguredPlugin>();
+            foreach (var plugin in _plugins.Where(p => p.Status == PluginStatus.Unconfigured))
+            {
+                var manifest = plugin.Instance.Manifest;
+                var schema = plugin.Instance.ConfigurationSchema;
+                if (schema is null) continue;
+
+                var errors = _configuration is not null
+                    ? ValidatePluginConfiguration(manifest.ConfigSectionName, schema, _configuration)
+                    : ["No configuration available"];
+
+                result.Add(new UnconfiguredPlugin(
+                    manifest.Id,
+                    manifest.Name,
+                    plugin.Directory,
+                    schema,
+                    errors));
+            }
+            return result;
         }
         finally
         {
@@ -896,6 +1058,7 @@ public record LoadedPlugin(
     AssemblyLoadContext LoadContext,
     string Directory)
 {
+    public PluginStatus Status { get; internal set; } = PluginStatus.Active;
     public ServiceCollection Services { get; } = new();
     public IServiceProvider? ServiceProvider { get; internal set; }
 }

--- a/src/Ivy/Core/Plugins/PluginStateService.cs
+++ b/src/Ivy/Core/Plugins/PluginStateService.cs
@@ -16,10 +16,12 @@ internal class PluginStateService : IPluginStateService
         _pluginManager.PluginLoaded += OnPluginChanged;
         _pluginManager.PluginUnloaded += OnPluginChanged;
         _pluginManager.PluginReloaded += OnPluginChanged;
+        _pluginManager.PluginActivated += OnPluginChanged;
+        _pluginManager.PluginDeactivated += OnPluginChanged;
     }
 
     private void OnPluginChanged(string pluginId) => PluginStateChanged?.Invoke();
 
-    public IReadOnlyList<string> GetLoadedPluginIds() =>
-        _pluginManager.GetLoadedPluginIds();
+    public IReadOnlyList<string> GetActivePluginIds() =>
+        _pluginManager.GetActivePluginIds();
 }

--- a/src/Ivy/Server.cs
+++ b/src/Ivy/Server.cs
@@ -566,7 +566,7 @@ public class Server
             hostVersion ?? Assembly.GetEntryAssembly()!.GetName().Version!,
             bootstrapProvider);
 
-        loader.ConfigureServices(Services, Configuration);
+        loader.SetConfiguration(Configuration);
 
         _pluginLoader = loader;
         _pluginContextFactory = contextFactory;

--- a/src/plugins/plugins/Ivy.Plugin.Example.AppProvider/ExampleAppProviderPlugin.cs
+++ b/src/plugins/plugins/Ivy.Plugin.Example.AppProvider/ExampleAppProviderPlugin.cs
@@ -1,6 +1,4 @@
 using Ivy.Plugins;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
 
 [assembly: IvyPlugin(typeof(Ivy.Plugin.Example.AppProvider.ExampleAppProviderPlugin))]
 
@@ -22,10 +20,6 @@ public class ExampleAppProviderPlugin : IIvyPlugin
     };
 
     public PluginConfigurationSchema? ConfigurationSchema => null;
-
-    public void ConfigureServices(IServiceCollection services, IConfiguration configuration)
-    {
-    }
 
     public void Configure(IIvyPluginContext context)
     {

--- a/src/plugins/plugins/Ivy.Plugin.HelloWorld/HelloWorldPlugin.cs
+++ b/src/plugins/plugins/Ivy.Plugin.HelloWorld/HelloWorldPlugin.cs
@@ -1,6 +1,4 @@
 using Ivy.Plugins;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
 
 [assembly: IvyPlugin(typeof(Ivy.Plugin.HelloWorld.HelloWorldPlugin))]
 
@@ -17,10 +15,6 @@ public class HelloWorldPlugin : IIvyPlugin
     };
 
     public PluginConfigurationSchema? ConfigurationSchema => null;
-
-    public void ConfigureServices(IServiceCollection services, IConfiguration configuration)
-    {
-    }
 
     public void Configure(IIvyPluginContext context)
     {


### PR DESCRIPTION
## Summary

- Plugins with missing/invalid configuration are now kept loaded in an **Unconfigured** state instead of being unloaded or moved to failed plugins
- Adds `ReconfigurePlugin(pluginId)` for the host to trigger re-validation after updating config — transitions plugins between Active/Unconfigured as needed
- Removes unused `ConfigureServices` from `IIvyPlugin` interface (all implementations were empty)
- Renames `GetLoadedPluginIds` → `GetActivePluginIds` (returns only fully-configured plugins)
- Adds `GetUnconfiguredPlugins()` returning schema + validation errors for UI consumption
- Updates `PluginManagerApp` with a new "Unconfigured Plugins" section

## State model

```
Unloaded  →  Loaded (Unconfigured)  →  Loaded (Active)
                                     ←  (via ReconfigurePlugin)
```