### PR TITLE
(datatable): add resize icon on active column for mobile devices

### DIFF
--- a/src/frontend/src/widgets/dataTables/components/GridContainer.tsx
+++ b/src/frontend/src/widgets/dataTables/components/GridContainer.tsx
@@ -58,6 +58,7 @@ interface GridContainerProps {
   footer?: React.ReactNode;
   height?: number;
   hasEmptyRows?: boolean;
+  columnResizeOverlay?: React.ReactNode;
 }
 
 /**
@@ -105,6 +106,7 @@ export const GridContainer: React.FC<GridContainerProps> = ({
   footer,
   height,
   hasEmptyRows = false,
+  columnResizeOverlay,
 }) => {
   const containerStyle = hasOptions
     ? tableStyles.tableEditor.gridContainerWithOptions
@@ -164,6 +166,8 @@ export const GridContainer: React.FC<GridContainerProps> = ({
           onItemHovered={onItemHovered}
           getRowThemeOverride={getRowThemeOverride}
         />
+
+        {columnResizeOverlay}
 
         {rowActions && rowActions.length > 0 && (
           <RowActionButtons

--- a/src/frontend/src/widgets/dataTables/components/MobileColumnResizeOverlay.tsx
+++ b/src/frontend/src/widgets/dataTables/components/MobileColumnResizeOverlay.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { GripVertical } from "lucide-react";
+import type { ColumnResizeHandle } from "../hooks/useMobileColumnResize";
+
+interface MobileColumnResizeOverlayProps {
+  handles: ColumnResizeHandle[];
+  onHandlePointerDown: (colIndex: number, e: React.PointerEvent<HTMLDivElement>) => void;
+}
+
+/**
+ * Grip on the active column header right edge for touch resize (Google Sheets–style on phones).
+ */
+export const MobileColumnResizeOverlay: React.FC<MobileColumnResizeOverlayProps> = ({
+  handles,
+  onHandlePointerDown,
+}) => {
+  const handle = handles[0];
+  if (!handle) return null;
+
+  return (
+    <div
+      role="separator"
+      aria-orientation="vertical"
+      aria-label={`Resize ${handle.column.title ?? "column"}`}
+      className="ivy-datatable-column-resize-handle ivy-datatable-column-resize-handle--active fixed z-30 flex items-center justify-center touch-none select-none"
+      style={{
+        left: handle.x,
+        top: handle.y,
+        width: handle.width,
+        height: handle.height,
+      }}
+      onPointerDown={(e) => onHandlePointerDown(handle.colIndex, e)}
+    >
+      <span
+        className="flex h-5 w-3.5 items-center justify-center rounded-sm border border-primary bg-background/95 text-primary shadow-sm"
+        aria-hidden
+      >
+        <GripVertical className="h-3 w-3" strokeWidth={2} />
+      </span>
+    </div>
+  );
+};

--- a/src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx
+++ b/src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx
@@ -29,9 +29,12 @@ import {
   useDataLoading,
   useLinkCellHover,
   useDoubleTapLink,
+  useMobileColumnResize,
+  getActiveColumnIndex,
 } from "../hooks";
 import { useFooterColumnLayout } from "../hooks/useFooterColumnLayout";
 import { GridContainer } from "../components/GridContainer";
+import { MobileColumnResizeOverlay } from "../components/MobileColumnResizeOverlay";
 import { AggregateFooter } from "../DataTableFooter";
 import { MenuItem } from "@/types/widgets";
 import { DENSITY_CONFIG } from "./constants";
@@ -114,6 +117,7 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
   // Grid ref
   const gridRef = useRef<DataEditorRef | null>(null);
   const prevVisibleScrollOriginRef = useRef<{ x: number; y: number } | null>(null);
+  const [visibleScrollX, setVisibleScrollX] = React.useState(0);
 
   // Cell content
   const { getCellContent } = useCellContent({
@@ -242,6 +246,27 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
     activeSort,
   });
 
