### PR TITLE
Move ActivityHeatmap and QRCode Tests out of `Ivy.Test`

### DIFF
--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/Ivy.Widgets.ActivityHeatmap.csproj
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/Ivy.Widgets.ActivityHeatmap.csproj
@@ -42,6 +42,7 @@
   <ItemGroup>
     <Compile Remove=".samples\**\*.cs" />
     <Compile Remove="frontend\node_modules\**" />
+    <Compile Remove="Tests\**\*.cs" />
     <None Include=".samples\**\*" CopyToOutputDirectory="Never" />
   </ItemGroup>
 

--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/Tests/ActivityHeatmapTests.cs
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/Tests/ActivityHeatmapTests.cs
@@ -1,6 +1,6 @@
 using Ivy.Widgets.ActivityHeatmap;
 
-namespace Ivy.Test;
+namespace Ivy.Widgets.ActivityHeatmap.Tests;
 
 public class ActivityHeatmapTests
 {

--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/Tests/Ivy.Widgets.ActivityHeatmap.Tests.csproj
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/Tests/Ivy.Widgets.ActivityHeatmap.Tests.csproj
@@ -1,13 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="../../../Ivy/Directory.Build.props" Condition="Exists('../../../Ivy/Directory.Build.props')" />
-
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <NoWarn>CS1591</NoWarn>
-
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
@@ -27,11 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="../Ivy/Ivy.csproj" />
+    <ProjectReference Include="..\Ivy.Widgets.ActivityHeatmap.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/widgets/Ivy.Widgets.QRCode/Ivy.Widgets.QRCode.csproj
+++ b/src/widgets/Ivy.Widgets.QRCode/Ivy.Widgets.QRCode.csproj
@@ -41,6 +41,7 @@
 
   <ItemGroup>
     <Compile Remove=".samples\**\*.cs" />
+    <Compile Remove="Tests\**\*.cs" />
     <None Include=".samples\**\*" CopyToOutputDirectory="Never" />
   </ItemGroup>
 

--- a/src/widgets/Ivy.Widgets.QRCode/Tests/Ivy.Widgets.QRCode.Tests.csproj
+++ b/src/widgets/Ivy.Widgets.QRCode/Tests/Ivy.Widgets.QRCode.Tests.csproj
@@ -1,13 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="../../../Ivy/Directory.Build.props" Condition="Exists('../../../Ivy/Directory.Build.props')" />
-
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <NoWarn>CS1591</NoWarn>
-
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
@@ -27,11 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="../Ivy/Ivy.csproj" />
+    <ProjectReference Include="..\Ivy.Widgets.QRCode.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/widgets/Ivy.Widgets.QRCode/Tests/QRCodeTests.cs
+++ b/src/widgets/Ivy.Widgets.QRCode/Tests/QRCodeTests.cs
@@ -5,7 +5,7 @@ using Ivy.Core;
 using Ivy.Widgets.QRCode;
 using Xunit.Abstractions;
 
-namespace Ivy.Test;
+namespace Ivy.Widgets.QRCode.Tests;
 
 public class QRCodeTests(ITestOutputHelper output)
 {


### PR DESCRIPTION
## Summary
Created widget-local xunit test projects for `Ivy.Widgets.ActivityHeatmap` and `Ivy.Widgets.QRCode`, each in a `Tests/` subdirectory of the external widget's folder. Moved `ActivityHeatmapTests.cs` and `QRCodeTests.cs` from `Ivy.Test` into these new projects with updated namespaces, and removed the widget project references from `Ivy.Test.csproj`. Added `<Compile Remove="Tests\**\*.cs" />` to both external widget `.csproj` files to prevent the SDK from auto-including test files in the widget library builds.

## Files Modified

**New test projects:**
- `src/widgets/Ivy.Widgets.ActivityHeatmap/Tests/Ivy.Widgets.ActivityHeatmap.Tests.csproj` — new xunit test project
- `src/widgets/Ivy.Widgets.ActivityHeatmap/Tests/ActivityHeatmapTests.cs` — moved from `Ivy.Test`, namespace updated to `Ivy.Widgets.ActivityHeatmap.Tests`
- `src/widgets/Ivy.Widgets.QRCode/Tests/Ivy.Widgets.QRCode.Tests.csproj` — new xunit test project
- `src/widgets/Ivy.Widgets.QRCode/Tests/QRCodeTests.cs` — moved from `Ivy.Test`, namespace updated to `Ivy.Widgets.QRCode.Tests`

**Modified widget projects:**
- `src/widgets/Ivy.Widgets.ActivityHeatmap/Ivy.Widgets.ActivityHeatmap.csproj` — added `<Compile Remove="Tests\**\*.cs" />`
- `src/widgets/Ivy.Widgets.QRCode/Ivy.Widgets.QRCode.csproj` — added `<Compile Remove="Tests\**\*.cs" />`

**Cleaned up:**
- `src/Ivy.Test/Ivy.Test.csproj` — removed `ActivityHeatmap` and `QRCode` project references
- `src/Ivy.Test/ActivityHeatmapTests.cs` — deleted
- `src/Ivy.Test/QRCodeTests.cs` — deleted

---
- 92682b339 [00071] Move ActivityHeatmap and QRCode tests to widget-local test projects
- e4015a96f [00071] Exclude Tests/ subdirectory from widget library compilation