### PR TITLE
[00269] Keep theme selector open when selecting a theme

### DIFF
--- a/src/Ivy/Widgets/DropDownMenu.cs
+++ b/src/Ivy/Widgets/DropDownMenu.cs
@@ -59,6 +59,8 @@ public record DropDownMenu : WidgetBase<DropDownMenu>
 
     [Prop] public int AlignOffset { get; set; } = 0;
 
+    [Prop] public bool StayOpen { get; set; } = false;
+
     [Event] public EventHandler<Event<DropDownMenu, object>>? OnSelect { get; set; }
 
     public static DropDownMenu operator |(DropDownMenu widget, object child)
@@ -121,6 +123,11 @@ public static class DropDownMenuExtensions
     public static DropDownMenu Left(this DropDownMenu dropDownMenu)
     {
         return dropDownMenu with { Side = DropDownMenu.SideOptions.Left };
+    }
+
+    public static DropDownMenu StayOpen(this DropDownMenu dropDownMenu, bool stayOpen = true)
+    {
+        return dropDownMenu with { StayOpen = stayOpen };
     }
 
     public static DropDownMenu Items(this DropDownMenu dropDownMenu, IEnumerable<MenuItem> items)

--- a/src/frontend/src/widgets/dropDownMenu/DropDownMenuWidget.tsx
+++ b/src/frontend/src/widgets/dropDownMenu/DropDownMenuWidget.tsx
@@ -30,6 +30,7 @@ interface DropDownMenuWidgetProps {
   align?: "Start" | "Center" | "End";
   side?: "Top" | "Right" | "Bottom" | "Left";
   alignOffset?: number;
+  stayOpen?: boolean;
   density?: Densities;
   events?: string[];
   slots?: {
@@ -42,9 +43,10 @@ interface DropDownMenuItemGroupProps {
   items: MenuItem[];
   onItemClick: (item: MenuItem) => void;
   iconSize: number;
+  stayOpen?: boolean;
 }
 
-const DropDownMenuItemGroup = ({ items, onItemClick, iconSize }: DropDownMenuItemGroupProps) => {
+const DropDownMenuItemGroup = ({ items, onItemClick, iconSize, stayOpen }: DropDownMenuItemGroupProps) => {
   return items.map((item, i) => {
     const colorStyle = item.color ? getColor(item.color, "color") : {};
 
@@ -59,6 +61,7 @@ const DropDownMenuItemGroup = ({ items, onItemClick, iconSize }: DropDownMenuIte
               items={item.children}
               onItemClick={onItemClick}
               iconSize={iconSize}
+              stayOpen={stayOpen}
             />
           </DropdownMenuGroup>
         </React.Fragment>
@@ -76,6 +79,7 @@ const DropDownMenuItemGroup = ({ items, onItemClick, iconSize }: DropDownMenuIte
         <DropdownMenuItem
           key={item.label}
           onClick={() => onItemClick(item)}
+          onSelect={stayOpen ? (e) => e.preventDefault() : undefined}
           disabled={item.disabled}
           style={colorStyle}
           className={item.checked ? "bg-accent" : ""}
@@ -95,6 +99,7 @@ const DropDownMenuItemGroup = ({ items, onItemClick, iconSize }: DropDownMenuIte
         <DropdownMenuItem
           key={item.label}
           onClick={() => onItemClick(item)}
+          onSelect={stayOpen ? (e) => e.preventDefault() : undefined}
           disabled={item.disabled}
           style={colorStyle}
           className={item.checked ? "bg-accent" : ""}
@@ -126,6 +131,7 @@ const DropDownMenuItemGroup = ({ items, onItemClick, iconSize }: DropDownMenuIte
                 items={item.children}
                 onItemClick={onItemClick}
                 iconSize={iconSize}
+                stayOpen={stayOpen}
               />
             </DropdownMenuSubContent>
           </DropdownMenuPortal>
@@ -138,6 +144,7 @@ const DropDownMenuItemGroup = ({ items, onItemClick, iconSize }: DropDownMenuIte
       <DropdownMenuItem
         key={item.label}
         onClick={() => onItemClick(item)}
+        onSelect={stayOpen ? (e) => e.preventDefault() : undefined}
         disabled={item.disabled}
         style={colorStyle}
       >
@@ -158,6 +165,7 @@ export const DropDownMenuWidget: React.FC<DropDownMenuWidgetProps> = ({
   align = "Start",
   side = "Bottom",
   alignOffset = 0,
+  stayOpen = false,
   density = Densities.Medium,
   events = [],
 }) => {
@@ -203,7 +211,7 @@ export const DropDownMenuWidget: React.FC<DropDownMenuWidgetProps> = ({
         alignOffset={alignOffset}
       >
         {slots.Header && <DropdownMenuLabel>{slots.Header}</DropdownMenuLabel>}
-        <DropDownMenuItemGroup items={items} onItemClick={onItemClick} iconSize={iconSize} />
+        <DropDownMenuItemGroup items={items} onItemClick={onItemClick} iconSize={iconSize} stayOpen={stayOpen} />
       </DropdownMenuContent>
     </DropdownMenu>
   );


### PR DESCRIPTION
Added a `StayOpen` property to the `DropDownMenu` widget that prevents the menu from closing when an item is selected. When `stayOpen` is true, `onSelect={(e) => e.preventDefault()}` is applied to menu items to prevent Radix's default close-on-select behavior.

## API Changes

- `DropDownMenu.StayOpen` — new `[Prop] public bool StayOpen { get; set; }` property
- `DropDownMenuExtensions.StayOpen(this DropDownMenu, bool)` — new extension method

## Commits

- `142e47f53` [00269] Add StayOpen property to DropDownMenu widget