### PR TITLE
Add status indicator dot to AgentOutputView tool calls

### DIFF
--- a/src/widgets/Ivy.Widgets.AgentOutputView/frontend/src/AgentOutputView.tsx
+++ b/src/widgets/Ivy.Widgets.AgentOutputView/frontend/src/AgentOutputView.tsx
@@ -140,7 +140,7 @@ export const AgentOutputView: React.FC<AgentOutputViewProps> = ({
               return (
                 <ToolUseCard
                   key={idx}
-                  tool={{ name: event.name, input: event.input, result: event.result }}
+                  tool={{ name: event.name, input: event.input, result: event.result, isError: event.isError }}
                 />
               );
             case "system":

--- a/src/widgets/Ivy.Widgets.AgentOutputView/frontend/src/agent-output-view.css
+++ b/src/widgets/Ivy.Widgets.AgentOutputView/frontend/src/agent-output-view.css
@@ -256,6 +256,31 @@
   transform: rotate(180deg);
 }
 
+.aov-tool-status {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.aov-tool-status--success {
+  background: #22c55e;
+}
+
+.aov-tool-status--error {
+  background: #ef4444;
+}
+
+.aov-tool-status--running {
+  background: #3b82f6;
+  animation: aov-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes aov-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
 .aov-tool-name {
   color: var(--aov-accent);
   font-weight: 600;

--- a/src/widgets/Ivy.Widgets.AgentOutputView/frontend/src/renderers/claude-renderer.ts
+++ b/src/widgets/Ivy.Widgets.AgentOutputView/frontend/src/renderers/claude-renderer.ts
@@ -10,6 +10,7 @@ interface ClaudeContentBlock {
   input?: Record<string, unknown>;
   tool_use_id?: string;
   content?: unknown;
+  is_error?: boolean;
 }
 
 interface ClaudeMessage {
@@ -40,6 +41,7 @@ export const claudeRenderer: JsonStreamRenderer = {
 
     // First pass: collect tool results keyed by tool_use_id
     const toolResults = new Map<string, string>();
+    const toolErrors = new Set<string>();
     for (const e of raw) {
       if (e.type !== "user") continue;
       const blocks = e.message?.content ?? [];
@@ -51,6 +53,7 @@ export const claudeRenderer: JsonStreamRenderer = {
             contentToString(e.tool_use_result?.content) ||
             "";
           toolResults.set(b.tool_use_id, text);
+          if (b.is_error) toolErrors.add(b.tool_use_id);
         }
       }
     }
@@ -78,6 +81,7 @@ export const claudeRenderer: JsonStreamRenderer = {
               name: b.name,
               input: b.input ?? {},
               result: id ? toolResults.get(id) : undefined,
+              isError: id ? toolErrors.has(id) : undefined,
             });
           }
         }

--- a/src/widgets/Ivy.Widgets.AgentOutputView/frontend/src/tool-use-card.tsx
+++ b/src/widgets/Ivy.Widgets.AgentOutputView/frontend/src/tool-use-card.tsx
@@ -4,6 +4,7 @@ interface ToolCall {
   name: string;
   input: Record<string, unknown>;
   result?: string;
+  isError?: boolean;
 }
 
 interface ToolUseCardProps {
@@ -54,8 +55,17 @@ const ChevronDownIcon: React.FC = () => (
   </svg>
 );
 
+type ToolStatus = "running" | "success" | "error";
+
+function getToolStatus(tool: ToolCall): ToolStatus {
+  if (tool.result === undefined) return "running";
+  if (tool.isError) return "error";
+  return "success";
+}
+
 export const ToolUseCard: React.FC<ToolUseCardProps> = ({ tool }) => {
   const pending = tool.result === undefined;
+  const status = getToolStatus(tool);
   const [open, setOpen] = useState(false);
 
   const handleToggle = () => setOpen((o) => !o);
@@ -81,6 +91,7 @@ export const ToolUseCard: React.FC<ToolUseCardProps> = ({ tool }) => {
         <span className={`aov-tool-chevron ${open ? "open" : ""}`}>
           <ChevronDownIcon />
         </span>
+        <span className={`aov-tool-status aov-tool-status--${status}`} />
         <span className="aov-tool-name">{tool.name}</span>
         {headerPreview && <span className="aov-tool-preview">{headerPreview}</span>}
         {pending && <span className="aov-tool-running">running…</span>}


### PR DESCRIPTION
## Summary
- Add a small colored circle before each tool name in the AgentOutputView
- Green = finished successfully, Red = error, Blue (pulsing) = running
- Claude renderer tracks `is_error` from tool_result blocks to distinguish success/failure

## Test plan
- [x] TypeScript compiles cleanly
- [x] Vite production build succeeds
- [ ] Visual verification in running Tendril instance