### PR TITLE
[SelectInput]: align trigger actions, fix dropdown clipping in dialogs, and improve multi-select focus

### DIFF
--- a/src/frontend/src/components/ui/multiselect.tsx
+++ b/src/frontend/src/components/ui/multiselect.tsx
@@ -121,12 +121,34 @@ const MultipleSelector = React.forwardRef<
     const [visibleCount, setVisibleCount] = React.useState(maxVisibleBadges ?? 1);
     const hasAutoFocusedRef = React.useRef(false);
 
+    const closeDropdown = React.useCallback(() => {
+      setOpen(false);
+      setInputValue("");
+      if (containerRef.current) {
+        containerRef.current.scrollLeft = 0;
+      }
+    }, []);
+
     React.useEffect(() => {
       if (autoFocus && !disabled && !hasAutoFocusedRef.current) {
         hasAutoFocusedRef.current = true;
         inputRef.current?.focus();
       }
     }, [autoFocus, disabled]);
+
+    React.useEffect(() => {
+      if (!open) return;
+
+      const handlePointerDownOutside = (event: MouseEvent) => {
+        const target = event.target as Node;
+        if (triggerWrapperRef.current?.contains(target)) return;
+        closeDropdown();
+        inputRef.current?.blur();
+      };
+
+      document.addEventListener("mousedown", handlePointerDownOutside, true);
+      return () => document.removeEventListener("mousedown", handlePointerDownOutside, true);
+    }, [open, closeDropdown]);
 
     const updateOpenDirection = React.useCallback(() => {
       const trigger = triggerWrapperRef.current;
@@ -261,11 +283,12 @@ const MultipleSelector = React.forwardRef<
             }
           }
           if (e.key === "Escape") {
+            closeDropdown();
             input.blur();
           }
         }
       },
