### PR TITLE
[00273] Fix unused catch variable in filter-query-editor formatting

### DIFF
--- a/src/frontend/src/lib/filter-query-editor/components/extensions/formatting.ts
+++ b/src/frontend/src/lib/filter-query-editor/components/extensions/formatting.ts
@@ -72,7 +72,7 @@ function formatDocument(view: EditorView, columns: ColumnDef[]): boolean {
     }
 
     return true;
-  } catch (error) {
+  } catch {
     // Silently ignore formatting errors
     // The validation extension will show the actual errors
     return false;


### PR DESCRIPTION
Replace `catch (error)` with `catch` in `src/frontend/src/lib/filter-query-editor/components/extensions/formatting.ts` to suppress the unused variable lint warning.

---

**Commits:**
- 4231059d1 — Remove unused catch variable in filter-query-editor formatting