### PR TITLE
fix(frontend): prevent DialogWidget from closing on unmounted/detached element interactions

### DIFF
--- a/src/Ivy/Widgets/Primitives/LogoLoading.cs
+++ b/src/Ivy/Widgets/Primitives/LogoLoading.cs
@@ -1,0 +1,10 @@
+// ReSharper disable once CheckNamespace
+namespace Ivy;
+
+/// <summary>
+/// An animated loading indicator rendering the custom Ivy logo grid mutation.
+/// </summary>
+public record LogoLoading : WidgetBase<LogoLoading>
+{
+    public LogoLoading() { }
+}

--- a/src/frontend/src/components/LogoLoading.tsx
+++ b/src/frontend/src/components/LogoLoading.tsx
@@ -1,0 +1,212 @@
+import { useState, useEffect, useMemo, useCallback } from "react";
+
+const SHAPES = [
+  undefined,
+  "M0 0 H28 V28 H0 Z", // Square
+  "M28 0H0V28C15.46 28 28 15.46 28 0Z", // Perfect quarter circle
+];
+const SHAPE_LIKELIHOODS = [0, 0.4, 0.6];
+const COLORS = ["#00CC92", "#0D4A2F", "#80E6C9"];
+const COLOR_LIKELIHOODS = [0.6, 0.2, 0.2];
+const STEP_INTERVAL_MS = 200;
+const CELLS_TO_MUTATE_PER_STEP = 2;
+const MUTATION_STEPS_FORWARD = 6;
+const PAUSE_DURATION_MS = 1000;
+
+export function LogoLoading() {
+  const initialMatrix = useMemo(
+    () => [
+      [2, 0, 0],
+      [0, 0, 0],
+      [0, 0, 0],
+      [0, 0, 0],
+      [0, 0, 0],
+      [1, 0, 0],
+      [2, 0, 3],
+      [2, 0, 2],
+      [2, 0, 3],
+      [2, 0, 2],
+      [1, 0, 0],
+      [2, 0, 1],
+      [2, 0, 0],
+      [2, 0, 1],
+      [1, 0, 0],
+      [0, 0, 0],
+      [0, 0, 0],
+      [0, 0, 0],
+      [2, 0, 1],
+      [2, 0, 0],
+    ],
+    [],
+  );
+
+  const [current, setCurrent] = useState(initialMatrix);
+  const [history, setHistory] = useState([initialMatrix]);
+  const [forwardStepCount, setForwardStepCount] = useState(0);
+  const [isReverting, setIsReverting] = useState(false);
+  const [isPaused, setIsPaused] = useState(true); // Start paused
+  const [lastMutatedIndices, setLastMutatedIndices] = useState(new Set<number>());
+
+  const mutableCellIndices = useMemo(() => {
+    return initialMatrix
+      .map((cell, index) => (cell[0] !== 0 ? index : -1))
+      .filter((index) => index !== -1);
+  }, [initialMatrix]);
+
+  const performStep = useCallback(() => {
+    if (!isReverting) {
+      // MUTATING FORWARD
+      if (forwardStepCount < MUTATION_STEPS_FORWARD) {
+        const availableForMutationThisStep = mutableCellIndices.filter(
+          (idx) => !lastMutatedIndices.has(idx),
+        );
+
+        if (availableForMutationThisStep.length === 0 && mutableCellIndices.length > 0) {
+          // All mutable cells were mutated in the last step. Skip mutation this turn.
+          setCurrent((prevCurrent) => {
+            setHistory((prevHistory) => [...prevHistory, prevCurrent]); // Add current (unchanged) state to history
+            return prevCurrent; // No change to current
+          });
+          setLastMutatedIndices(new Set()); // Reset for the next step, allowing any mutable cell
+          setForwardStepCount((prevCount) => prevCount + 1);
+          return; // Exit performStep for this tick
+        }
+
+        const cellsToMutateCount = Math.min(
+          CELLS_TO_MUTATE_PER_STEP,
+          availableForMutationThisStep.length,
+        );
+
+        const indicesMutatedThisStep = new Set<number>();
+        const pickableIndices = [...availableForMutationThisStep];
+
+        while (indicesMutatedThisStep.size < cellsToMutateCount && pickableIndices.length > 0) {
+          const randomIndexInPickable = Math.floor(Math.random() * pickableIndices.length);
+          const actualCellIndex = pickableIndices[randomIndexInPickable];
+          indicesMutatedThisStep.add(actualCellIndex);
+          pickableIndices.splice(randomIndexInPickable, 1); // Ensure unique picks for this step
+        }
+
+        if (indicesMutatedThisStep.size > 0) {
+          setCurrent((prevCurrent) => {
+            const nextMatrix = prevCurrent.map((cell, index) => {
+              if (indicesMutatedThisStep.has(index)) {
+                const newShapeIndex = getWeightedRandomIndex(SHAPE_LIKELIHOODS);
+                const newColorIndex = getWeightedRandomIndex(COLOR_LIKELIHOODS);
+                const newRotation = Math.floor(Math.random() * 4);
+                return [newShapeIndex, newColorIndex, newRotation];
+              }
+              return cell;
+            });
+            setHistory((prevHistory) => [...prevHistory, nextMatrix]);
+            return nextMatrix;
+          });
+          setLastMutatedIndices(indicesMutatedThisStep);
+        } else {
+          // No cells were actually mutated (e.g., if availableForMutationThisStep was empty initially and mutableCellIndices was also empty)
+          setCurrent((prevCurrent) => {
+            setHistory((prevHistory) => [...prevHistory, prevCurrent]);
+            return prevCurrent;
+          });
+          setLastMutatedIndices(new Set());
+        }
+        setForwardStepCount((prevCount) => prevCount + 1);
+      } else {
+        // Reached MUTATION_STEPS_FORWARD forward steps, switch to reverting
+        setIsReverting(true);
+        setLastMutatedIndices(new Set()); // Reset for when/if we go forward again
+      }
+    } else {
+      // REVERTING
+      if (history.length > 1) {
+        const newHistory = history.slice(0, -1);
+        setHistory(newHistory);
+        setCurrent(newHistory[newHistory.length - 1]);
+
+        if (newHistory.length === 1) {
+          // Just reverted to initialMatrix
+          setIsReverting(false);
+          setForwardStepCount(0);
+          setIsPaused(true); // Trigger pause
+          setLastMutatedIndices(new Set()); // Reset for the new cycle
+        }
+      }
+    }
+  }, [
+    isReverting,
+    forwardStepCount,
+    history,
+    mutableCellIndices,
+    lastMutatedIndices,
+    setIsReverting,
+    setForwardStepCount,
+    setIsPaused,
+    setHistory,
+    setCurrent,
+    setLastMutatedIndices,
+  ]);
+
+  useEffect(() => {
+    if (isPaused) {
+      const timeoutId = setTimeout(() => {
+        setIsPaused(false);
+      }, PAUSE_DURATION_MS);
+      return () => clearTimeout(timeoutId);
+    } else {
+      const intervalId = setInterval(performStep, STEP_INTERVAL_MS);
+      return () => clearInterval(intervalId);
+    }
+  }, [isPaused, performStep]); // STEP_INTERVAL_MS is a const, not needed here if defined outside component scope
+
+  return (
+    <div className="grid grid-cols-5 gap-0 w-fit">
+      {current.map((item, index) => {
+        const [shapeIndex, colorIndex, rotation] = item;
+        const shape = SHAPES[shapeIndex];
+        const color = COLORS[colorIndex] || COLORS[0];
+
+        return (
+          <div key={index} className="w-7 h-7" style={{ margin: "-0.5px" }}>
+            {shape && (
+              <svg
+                viewBox="0 0 28 28"
+                className="w-full h-full"
+                style={{
+                  transform: `rotate(${rotation * 90}deg)`,
+                  transitionProperty: "transform",
+                  transitionDuration: "0.2s",
+                  transitionTimingFunction: "ease-in-out",
+                  display: "block",
+                }}
+              >
+                <path
+                  d={shape}
+                  fill={color}
+                  style={{
+                    transitionProperty: "fill",
+                    transitionDuration: "0.3s",
+                    transitionTimingFunction: "ease-in-out",
+                  }}
+                />
+              </svg>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+const getWeightedRandomIndex = (likelihoods: number[]): number => {
+  const sumOfLikelihoods = likelihoods.reduce((sum, L) => sum + L, 0);
+  let randomNum = Math.random() * sumOfLikelihoods;
+
+  for (let i = 0; i < likelihoods.length; i++) {
+    if (randomNum < likelihoods[i]) {
+      return i;
+    } else {
+      randomNum -= likelihoods[i];
+    }
+  }
+  return likelihoods.length - 1;
+};

--- a/src/frontend/src/widgets/dialogs/DialogWidget.tsx
+++ b/src/frontend/src/widgets/dialogs/DialogWidget.tsx
@@ -50,6 +50,18 @@ export const DialogWidget: React.FC<DialogWidgetProps> = ({
           }
         }}
         onCloseAutoFocus={(e) => e.preventDefault()}
+        onPointerDownOutside={(e) => {
+          const target = e.target as HTMLElement | null;
+          if (target && !document.body.contains(target)) {
+            e.preventDefault();
+          }
+        }}
+        onInteractOutside={(e) => {
+          const target = e.target as HTMLElement | null;
+          if (target && !document.body.contains(target)) {
+            e.preventDefault();
+          }
+        }}
       >
         {children}
       </DialogContent>

--- a/src/frontend/src/widgets/primitives/LogoLoadingWidget.tsx
+++ b/src/frontend/src/widgets/primitives/LogoLoadingWidget.tsx
@@ -1,0 +1,4 @@
+import { LogoLoading } from "@/components/LogoLoading";
+import React from "react";
+
+export const LogoLoadingWidget: React.FC = () => <LogoLoading />;

--- a/src/frontend/src/widgets/widgetMap.ts
+++ b/src/frontend/src/widgets/widgetMap.ts
@@ -59,6 +59,7 @@ import { SpacerWidget } from "@/widgets/primitives/SpacerWidget";
 import { WireframeNoteWidget } from "@/widgets/wireframe/WireframeNoteWidget";
 import { WireframeCalloutWidget } from "@/widgets/wireframe/WireframeCalloutWidget";
 import { LoadingWidget } from "@/widgets/primitives/LoadingWidget";
+import { LogoLoadingWidget } from "@/widgets/primitives/LogoLoadingWidget";
 import { AppHostWidget } from "@/widgets/primitives/AppHostWidget";
 import { AutoScrollWidget } from "@/widgets/primitives/AutoScrollWidget";
 import { TableWidget, TableRowWidget, TableCellWidget } from "@/widgets/tables";
@@ -98,6 +99,7 @@ export const widgetMap = {
   "Ivy.IvyLogo": IvyLogoWidget,
   "Ivy.Spacer": SpacerWidget,
   "Ivy.Loading": LoadingWidget,
+  "Ivy.LogoLoading": LogoLoadingWidget,
   "Ivy.AppHost": AppHostWidget,
   "Ivy.AutoScroll": AutoScrollWidget,
   "Ivy.AudioPlayer": lazyWithRetry(() =>


### PR DESCRIPTION
Ignores pointer down and interaction outside events in DialogWidget when the target element is detached/unmounted from the DOM, which occurs when key recreation/value-change unmounts components.