### PR TITLE
[00284] Remove 'No rows to display' message from DataTable

### DIFF
--- a/src/frontend/src/widgets/dataTables/DataTableWidget.tsx
+++ b/src/frontend/src/widgets/dataTables/DataTableWidget.tsx
@@ -97,7 +97,7 @@ export const DataTable: React.FC<DataTableWidgetProps> = ({
   // In unconstrained parents (e.g. Layout.Vertical() with no explicit height),
   // height: 100% resolves to 0 because the parent has no definite height.
   // flexGrow fills available space in flex parents. When empty, the table
-  // collapses to just headers + "no rows" message with no forced min height.
+  // collapses to just headers with no forced min height.
   if (height === "Full") {
     delete containerStyle.height;
     containerStyle.display = "flex";

--- a/src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx
+++ b/src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx
@@ -472,20 +472,6 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
         footer={footerNode}
         hasEmptyRows={emptyRowsCount > 0}
       />
-      {visibleRows === 0 && !isLoading && (
-        <div
-          style={{
-            padding: "12px 16px",
-            textAlign: "center",
-            color: "var(--muted-foreground)",
-            fontSize: "0.875rem",
-            borderTop: "1px solid var(--border)",
-          }}
-          data-testid="datatable-no-rows-message"
-        >
-          No rows to display
-        </div>
-      )}
       {supportsHoverTooltip ? linkTooltipNode : null}
       {cellActionIndicatorNode}
     </>

--- a/src/frontend/src/widgets/dataTables/hooks/useEmptyRows.ts
+++ b/src/frontend/src/widgets/dataTables/hooks/useEmptyRows.ts
@@ -22,7 +22,6 @@ export const useEmptyRows = ({
 }: UseEmptyRowsProps) => {
   const whitespaceHeight = useMemo(() => {
     // When there are no visible rows, collapse — don't fill with empty rows.
-    // The "no rows to display" message is shown separately below the grid.
     if (visibleRows === 0) return 0;
     if (hasMore || scrollContainerHeight === 0) return 0;
 


### PR DESCRIPTION
Removes the "No rows to display" message div from the DataTable component. When there are no visible rows, the table now simply shows as empty (headers only) without any message text. The table collapse behavior remains intact.

---

**Commits:**
- 664654d52 [00284] Remove 'No rows to display' message from DataTable