### PR TITLE
[00286] Fix stale DataTable frontend tests expecting removed minHeight

### DIFF
--- a/src/frontend/src/widgets/dataTables/DataTableWidget.test.ts
+++ b/src/frontend/src/widgets/dataTables/DataTableWidget.test.ts
@@ -14,9 +14,8 @@ describe("DataTableWidget - container style for height modes", () => {
     expect(source).toContain('containerStyle.flexDirection = "column"');
   });
 
-  it("should set flexGrow and minHeight for Full height mode", () => {
+  it("should set flexGrow for Full height mode", () => {
     expect(source).toContain("containerStyle.flexGrow = 1");
-    expect(source).toContain('containerStyle.minHeight = "200px"');
   });
 
   it("should apply getHeight for explicit pixel heights", () => {

--- a/src/frontend/src/widgets/dataTables/hooks/useContainerSize.test.ts
+++ b/src/frontend/src/widgets/dataTables/hooks/useContainerSize.test.ts
@@ -73,19 +73,13 @@ describe("useContainerSize - synchronous initial measurement", () => {
 });
 
 /**
- * Tests for DataTableWidget min-height fallback.
+ * Tests for DataTableWidget flex sizing in unconstrained parents.
  *
- * When height="Full", the container must have a non-zero min-height
- * so that useContainerSize can measure something even in unconstrained parents.
+ * When height="Full", the container uses flex-based sizing instead of
+ * height: 100% (which resolves to 0 in unconstrained parents).
  */
-describe("DataTableWidget - min-height fallback for unconstrained parents", () => {
+describe("DataTableWidget - flex sizing for unconstrained parents", () => {
   const widgetSource = fs.readFileSync(path.resolve(__dirname, "../DataTableWidget.tsx"), "utf-8");
-
-  it('should set minHeight to "200px" when height is "Full"', () => {
-    // The fix adds minHeight: "200px" to ensure the container has a
-    // non-zero height for measurement in unconstrained flex parents
-    expect(widgetSource).toContain('minHeight = "200px"');
-  });
 
   it('should remove height: 100% when height is "Full"', () => {
     // height: 100% doesn't work in unconstrained parents (resolves to 0)


### PR DESCRIPTION
# Summary

## Changes

Removed stale `minHeight = "200px"` assertions from two DataTable frontend test files. Plan [00280] deliberately removed the minimum height from DataTableWidget, but the tests were not updated to match. The tests now correctly validate the flex-based sizing behavior.

## API Changes

None.

## Files Modified

- `src/frontend/src/widgets/dataTables/DataTableWidget.test.ts` — Removed `minHeight` assertion, renamed test
- `src/frontend/src/widgets/dataTables/hooks/useContainerSize.test.ts` — Removed `minHeight` test case, renamed describe block

---

**Commits:**
- 661eaab70 [00286] Remove stale minHeight assertions from DataTable tests