### PR TITLE
feat: add release notes automation skill and compile weekly notes

### DIFF
--- a/src/.releases/CreateNotes.ps1
+++ b/src/.releases/CreateNotes.ps1
@@ -1,4 +1,4 @@
-﻿param(
+param(
     [switch]$SkipDownloads
 )
 
@@ -52,5 +52,22 @@ if (-not $SkipDownloads) {
 }
 
 $promptFile = Join-Path $scriptDir "prompt.md"
+$tempPromptFile = Join-Path $scriptDir "temp-prompt.md"
 $commitFiles = Join-Path $commitsFolder "*.md"
-./LlmEach.ps1 $commitFiles -PromptFile $promptFile -Parallel 1 -YesToAll
+
+# Load the prompt template and dynamically replace {{NotesFile}} with the absolute path of the notes file
+$promptContent = Get-Content $promptFile -Raw
+# Using literal string .Replace to avoid regex escaping issues
+$customPrompt = $promptContent.Replace('{{NotesFile}}', $filePath)
+$customPrompt | Out-File -FilePath $tempPromptFile -Encoding UTF8
+
+try {
+    # Run the LLM notes generator on each commit file
+    & "$scriptDir\LlmEach.ps1" $commitFiles -PromptFile $tempPromptFile -Parallel 1 -YesToAll
+}
+finally {
+    # Ensure temporary prompt file is cleaned up
+    if (Test-Path $tempPromptFile) {
+        Remove-Item -Path $tempPromptFile -Force
+    }
+}

--- a/src/.releases/prompt.md
+++ b/src/.releases/prompt.md
@@ -7,16 +7,14 @@ Repo 2: Ivy CLI - Command line tools for the Ivy Framework. (Not Open Source)
 
 One of these files are {{File}} (COMMIT)
 
-Our overall goals is to write an update article about all the changes that have been done in these two repos. We want
-it to be interesting for someone using the framework and the CLI and short and descriptive.
+Our overall goal is to write an update article about all the changes that have been done in these two repos. We want it to be interesting for someone using the framework and the CLI and short and descriptive.
 
 For API changes/additions, we want to show code examples on how to use the new APIs.
 
-Read /Users/rorychatt/git/ivy-bot1/Ivy-Framework/src/.releases/weekly-notes-2026-04-06.md (NOTES)
+Read {{NotesFile}} (NOTES)
 
 Read the COMMIT and update NOTES with the new changes. We will trigger this agent for each commit so don't spend time reading the others.
 
-Skip stuff that doesn't affect the user of the framework or the CLI. Some commits are just internal refactorings or
-changes that don't affect the user. Merge commits can be skipped. It is fine to do no edits to (NOTES) if there's noting interesting in the commit.
+Skip stuff that doesn't affect the user of the framework or the CLI. Some commits are just internal refactorings or changes that don't affect the user. Merge commits can be skipped. It is fine to do no edits to (NOTES) if there's nothing interesting in the commit.
 
 Write it all as a markdown article and add it to the file under an appropriate section. Make sure that you each time leave the article nice and coherent.

--- a/src/.releases/weekly-notes-2026-05-20.md
+++ b/src/.releases/weekly-notes-2026-05-20.md
@@ -1,0 +1,94 @@
+# Ivy Framework Weekly Notes - Week of 2026-05-20
+
+> [!NOTE]
+> We usually release on Fridays every week. Sign up on [https://ivy.app/](https://ivy.app/auth/sign-up) to get release notes directly to your inbox.
+
+## Plugin System
+
+### Simplified Plugin Interface & Configuration States
+
+The `IIvyPlugin` interface has been streamlined — `ConfigureServices` has been removed. Plugins now only need to implement `Manifest`, `ConfigurationSchema`, and `Configure`:
+
+```csharp
+public class MyPlugin : IIvyPlugin
+{
+    public PluginManifest Manifest => new("my-plugin", "My Plugin", "1.0.0");
+    public PluginConfigurationSchema? ConfigurationSchema => null;
+
+    public void Configure(IIvyPluginContext context)
+    {
+        // Register your services here
+    }
+}
+```
+
+The plugin manager now supports configuration states. Plugins can be **Active** or **Unconfigured**, and the new `IPluginManager` API reflects this:
+
+- `GetActivePluginIds()` (renamed from `GetLoadedPluginIds`)
+- `GetUnconfiguredPlugins()` — returns plugins that need configuration before activation
+- `ReconfigurePlugin(pluginId)` — trigger reconfiguration of a plugin
+- New events: `PluginActivated` and `PluginDeactivated`
+
+---
+
+## New Features
+
+### DropDownMenu StayOpen Support
+
+Added the `.StayOpen()` modifier to the `DropDownMenu` widget. When enabled, selecting an item in the menu will not automatically close the dropdown list. This is particularly useful for menus containing checkbox items, multi-select values, or submenus where users make multiple selections at once.
+
+```csharp
+new DropDownMenu()
+    .StayOpen()
+    .Items(new[]
+    {
+        new MenuItem("Enable Feature A").Checked(true),
+        new MenuItem("Enable Feature B").Checked(false),
+        new MenuItem("Enable Feature C").Checked(false)
+    });
+```
+
+### Markdown Article Grade Typography
+
+Introduced an opt-in `Article` typography mode for the `Markdown` widget via the `Markdown.Article()` builder method. This allows standalone markdown content to automatically render with the same premium typography styling (such as relaxed paragraph line-heights, heading top margins, and elegant H2 dividers) as the full `Ivy.Article` widget, without needing its surrounding table of contents or page footer chrome.
+
+```csharp
+new Markdown("# Getting Started\nThis is a paragraph of text...")
+    .Article();
+```
+
+### MultipleSelector Customization (rightSlot)
+
+The `MultipleSelector` component (used for select-many fields) now supports a `rightSlot` property to place custom action buttons or indicators (e.g. clear button, custom dropdown indicators, loaders, or validation feedback icon) aligned to the right inside the selector input field. 
+
+We also refactored `SelectMultiVariant` to move the loading spinner, invalid icon, and "Clear All" (`X`) button inside this new `rightSlot`, maintaining a consistent visual layout across all inputs.
+
+---
+
+## Improvements & Bug Fixes
+
+### DataTable empty states and filters
+
+- **Interactive Empty Tables:** Previously, when a filter matched zero rows, the table component would collapse and replace the whole container with the empty view (which also removed the headers and filter input, preventing the user from clearing their search). Now, the full table (header, border, filters) remains visible, and the empty view is displayed as a centered overlay above the empty grid body.
+- **Single-Line Filter Editor Newline Fix:** Fixed an issue in CodeMirror single-line filter inputs where pressing Enter to submit the filter would insert a trailing space. Enter is now correctly intercepted and consumed by the editor.
+- **Empty Rows & Sizing:** Fixed height calculation for filtered tables. The grid maintains its border height and headers, displaying "No rows to display" when empty instead of collapsing down to 0 height.
+- **Grid Cell Enhancements:** Column headers now show a dedicated style when filtering is active, cells truncate overflown text with ellipses (`...`), and we added a column resize handle icon on active headers for mobile and touch devices.
+
+### Charts & Visualization
+
+- **Tooltip Axis Formatters:** Fixed Chart tooltip formatting. Tooltips now format their headers using the active axis tick formatter instead of the raw data value (e.g., currency `C0` or percentage `P0` formatters).
+
+### Input Widgets & Window Sizing
+
+- **Affix Button Alignment:** Consistently integrated `affixEmbeddedButtonClasses` and `affixIconOnlyCellPaddingClasses` into `DateRangeInputWidget` and `DateTimeInputWidget` to align buttons with prefix/suffix elements correctly.
+- **Desktop Window Bounds:** Added a default minimum window size constraint to the `DesktopWindow` container to prevent applications from being resized down to an unusable size.
+- **Dialogs & Swatches:** Adjusted dialog overlays to stack from top-to-bottom for natural visual hierarchy, and fixed the popover picker to automatically close when selecting a color swatch.
+
+---
+
+## Builds & Internal Maintenance
+
+- **React 19 Build Restoration:** Fixed Vite frontend configuration to resolve TypeScript compilation errors, React 19 merge compilation issues, and conditional `useState` hooks.
+- **Frontend Diagnostics:** Integrated `react-doctor.config.json` to focus on React correctness and performance optimizations.
+- **Test Relocation:** Moved `ActivityHeatmap` and `QRCode` tests into separate widget-local test projects and excluded test files from the main widget compilation step to speed up production builds.
+- **CI / Build Pipeline:** Added checkout and build automation for the `Ivy-Examples` repository during automated release package builds.

--- a/src/claude-plugin/skills/ivy-create-release-notes/SKILL.md
+++ b/src/claude-plugin/skills/ivy-create-release-notes/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: ivy-create-release-notes
+description: >
+  Generate release notes / weekly notes for the Ivy Framework by analyzing git commits and code diffs since the last tag or a specific commit.
+  Use when the user wants to compile patch notes, changelogs, or weekly updates for the project.
+allowed-tools: Bash(git:*) Read Write Edit Glob Grep
+effort: high
+argument-hint: "[optional start tag or commit hash]"
+---
+
+# ivy-create-release-notes
+
+Analyze recent changes and generate structured release/weekly notes for the Ivy Framework.
+
+## Pre-flight: Read Learnings
+
+If the file `.ivy/learnings/ivy-create-release-notes.md` exists in the project directory, read it first and apply any lessons learned from previous runs of this skill.
+
+## Workflow
+
+### 1. Plan and Determine Range
+- Check git tags in the repository using `git tag --sort=-v:refname`.
+- Identify the latest tag (e.g. `v1.2.56`).
+- Ask the user to confirm the tag/commit range. By default, analyze changes from the latest release tag to the current `HEAD` (or the last 7 days).
+- If the user specified a start commit or tag in their prompt, use that.
+
+### 2. Download and Extract Commits
+- Run the PowerShell script `src/.releases/CreateNotes.ps1` to download and extract commits for the selected period into the `src/.releases/Commits/` directory.
+- This creates individual markdown files containing commit messages and code diffs for all commits.
+
+### 3. Generate Release Notes
+Depending on the local environment, choose one of the following paths:
+
+#### Path A: Script Execution (If `claude` CLI is installed and configured)
+- Allow the `CreateNotes.ps1` script to run the automated pipeline.
+- It will invoke `LlmEach.ps1` which uses the local `claude` command-line utility to incrementally write changes to `src/.releases/weekly-notes-YYYY-MM-DD.md`.
+
+#### Path B: Agent-Guided Fallback (Recommended if `claude` CLI is missing or errors)
+If `claude` is not available, process the files using your own agent context:
+1. Initialize the release notes file `src/.releases/weekly-notes-YYYY-MM-DD.md` (if it does not exist) with the header:
+   ```markdown
+   # Ivy Framework Weekly Notes - Week of YYYY-MM-DD
+
+   > [!NOTE]
+   > We usually release on Fridays every week. Sign up on [https://ivy.app/](https://ivy.app/auth/sign-up) to get release notes directly to your inbox.
+   ```
+2. Read the commit files from `src/.releases/Commits/` sorted sequentially.
+3. For each commit:
+   - Analyze the commit message and file diffs.
+   - Ignore internal refactorings, merge commits, or test-only changes that do not affect users of the framework/CLI.
+   - Categorize the change (e.g., New Features, Component Updates, Breaking Changes, Bug Fixes).
+   - Write clear, user-facing descriptions.
+   - For new APIs or major updates, write a concise C# code block showing how to use the feature. Refer to `references/AGENTS.md` to ensure correct Ivy conventions.
+   - Edit `src/.releases/weekly-notes-YYYY-MM-DD.md` to add/merge the changes cleanly.
+4. Clean up any temporary files or the `Commits/` folder if requested.
+
+### 4. Review and Finalize
+- Read the generated `weekly-notes-YYYY-MM-DD.md` file.
+- Verify that the layout, headers, and C# examples conform to the standard style (e.g. look at `weekly-notes-2026-04-07.md` for reference).
+- Present the location and key highlights of the generated release notes to the user.

--- a/src/claude-plugin/skills/ivy/SKILL.md
+++ b/src/claude-plugin/skills/ivy/SKILL.md
@@ -80,6 +80,12 @@ When the user's request matches a specialized task, delegate to the appropriate 
 | Create a custom React-backed widget (wrap npm package) | `/ivy-create-external-widget` |
 | Deploy as a desktop application (.exe) | `/ivy-deploy-to-desktop` |
 
+### Releases and Maintenance
+
+| User wants... | Skill |
+|---|---|
+| Generate release/patch notes by analyzing code changes since the last release | `/ivy-create-release-notes` |
+
 ## Direct Implementation
 
 If the user's request does not match any specialized skill above -- for example, modifying existing views, fixing bugs, adding features to existing apps, or general Ivy development -- implement it directly using the AGENTS.md reference and the `ivy` CLI for documentation.


### PR DESCRIPTION
Adds the /ivy-create-release-notes skill, adapts existing scripts by fixing hardcoded path dependencies, and includes weekly notes for 2026-05-20.