### PR TITLE
[TextInput]: remove border between affix slot and input field

### DIFF
--- a/src/frontend/src/components/ui/input/text-input-variant.ts
+++ b/src/frontend/src/components/ui/input/text-input-variant.ts
@@ -2,13 +2,18 @@ import { cva } from "class-variance-authority";
 
 import { cn } from "@/lib/utils";
 
+/** Ivy.Button in affix: cell provides px-3; strip Button sm horizontal padding. */
+export const affixEmbeddedButtonClasses =
+  "[&_button]:!px-0 [&_button]:shadow-none [&_button]:rounded [&_button]:hover:bg-accent [&_button]:cursor-pointer [&_button]:transition-colors";
+
 /** Affix cells: muted box by default; ghost uses transparent chrome with tight padding toward the input. */
 export function textInputAffixCellClasses(
   side: "prefix" | "suffix",
   ghostWithAffixes: boolean,
 ): string {
   return cn(
-    "flex items-center text-muted-foreground [&_button]:rounded [&_button]:px-1 [&_button]:hover:bg-accent [&_button]:cursor-pointer [&_button]:transition-colors",
+    "flex items-center text-muted-foreground",
+    affixEmbeddedButtonClasses,
     ghostWithAffixes
       ? side === "suffix"
         ? "shrink-0 bg-transparent pl-0 pr-1.5"

--- a/src/frontend/src/components/ui/input/text-input-variant.ts
+++ b/src/frontend/src/components/ui/input/text-input-variant.ts
@@ -2,9 +2,17 @@ import { cva } from "class-variance-authority";
 
 import { cn } from "@/lib/utils";
 
-/** Ivy.Button in affix: cell provides px-3; strip Button sm horizontal padding. */
+/**
+ * Ivy.Button in affix: outer cell owns spacing (`px-3` or tighter for icon-only).
+ * Text buttons: strip `sm` px. Icon-only (`icon-sm` / `icon`): shrink hit box — the
+ * `size-6`/`size-8` target is larger than the glyph, which reads as extra padding.
+ */
 export const affixEmbeddedButtonClasses =
-  "[&_button]:!px-0 [&_button]:shadow-none [&_button]:rounded [&_button]:hover:bg-accent [&_button]:cursor-pointer [&_button]:transition-colors";
+  "[&_button]:!px-0 [&_button]:shadow-none [&_button]:rounded [&_button]:hover:bg-accent [&_button]:cursor-pointer [&_button]:transition-colors [&_button.size-6]:!size-4 [&_button.size-8]:!size-6";
+
+/** Tighter affix cell padding when the slot only contains an icon-sized button. */
+export const affixIconOnlyCellPaddingClasses =
+  "has-[button.size-6]:px-1.5 has-[button.size-8]:px-2";
 
 /** Affix cells: muted box by default; ghost uses transparent chrome with tight padding toward the input. */
 export function textInputAffixCellClasses(
@@ -20,6 +28,7 @@ export function textInputAffixCellClasses(
         : "shrink-0 bg-transparent pl-2 pr-0.5"
       : cn(
           "px-3 bg-muted",
+          affixIconOnlyCellPaddingClasses,
           side === "prefix"
             ? "rounded-tl-fields rounded-bl-fields"
             : "rounded-tr-fields rounded-br-fields",

--- a/src/frontend/src/components/ui/input/text-input-variant.ts
+++ b/src/frontend/src/components/ui/input/text-input-variant.ts
@@ -5,7 +5,6 @@ import { cn } from "@/lib/utils";
 /** Affix cells: muted box by default; ghost uses transparent chrome with tight padding toward the input. */
 export function textInputAffixCellClasses(
   side: "prefix" | "suffix",
-  isFocused: boolean,
   ghostWithAffixes: boolean,
 ): string {
   return cn(
@@ -20,9 +19,6 @@ export function textInputAffixCellClasses(
             ? "rounded-tl-fields rounded-bl-fields"
             : "rounded-tr-fields rounded-br-fields",
         ),
-    side === "prefix"
-      ? !ghostWithAffixes && !isFocused && "border-r border-input"
-      : !ghostWithAffixes && !isFocused && "border-l border-input",
   );
 }
 

--- a/src/frontend/src/widgets/inputs/DateRangeInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/DateRangeInputWidget.tsx
@@ -23,7 +23,10 @@ import {
   dateRangeInputIconVariant,
   dateRangeInputTextVariant,
 } from "@/components/ui/input/date-range-input-variant";
-import { affixEmbeddedButtonClasses } from "@/components/ui/input/text-input-variant";
+import {
+  affixEmbeddedButtonClasses,
+  affixIconOnlyCellPaddingClasses,
+} from "@/components/ui/input/text-input-variant";
 import { EMPTY_ARRAY } from "@/lib/constants";
 import { DateRangePresets } from "./DateRangePresets";
 
@@ -331,6 +334,7 @@ export const DateRangeInputWidget: React.FC<DateRangeInputWidgetProps> = ({
               className={cn(
                 "flex items-center px-3 bg-muted text-muted-foreground rounded-tl-[var(--radius-fields)] rounded-bl-[var(--radius-fields)]",
                 affixEmbeddedButtonClasses,
+                affixIconOnlyCellPaddingClasses,
                 !isOpen && "border-r border-input",
               )}
             >
@@ -343,6 +347,7 @@ export const DateRangeInputWidget: React.FC<DateRangeInputWidgetProps> = ({
               className={cn(
                 "flex items-center px-3 bg-muted text-muted-foreground rounded-tr-[var(--radius-fields)] rounded-br-[var(--radius-fields)]",
                 affixEmbeddedButtonClasses,
+                affixIconOnlyCellPaddingClasses,
                 !isOpen && "border-l border-input",
               )}
             >

--- a/src/frontend/src/widgets/inputs/DateRangeInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/DateRangeInputWidget.tsx
@@ -23,6 +23,7 @@ import {
   dateRangeInputIconVariant,
   dateRangeInputTextVariant,
 } from "@/components/ui/input/date-range-input-variant";
+import { affixEmbeddedButtonClasses } from "@/components/ui/input/text-input-variant";
 import { EMPTY_ARRAY } from "@/lib/constants";
 import { DateRangePresets } from "./DateRangePresets";
 
@@ -329,6 +330,7 @@ export const DateRangeInputWidget: React.FC<DateRangeInputWidgetProps> = ({
             <div
               className={cn(
                 "flex items-center px-3 bg-muted text-muted-foreground rounded-tl-[var(--radius-fields)] rounded-bl-[var(--radius-fields)]",
+                affixEmbeddedButtonClasses,
                 !isOpen && "border-r border-input",
               )}
             >
@@ -340,6 +342,7 @@ export const DateRangeInputWidget: React.FC<DateRangeInputWidgetProps> = ({
             <div
               className={cn(
                 "flex items-center px-3 bg-muted text-muted-foreground rounded-tr-[var(--radius-fields)] rounded-br-[var(--radius-fields)]",
+                affixEmbeddedButtonClasses,
                 !isOpen && "border-l border-input",
               )}
             >

--- a/src/frontend/src/widgets/inputs/DateTimeInputWidget/DateTimeInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/DateTimeInputWidget/DateTimeInputWidget.tsx
@@ -19,6 +19,7 @@ import { WeekVariant } from "./WeekVariant";
 import { YearVariant } from "./YearVariant";
 import { EMPTY_ARRAY } from "@/lib/constants";
 import { cn } from "@/lib/utils";
+import { affixEmbeddedButtonClasses } from "@/components/ui/input/text-input-variant";
 
 const VariantComponents: Record<
   VariantType,
@@ -169,7 +170,12 @@ export const DateTimeInputWidget: React.FC<DateTimeInputWidgetProps> = ({
       )}
     >
       {hasPrefix && (
-        <div className="flex items-center px-3 bg-muted text-muted-foreground border-r border-input rounded-tl-[var(--radius-fields)] rounded-bl-[var(--radius-fields)]">
+        <div
+          className={cn(
+            "flex items-center px-3 bg-muted text-muted-foreground border-r border-input rounded-tl-[var(--radius-fields)] rounded-bl-[var(--radius-fields)]",
+            affixEmbeddedButtonClasses,
+          )}
+        >
           {prefixContent}
         </div>
       )}
@@ -183,7 +189,12 @@ export const DateTimeInputWidget: React.FC<DateTimeInputWidgetProps> = ({
         {variantElement}
       </div>
       {hasSuffix && (
-        <div className="flex items-center px-3 bg-muted text-muted-foreground border-l border-input rounded-tr-[var(--radius-fields)] rounded-br-[var(--radius-fields)]">
+        <div
+          className={cn(
+            "flex items-center px-3 bg-muted text-muted-foreground border-l border-input rounded-tr-[var(--radius-fields)] rounded-br-[var(--radius-fields)]",
+            affixEmbeddedButtonClasses,
+          )}
+        >
           {suffixContent}
         </div>
       )}

--- a/src/frontend/src/widgets/inputs/DateTimeInputWidget/DateTimeInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/DateTimeInputWidget/DateTimeInputWidget.tsx
@@ -19,7 +19,10 @@ import { WeekVariant } from "./WeekVariant";
 import { YearVariant } from "./YearVariant";
 import { EMPTY_ARRAY } from "@/lib/constants";
 import { cn } from "@/lib/utils";
-import { affixEmbeddedButtonClasses } from "@/components/ui/input/text-input-variant";
+import {
+  affixEmbeddedButtonClasses,
+  affixIconOnlyCellPaddingClasses,
+} from "@/components/ui/input/text-input-variant";
 
 const VariantComponents: Record<
   VariantType,
@@ -174,6 +177,7 @@ export const DateTimeInputWidget: React.FC<DateTimeInputWidgetProps> = ({
           className={cn(
             "flex items-center px-3 bg-muted text-muted-foreground border-r border-input rounded-tl-[var(--radius-fields)] rounded-bl-[var(--radius-fields)]",
             affixEmbeddedButtonClasses,
+            affixIconOnlyCellPaddingClasses,
           )}
         >
           {prefixContent}
@@ -193,6 +197,7 @@ export const DateTimeInputWidget: React.FC<DateTimeInputWidgetProps> = ({
           className={cn(
             "flex items-center px-3 bg-muted text-muted-foreground border-l border-input rounded-tr-[var(--radius-fields)] rounded-br-[var(--radius-fields)]",
             affixEmbeddedButtonClasses,
+            affixIconOnlyCellPaddingClasses,
           )}
         >
           {suffixContent}

--- a/src/frontend/src/widgets/inputs/TextInputWidget/variants/DefaultVariant.tsx
+++ b/src/frontend/src/widgets/inputs/TextInputWidget/variants/DefaultVariant.tsx
@@ -93,7 +93,7 @@ export const DefaultVariant: React.FC<DefaultVariantProps> = ({
       >
         {/* Prefix with background and separator */}
         {hasPrefix && (
-          <div className={textInputAffixCellClasses("prefix", isFocused, ghostAffixChrome)}>
+          <div className={textInputAffixCellClasses("prefix", ghostAffixChrome)}>
             {prefixContent}
           </div>
         )}
@@ -194,7 +194,7 @@ export const DefaultVariant: React.FC<DefaultVariantProps> = ({
 
         {/* Suffix with background and separator */}
         {hasSuffix && (
-          <div className={textInputAffixCellClasses("suffix", isFocused, ghostAffixChrome)}>
+          <div className={textInputAffixCellClasses("suffix", ghostAffixChrome)}>
             {suffixContent}
           </div>
         )}

--- a/src/frontend/src/widgets/inputs/TextInputWidget/variants/SearchVariant.tsx
+++ b/src/frontend/src/widgets/inputs/TextInputWidget/variants/SearchVariant.tsx
@@ -156,7 +156,7 @@ export const SearchVariant: React.FC<SearchVariantProps> = ({
         )}
       >
         {hasPrefix && (
-          <div className={textInputAffixCellClasses("prefix", isFocused, ghostAffixChrome)}>
+          <div className={textInputAffixCellClasses("prefix", ghostAffixChrome)}>
             {prefixContent}
           </div>
         )}
@@ -216,7 +216,7 @@ export const SearchVariant: React.FC<SearchVariantProps> = ({
         )}
 
         {hasSuffix && (
-          <div className={textInputAffixCellClasses("suffix", isFocused, ghostAffixChrome)}>
+          <div className={textInputAffixCellClasses("suffix", ghostAffixChrome)}>
             {suffixContent}
           </div>
         )}


### PR DESCRIPTION
## What

Remove the prominent dividing border between the text input field and its prefix/suffix slot.

## Why

The `border-r` / `border-l` line between the affix cell and the input created a visually heavy separator that felt out of place. The `bg-muted` background on the affix cell is sufficient to distinguish the slot without an additional hard border.

## Changes

- `text-input-variant.ts` — removed conditional `border-r border-input` (prefix) and `border-l border-input` (suffix) classes from `textInputAffixCellClasses()`

## Affected variants

All variants that use the shared helper: **Default**, **Search**, **Password**, **Textarea**.


## Before
<img width="387" height="333" alt="Знімок екрана 2026-05-19 о 16 06 53" src="https://github.com/user-attachments/assets/6cde2e6e-4334-4d47-96fe-d8e9bfd0aab1" />


## After
<img width="391" height="347" alt="Знімок екрана 2026-05-19 о 16 07 06" src="https://github.com/user-attachments/assets/d82bbc80-c5ae-4a50-aab0-c8bf34d4dcb8" />