+  const groupHeaderHeight = showGroups ? densityConfig.groupHeaderHeight : 0;
+
+  const selectedColIndex = useMemo(() => getActiveColumnIndex(gridSelection), [gridSelection]);
+
+  const mobileColumnResizeLayoutKey = `${visibleScrollX}:${JSON.stringify(columnWidths)}:${finalColumns.length}:${selectedColIndex ?? ""}`;
+
+  const {
+    useMobileHandles: useMobileColumnResizeHandles,
+    handles: mobileResizeHandles,
+    onHandlePointerDown: onMobileResizeHandlePointerDown,
+  } = useMobileColumnResize({
+    enabled: allowColumnResizing ?? true,
+    gridRef,
+    containerRef,
+    columns: finalColumns,
+    groupHeaderHeight,
+    selectedColIndex,
+    onColumnResize: handleColumnResize,
+    layoutKey: mobileColumnResizeLayoutKey,
+  });
+
   // Double-tap link cells on touch (desktop uses ⌘/Ctrl+click via useCellInteractions)
   useDoubleTapLink({
     containerRef,
@@ -268,6 +293,7 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
   const handleVisibleRegionChangedForGrid = useCallback(
     (range: { x: number; y: number; width: number; height: number }) => {
       handleVisibleRegionChanged(range);
+      setVisibleScrollX(range.x);
       const prev = prevVisibleScrollOriginRef.current;
       const verticalScrolled = prev !== null && prev.y !== range.y;
       prevVisibleScrollOriginRef.current = { x: range.x, y: range.y };
@@ -436,7 +462,17 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
           ] as unknown as readonly CustomRenderer[]
         }
         headerIcons={headerIcons}
-        onColumnResize={allowColumnResizing ? handleColumnResize : undefined}
+        onColumnResize={
+          allowColumnResizing && !useMobileColumnResizeHandles ? handleColumnResize : undefined
+        }
+        columnResizeOverlay={
+          useMobileColumnResizeHandles ? (
+            <MobileColumnResizeOverlay
+              handles={mobileResizeHandles}
+              onHandlePointerDown={onMobileResizeHandlePointerDown}
+            />
+          ) : undefined
+        }
         onVisibleRegionChanged={handleVisibleRegionChangedForGrid}
         onHeaderClicked={allowSorting ? handleHeaderMenuClick : undefined}
         theme={tableTheme}

--- a/src/frontend/src/widgets/dataTables/hooks/index.ts
+++ b/src/frontend/src/widgets/dataTables/hooks/index.ts
@@ -10,3 +10,4 @@ export { useEmptyRows } from "./useEmptyRows";
 export { useDataLoading } from "./useDataLoading";
 export { useLinkCellHover } from "./useLinkCellHover";
 export { useDoubleTapLink } from "./useDoubleTapLink";
+export { useMobileColumnResize, getActiveColumnIndex } from "./useMobileColumnResize";

--- a/src/frontend/src/widgets/dataTables/hooks/useMobileColumnResize.test.ts
+++ b/src/frontend/src/widgets/dataTables/hooks/useMobileColumnResize.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+describe("useMobileColumnResize", () => {
+  const hookSource = fs.readFileSync(
+    path.resolve(__dirname, "./useMobileColumnResize.ts"),
+    "utf-8",
+  );
+  const editorSource = fs.readFileSync(
+    path.resolve(__dirname, "../dataTableEditor/DataTableEditor.tsx"),
+    "utf-8",
+  );
+
+  it("should enable mobile handles only on coarse pointer", () => {
+    expect(hookSource).toContain("(pointer: coarse)");
+    expect(hookSource).toContain("useMobileHandles");
+  });
+
+  it("should show resize grip only for the selected column", () => {
+    expect(hookSource).toContain("getActiveColumnIndex");
+    expect(hookSource).toContain("selectedColIndex");
+    expect(hookSource).toContain("resizingColIndex ?? selectedColIndex");
+    expect(editorSource).toContain("getActiveColumnIndex(gridSelection)");
+  });
+
+  it("should disable Glide native resize when mobile handles are active", () => {
+    expect(editorSource).toContain("!useMobileColumnResizeHandles");
+    expect(editorSource).toContain("useMobileColumnResize");
+  });
+
+  it("should prevent horizontal scroll while dragging via body class", () => {
+    expect(hookSource).toContain("ivy-datatable-column-resize-active");
+    const cssSource = fs.readFileSync(path.resolve(__dirname, "../styles/checkbox.css"), "utf-8");
+    expect(cssSource).toContain("ivy-datatable-column-resize-active .dvn-scroller");
+    expect(cssSource).toContain("touch-action: pan-y");
+  });
+});

--- a/src/frontend/src/widgets/dataTables/hooks/useMobileColumnResize.ts
+++ b/src/frontend/src/widgets/dataTables/hooks/useMobileColumnResize.ts
@@ -1,0 +1,221 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, type RefObject } from "react";
+import { DataEditorRef, GridColumn, GridSelection } from "@glideapps/glide-data-grid";
+
+const MIN_COLUMN_WIDTH = 50;
+const MAX_COLUMN_WIDTH = 2000;
+const HANDLE_HIT_WIDTH = 28;
+
+export interface ColumnResizeHandle {
+  colIndex: number;
+  column: GridColumn;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+function isCoarsePointer(): boolean {
+  if (typeof window === "undefined") return false;
+  return window.matchMedia("(pointer: coarse)").matches;
+}
+
+function clampWidth(width: number): number {
+  return Math.max(MIN_COLUMN_WIDTH, Math.min(MAX_COLUMN_WIDTH, Math.round(width)));
+}
+
+/** Column that should show the mobile resize grip (selected cell or selected column). */
+export function getActiveColumnIndex(selection: GridSelection): number | null {
+  const cellCol = selection.current?.cell[0];
+  if (cellCol !== undefined) return cellCol;
+  return selection.columns.first() ?? null;
+}
+
+interface UseMobileColumnResizeProps {
+  enabled: boolean;
+  gridRef: RefObject<DataEditorRef | null>;
+  containerRef: RefObject<HTMLDivElement | null>;
+  columns: GridColumn[];
+  groupHeaderHeight: number;
+  selectedColIndex: number | null;
+  onColumnResize: (column: GridColumn, newSize: number) => void;
+  layoutKey: string;
+}
+
+/**
+ * Touch-friendly column resize: visible grip on header right edge, drag resizes the column
+ * without horizontal table scroll (Glide edge-drag is disabled on coarse pointers).
+ */
+export function useMobileColumnResize({
+  enabled,
+  gridRef,
+  containerRef,
+  columns,
+  groupHeaderHeight,
+  selectedColIndex,
+  onColumnResize,
+  layoutKey,
+}: UseMobileColumnResizeProps) {
+  const [coarsePointer, setCoarsePointer] = useState(isCoarsePointer);
+  const [handles, setHandles] = useState<ColumnResizeHandle[]>([]);
+  const [resizingColIndex, setResizingColIndex] = useState<number | null>(null);
+  const dragRef = useRef<{ colIndex: number; startX: number; startWidth: number } | null>(null);
+  const onColumnResizeRef = useRef(onColumnResize);
+  onColumnResizeRef.current = onColumnResize;
+
+  useEffect(() => {
+    const mql = window.matchMedia("(pointer: coarse)");
+    const onChange = () => setCoarsePointer(mql.matches);
+    mql.addEventListener("change", onChange);
+    onChange();
+    return () => mql.removeEventListener("change", onChange);
+  }, []);
+
+  const useMobileHandles = enabled && coarsePointer;
+
+  const syncHandles = useCallback(() => {
+    const grid = gridRef.current;
+    const container = containerRef.current;
+    if (!useMobileHandles || !grid || !container) {
+      setHandles([]);
+      return;
+    }
+
+    const targetColIndex = resizingColIndex ?? selectedColIndex;
+    if (targetColIndex === null) {
+      setHandles([]);
+      return;
+    }
+
+    const column = columns[targetColIndex];
+    if (!column) {
+      setHandles([]);
+      return;
+    }
+
+    const headerBounds = grid.getBounds(targetColIndex, -1);
+    if (!headerBounds || headerBounds.width < 1) {
+      setHandles([]);
+      return;
+    }
+
+    const containerRect = container.getBoundingClientRect();
+    const right = headerBounds.x + headerBounds.width;
+    if (right < containerRect.left || headerBounds.x > containerRect.right) {
+      setHandles([]);
+      return;
+    }
+
+    const top = groupHeaderHeight > 0 ? headerBounds.y - groupHeaderHeight : headerBounds.y;
+    const height = headerBounds.height + groupHeaderHeight;
+
+    setHandles([
+      {
+        colIndex: targetColIndex,
+        column,
+        x: right - HANDLE_HIT_WIDTH / 2,
+        y: top,
+        width: HANDLE_HIT_WIDTH,
+        height,
+      },
+    ]);
+  }, [
+    columns,
+    containerRef,
+    gridRef,
+    groupHeaderHeight,
+    resizingColIndex,
+    selectedColIndex,
+    useMobileHandles,
+  ]);
+
+  useLayoutEffect(() => {
+    syncHandles();
+  }, [syncHandles, layoutKey]);
+
+  useEffect(() => {
+    if (!useMobileHandles) return;
+
+    const container = containerRef.current;
+    if (!container) return;
+
+    const scroller = container.querySelector(".dvn-scroller");
+    const onScrollOrResize = () => requestAnimationFrame(syncHandles);
+
+    scroller?.addEventListener("scroll", onScrollOrResize, { passive: true });
+    window.addEventListener("resize", onScrollOrResize);
+
+    return () => {
+      scroller?.removeEventListener("scroll", onScrollOrResize);
+      window.removeEventListener("resize", onScrollOrResize);
+    };
+  }, [containerRef, syncHandles, useMobileHandles]);
+
+  const endDrag = useCallback(() => {
+    dragRef.current = null;
+    setResizingColIndex(null);
+    document.body.classList.remove("ivy-datatable-column-resize-active");
+  }, []);
+
+  useEffect(() => {
+    if (!useMobileHandles) return;
+
+    const onPointerMove = (e: PointerEvent) => {
+      const drag = dragRef.current;
+      if (!drag) return;
+
+      e.preventDefault();
+      const delta = e.clientX - drag.startX;
+      const newSize = clampWidth(drag.startWidth + delta);
+      const column = columns[drag.colIndex];
+      if (!column) return;
+      onColumnResizeRef.current(column, newSize);
+      requestAnimationFrame(syncHandles);
+    };
+
+    const onPointerUp = () => endDrag();
+
+    const onPointerCancel = () => endDrag();
+
+    window.addEventListener("pointermove", onPointerMove, { passive: false });
+    window.addEventListener("pointerup", onPointerUp);
+    window.addEventListener("pointercancel", onPointerCancel);
+
+    return () => {
+      window.removeEventListener("pointermove", onPointerMove);
+      window.removeEventListener("pointerup", onPointerUp);
+      window.removeEventListener("pointercancel", onPointerCancel);
+    };
+  }, [columns, endDrag, syncHandles, useMobileHandles]);
+
+  const onHandlePointerDown = useCallback(
+    (colIndex: number, e: React.PointerEvent<HTMLDivElement>) => {
+      if (!useMobileHandles) return;
+
+      const column = columns[colIndex];
+      const grid = gridRef.current;
+      if (!column || !grid) return;
+
+      const bounds = grid.getBounds(colIndex, -1);
+      if (!bounds) return;
+
+      e.preventDefault();
+      e.stopPropagation();
+      e.currentTarget.setPointerCapture(e.pointerId);
+
+      dragRef.current = {
+        colIndex,
+        startX: e.clientX,
+        startWidth: bounds.width,
+      };
+      setResizingColIndex(colIndex);
+      document.body.classList.add("ivy-datatable-column-resize-active");
+    },
+    [columns, gridRef, useMobileHandles],
+  );
+
+  return {
+    useMobileHandles,
+    handles,
+    onHandlePointerDown,
+  };
+}

--- a/src/frontend/src/widgets/dataTables/styles/checkbox.css
+++ b/src/frontend/src/widgets/dataTables/styles/checkbox.css
@@ -102,6 +102,20 @@
   display: none;
 }
 
+/* Mobile column resize: grip handles + block horizontal scroll while dragging */
+.ivy-datatable-column-resize-handle {
+  touch-action: none;
+}
+
+.ivy-datatable-column-resize-handle--active span {
+  background-color: hsl(var(--background));
+}
+
+body.ivy-datatable-column-resize-active .dvn-scroller {
+  touch-action: pan-y !important;
+  overscroll-behavior-x: none;
+}
+
 .gdg-search-bar::after {
   content: "";
   position: absolute;


### PR DESCRIPTION
Datatable had pure UI that didn't indicate user that column can be resized and actually it was quiet hard to do on mobile devices:

https://github.com/user-attachments/assets/dcda8323-4c16-4b44-8aac-4cbaec3d5809

Solved this problem by showing resizing icon on active column:

https://github.com/user-attachments/assets/2118456c-240e-4eb0-b8f8-f976eebfa70e
