### PR TITLE
[00001] Change default chart label fill color from black to green

### DIFF
--- a/src/Ivy/Widgets/Charts/Shared/LabelList.cs
+++ b/src/Ivy/Widgets/Charts/Shared/LabelList.cs
@@ -21,7 +21,7 @@ public record LabelList
 
     public Positions? Position { get; set; } = Positions.Outside;
 
-    public Colors? Fill { get; set; } = Colors.Black;
+    public Colors? Fill { get; set; } = Colors.Green;
 
     public double? FillOpacity { get; set; } = null;
 


### PR DESCRIPTION
Change `LabelList` default `Fill` color from `Colors.Black` to `Colors.Green`.

Charts that add a `LabelList` without explicitly setting `Fill` will now render labels in green instead of black. All existing callers that set `Fill` explicitly are unaffected.

## Solution

Changed line 24 of `LabelList.cs`:

```csharp
// before
public Colors? Fill { get; set; } = Colors.Black;

// after
public Colors? Fill { get; set; } = Colors.Green;
```

## Commits

- 71cd62d8a Change default chart label fill color from black to green