### PR TITLE
[00280] DataTable: Collapse height and show 'no rows' message when empty or filtered to zero

### DIFF
--- a/src/frontend/src/widgets/dataTables/DataTableWidget.tsx
+++ b/src/frontend/src/widgets/dataTables/DataTableWidget.tsx
@@ -37,11 +37,7 @@ const TableLayout: React.FC<TableLayoutProps> = ({ children }) => {
     );
   }
 
-  return (
-    <div style={{ ...tableStyles.table.container }}>
-      {children}
-    </div>
-  );
+  return <div style={{ ...tableStyles.table.container }}>{children}</div>;
 };
 
 interface DataTableWidgetProps extends TableProps {

--- a/src/frontend/src/widgets/dataTables/DataTableWidget.tsx
+++ b/src/frontend/src/widgets/dataTables/DataTableWidget.tsx
@@ -19,11 +19,10 @@ import type { SpriteMap } from "@glideapps/glide-data-grid";
 
 interface TableLayoutProps {
   children?: React.ReactNode;
-  emptyView?: React.ReactNode[];
 }
 
-const TableLayout: React.FC<TableLayoutProps> = ({ children, emptyView }) => {
-  const { error, columns, visibleRows, isLoading } = useTable();
+const TableLayout: React.FC<TableLayoutProps> = ({ children }) => {
+  const { error, columns } = useTable();
   const showTableEditor = columns.length > 0;
 
   if (error) {
@@ -38,34 +37,9 @@ const TableLayout: React.FC<TableLayoutProps> = ({ children, emptyView }) => {
     );
   }
 
-  // When the table has loaded but holds no rows (e.g. a filter matched
-  // nothing) keep the full table chrome — header, filter bar, borders —
-  // rendered, and overlay the empty-view slot on top of the (now empty)
-  // grid body instead of replacing the whole component with it. Replacing
-  // it removed the filter input, so the user could no longer change or
-  // clear the filter that produced the empty result.
-  const showEmptyOverlay = !isLoading && visibleRows === 0 && !!emptyView && emptyView.length > 0;
-
   return (
-    <div style={{ ...tableStyles.table.container, position: "relative" }}>
+    <div style={{ ...tableStyles.table.container }}>
       {children}
-      {showEmptyOverlay && (
-        <div
-          style={{
-            position: "absolute",
-            inset: 0,
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            // Let the header / filter bar above stay interactive; only the
-            // grid body region is covered by this overlay.
-            pointerEvents: "none",
-          }}
-          data-testid="datatable-empty-overlay"
-        >
-          <div style={{ pointerEvents: "auto" }}>{emptyView}</div>
-        </div>
-      )}
     </div>
   );
 };
@@ -126,14 +100,13 @@ export const DataTable: React.FC<DataTableWidgetProps> = ({
   // If height is Full, use flex-based sizing instead of height: 100%.
   // In unconstrained parents (e.g. Layout.Vertical() with no explicit height),
   // height: 100% resolves to 0 because the parent has no definite height.
-  // flexGrow fills available space in flex parents, while minHeight ensures
-  // at least ~5 rows are visible in unconstrained parents.
+  // flexGrow fills available space in flex parents. When empty, the table
+  // collapses to just headers + "no rows" message with no forced min height.
   if (height === "Full") {
     delete containerStyle.height;
     containerStyle.display = "flex";
     containerStyle.flexDirection = "column";
     containerStyle.flexGrow = 1;
-    containerStyle.minHeight = "200px";
   }
 
   return (
@@ -146,7 +119,7 @@ export const DataTable: React.FC<DataTableWidgetProps> = ({
         density={density}
         updateStream={updateStream}
       >
-        <TableLayout emptyView={slots?.EmptyView}>
+        <TableLayout>
           <DataTableHeader>
             <div className="flex items-center gap-2 w-full">
               <div className="flex items-center gap-1">

--- a/src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx
+++ b/src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx
@@ -472,6 +472,20 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
         footer={footerNode}
         hasEmptyRows={emptyRowsCount > 0}
       />
+      {visibleRows === 0 && !isLoading && (
+        <div
+          style={{
+            padding: "12px 16px",
+            textAlign: "center",
+            color: "var(--muted-foreground)",
+            fontSize: "0.875rem",
+            borderTop: "1px solid var(--border)",
+          }}
+          data-testid="datatable-no-rows-message"
+        >
+          No rows to display
+        </div>
+      )}
       {supportsHoverTooltip ? linkTooltipNode : null}
       {cellActionIndicatorNode}
     </>

--- a/src/frontend/src/widgets/dataTables/hooks/useEmptyRows.ts
+++ b/src/frontend/src/widgets/dataTables/hooks/useEmptyRows.ts
@@ -21,11 +21,9 @@ export const useEmptyRows = ({
   rowHeight,
 }: UseEmptyRowsProps) => {
   const whitespaceHeight = useMemo(() => {
-    // visibleRows === 0 is intentionally NOT short-circuited: a loaded but
-    // empty result (e.g. a filter that matched nothing) still needs filler
-    // rows so the grid keeps its header and a full-height empty body.
-    // Without this the grid collapses to ~0 height and the whole table
-    // appears to be removed from the page.
+    // When there are no visible rows, collapse — don't fill with empty rows.
+    // The "no rows to display" message is shown separately below the grid.
+    if (visibleRows === 0) return 0;
     if (hasMore || scrollContainerHeight === 0) return 0;
 
     const totalHeaderHeight = rowHeight + (showGroups ? GROUP_HEADER_HEIGHT : 0);


### PR DESCRIPTION
# Summary

## Changes

Modified the DataTable widget to collapse its height and show a "No rows to display" message when there are zero visible rows (empty dataset or filter matches nothing). Removed the previous behavior of filling the grid with empty filler rows and showing an absolute-positioned overlay.

## API Changes

- `TableLayout` component no longer accepts or renders the `emptyView` prop (the `EmptyView` slot type is preserved in `DataTableWidgetProps` for backward compatibility but is no longer rendered)
- Removed `minHeight: "200px"` from the Full height container style
- Added `data-testid="datatable-no-rows-message"` to the new no-rows message element

## Files Modified

- **src/frontend/src/widgets/dataTables/hooks/useEmptyRows.ts** — Added early return of 0 when `visibleRows === 0`
- **src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx** — Added "No rows to display" message after GridContainer
- **src/frontend/src/widgets/dataTables/DataTableWidget.tsx** — Removed empty overlay from TableLayout, removed minHeight

---

### Commits
- 5976da157 [00280] Collapse DataTable height and show 'no rows' message when empty
- b68d338f6 [00280] Fix formatting in DataTableWidget