### PR TITLE
[00073] Remove running italic label from AgentOutputView tool cards

### DIFF
--- a/src/widgets/Ivy.Widgets.AgentOutputView/frontend/src/agent-output-view.css
+++ b/src/widgets/Ivy.Widgets.AgentOutputView/frontend/src/agent-output-view.css
@@ -295,11 +295,6 @@
   min-width: 0;
 }
 
-.aov-tool-running {
-  color: var(--aov-fg-faint);
-  font-style: italic;
-}
-
 .aov-tool-body {
   padding: 4px 0 4px 22px;
   animation: aov-tool-expand 0.2s ease-out both;

--- a/src/widgets/Ivy.Widgets.AgentOutputView/frontend/src/tool-use-card.tsx
+++ b/src/widgets/Ivy.Widgets.AgentOutputView/frontend/src/tool-use-card.tsx
@@ -64,7 +64,6 @@ function getToolStatus(tool: ToolCall): ToolStatus {
 }
 
 export const ToolUseCard: React.FC<ToolUseCardProps> = ({ tool }) => {
-  const pending = tool.result === undefined;
   const status = getToolStatus(tool);
   const [open, setOpen] = useState(false);
 
@@ -94,7 +93,6 @@ export const ToolUseCard: React.FC<ToolUseCardProps> = ({ tool }) => {
         <span className={`aov-tool-status aov-tool-status--${status}`} />
         <span className="aov-tool-name">{tool.name}</span>
         {headerPreview && <span className="aov-tool-preview">{headerPreview}</span>}
-        {pending && <span className="aov-tool-running">running…</span>}
       </div>
       {open && (
         <div className="aov-tool-body">


### PR DESCRIPTION
# Summary

## Changes

Removed the "running…" italic label that appeared next to tool names in AgentOutputView tool call cards when tools were pending. This simplifies the UI by relying solely on the visual status indicator dot to convey tool execution state.

## API Changes

None.

## Files Modified

- **src/widgets/Ivy.Widgets.AgentOutputView/frontend/src/tool-use-card.tsx** — Removed `pending` variable and JSX element rendering "running…" label
- **src/widgets/Ivy.Widgets.AgentOutputView/frontend/src/agent-output-view.css** — Removed `.aov-tool-running` CSS class

---

## Commits

- 81bba7798 [00073] Remove running… label from AgentOutputView tool cards