### PR TITLE
[00268] Fix DataTable filter loading indicator and clear button position

### DIFF
--- a/src/frontend/src/widgets/dataTables/options/DataTableFilterOption.tsx
+++ b/src/frontend/src/widgets/dataTables/options/DataTableFilterOption.tsx
@@ -272,7 +272,7 @@ export const DataTableFilterOption: React.FC<{
       <div
         className={cn(
           "query-editor-wrapper relative cursor-text",
-          "flex h-full min-h-9 w-full max-w-full min-w-0 flex-col",
+          "flex h-full w-full max-w-full min-w-0 flex-col",
           "min-h-0 overflow-hidden bg-background text-sm",
         )}
         data-query-valid={isQueryValid}
@@ -293,7 +293,7 @@ export const DataTableFilterOption: React.FC<{
         <style>{tableStyles.queryEditor.css}</style>
 
         {isParsing ? (
-          <div className="absolute right-0 top-1/2 z-10 flex h-9 -translate-y-1/2 items-center border-l border-input bg-background px-2.5">
+          <div className="absolute right-0 top-0 z-10 flex h-9 items-center border-l border-input bg-background px-2.5">
             <Loader2 className="h-4 w-4 shrink-0 animate-spin text-muted-foreground" />
           </div>
         ) : (
@@ -303,7 +303,7 @@ export const DataTableFilterOption: React.FC<{
             onClick={handleClearFilter}
             disabled={!query}
             className={cn(
-              "absolute right-0 top-1/2 z-10 h-9 -translate-y-1/2 shrink-0 border-l border-input bg-background px-3 text-sm shadow-none hover:bg-muted hover:text-accent-foreground focus-visible:ring-0 focus-visible:ring-offset-0",
+              "absolute right-0 top-0 z-10 h-9 shrink-0 border-l border-input bg-background px-3 text-sm shadow-none hover:bg-muted hover:text-accent-foreground focus-visible:ring-0 focus-visible:ring-offset-0",
               query ? "" : "hidden",
             )}
           >


### PR DESCRIPTION
# Summary

## Changes

Fixed the DataTable filter loading spinner and clear button positioning by replacing `top-1/2 -translate-y-1/2` transform-based vertical centering with `top-0` alignment. Removed a conflicting `min-h-9` class from the query editor wrapper div that was redundant with the existing `min-h-0` class.

## API Changes

None.

## Files Modified

- **src/frontend/src/widgets/dataTables/options/DataTableFilterOption.tsx** — Fixed CSS positioning classes for loading indicator (line 296), clear button (line 306), and removed conflicting min-height class from wrapper div (line 275).

---

Commits: 3db1cfd3c