### PR TITLE
[00258] Close color picker popover on swatch selection

### DIFF
--- a/src/frontend/src/widgets/inputs/ColorInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/ColorInputWidget.tsx
@@ -418,13 +418,15 @@ export const ColorInputWidget: React.FC<ColorInputWidgetProps> = ({
   }
 
   if (variant === "SwatchPicker") {
+    const [swatchPickerOpen, setSwatchPickerOpen] = useState(false);
     const handleSwatchSelect = (colorName: string) => {
       fireColorChange(colorName);
+      setSwatchPickerOpen(false);
     };
 
     return (
       <div className="flex items-center space-x-2">
-        <Popover>
+        <Popover open={swatchPickerOpen} onOpenChange={setSwatchPickerOpen}>
           <PopoverTrigger asChild>
             <button
               type="button"


### PR DESCRIPTION
## Changes

Converted the SwatchPicker variant's Radix UI Popover from uncontrolled to controlled by adding `useState` for open state. The popover now closes automatically when a color swatch is selected.

## API Changes

None.

## Files Modified

- `src/frontend/src/widgets/inputs/ColorInputWidget.tsx` — Added controlled open state to SwatchPicker Popover

---

**Commits:**
- ea697dbd5 [00258] Close color picker popover on swatch selection