### PR TITLE
[00288] Add overflow-hidden to CodeBlock widget to clip content at rounded corners

### DIFF
--- a/src/frontend/src/widgets/primitives/CodeBlockWidget.tsx
+++ b/src/frontend/src/widgets/primitives/CodeBlockWidget.tsx
@@ -183,7 +183,7 @@ const CodeWidget: React.FC<CodeWidgetProps> = memo(
           className={cn(
             "w-full",
             isFull ? "flex-1 min-h-0" : "h-full",
-            showBorder && "rounded-md border border-border",
+            showBorder && "overflow-hidden rounded-md border border-border",
           )}
           viewportClassName="min-w-0"
           viewportStyle={copyViewportInset}


### PR DESCRIPTION
## Changes

Added `overflow-hidden` to the `ScrollArea` className in `CodeBlockWidget.tsx`, conditional on `showBorder`, so inner content (syntax-highlighted code, backgrounds) is clipped at the rounded corners. This mirrors the fix previously applied to `CodeInputWidget.tsx`.

## Files Modified

- `src/frontend/src/widgets/primitives/CodeBlockWidget.tsx` — Added `overflow-hidden` to ScrollArea className when border is shown

---

**Commits:**
- 396a7e84c [00288] Add overflow-hidden to CodeBlock widget to clip content at rounded corners