### PR TITLE
[Scroll]: add horizontal and bidirectional scroll support to StackLayout

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/04_Layout.md
+++ b/src/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/04_Layout.md
@@ -180,10 +180,34 @@ Layout.Vertical().Gap(4)
 
 ### Scroll
 
-Add scrollable behavior to layouts with constrained height using `.Scroll()`:
+Add scrollable behavior to layouts using `.Scroll()`. The available modes are:
+
+| Mode | Description |
+|------|-------------|
+| `Scroll.Vertical` | Scrolls vertically when content overflows the height |
+| `Scroll.Horizontal` | Scrolls horizontally when content overflows the width |
+| `Scroll.Both` | Scrolls in both directions |
+| `Scroll.Auto` | Same as `Scroll.Vertical` — scrolls vertically when needed |
+| `Scroll.None` | No scrolling (default) |
+
+Vertical scroll — constrain the height and let content overflow downward:
 
 ```csharp demo-tabs
 Layout.Vertical().Height(Size.Units(30)).Scroll(Scroll.Vertical).Gap(2)
+    | new Badge("Item 1") | new Badge("Item 2") | new Badge("Item 3")
+    | new Badge("Item 4") | new Badge("Item 5") | new Badge("Item 6")
+    | new Badge("Item 7") | new Badge("Item 8") | new Badge("Item 9")
+    | new Badge("Item 10") | new Badge("Item 11") | new Badge("Item 12")
+```
+
+Horizontal scroll — constrain the width and let content overflow sideways. Useful for action bars, button rows, or any wide content in a narrow container:
+
+```csharp demo-tabs
+Layout.Horizontal()
+    .Width(Size.Units(60))
+    .Height(Size.Units(10))
+    .Scroll(Scroll.Horizontal)
+    .Gap(2)
     | new Badge("Item 1") | new Badge("Item 2") | new Badge("Item 3")
     | new Badge("Item 4") | new Badge("Item 5") | new Badge("Item 6")
     | new Badge("Item 7") | new Badge("Item 8") | new Badge("Item 9")

--- a/src/frontend/src/components/ui/scroll-area.tsx
+++ b/src/frontend/src/components/ui/scroll-area.tsx
@@ -8,10 +8,19 @@ const ScrollArea = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root> & {
     viewportClassName?: string;
     viewportStyle?: React.CSSProperties;
+    orientation?: "vertical" | "horizontal" | "both";
   }
 >(
   (
-    { className, children, scrollHideDelay = 0, viewportClassName, viewportStyle, ...props },
+    {
+      className,
+      children,
+      scrollHideDelay = 0,
+      viewportClassName,
+      viewportStyle,
+      orientation = "vertical",
+      ...props
+    },
     ref,
   ) => (
     <ScrollAreaPrimitive.Root
@@ -26,7 +35,12 @@ const ScrollArea = React.forwardRef<
       >
         {children}
       </ScrollAreaPrimitive.Viewport>
-      <ScrollBar />
+      {(orientation === "vertical" || orientation === "both") && (
+        <ScrollBar orientation="vertical" />
+      )}
+      {(orientation === "horizontal" || orientation === "both") && (
+        <ScrollBar orientation="horizontal" />
+      )}
       <ScrollAreaPrimitive.Corner />
     </ScrollAreaPrimitive.Root>
   ),

--- a/src/frontend/src/widgets/layouts/StackLayoutWidget.tsx
+++ b/src/frontend/src/widgets/layouts/StackLayoutWidget.tsx
@@ -157,6 +157,9 @@ export const StackLayoutWidget: React.FC<StackLayoutWidgetProps> = ({
       ...getHeight(height),
     };
 
+    const scrollOrientation =
+      scroll === "Horizontal" ? "horizontal" : scroll === "Both" ? "both" : "vertical";
+
     return (
       <ImageOverlayProvider>
         <ScrollArea
@@ -164,6 +167,7 @@ export const StackLayoutWidget: React.FC<StackLayoutWidgetProps> = ({
           style={outerStyles}
           type="scroll"
           scrollHideDelay={600}
+          orientation={scrollOrientation}
         >
           <div style={flexStyles}>{wrappedChildren}</div>
         </ScrollArea>


### PR DESCRIPTION
## Summary

`Scroll.Horizontal` and `Scroll.Both` were already defined in the `Scroll` enum and
documented in the API, but had no effect — the frontend only checked `scroll !== "None"`
and always rendered a vertical-only `ScrollArea`.

This PR wires up the missing frontend support and expands the documentation.

## Changes

### `ScrollArea` component (`scroll-area.tsx`)
- Added `orientation` prop (`"vertical"` | `"horizontal"` | `"both"`, default `"vertical"`)
- Renders the appropriate `<ScrollBar>` components based on orientation
- Backward compatible — all existing usages without `orientation` behave identically

### `StackLayoutWidget` (`StackLayoutWidget.tsx`)
- Maps `Scroll.Horizontal` → `orientation: "horizontal"`
- Maps `Scroll.Both` → `orientation: "both"`
- Maps `Scroll.Vertical` / `Scroll.Auto` → `orientation: "vertical"` (unchanged behavior)

### Docs (`04_Layout.md`)
- Expanded the Scroll section with a table of all modes and their descriptions
- Added a horizontal scroll example alongside the existing vertical one

### Samples (`StackLayoutApp.cs`)
- Added `Scroll.Vertical` and `Scroll.Horizontal` live demo examples

## Usage

```csharp
// Action bars, button rows, wide content in narrow containers
Layout.Horizontal()
    .Width(Size.Full())
    .Scroll(Scroll.Horizontal)
    | new Button("One") | new Button("Two") | /* ... */;
```

## Related
Fixes horizontal scroll support needed by Ivy-Tendril#724

https://github.com/user-attachments/assets/80c54d02-8d57-44aa-ad9f-d82c1c46efb3

