### PR TITLE
fix: format chart tooltip headers using active axis tick formatters

### DIFF
--- a/src/frontend/src/widgets/charts/AreaChartWidget.tsx
+++ b/src/frontend/src/widgets/charts/AreaChartWidget.tsx
@@ -13,6 +13,7 @@ import {
   getColors,
   getTransformValueFn,
   formatTooltipValue,
+  formatTooltipHeader,
 } from "./sharedUtils";
 import { getHeight, getWidth } from "@/lib/styles";
 import { useThemeWithMonitoring } from "@/components/theme-provider";
@@ -200,7 +201,9 @@ const AreaChartWidget: React.FC<AreaChartWidgetProps> = ({
             Array.isArray(p.value) ? p.value[isVertical ? 1 : 0] : p.value;
           if (Array.isArray(params)) {
             // Multi-series: add category header from first param
-            const header = params[0]?.name ? `<strong>${params[0].name}</strong><br/>` : "";
+            const header = params[0]?.name
+              ? `<strong>${formatTooltipHeader(params[0].name, xAxis, yAxis, isVertical)}</strong><br/>`
+              : "";
             const lines = params
               .map((p) => {
                 const value = formatTooltipValue(extractValue(p), tooltip);
@@ -210,7 +213,9 @@ const AreaChartWidget: React.FC<AreaChartWidgetProps> = ({
             return header + lines;
           }
           // Single series: add category header
-          const header = params.name ? `<strong>${params.name}</strong><br/>` : "";
+          const header = params.name
+            ? `<strong>${formatTooltipHeader(params.name, xAxis, yAxis, isVertical)}</strong><br/>`
+            : "";
           const value = formatTooltipValue(extractValue(params), tooltip);
           return `${header}${params.marker} ${params.seriesName}: <strong>${value}</strong>`;
         },

--- a/src/frontend/src/widgets/charts/BarChartWidget.tsx
+++ b/src/frontend/src/widgets/charts/BarChartWidget.tsx
@@ -12,6 +12,7 @@ import {
   generateYAxis,
   getColors,
   formatTooltipValue,
+  formatTooltipHeader,
 } from "./sharedUtils";
 import { useThemeWithMonitoring } from "@/components/theme-provider";
 import { getHeight, getWidth } from "@/lib/styles";
@@ -254,7 +255,9 @@ const BarChartWidget: React.FC<BarChartWidgetProps> = ({
             Array.isArray(p.value) ? p.value[isVertical ? 1 : 0] : p.value;
           if (Array.isArray(params)) {
             // Multi-series: add category header from first param
-            const header = params[0]?.name ? `<strong>${params[0].name}</strong><br/>` : "";
+            const header = params[0]?.name
+              ? `<strong>${formatTooltipHeader(params[0].name, xAxis, yAxis, isVertical)}</strong><br/>`
+              : "";
             const lines = params
               .map((p) => {
                 const value = formatTooltipValue(extractValue(p), tooltip);
@@ -264,7 +267,9 @@ const BarChartWidget: React.FC<BarChartWidgetProps> = ({
             return header + lines;
           }
           // Single series: add category header
-          const header = params.name ? `<strong>${params.name}</strong><br/>` : "";
+          const header = params.name
+            ? `<strong>${formatTooltipHeader(params.name, xAxis, yAxis, isVertical)}</strong><br/>`
+            : "";
           const value = formatTooltipValue(extractValue(params), tooltip);
           return `${header}${params.marker} ${params.seriesName}: <strong>${value}</strong>`;
         },

--- a/src/frontend/src/widgets/charts/LineChartWidget.tsx
+++ b/src/frontend/src/widgets/charts/LineChartWidget.tsx
@@ -15,6 +15,7 @@ import {
   getTransformValueFn,
   generateEChartToolbox,
   formatTooltipValue,
+  formatTooltipHeader,
 } from "./sharedUtils";
 import { getChartThemeColors } from "./styles";
 import { LineChartWidgetProps, ChartType } from "./chartTypes";
@@ -114,7 +115,9 @@ const LineChartWidget: React.FC<LineChartWidgetProps> = ({
             Array.isArray(p.value) ? p.value[isVertical ? 1 : 0] : p.value;
           if (Array.isArray(params)) {
             // Multi-series: add category header from first param
-            const header = params[0]?.name ? `<strong>${params[0].name}</strong><br/>` : "";
+            const header = params[0]?.name
+              ? `<strong>${formatTooltipHeader(params[0].name, xAxis, yAxis, isVertical)}</strong><br/>`
+              : "";
             const lines = params
               .map((p) => {
                 const value = formatTooltipValue(extractValue(p), tooltip);
@@ -124,7 +127,9 @@ const LineChartWidget: React.FC<LineChartWidgetProps> = ({
             return header + lines;
           }
           // Single series: add category header
-          const header = params.name ? `<strong>${params.name}</strong><br/>` : "";
+          const header = params.name
+            ? `<strong>${formatTooltipHeader(params.name, xAxis, yAxis, isVertical)}</strong><br/>`
+            : "";
           const value = formatTooltipValue(extractValue(params), tooltip);
           return `${header}${params.marker} ${params.seriesName}: <strong>${value}</strong>`;
         },

--- a/src/frontend/src/widgets/charts/sharedUtils.ts
+++ b/src/frontend/src/widgets/charts/sharedUtils.ts
@@ -808,3 +808,22 @@ export const generateEChartToolbox = (toolbox?: ToolboxProps) => {
     },
   };
 };
+
+export const formatTooltipHeader = (
+  value: number | string | undefined | null,
+  xAxis?: XAxisProps[],
+  yAxis?: YAxisProps[],
+  isVertical?: boolean,
+) => {
+  if (value == null) return "";
+  const categoryAxis = isVertical ? xAxis?.[0] : yAxis?.[0];
+  if (!categoryAxis || !categoryAxis.tickFormatter) {
+    return String(value);
+  }
+  return formatTickLabel(
+    value,
+    categoryAxis.tickFormatter,
+    categoryAxis.timeZone,
+    categoryAxis.tickFormatterType,
+  );
+};


### PR DESCRIPTION
This PR formats chart tooltip category headers using the tick formatter defined on the active category axis (X-axis or Y-axis depending on chart orientation). This resolves the issue where raw ISO dates like \2026-05-19T20:00:00Z\ were displayed in tooltips instead of formatted labels.