### PR TITLE
[DesktopWindow]: set default minimum window size

### DIFF
--- a/src/Ivy.Desktop/DesktopWindow.cs
+++ b/src/Ivy.Desktop/DesktopWindow.cs
@@ -21,7 +21,7 @@ public class DesktopWindow(Server server)
     private bool _iconSet = false;
     private string? _iconFilePath = null;
     private (int X, int Y)? _position;
-    private (int W, int H)? _minSize;
+    private (int W, int H)? _minSize = (600, 400);
     private (int W, int H)? _maxSize;
     private bool _chromeless;
     private bool _transparent;


### PR DESCRIPTION
Closes https://github.com/Ivy-Interactive/Ivy-Tendril/issues/544

## Problem

Desktop apps built with `Ivy.Desktop` had no default minimum window size constraint. Users could resize the window to arbitrarily small dimensions, making the UI completely unusable — in extreme cases, only the OS window control buttons (close/minimize/maximize) remained visible.

## Solution

Set a default minimum window size of **600×400** at the framework level in `DesktopWindow`.

```diff
- private (int W, int H)? _minSize;
+ private (int W, int H)? _minSize = (600, 400);
```

### Why framework-level instead of per-app?

The fix was intentionally made in `Ivy.Desktop` rather than in individual apps (e.g. Ivy Tendril) because:

1. **All desktop apps benefit** — every app built on `Ivy.Desktop` gets a sensible default out of the box, preventing this class of UX issues entirely
2. **No opt-in required** — developers don't need to remember to call `.MinSize()` for basic usability
3. **Still overridable** — apps that need different constraints can still call `.MinSize(width, height)` to set their own values (e.g. `Ivy.Desktop.Samples` already uses `.MinSize(800, 600)`)

### Why 600×400?

- **Large enough** to prevent the window from becoming unusable
- **Small enough** to not restrict apps that intentionally need compact windows
- Individual apps like Tendril can override with larger values if their UI requires more space

## Changes

- **`Ivy.Desktop/DesktopWindow.cs`** — Changed `_minSize` field default from `null` to `(600, 400)`

## Testing

- Built `Ivy.Desktop` and ran Tendril in desktop mode (`dotnet run -- --desktop`)
- Verified the window cannot be resized below 600×400
- Confirmed existing `.MinSize()` calls in `Ivy.Desktop.Samples` continue to work as expected

<img width="615" height="449" alt="image" src="https://github.com/user-attachments/assets/193c4746-c9bb-4b1d-a2c6-e299d02b63ae" />

