### PR TITLE
[00272] Fix CI errors on port/filter-query-editor PR

### DIFF
--- a/src/frontend/src/lib/filter-query-editor/components/ui/card.tsx
+++ b/src/frontend/src/lib/filter-query-editor/components/ui/card.tsx
@@ -20,12 +20,14 @@ const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDiv
 CardHeader.displayName = "CardHeader";
 
 const CardTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
-  ({ className, ...props }, ref) => (
+  ({ className, children, ...props }, ref) => (
     <h3
       ref={ref}
       className={cn("text-2xl font-semibold leading-none tracking-tight", className)}
       {...props}
-    />
+    >
+      {children}
+    </h3>
   ),
 );
 CardTitle.displayName = "CardTitle";

--- a/src/frontend/src/widgets/dropDownMenu/DropDownMenuWidget.tsx
+++ b/src/frontend/src/widgets/dropDownMenu/DropDownMenuWidget.tsx
@@ -46,7 +46,12 @@ interface DropDownMenuItemGroupProps {
   stayOpen?: boolean;
 }
 
-const DropDownMenuItemGroup = ({ items, onItemClick, iconSize, stayOpen }: DropDownMenuItemGroupProps) => {
+const DropDownMenuItemGroup = ({
+  items,
+  onItemClick,
+  iconSize,
+  stayOpen,
+}: DropDownMenuItemGroupProps) => {
   return items.map((item, i) => {
     const colorStyle = item.color ? getColor(item.color, "color") : {};
 
@@ -211,7 +216,12 @@ export const DropDownMenuWidget: React.FC<DropDownMenuWidgetProps> = ({
         alignOffset={alignOffset}
       >
         {slots.Header && <DropdownMenuLabel>{slots.Header}</DropdownMenuLabel>}
-        <DropDownMenuItemGroup items={items} onItemClick={onItemClick} iconSize={iconSize} stayOpen={stayOpen} />
+        <DropDownMenuItemGroup
+          items={items}
+          onItemClick={onItemClick}
+          iconSize={iconSize}
+          stayOpen={stayOpen}
+        />
       </DropdownMenuContent>
     </DropdownMenu>
   );


### PR DESCRIPTION
Fixed two CI failures on the port/filter-query-editor PR: applied `vp fmt` formatting to DropDownMenuWidget.tsx (inherited from a development branch commit), and added explicit `children` prop handling to CardTitle component in card.tsx to satisfy the `jsx-a11y/heading-has-content` lint rule. The third CI issue (unnecessary `using Ivy;` directive) was already resolved by a prior commit on the PR branch.

## Files Modified

- `src/frontend/src/widgets/dropDownMenu/DropDownMenuWidget.tsx` — formatting fix (StayOpen property code style)
- `src/frontend/src/lib/filter-query-editor/components/ui/card.tsx` — CardTitle now explicitly renders `children` instead of relying on spread props

---

Commits:
- 290afcbb5 [00272] Fix CI errors: remove unused using, fix heading a11y, format DropDownMenu