-      [value, handleUnselect],
+      [value, handleUnselect, closeDropdown],
     );
 
     const isSelected = React.useCallback(
@@ -457,11 +480,7 @@ const MultipleSelector = React.forwardRef<
                   window.requestAnimationFrame(() => {
                     window.requestAnimationFrame(() => {
                       if (triggerWrapperRef.current?.contains(document.activeElement)) return;
-                      setOpen(false);
-                      setInputValue("");
-                      if (containerRef.current) {
-                        containerRef.current.scrollLeft = 0;
-                      }
+                      closeDropdown();
                       onBlur?.(e);
                     });
                   });

--- a/src/frontend/src/components/ui/multiselect.tsx
+++ b/src/frontend/src/components/ui/multiselect.tsx
@@ -76,6 +76,7 @@ interface MultipleSelectorProps {
   minSelections?: number;
   onNullableClear?: () => void;
   autoFocus?: boolean;
+  rightSlot?: React.ReactNode;
 }
 
 const MultipleSelector = React.forwardRef<
@@ -104,6 +105,7 @@ const MultipleSelector = React.forwardRef<
       minSelections,
       onNullableClear,
       autoFocus = false,
+      rightSlot,
     },
     ref,
   ) => {
@@ -480,9 +482,14 @@ const MultipleSelector = React.forwardRef<
                 className="ml-2 bg-transparent outline-none placeholder:text-muted-foreground flex-1 min-w-[120px] cursor-pointer"
               />
             </span>
+            {rightSlot && (
+              <div className="flex items-center gap-1 shrink-0 pointer-events-none">
+                {rightSlot}
+              </div>
+            )}
             <ChevronDown
               className={cn(
-                "size-4 ml-2 opacity-50 shrink-0 cursor-pointer",
+                "size-4 ml-1 opacity-50 shrink-0 cursor-pointer",
                 disabled && "cursor-not-allowed opacity-50",
               )}
               onClick={(e) => {

--- a/src/frontend/src/components/ui/multiselect.tsx
+++ b/src/frontend/src/components/ui/multiselect.tsx
@@ -113,6 +113,7 @@ const MultipleSelector = React.forwardRef<
     const dropdownRef = React.useRef<HTMLDivElement>(null);
     const [open, setOpen] = React.useState(false);
     const [openUpward, setOpenUpward] = React.useState(false);
+    const [dropdownMaxHeight, setDropdownMaxHeight] = React.useState(300);
     const [inputValue, setInputValue] = React.useState("");
     const measureRef = React.useRef<HTMLDivElement>(null);
     const [visibleCount, setVisibleCount] = React.useState(maxVisibleBadges ?? 1);
@@ -133,10 +134,16 @@ const MultipleSelector = React.forwardRef<
       const dropdownHeight = dropdownRef.current?.offsetHeight ?? 0;
 
       const dialogBoundary = trigger.closest<HTMLElement>("[role='dialog']");
-      const boundaryBottom = dialogBoundary?.getBoundingClientRect().bottom ?? window.innerHeight;
-      const spaceBelow = Math.max(0, boundaryBottom - triggerRect.bottom);
+      const dialogRect = dialogBoundary?.getBoundingClientRect();
+      const boundaryTop = dialogRect?.top ?? 0;
+      const boundaryBottom = dialogRect?.bottom ?? window.innerHeight;
 
-      setOpenUpward(spaceBelow < dropdownHeight + 8);
+      const spaceBelow = Math.max(0, boundaryBottom - triggerRect.bottom - 8);
+      const spaceAbove = Math.max(0, triggerRect.top - boundaryTop - 8);
+
+      const shouldOpenUpward = spaceBelow < dropdownHeight + 8;
+      setOpenUpward(shouldOpenUpward);
+      setDropdownMaxHeight(Math.min(300, shouldOpenUpward ? spaceAbove : spaceBelow));
     }, []);
 
     React.useLayoutEffect(() => {
@@ -517,7 +524,10 @@ const MultipleSelector = React.forwardRef<
             >
               {defaultOptions.length > 0 ? (
                 <>
-                  <CommandGroup className="h-full overflow-auto max-h-[300px] slim-scrollbar">
+                  <CommandGroup
+                    className="h-full overflow-auto slim-scrollbar"
+                    style={{ maxHeight: dropdownMaxHeight }}
+                  >
                     {defaultOptions.map((option) => {
                       const selected = isSelected(option);
                       return (

--- a/src/frontend/src/components/ui/multiselect.tsx
+++ b/src/frontend/src/components/ui/multiselect.tsx
@@ -13,7 +13,10 @@ import {
 import { cva } from "class-variance-authority";
 import { Densities } from "@/types/density";
 import { xIconVariant } from "@/components/ui/input/text-input-variant";
-import { selectMultiTriggerVariant } from "@/components/ui/select/variant";
+import {
+  selectMultiTriggerVariant,
+  selectTriggerEndActionsVariant,
+} from "@/components/ui/select/variant";
 
 // Variants for menu items
 const menuItemVariant = cva("cursor-pointer", {
@@ -479,31 +482,15 @@ const MultipleSelector = React.forwardRef<
                 className="ml-2 bg-transparent outline-none placeholder:text-muted-foreground flex-1 min-w-[120px] cursor-pointer"
               />
             </span>
-            {rightSlot && (
-              <div className="flex items-center gap-1 shrink-0 pointer-events-none">
-                {rightSlot}
-              </div>
-            )}
-            <ChevronDown
-              className={cn(
-                "size-4 ml-1 opacity-50 shrink-0 cursor-pointer",
-                disabled && "cursor-not-allowed opacity-50",
-              )}
-              onClick={(e) => {
-                if (disabled) return;
-                e.preventDefault();
-                e.stopPropagation();
-                if (inputRef.current) {
-                  if (open) {
-                    inputRef.current.blur();
-                  } else {
-                    inputRef.current.focus();
-                  }
-                }
-              }}
-              onKeyDown={(e) => {
-                if (disabled) return;
-                if (e.key === "Enter" || e.key === " ") {
+            <div className={selectTriggerEndActionsVariant()}>
+              {rightSlot}
+              <ChevronDown
+                className={cn(
+                  "size-4 opacity-50 shrink-0 cursor-pointer pointer-events-auto",
+                  disabled && "cursor-not-allowed opacity-50",
+                )}
+                onClick={(e) => {
+                  if (disabled) return;
                   e.preventDefault();
                   e.stopPropagation();
                   if (inputRef.current) {
@@ -513,12 +500,26 @@ const MultipleSelector = React.forwardRef<
                       inputRef.current.focus();
                     }
                   }
-                }
-              }}
-              role="button"
-              tabIndex={disabled ? -1 : 0}
-              aria-label="Toggle dropdown"
-            />
+                }}
+                onKeyDown={(e) => {
+                  if (disabled) return;
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    if (inputRef.current) {
+                      if (open) {
+                        inputRef.current.blur();
+                      } else {
+                        inputRef.current.focus();
+                      }
+                    }
+                  }
+                }}
+                role="button"
+                tabIndex={disabled ? -1 : 0}
+                aria-label="Toggle dropdown"
+              />
+            </div>
           </div>
           {open && (
             <div

--- a/src/frontend/src/components/ui/multiselect.tsx
+++ b/src/frontend/src/components/ui/multiselect.tsx
@@ -133,10 +133,12 @@ const MultipleSelector = React.forwardRef<
       const triggerRect = trigger.getBoundingClientRect();
       const dropdownHeight = dropdownRef.current?.offsetHeight ?? 0;
 
+      const sectionBoundary = trigger.closest<HTMLElement>("[role='document']");
       const dialogBoundary = trigger.closest<HTMLElement>("[role='dialog']");
-      const dialogRect = dialogBoundary?.getBoundingClientRect();
-      const boundaryTop = dialogRect?.top ?? 0;
-      const boundaryBottom = dialogRect?.bottom ?? window.innerHeight;
+      const boundaryEl = sectionBoundary ?? dialogBoundary;
+      const boundaryRect = boundaryEl?.getBoundingClientRect();
+      const boundaryTop = boundaryRect?.top ?? 0;
+      const boundaryBottom = boundaryRect?.bottom ?? window.innerHeight;
 
       const spaceBelow = Math.max(0, boundaryBottom - triggerRect.bottom - 8);
       const spaceAbove = Math.max(0, triggerRect.top - boundaryTop - 8);

--- a/src/frontend/src/components/ui/multiselect.tsx
+++ b/src/frontend/src/components/ui/multiselect.tsx
@@ -13,10 +13,7 @@ import {
 import { cva } from "class-variance-authority";
 import { Densities } from "@/types/density";
 import { xIconVariant } from "@/components/ui/input/text-input-variant";
-import { selectTriggerVariant } from "@/components/ui/select/variant";
-
-// Variants for MultipleSelector - matches selectTriggerVariant exactly
-const multipleSelectorVariant = selectTriggerVariant;
+import { selectMultiTriggerVariant } from "@/components/ui/select/variant";
 
 // Variants for menu items
 const menuItemVariant = cva("cursor-pointer", {
@@ -392,7 +389,7 @@ const MultipleSelector = React.forwardRef<
           )}
           <div
             className={cn(
-              multipleSelectorVariant({ density }),
+              selectMultiTriggerVariant({ density }),
               disabled && "cursor-not-allowed opacity-50",
               (!value || value.length === 0) && "text-muted-foreground",
               invalid

--- a/src/frontend/src/components/ui/select.tsx
+++ b/src/frontend/src/components/ui/select.tsx
@@ -8,6 +8,7 @@ import {
   selectSingleTriggerVariant,
   selectContentVariant,
   selectItemVariant,
+  selectTriggerEndActionsVariant,
 } from "./select/variant";
 
 const Select = SelectPrimitive.Root;
@@ -27,12 +28,25 @@ const SelectTrigger = React.forwardRef<
     {...props}
   >
     {children}
-    <SelectPrimitive.Icon asChild>
-      <ChevronDown className="size-4 opacity-50 flex-shrink-0" />
-    </SelectPrimitive.Icon>
   </SelectPrimitive.Trigger>
 ));
 SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
+
+const SelectTriggerEndActions = ({
+  children,
+  className,
+}: {
+  children?: React.ReactNode;
+  className?: string;
+}) => (
+  <div className={cn(selectTriggerEndActionsVariant(), className)}>
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <ChevronDown className="size-4 opacity-50 flex-shrink-0" />
+    </SelectPrimitive.Icon>
+  </div>
+);
+SelectTriggerEndActions.displayName = "SelectTriggerEndActions";
 
 const SelectScrollUpButton = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
@@ -145,6 +159,7 @@ export {
   SelectGroup,
   SelectValue,
   SelectTrigger,
+  SelectTriggerEndActions,
   SelectContent,
   SelectLabel,
   SelectItem,

--- a/src/frontend/src/components/ui/select.tsx
+++ b/src/frontend/src/components/ui/select.tsx
@@ -4,7 +4,11 @@ import { Check, ChevronDown, ChevronUp } from "lucide-react";
 import type { VariantProps } from "class-variance-authority";
 
 import { cn } from "@/lib/utils";
-import { selectTriggerVariant, selectContentVariant, selectItemVariant } from "./select/variant";
+import {
+  selectSingleTriggerVariant,
+  selectContentVariant,
+  selectItemVariant,
+} from "./select/variant";
 
 const Select = SelectPrimitive.Root;
 
@@ -15,11 +19,11 @@ const SelectValue = SelectPrimitive.Value;
 const SelectTrigger = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Trigger>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger> &
-    VariantProps<typeof selectTriggerVariant>
+    VariantProps<typeof selectSingleTriggerVariant>
 >(({ className, density, children, ...props }, ref) => (
   <SelectPrimitive.Trigger
     ref={ref}
-    className={cn(selectTriggerVariant({ density, className }))}
+    className={cn(selectSingleTriggerVariant({ density, className }))}
     {...props}
   >
     {children}

--- a/src/frontend/src/components/ui/select/variant.ts
+++ b/src/frontend/src/components/ui/select/variant.ts
@@ -21,15 +21,21 @@ export const selectSingleTriggerVariant = cva(selectTriggerBase, {
 export const selectMultiTriggerVariant = cva(selectTriggerBase, {
   variants: {
     density: {
-      Small: "h-7 px-0 py-1 text-xs",
-      Medium: "h-9 px-1 py-2 text-sm",
-      Large: "h-11 px-2 py-3 text-base",
+      // Match single-select right padding so clear + chevron align across variants.
+      Small: "h-7 pl-0 pr-2 py-1 text-xs",
+      Medium: "h-9 pl-1 pr-3 py-2 text-sm",
+      Large: "h-11 pl-2 pr-4 py-3 text-base",
     },
   },
   defaultVariants: {
     density: "Medium",
   },
 });
+
+/** Clear, loading, invalid, and chevron cluster at the end of select triggers. */
+export const selectTriggerEndActionsVariant = cva(
+  "flex items-center gap-1 shrink-0 ml-auto px-1 pointer-events-none",
+);
 
 /** @deprecated Prefer {@link selectSingleTriggerVariant}. */
 export const selectTriggerVariant = selectSingleTriggerVariant;
@@ -66,18 +72,5 @@ export const selectItemVariant = cva(
   },
 );
 
-export const selectIconContainerVariant = cva(
-  "absolute right-2 top-1/2 -translate-y-1/2 flex flex-row items-center gap-1 p-1 pointer-events-none h-6",
-  {
-    variants: {
-      density: {
-        Small: "right-5",
-        Medium: "right-6",
-        Large: "right-8",
-      },
-    },
-    defaultVariants: {
-      density: "Medium",
-    },
-  },
-);
+/** @deprecated Use {@link selectTriggerEndActionsVariant} inside the trigger flex row. */
+export const selectIconContainerVariant = selectTriggerEndActionsVariant;

--- a/src/frontend/src/components/ui/select/variant.ts
+++ b/src/frontend/src/components/ui/select/variant.ts
@@ -1,20 +1,38 @@
 import { cva } from "class-variance-authority";
 
-export const selectTriggerVariant = cva(
-  "box-border flex w-full items-center justify-between whitespace-nowrap rounded-field border border-input bg-transparent shadow-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span:first-child]:flex-1 [&>span:first-child]:min-w-0 [&>span:first-child]:truncate [&>span:first-child]:text-left cursor-pointer dark:bg-white/5 dark:hover:bg-white/10 dark:border-white/10",
-  {
-    variants: {
-      density: {
-        Small: "h-7 px-2 py-1 text-xs",
-        Medium: "h-9 px-3 py-2 text-sm",
-        Large: "h-11 px-4 py-3 text-base",
-      },
-    },
-    defaultVariants: {
-      density: "Medium",
+const selectTriggerBase =
+  "box-border flex w-full items-center justify-between whitespace-nowrap rounded-field border border-input bg-transparent shadow-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span:first-child]:flex-1 [&>span:first-child]:min-w-0 [&>span:first-child]:truncate [&>span:first-child]:text-left cursor-pointer dark:bg-white/5 dark:hover:bg-white/10 dark:border-white/10";
+
+/** Single-value select trigger (e.g. Assignee). */
+export const selectSingleTriggerVariant = cva(selectTriggerBase, {
+  variants: {
+    density: {
+      Small: "h-7 px-2 py-1 text-xs",
+      Medium: "h-9 px-3 py-2 text-sm",
+      Large: "h-11 px-4 py-3 text-base",
     },
   },
-);
+  defaultVariants: {
+    density: "Medium",
+  },
+});
+
+/** Multi-value select trigger with badge chips (e.g. Labels). */
+export const selectMultiTriggerVariant = cva(selectTriggerBase, {
+  variants: {
+    density: {
+      Small: "h-7 px-0 py-1 text-xs",
+      Medium: "h-9 px-1 py-2 text-sm",
+      Large: "h-11 px-2 py-3 text-base",
+    },
+  },
+  defaultVariants: {
+    density: "Medium",
+  },
+});
+
+/** @deprecated Prefer {@link selectSingleTriggerVariant}. */
+export const selectTriggerVariant = selectSingleTriggerVariant;
 
 export const selectContentVariant = cva(
   "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-box border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",

--- a/src/frontend/src/widgets/dialogs/DialogBodyWidget.tsx
+++ b/src/frontend/src/widgets/dialogs/DialogBodyWidget.tsx
@@ -11,7 +11,7 @@ export const DialogBodyWidget: React.FC<DialogBodyWidgetProps> = ({ id, children
   return (
     <section
       id={id}
-      className="flex-1 min-h-0 flex flex-col overflow-auto p-4"
+      className="flex-1 min-h-0 flex flex-col p-4"
       role="document"
       aria-describedby={descriptionId}
     >

--- a/src/frontend/src/widgets/inputs/SelectMultiVariant.tsx
+++ b/src/frontend/src/widgets/inputs/SelectMultiVariant.tsx
@@ -4,7 +4,6 @@ import { MultipleSelector, Option as MultiSelectOption } from "@/components/ui/m
 import { Loader2, X } from "lucide-react";
 import { InvalidIcon } from "@/components/InvalidIcon";
 import { logger } from "@/lib/logger";
-import { selectIconContainerVariant } from "@/components/ui/select/variant";
 import { xIconVariant } from "@/components/ui/input/text-input-variant";
 import { SelectInputWidgetProps, Option } from "./select-types";
 import { convertValuesToOriginalType } from "./select-utils";

--- a/src/frontend/src/widgets/inputs/SelectMultiVariant.tsx
+++ b/src/frontend/src/widgets/inputs/SelectMultiVariant.tsx
@@ -134,78 +134,79 @@ export const SelectMultiVariant: React.FC<SelectInputWidgetProps> = ({
   const hasSuffix = (suffixContent?.length ?? 0) > 0;
   const hasAffixes = hasPrefix || hasSuffix;
 
-  const multiSelectorContent = (
-    <>
-      <MultipleSelector
-        value={selectedMultiSelectOptions}
-        defaultOptions={multiSelectOptions}
-        onValueChange={handleMultiSelectChange}
-        placeholder={placeholder}
-        disabled={disabled || loading}
-        className={cn(
-          "w-full",
-          ghost && "ghost",
-          hasAffixes && "border-0 shadow-none",
-          hasPrefix && "rounded-l-none",
-          hasSuffix && "rounded-r-none",
+  const rightSlot =
+    loading || (selectedMultiSelectOptions.length > 0 && !disabled) || invalid ? (
+      <>
+        {loading && (
+          <div className="pointer-events-auto flex items-center h-6 p-1">
+            <Loader2 className="size-4 animate-spin text-muted-foreground text-opacity-50" />
+          </div>
         )}
-        invalid={!!invalid}
-        hidePlaceholderWhenSelected
-        density={density}
-        ghost={ghost}
-        onBlur={handleBlur}
-        onFocus={handleFocus}
-        data-testid={dataTestId}
-        showActions={showActions && selectMany}
-        maxSelections={maxSelections}
-        minSelections={minSelections}
-        onNullableClear={
-          nullable
-            ? () => {
-                if (events.includes("OnChange")) eventHandler("OnChange", id, [null]);
-              }
-            : undefined
-        }
-        autoFocus={autoFocus}
-      />
-      {(selectedMultiSelectOptions.length > 0 && !disabled) || invalid || loading ? (
-        <div className={selectIconContainerVariant({ density })} style={{ zIndex: 2 }}>
-          {loading && (
-            <div className="pointer-events-auto flex items-center h-6 p-1">
-              <Loader2 className="size-4 animate-spin text-muted-foreground text-opacity-50" />
-            </div>
-          )}
-          {selectedMultiSelectOptions.length > 0 && !disabled && (
-            <button
-              type="button"
-              tabIndex={-1}
-              aria-label="Clear All"
-              onClick={(e) => {
+        {selectedMultiSelectOptions.length > 0 && !disabled && (
+          <button
+            type="button"
+            tabIndex={-1}
+            aria-label="Clear All"
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              logger.debug("Select input clear button clicked (MultiSelect)", { id });
+              if (events.includes("OnChange")) eventHandler("OnChange", id, [null]);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
                 e.preventDefault();
                 e.stopPropagation();
-                logger.debug("Select input clear button clicked (MultiSelect)", { id });
                 if (events.includes("OnChange")) eventHandler("OnChange", id, [null]);
-              }}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" || e.key === " ") {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  if (events.includes("OnChange")) eventHandler("OnChange", id, [null]);
-                }
-              }}
-              className="pointer-events-auto p-1 rounded hover:bg-accent focus:outline-none cursor-pointer flex items-center h-6"
-            >
-              <X className={xIconVariant({ density })} />
-            </button>
-          )}
-          {invalid && (
-            <div className="pointer-events-auto flex items-center h-6 p-1">
-              <InvalidIcon message={invalid} />
-            </div>
-          )}
-        </div>
-      ) : null}
-    </>
+              }
+            }}
+            className="pointer-events-auto p-1 rounded hover:bg-accent focus:outline-none cursor-pointer flex items-center h-6"
+          >
+            <X className={xIconVariant({ density })} />
+          </button>
+        )}
+        {invalid && (
+          <div className="pointer-events-auto flex items-center h-6 p-1">
+            <InvalidIcon message={invalid} />
+          </div>
+        )}
+      </>
+    ) : undefined;
+
+  const multiSelectorContent = (
+    <MultipleSelector
+      value={selectedMultiSelectOptions}
+      defaultOptions={multiSelectOptions}
+      onValueChange={handleMultiSelectChange}
+      placeholder={placeholder}
+      disabled={disabled || loading}
+      className={cn(
+        "w-full",
+        ghost && "ghost",
+        hasAffixes && "border-0 shadow-none",
+        hasPrefix && "rounded-l-none",
+        hasSuffix && "rounded-r-none",
+      )}
+      invalid={!!invalid}
+      hidePlaceholderWhenSelected
+      density={density}
+      ghost={ghost}
+      onBlur={handleBlur}
+      onFocus={handleFocus}
+      data-testid={dataTestId}
+      showActions={showActions && selectMany}
+      maxSelections={maxSelections}
+      minSelections={minSelections}
+      onNullableClear={
+        nullable
+          ? () => {
+              if (events.includes("OnChange")) eventHandler("OnChange", id, [null]);
+            }
+          : undefined
+      }
+      autoFocus={autoFocus}
+      rightSlot={rightSlot}
+    />
   );
 
   return (

--- a/src/frontend/src/widgets/inputs/SelectMultiVariant.tsx
+++ b/src/frontend/src/widgets/inputs/SelectMultiVariant.tsx
@@ -146,6 +146,11 @@ export const SelectMultiVariant: React.FC<SelectInputWidgetProps> = ({
             type="button"
             tabIndex={-1}
             aria-label="Clear All"
+            onMouseDown={(e) => {
+              // Keep focus on the input so blur/outside-close still works after clearing.
+              e.preventDefault();
+              e.stopPropagation();
+            }}
             onClick={(e) => {
               e.preventDefault();
               e.stopPropagation();

--- a/src/frontend/src/widgets/inputs/SelectSingleVariant.tsx
+++ b/src/frontend/src/widgets/inputs/SelectSingleVariant.tsx
@@ -8,6 +8,7 @@ import {
   SelectLabel,
   SelectSeparator,
   SelectTrigger,
+  SelectTriggerEndActions,
 } from "@/components/ui/select";
 import { Tooltip, TooltipProvider, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { Input } from "@/components/ui/input";
@@ -222,46 +223,44 @@ export const SelectSingleVariant: React.FC<SelectInputWidgetProps> = ({
       >
         {hasValue ? (selectedLabel ?? stringValue) : placeholder}
       </span>
-      {((nullable && hasValue && !disabled) || invalid || loading) && (
-        <div className="flex items-center gap-1 px-1 ml-auto shrink-0 pointer-events-none">
-          {loading && (
-            <div className="flex items-center h-6 pointer-events-auto">
-              <Loader2 className="size-4 animate-spin text-muted-foreground text-opacity-50" />
-            </div>
-          )}
-          {nullable && hasValue && !disabled && (
-            <div
-              role="button"
-              tabIndex={-1}
-              aria-label="Clear"
-              onClick={(e) => {
+      <SelectTriggerEndActions>
+        {loading && (
+          <div className="flex items-center h-6 pointer-events-auto">
+            <Loader2 className="size-4 animate-spin text-muted-foreground text-opacity-50" />
+          </div>
+        )}
+        {nullable && hasValue && !disabled && (
+          <div
+            role="button"
+            tabIndex={-1}
+            aria-label="Clear"
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              if (events.includes("OnChange")) eventHandler("OnChange", id, [null]);
+            }}
+            onPointerDown={(e) => e.stopPropagation()}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
                 e.preventDefault();
                 e.stopPropagation();
                 if (events.includes("OnChange")) eventHandler("OnChange", id, [null]);
-              }}
-              onPointerDown={(e) => e.stopPropagation()}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" || e.key === " ") {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  if (events.includes("OnChange")) eventHandler("OnChange", id, [null]);
-                }
-              }}
-              className="p-1 rounded hover:bg-accent focus:outline-none cursor-pointer flex items-center h-6 pointer-events-auto"
-            >
-              <X className={xIconVariant({ density })} />
-            </div>
-          )}
-          {invalid && (
-            <div
-              className="flex items-center h-6 cursor-default pointer-events-auto"
-              onPointerDown={(e) => e.stopPropagation()}
-            >
-              <InvalidIcon message={invalid} />
-            </div>
-          )}
-        </div>
-      )}
+              }
+            }}
+            className="p-1 rounded hover:bg-accent focus:outline-none cursor-pointer flex items-center h-6 pointer-events-auto"
+          >
+            <X className={xIconVariant({ density })} />
+          </div>
+        )}
+        {invalid && (
+          <div
+            className="flex items-center h-6 cursor-default pointer-events-auto"
+            onPointerDown={(e) => e.stopPropagation()}
+          >
+            <InvalidIcon message={invalid} />
+          </div>
+        )}
+      </SelectTriggerEndActions>
     </SelectTrigger>
   );
 


### PR DESCRIPTION
## Summary

Improves **SelectInput** single- and multi-select triggers so clear/chevron actions line up, text padding is consistent, and multi-select dropdowns are no longer clipped or stuck open inside dialogs. Builds on recent dropdown work (boundary-aware flip, `rightSlot`, shared trigger variants).

## Problem

- Single-select (e.g. Assignee) and multi-select (e.g. Labels) placed **clear (×)** and **chevron** at different horizontal positions.
- Multi-select used tighter padding than single-select, so right-side actions and left text inset did not match.
- Clear/loading/invalid icons in multi-select were absolutely positioned over the trigger instead of living in the flex layout.
- Multi-select dropdown could be **clipped** in dialogs/sections because positioning only considered the viewport/dialog edge partially and `DialogBody` used `overflow-auto`.
- After **Clear all** with the dropdown open, clicking outside sometimes **did not close** the list because focus moved to the clear button and was lost when the button unmounted.

## Changes

### Trigger layout & styling
- Split trigger variants into `selectSingleTriggerVariant` and `selectMultiTriggerVariant` with **matched right padding** (`pr-3` on medium) while keeping compact left padding for badge chips.
- Introduced shared `selectTriggerEndActionsVariant` and `SelectTriggerEndActions` so **×, loading, invalid, and chevron** share one flex cluster in both variants.
- Moved multi-select action icons from absolute overlay into `MultipleSelector` via new **`rightSlot`** prop (inline with chevron, same pattern as single-select).

### Dropdown in dialogs
- Multi-select flip/height logic now respects **`[role='document']`** (dialog body) and **`[role='dialog']`** boundaries, with dynamic **`dropdownMaxHeight`** so the list is not cut off.
- Removed `overflow-auto` from `DialogBodyWidget` so popovers/dropdowns can extend outside the scroll area without being clipped.

### Interaction
- Document **mousedown** listener (capture) to close multi-select when clicking outside.
- **Clear all** uses `onMouseDown` + `preventDefault` so focus stays on the input; dropdown stays open on clear and closes correctly on outside click.
- **Escape** explicitly closes the multi-select dropdown.

## Files changed

- `src/frontend/src/components/ui/select/variant.ts`
- `src/frontend/src/components/ui/select.tsx`
- `src/frontend/src/components/ui/multiselect.tsx`
- `src/frontend/src/widgets/inputs/SelectSingleVariant.tsx`
- `src/frontend/src/widgets/inputs/SelectMultiVariant.tsx`
- `src/frontend/src/widgets/dialogs/DialogBodyWidget.tsx`

## How to test

1. **Side-by-side layout** — Open a form with single-select and multi-select (e.g. Assignee + Labels). Confirm × and chevron align on the right and left text/chip padding looks consistent.
2. **Dialog** — Open the same fields inside a dialog near the bottom of the viewport. Confirm the dropdown is fully visible (flips upward if needed) and is not clipped by the dialog body.
3. **Clear all (multi-select)** — Open the dropdown, click **Clear all (×)**. List should **stay open**. Click outside — list should **close**.
4. **Single-select clear** — With a value selected, confirm clear + chevron still align and the dropdown behavior is unchanged.
5. **Densities** — Smoke-test Small / Medium / Large if your sample app exposes them.


https://github.com/user-attachments/assets/b2571ecb-ddae-4abe-9bb3-4c4af21afd03

<img width="550" height="429" alt="Знімок екрана 2026-05-19 о 12 47 32" src="https://github.com/user-attachments/assets/069b2ecd-0cfe-4353-b955-6c80ab64145b" />
