### PR TITLE
(datatable): fix header cell styling when sorting

### DIFF
--- a/src/frontend/src/widgets/dataTables/components/GridContainer.tsx
+++ b/src/frontend/src/widgets/dataTables/components/GridContainer.tsx
@@ -7,6 +7,7 @@ import DataEditor, {
   GridMouseEventArgs,
   GridSelection,
   GroupHeaderClickedEventArgs,
+  HeaderClickedEventArgs,
   Highlight,
   Item,
   SpriteMap,
@@ -27,7 +28,7 @@ interface GridContainerProps {
   headerIcons: SpriteMap;
   onColumnResize?: (column: GridColumn, newSize: number) => void;
   onVisibleRegionChanged: (range: { x: number; y: number; width: number; height: number }) => void;
-  onHeaderClicked?: (col: number) => void;
+  onHeaderClicked?: (col: number, event: HeaderClickedEventArgs) => void;
   theme: Partial<Theme> | undefined;
   rowHeight: number;
   headerHeight: number;

--- a/src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx
+++ b/src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx
@@ -115,6 +115,10 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
   const gridRef = useRef<DataEditorRef | null>(null);
   const prevVisibleScrollOriginRef = useRef<{ x: number; y: number } | null>(null);
 
+  const sortingEnabled = allowSorting ?? true;
+  // Header clicks sort columns; column-select on mousedown would paint accentColor headers.
+  const columnSelect = sortingEnabled ? "none" : selectionProps.columnSelect;
+
   // Cell content
   const { getCellContent } = useCellContent({
     columns,
@@ -128,6 +132,7 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
   const { gridSelection, handleGridSelectionChange, setGridSelection } = useGridSelection({
     visibleRows,
     getCellContent,
+    allowSorting: sortingEnabled,
   });
 
   // Cell interactions
@@ -182,6 +187,7 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
     visibleRows,
     hoverRow,
     density,
+    suppressHeaderHoverHighlight: sortingEnabled,
   });
 
   const { onSearchResultsChanged, onSearchClose, highlightRegions } = useSearchNavigation(
@@ -223,8 +229,10 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
   // Header menu handling
   const { handleHeaderMenuClick } = useHeaderMenu({
     columns,
-    allowSorting: allowSorting ?? true,
+    columnOrder,
+    allowSorting: sortingEnabled,
     handleSort,
+    setGridSelection,
   });
 
   // Grid columns configuration (last column uses grow:1 to fill space; no manual
@@ -445,7 +453,7 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
         freezeColumns={freezeColumns ?? 0}
         getCellsForSelection={(allowCopySelection ?? true) ? true : undefined}
         rowSelect={selectionProps.rowSelect}
-        columnSelect={selectionProps.columnSelect}
+        columnSelect={columnSelect}
         rangeSelect={selectionProps.rangeSelect}
         gridSelection={gridSelection}
         onGridSelectionChange={handleGridSelectionChange}

--- a/src/frontend/src/widgets/dataTables/dataTableEditor/hooks/useHeaderMenu.ts
+++ b/src/frontend/src/widgets/dataTables/dataTableEditor/hooks/useHeaderMenu.ts
@@ -1,31 +1,50 @@
-import { useCallback } from "react";
+import { useCallback, type Dispatch, type SetStateAction } from "react";
+import {
+  CompactSelection,
+  GridSelection,
+  HeaderClickedEventArgs,
+} from "@glideapps/glide-data-grid";
+import { getOrderedVisibleDataColumns } from "../../utils/columnHelpers";
 import { DataColumn } from "../../types/types";
 
 interface UseHeaderMenuProps {
   columns: DataColumn[];
+  columnOrder: number[];
   allowSorting: boolean;
   handleSort: (columnName: string) => void;
+  setGridSelection: Dispatch<SetStateAction<GridSelection>>;
 }
 
 /**
  * Hook for handling header menu interactions (e.g., sorting)
  */
-export const useHeaderMenu = ({ columns, allowSorting, handleSort }: UseHeaderMenuProps) => {
+export const useHeaderMenu = ({
+  columns,
+  columnOrder,
+  allowSorting,
+  handleSort,
+  setGridSelection,
+}: UseHeaderMenuProps) => {
   const handleHeaderMenuClick = useCallback(
-    (col: number) => {
-      // Only handle sorting if it's enabled globally
+    (col: number, event: HeaderClickedEventArgs) => {
       if (!allowSorting) return;
+      // Modifier clicks are for column selection, not sorting.
+      if (event.ctrlKey || event.metaKey || event.shiftKey) return;
 
-      // Get visible columns to map the correct column index
-      const visibleColumns = columns.filter((c) => !c.hidden);
+      event.preventDefault();
+
+      const visibleColumns = getOrderedVisibleDataColumns(columns, columnOrder);
       const column = visibleColumns[col];
 
-      // Check if this specific column is sortable (defaults to true if not specified)
       if (column && (column.sortable ?? true)) {
         handleSort(column.name);
+        setGridSelection((prev) => ({
+          ...prev,
+          columns: CompactSelection.empty(),
+        }));
       }
     },
-    [columns, handleSort, allowSorting],
+    [columns, columnOrder, handleSort, allowSorting, setGridSelection],
   );
 
   return { handleHeaderMenuClick };

--- a/src/frontend/src/widgets/dataTables/hooks/useGridSelection.ts
+++ b/src/frontend/src/widgets/dataTables/hooks/useGridSelection.ts
@@ -10,12 +10,17 @@ import {
 interface UseGridSelectionProps {
   visibleRows: number;
   getCellContent: (cell: Item) => GridCell;
+  allowSorting?: boolean;
 }
 
 /**
  * Hook to manage grid selection state and changes
  */
-export const useGridSelection = ({ visibleRows, getCellContent }: UseGridSelectionProps) => {
+export const useGridSelection = ({
+  visibleRows,
+  getCellContent,
+  allowSorting = false,
+}: UseGridSelectionProps) => {
   const [gridSelection, setGridSelection] = useState<GridSelection>({
     columns: CompactSelection.empty(),
     rows: CompactSelection.empty(),
@@ -23,6 +28,14 @@ export const useGridSelection = ({ visibleRows, getCellContent }: UseGridSelecti
 
   const handleGridSelectionChange = useCallback(
     (newSelection: GridSelection) => {
+      if (allowSorting && newSelection.columns.length > 0) {
+        setGridSelection({
+          ...newSelection,
+          columns: CompactSelection.empty(),
+        });
+        return;
+      }
+
       // Consolidate check for newSelection.current
       if (newSelection.current !== undefined) {
         const [col, row] = newSelection.current.cell;
@@ -53,7 +66,7 @@ export const useGridSelection = ({ visibleRows, getCellContent }: UseGridSelecti
 
       setGridSelection(newSelection);
     },
-    [getCellContent, visibleRows],
+    [getCellContent, visibleRows, allowSorting],
   );
 
   return {

--- a/src/frontend/src/widgets/dataTables/hooks/useTableTheme.ts
+++ b/src/frontend/src/widgets/dataTables/hooks/useTableTheme.ts
@@ -11,6 +11,8 @@ interface UseTableThemeProps {
   visibleRows: number;
   hoverRow: number | undefined;
   density?: Densities;
+  /** When true, header hover uses the same color as the default header (no click flash). */
+  suppressHeaderHoverHighlight?: boolean;
 }
 
 /**
@@ -22,6 +24,7 @@ export const useTableTheme = ({
   visibleRows,
   hoverRow,
   density = Densities.Medium,
+  suppressHeaderHoverHighlight = false,
 }: UseTableThemeProps) => {
   const densityConfig = DENSITY_CONFIG[density];
   const {
@@ -31,42 +34,47 @@ export const useTableTheme = ({
   } = useThemeWithMonitoring<Partial<Theme>>({
     monitorDOM: true,
     monitorSystem: true,
-    customThemeGenerator: (colors: ThemeColors, isDark: boolean): Partial<Theme> => ({
-      bgCell: colors.background || (isDark ? "#000000" : "#ffffff"),
-      bgHeader: colors.background || (isDark ? "#1a1a1f" : "#f9fafb"),
-      bgHeaderHasFocus: colors.muted || (isDark ? "#26262b" : "#f3f4f6"),
-      bgHeaderHovered: colors.accent || (isDark ? "#26262b" : "#e5e7eb"),
-      textHeader: colors.foreground || (isDark ? "#f8f8f8" : "#111827"),
-      // textHeaderSelected needs to contrast with accentColor background (used when column is sorted)
-      textHeaderSelected: colors.primaryForeground || (isDark ? "#f8f8f8" : "#ffffff"),
-      textDark: colors.foreground || (isDark ? "#f8f8f8" : "#111827"),
-      textMedium: colors.mutedForeground || (isDark ? "#a1a1aa" : "#6b7280"),
-      textLight: colors.mutedForeground || (isDark ? "#71717a" : "#9ca3af"),
-      // bgIconHeader is the background color for icon areas, should be subtle
-      bgIconHeader: colors.muted || (isDark ? "#26262b" : "#f3f4f6"),
-      // accentColor is used for the selected cell focus ring, sorted column header bg,
-      // fill handle, and highlighted checkbox — use primary so selection reads as deliberate
-      accentColor: colors.primary || (isDark ? "#3b82f6" : "#2563eb"),
-      // accentFg is the foreground/text color used on top of accentColor backgrounds
-      accentFg: colors.primaryForeground || (isDark ? "#f8f8f8" : "#ffffff"),
-      // column focus bg color
-      accentLight: colors.muted || (isDark ? "#27272a" : "#e4e4e7"),
-      horizontalBorderColor: colors.border || (isDark ? "#404045" : "#d1d5db"),
-      linkColor: colors.primary || colors.accent || (isDark ? "#3b82f6" : "#2563eb"),
-      // Control vertical borders by setting borderColor to transparent when disabled
-      borderColor:
-        (showVerticalBorders ?? false)
-          ? colors.border || (isDark ? "#404045" : "#d1d5db")
-          : "transparent",
-      bgSearchResult: isDark ? "#3f3520" : "#fff9e3",
-      cellHorizontalPadding: densityConfig.cellHorizontalPadding,
-      cellVerticalPadding: densityConfig.cellVerticalPadding,
-      headerIconSize: densityConfig.headerIconSize,
-      // Add proper text colors for group headers and icons
-      textGroupHeader: colors.mutedForeground || (isDark ? "#a1a1aa" : "#6b7280"),
-      // Icon foreground color
-      fgIconHeader: colors.mutedForeground || (isDark ? "#9ca3af" : "#6b7280"),
-    }),
+    customThemeGenerator: (colors: ThemeColors, isDark: boolean): Partial<Theme> => {
+      const bgHeader = colors.background || (isDark ? "#1a1a1f" : "#f9fafb");
+      return {
+        bgCell: colors.background || (isDark ? "#000000" : "#ffffff"),
+        bgHeader,
+        bgHeaderHasFocus: colors.muted || (isDark ? "#26262b" : "#f3f4f6"),
+        bgHeaderHovered: suppressHeaderHoverHighlight
+          ? bgHeader
+          : colors.accent || (isDark ? "#26262b" : "#e5e7eb"),
+        textHeader: colors.foreground || (isDark ? "#f8f8f8" : "#111827"),
+        // textHeaderSelected contrasts with accentColor (selected column headers in column-select mode)
+        textHeaderSelected: colors.primaryForeground || (isDark ? "#f8f8f8" : "#ffffff"),
+        textDark: colors.foreground || (isDark ? "#f8f8f8" : "#111827"),
+        textMedium: colors.mutedForeground || (isDark ? "#a1a1aa" : "#6b7280"),
+        textLight: colors.mutedForeground || (isDark ? "#71717a" : "#9ca3af"),
+        // bgIconHeader is the background color for icon areas, should be subtle
+        bgIconHeader: colors.muted || (isDark ? "#26262b" : "#f3f4f6"),
+        // accentColor is used for the selected cell focus ring, selected column header bg,
+        // fill handle, and highlighted checkbox — use primary so selection reads as deliberate
+        accentColor: colors.primary || (isDark ? "#3b82f6" : "#2563eb"),
+        // accentFg is the foreground/text color used on top of accentColor backgrounds
+        accentFg: colors.primaryForeground || (isDark ? "#f8f8f8" : "#ffffff"),
+        // column focus bg color
+        accentLight: colors.muted || (isDark ? "#27272a" : "#e4e4e7"),
+        horizontalBorderColor: colors.border || (isDark ? "#404045" : "#d1d5db"),
+        linkColor: colors.primary || colors.accent || (isDark ? "#3b82f6" : "#2563eb"),
+        // Control vertical borders by setting borderColor to transparent when disabled
+        borderColor:
+          (showVerticalBorders ?? false)
+            ? colors.border || (isDark ? "#404045" : "#d1d5db")
+            : "transparent",
+        bgSearchResult: isDark ? "#3f3520" : "#fff9e3",
+        cellHorizontalPadding: densityConfig.cellHorizontalPadding,
+        cellVerticalPadding: densityConfig.cellVerticalPadding,
+        headerIconSize: densityConfig.headerIconSize,
+        // Add proper text colors for group headers and icons
+        textGroupHeader: colors.mutedForeground || (isDark ? "#a1a1aa" : "#6b7280"),
+        // Icon foreground color
+        fgIconHeader: colors.mutedForeground || (isDark ? "#9ca3af" : "#6b7280"),
+      };
+    },
   });
 
   // Get row theme override for hover effect and empty filler rows

--- a/src/frontend/src/widgets/dataTables/utils/columnHelpers.test.ts
+++ b/src/frontend/src/widgets/dataTables/utils/columnHelpers.test.ts
@@ -415,7 +415,7 @@ describe("columnHelpers", () => {
       expect(result[1].icon).toBe("User");
     });
 
-    it("should use ArrowUp / ArrowDown when column is actively sorted", () => {
+    it("should use indicatorIcon ArrowUp / ArrowDown when column is actively sorted", () => {
       const columns: DataColumn[] = [
         { name: "Name", type: ColType.Text, width: 150, icon: "User" },
         { name: "Score", type: ColType.Number, width: 80 },
@@ -424,10 +424,13 @@ describe("columnHelpers", () => {
       const desc: SortOrder[] = [{ column: "Score", direction: "DESC" }];
       const ascResult = convertToGridColumns(columns, [], {}, false, true, undefined, asc);
       const descResult = convertToGridColumns(columns, [], {}, false, true, undefined, desc);
-      expect(ascResult[0].icon).toBe("ArrowUp");
+      expect(ascResult[0].icon).toBe("User");
+      expect(ascResult[0].indicatorIcon).toBe("ArrowUp");
       expect(ascResult[1].icon).toBe("headerNumber");
+      expect(ascResult[1].indicatorIcon).toBeUndefined();
       expect(descResult[0].icon).toBe("User");
-      expect(descResult[1].icon).toBe("ArrowDown");
+      expect(descResult[1].icon).toBe("headerNumber");
+      expect(descResult[1].indicatorIcon).toBe("ArrowDown");
     });
   });
 });

--- a/src/frontend/src/widgets/dataTables/utils/columnHelpers.ts
+++ b/src/frontend/src/widgets/dataTables/utils/columnHelpers.ts
@@ -108,13 +108,14 @@ export function convertToGridColumns(
     const effectiveGrow = grow !== undefined ? grow : isLastColumn ? 1 : undefined;
 
     const shouldShowIcon = Boolean(col.icon) || showColumnTypeIcons;
-    let columnIcon = shouldShowIcon ? mapColumnIcon(col) : undefined;
-    if (activeSort && activeSort.length > 0) {
-      const sortForColumn = activeSort.find((sort) => sort.column === col.name);
-      if (sortForColumn) {
-        columnIcon = sortForColumn.direction === "ASC" ? "ArrowUp" : "ArrowDown";
-      }
-    }
+    const columnIcon = shouldShowIcon ? mapColumnIcon(col) : undefined;
+    const sortForColumn = activeSort?.find((sort) => sort.column === col.name);
+    const indicatorIcon =
+      sortForColumn !== undefined
+        ? sortForColumn.direction === "ASC"
+          ? "ArrowUp"
+          : "ArrowDown"
+        : undefined;
 
     return {
       title: col.header || col.name,
@@ -122,6 +123,7 @@ export function convertToGridColumns(
       ...(effectiveGrow !== undefined && { grow: effectiveGrow }),
       group: showGroups ? col.group : undefined,
       icon: columnIcon,
+      ...(indicatorIcon !== undefined && { indicatorIcon }),
     };
   });
 }


### PR DESCRIPTION
Had a problem:
<img width="402" height="695" alt="image" src="https://github.com/user-attachments/assets/1e89adee-9e5e-4612-94ce-c07c47128fd4" />

Fixed:

https://github.com/user-attachments/assets/d8f34516-df4c-446a-ac2d-dccf34fa2d4d

The black header came from Glide’s column selection. That paints the header with accentColor (your theme’s primary, often near-black).

The pointer guard wasn’t reliable enough, so the fix is more direct:

- columnSelect: "none" when sorting is enabled — Glide no longer selects columns on header mousedown, so the accent fill never appears.
- Strip column selection in useGridSelection — Any column selection that still slips through is cleared immediately.
- Clear columns after sort — Safety net in useHeaderMenu so a sorted column doesn’t stay selected.
- Sort arrows still use indicatorIcon only; header background should match other columns.