### PR TITLE
Match ActivityHeatmap tooltip with other chart widgets

### DIFF
--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/.samples/Program.cs
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/.samples/Program.cs
@@ -58,14 +58,8 @@ class ActivityHeatmapDemo : ViewBase
         return new ActivityHeatmap().Data(data);
     }}
 }}", Languages.Csharp)
-            | (Layout
-                .Vertical()
-                .Gap(2)
-                .Padding(4)
-                .BottomMargin(16)
-                .BorderThickness(1)
-                .BorderRadius(BorderRadius.Rounded)
-                | new ActivityHeatmap().Data(data))
+            | new Card(new ActivityHeatmap().Data(data))
+                .WithMargin(0, 0, 0, 16)
 
             | Text.H2("With Optional Properties:")
             | new CodeBlock(@$"new ActivityHeatmap()
@@ -88,21 +82,14 @@ class ActivityHeatmapDemo : ViewBase
                         | showMonthLabels.ToBoolInput().Label("Show month labels"))
                     | nullableRange.ToDateRangeInput())
 
-            | (Layout
-                .Vertical()
-                .Gap(2)
-                .Padding(4)
-                .BorderThickness(1)
-                .BorderRadius(BorderRadius.Rounded)
-                | new ActivityHeatmap()
+            | new Card(new ActivityHeatmap()
                     .Data(data)
                     .StartDate(startDate)
                     .EndDate(endDate)
                     .ColorScheme(selectedColor.Value)
                     .ShowDayLabels(showDayLabels.Value)
                     .ShowMonthLabels(showMonthLabels.Value)
-                    .OnDayClick(day => Console.WriteLine($"Clicked {day.Date}: {day.Count}"))
-                    )
+                    .OnDayClick(day => Console.WriteLine($"Clicked {day.Date}: {day.Count}")))
 
                 | new DropDownMenu(@evt =>
                     {

--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/.samples/Program.cs
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/.samples/Program.cs
@@ -57,7 +57,7 @@ class ActivityHeatmapDemo : ViewBase
 
         return new ActivityHeatmap().Data(data);
     }}
-}}", Languages.Csharp)
+}}")
             | new Card(new ActivityHeatmap().Data(data))
                 .WithMargin(0, 0, 0, 16)
 
@@ -69,7 +69,7 @@ class ActivityHeatmapDemo : ViewBase
     .StartDate(DateOnly.Parse({$"\"{startDate}\""}))
     .EndDate(DateOnly.Parse({$"\"{endDate}\""}))
     .ColorScheme(Colors.{selectedColor.Value})
-    .OnDayClick(day => Console.WriteLine(...));", Languages.Csharp)
+    .OnDayClick(day => Console.WriteLine(...));")
 
             | (Layout
                     .Horizontal()

--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/ActivityHeatmap.tsx
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/ActivityHeatmap.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import "./style.css";
 import { ActivityHeatmapProps, Activity } from "./types";
 import { MONTH_NAMES, formatTooltipHeader, formatTooltipValue } from "./tooltipUtils";
@@ -126,6 +126,7 @@ export function ActivityHeatmap({
   const maxCount = Math.max(0, ...data.map((d) => d.count));
   const colors = buildColorScheme(`var(--color-${colorScheme.toLowerCase()})`);
   const clickable = events.includes("OnDayClick");
+  const gridContainer = useRef<HTMLDivElement>(null);
 
   const [tooltip, setTooltip] = useState<{ day: Activity; x: number; y: number } | null>(null);
 
@@ -153,7 +154,7 @@ export function ActivityHeatmap({
   };
 
   return (
-    <div className="flex w-full relative bg-background rounded border-secondary">
+    <div className="flex w-full relative rounded border-secondary bg-card">
       <div className=" overflow-x-auto p-0"
         style={{ direction: "rtl" }}>
         <div className="inline-flex flex-col gap-1 font-sans"
@@ -175,7 +176,7 @@ export function ActivityHeatmap({
 
           <div className="flex gap-1">
             {showDayLabels && (
-              <div className="flex flex-col justify-end absolute left-0 top-0 bottom-0 bg-background">
+              <div className="flex flex-col justify-end absolute left-0 top-0 bottom-0 bg-card">
                 <div
                   className="grid gap-0.5 text-secondary-foreground opacity-50 pt-0.5 *:pr-2 *:text-right"
                   style={{ gridTemplateRows: "repeat(7, 11px)", width: "28px" }}
@@ -191,8 +192,12 @@ export function ActivityHeatmap({
               </div>
             )}
 
-            <div className="flex gap-0.5 "
+            <div className="flex gap-0.5"
+              ref={gridContainer}
               style={{ paddingLeft: showDayLabels ? 28 : 0 }}
+              onMouseMove={(e) => {
+                if (tooltip) setTooltip((t) => t && { ...t, x: e.clientX, y: e.clientY });
+              }}
               onMouseLeave={() => setTooltip(null)}>
               {weeks.map((week, wi) => (
                 <div
@@ -206,15 +211,12 @@ export function ActivityHeatmap({
                     return (
                       <div
                         key={di}
-                        className={`w-[11px] h-[11px] rounded-sm ${clickable && day?.count ? "cursor-pointer" : "cursor-default"}`}
+                        className={`w-[11px] h-[11px] rounded-sm hover:rounded-none hover:scale-110 transition-transform duration-300 ease-in-out ${clickable && day?.count ? "cursor-pointer" : "cursor-default"}`}
                         style={{ backgroundColor: bg }}
                         onMouseEnter={(e) => {
                           if (showTooltip && day) {
                             setTooltip({ day, x: e.clientX, y: e.clientY });
                           }
-                        }}
-                        onMouseMove={(e) => {
-                          if (tooltip) setTooltip((t) => t && { ...t, x: e.clientX, y: e.clientY });
                         }}
                         onClick={day ? () => handleClick(day) : undefined}
                       />
@@ -229,25 +231,22 @@ export function ActivityHeatmap({
 
       {tooltip && (
         <div
+          className="fixed z-50 bg-card text-xs text-foreground pointer-events-none rounded-[4px] px-2 py-3 transition-transform duration-300 ease-in-out"
           style={{
-            position: "fixed",
-            left: tooltip.x + 12,
-            top: tooltip.y + 12,
-            backgroundColor: "var(--card, var(--background))",
-            color: "var(--foreground)",
-            fontFamily: "var(--font-sans)",
-            fontSize: "12px",
-            borderWidth: 0,
-            borderRadius: "4px",
-            padding: "8px 12px",
+            left: tooltip.x,
+            transform: `translate(${((tooltip.x > (gridContainer.current?.getBoundingClientRect().right ?? 0) / 2) ? -200 : 12)}px, ${tooltip.y > (window.innerHeight / 2) ? -80 : 12}px)`,
+            top: tooltip.y,
             minWidth: "180px",
             boxShadow: "0 4px 6px -1px rgba(0,0,0,.1), 0 2px 4px -2px rgba(0,0,0,.1)",
-            pointerEvents: "none",
-            zIndex: 9999,
           }}
         >
-          <div><strong>{formatTooltipHeader(tooltip.day)}</strong></div>
-          <div>{formatTooltipValue(tooltip.day)}</div>
+          <div className="font-bold">
+            {formatTooltipHeader(tooltip.day)}
+          </div>
+          <div className="flex gap-2 align-middle">
+            <div className="w-[11px] h-[11px] my-auto rounded-full" style={{ backgroundColor: colors[getLevel(tooltip.day.count, maxCount)] ?? colors[0]! }}></div>
+            <div>{formatTooltipValue(tooltip.day)}</div>
+          </div>
         </div>
       )}
     </div>

--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/ActivityHeatmap.tsx
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/ActivityHeatmap.tsx
@@ -202,6 +202,8 @@ export function ActivityHeatmap({
 
                 tooltipCoordinates.current = { x: e.clientX, y: e.clientY };
                 if (tooltipDiv.current) {
+                  tooltipDiv.current.style.left = e.clientX + "px";
+                  tooltipDiv.current.style.top = e.clientY + "px";
                   tooltipDiv.current.style.opacity = "1";
                   tooltipDiv.current.style.visibility = "visible";
                 }

--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/ActivityHeatmap.tsx
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/ActivityHeatmap.tsx
@@ -261,7 +261,7 @@ export function ActivityHeatmap({
 
       {showTooltip && <div
         ref={tooltipDiv}
-        className="fixed opacity-0 visibility-hidden z-50 bg-card text-xs text-foreground pointer-events-none rounded-[4px] px-2 py-3"
+        className="fixed opacity-0 z-50 bg-card text-xs text-foreground pointer-events-none rounded-[4px] px-2 py-3"
         style={{
           minWidth: "180px",
           boxShadow: "0 4px 6px -1px rgba(0,0,0,.1), 0 2px 4px -2px rgba(0,0,0,.1)",

--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/ActivityHeatmap.tsx
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/ActivityHeatmap.tsx
@@ -284,7 +284,7 @@ export function ActivityHeatmap({
 function getTooltipTransform(tooltipDiv: HTMLDivElement | null, tooltipCoordinates: { x: number; y: number }, gridContainer: HTMLDivElement | null): string {
   if (!tooltipDiv || !gridContainer) return "translate(0px, 0px)";
   const gridRect = gridContainer.getBoundingClientRect();
-  const xOffset = tooltipCoordinates.x > gridRect.left + gridRect.width / 2 ? -200 : 12;
-  const yOffset = tooltipCoordinates.y > window.innerHeight / 2 ? -80 : 12;
+  const xOffset = tooltipCoordinates.x > gridRect.left + gridRect.width / 2 ? -(tooltipDiv.offsetWidth + 20) : 20;
+  const yOffset = tooltipCoordinates.y > window.innerHeight / 2 ? -(tooltipDiv.offsetHeight + 20) : 20;
   return `translate(${xOffset}px, ${yOffset}px)`;
 }

--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/ActivityHeatmap.tsx
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/ActivityHeatmap.tsx
@@ -128,7 +128,9 @@ export function ActivityHeatmap({
   const clickable = events.includes("OnDayClick");
   const gridContainer = useRef<HTMLDivElement>(null);
 
-  const [tooltip, setTooltip] = useState<{ day: Activity; x: number; y: number } | null>(null);
+  const [tooltip, setTooltip] = useState<{ day: Activity; } | null>(null);
+  const tooltipCoordinates = useRef<{ x: number; y: number } | null>(null);
+  const tooltipDiv = useRef<HTMLDivElement>(null);
 
   // Compute month labels: for each week, check if the first non-null day is the first occurrence of a new month
   const monthLabels: string[] = weeks.map((week, wi) => {
@@ -195,10 +197,36 @@ export function ActivityHeatmap({
             <div className="flex gap-0.5"
               ref={gridContainer}
               style={{ paddingLeft: showDayLabels ? 28 : 0 }}
-              onMouseMove={(e) => {
-                if (tooltip) setTooltip((t) => t && { ...t, x: e.clientX, y: e.clientY });
+              onMouseEnter={(e) => {
+                if (!showTooltip) return;
+
+                tooltipCoordinates.current = { x: e.clientX, y: e.clientY };
+                if (tooltipDiv.current) {
+                  tooltipDiv.current.style.opacity = "1";
+                  tooltipDiv.current.style.visibility = "visible";
+                }
               }}
-              onMouseLeave={() => setTooltip(null)}>
+              onMouseMove={(e) => {
+                if (!showTooltip) return;
+
+                tooltipCoordinates.current = { x: e.clientX, y: e.clientY };
+                if (tooltipDiv.current) {
+                  tooltipDiv.current.style.left = e.clientX + "px";
+                  tooltipDiv.current.style.top = e.clientY + "px";
+                  tooltipDiv.current.style.transform = getTooltipTransform(tooltipDiv.current, tooltipCoordinates.current, gridContainer.current);
+                }
+              }}
+              onMouseLeave={() => {
+                if (!showTooltip) return;
+
+                tooltipCoordinates.current = null;
+                if (tooltipDiv.current) {
+                  tooltipDiv.current.style.opacity = "0";
+                  tooltipDiv.current.style.visibility = "hidden";
+                }
+                setTooltip(null);
+              }}
+            >
               {weeks.map((week, wi) => (
                 <div
                   key={wi}
@@ -211,11 +239,11 @@ export function ActivityHeatmap({
                     return (
                       <div
                         key={di}
-                        className={`w-[11px] h-[11px] rounded-sm hover:rounded-none hover:scale-110 transition-transform duration-300 ease-in-out ${clickable && day?.count ? "cursor-pointer" : "cursor-default"}`}
+                        className={`w-[11px] h-[11px] rounded-sm hover:rounded-none hover:scale-110 transition-all duration-300 ease-in-out ${clickable && day?.count ? "cursor-pointer" : "cursor-default"}`}
                         style={{ backgroundColor: bg }}
-                        onMouseEnter={(e) => {
+                        onMouseEnter={() => {
                           if (showTooltip && day) {
-                            setTooltip({ day, x: e.clientX, y: e.clientY });
+                            setTooltip({ day });
                           }
                         }}
                         onClick={day ? () => handleClick(day) : undefined}
@@ -229,26 +257,32 @@ export function ActivityHeatmap({
         </div>
       </div>
 
-      {tooltip && (
-        <div
-          className="fixed z-50 bg-card text-xs text-foreground pointer-events-none rounded-[4px] px-2 py-3 transition-transform duration-300 ease-in-out"
-          style={{
-            left: tooltip.x,
-            transform: `translate(${((tooltip.x > (gridContainer.current?.getBoundingClientRect().right ?? 0) / 2) ? -200 : 12)}px, ${tooltip.y > (window.innerHeight / 2) ? -80 : 12}px)`,
-            top: tooltip.y,
-            minWidth: "180px",
-            boxShadow: "0 4px 6px -1px rgba(0,0,0,.1), 0 2px 4px -2px rgba(0,0,0,.1)",
-          }}
-        >
-          <div className="font-bold">
-            {formatTooltipHeader(tooltip.day)}
-          </div>
-          <div className="flex gap-2 align-middle">
-            <div className="w-[11px] h-[11px] my-auto rounded-full" style={{ backgroundColor: colors[getLevel(tooltip.day.count, maxCount)] ?? colors[0]! }}></div>
-            <div>{formatTooltipValue(tooltip.day)}</div>
-          </div>
-        </div>
-      )}
+      {showTooltip && <div
+        ref={tooltipDiv}
+        className="fixed opacity-0 visibility-hidden z-50 bg-card text-xs text-foreground pointer-events-none rounded-[4px] px-2 py-3"
+        style={{
+          minWidth: "180px",
+          boxShadow: "0 4px 6px -1px rgba(0,0,0,.1), 0 2px 4px -2px rgba(0,0,0,.1)",
+          transition: "opacity 0.3s ease-in-out, visibility 0.3s ease-in-out, transform 0.3s ease-in-out",
+        }}
+      >
+        {tooltip &&
+          <>
+            <div className="font-bold">{formatTooltipHeader(tooltip.day)}</div>
+            <div className="flex gap-2 align-middle">
+              <div className="w-[11px] h-[11px] my-auto rounded-full" style={{ backgroundColor: colors[getLevel(tooltip.day.count, maxCount)] ?? colors[0]! }}></div>
+              <div>{formatTooltipValue(tooltip.day)}</div>
+            </div>
+          </>}
+      </div>}
     </div>
   );
+}
+
+function getTooltipTransform(tooltipDiv: HTMLDivElement | null, tooltipCoordinates: { x: number; y: number }, gridContainer: HTMLDivElement | null): string {
+  if (!tooltipDiv || !gridContainer) return "translate(0px, 0px)";
+  const gridRect = gridContainer.getBoundingClientRect();
+  const xOffset = tooltipCoordinates.x > gridRect.left + gridRect.width / 2 ? -200 : 12;
+  const yOffset = tooltipCoordinates.y > window.innerHeight / 2 ? -80 : 12;
+  return `translate(${xOffset}px, ${yOffset}px)`;
 }

--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/ActivityHeatmap.tsx
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/ActivityHeatmap.tsx
@@ -239,7 +239,7 @@ export function ActivityHeatmap({
                     return (
                       <div
                         key={di}
-                        className={`w-[11px] h-[11px] rounded-sm hover:rounded-none hover:scale-110 transition-all duration-300 ease-in-out ${clickable && day?.count ? "cursor-pointer" : "cursor-default"}`}
+                        className={`w-[11px] h-[11px] rounded-sm hover:rounded-none hover:scale-110 ${clickable && day?.count ? "cursor-pointer" : "cursor-default"}`}
                         style={{ backgroundColor: bg }}
                         onMouseEnter={() => {
                           if (showTooltip && day) {

--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/ActivityHeatmap.tsx
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/ActivityHeatmap.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState } from "react";
 import "./style.css";
 import { ActivityHeatmapProps, Activity } from "./types";
-import { MONTH_NAMES, formatTooltipHeader, formatTooltipValue } from "./tooltipUtils";
+import { MONTH_NAMES, formatTooltipHeader, formatTooltipValue, getTooltipTransform } from "./tooltipUtils";
 
 function buildColorScheme(baseColor: string): string[] {
   return [
@@ -279,12 +279,4 @@ export function ActivityHeatmap({
       </div>}
     </div>
   );
-}
-
-function getTooltipTransform(tooltipDiv: HTMLDivElement | null, tooltipCoordinates: { x: number; y: number }, gridContainer: HTMLDivElement | null): string {
-  if (!tooltipDiv || !gridContainer) return "translate(0px, 0px)";
-  const gridRect = gridContainer.getBoundingClientRect();
-  const xOffset = tooltipCoordinates.x > gridRect.left + gridRect.width / 2 ? -(tooltipDiv.offsetWidth + 20) : 20;
-  const yOffset = tooltipCoordinates.y > window.innerHeight / 2 ? -(tooltipDiv.offsetHeight + 20) : 20;
-  return `translate(${xOffset}px, ${yOffset}px)`;
 }

--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/ActivityHeatmap.tsx
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/ActivityHeatmap.tsx
@@ -240,7 +240,7 @@ export function ActivityHeatmap({
                     const bg = colors[level] ?? colors[0]!;
                     return (
                       <div
-                        key={di}
+                        key={day?.date ?? `${di}-${wi}`}
                         className={`w-[11px] h-[11px] rounded-sm hover:rounded-none hover:scale-110 ${clickable && day?.count ? "cursor-pointer" : "cursor-default"}`}
                         style={{ backgroundColor: bg }}
                         onMouseEnter={() => {

--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/ActivityHeatmap.tsx
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/ActivityHeatmap.tsx
@@ -192,7 +192,8 @@ export function ActivityHeatmap({
             )}
 
             <div className="flex gap-0.5 "
-              style={{ paddingLeft: showDayLabels ? 28 : 0 }}>
+              style={{ paddingLeft: showDayLabels ? 28 : 0 }}
+              onMouseLeave={() => setTooltip(null)}>
               {weeks.map((week, wi) => (
                 <div
                   key={wi}
@@ -215,7 +216,6 @@ export function ActivityHeatmap({
                         onMouseMove={(e) => {
                           if (tooltip) setTooltip((t) => t && { ...t, x: e.clientX, y: e.clientY });
                         }}
-                        onMouseLeave={() => setTooltip(null)}
                         onClick={day ? () => handleClick(day) : undefined}
                       />
                     );

--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/ActivityHeatmap.tsx
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/ActivityHeatmap.tsx
@@ -1,5 +1,7 @@
+import { useState } from "react";
 import "./style.css";
 import { ActivityHeatmapProps, Activity } from "./types";
+import { MONTH_NAMES, formatTooltipHeader, formatTooltipValue } from "./tooltipUtils";
 
 function buildColorScheme(baseColor: string): string[] {
   return [
@@ -11,10 +13,10 @@ function buildColorScheme(baseColor: string): string[] {
   ];
 }
 
-const preferredLanguage = navigator.languages.length ? navigator.languages : navigator.language;
-const monthFormatter = new Intl.DateTimeFormat(preferredLanguage, { month: "short" });
-const weekdayFormatter = new Intl.DateTimeFormat(preferredLanguage, { weekday: "short" });
-const MONTH_NAMES = Array.from({ length: 12 }, (_, i) => monthFormatter.format(new Date(0, i)));
+const weekdayFormatter = new Intl.DateTimeFormat(
+  navigator.languages.length ? navigator.languages : navigator.language,
+  { weekday: "short" }
+);
 
 const MONDAY = weekdayFormatter.format(new Date('2025-01-06'));
 const WEDNESDAY = weekdayFormatter.format(new Date('2025-01-08'));
@@ -108,15 +110,6 @@ function buildGridFromRange(
   return weeks;
 }
 
-function formatTooltip(day: Activity): string {
-  const date = new Date(day.date + "T00:00:00");
-  const month = MONTH_NAMES[date.getMonth()];
-  const dayNum = date.getDate();
-  const year = date.getFullYear();
-  const label = day.count === 1 ? "contribution" : "contributions";
-  return `${month} ${dayNum}, ${year} — ${day.count} ${label}`;
-}
-
 export function ActivityHeatmap({
   id,
   events = [],
@@ -133,6 +126,8 @@ export function ActivityHeatmap({
   const maxCount = Math.max(0, ...data.map((d) => d.count));
   const colors = buildColorScheme(`var(--color-${colorScheme.toLowerCase()})`);
   const clickable = events.includes("OnDayClick");
+
+  const [tooltip, setTooltip] = useState<{ day: Activity; x: number; y: number } | null>(null);
 
   // Compute month labels: for each week, check if the first non-null day is the first occurrence of a new month
   const monthLabels: string[] = weeks.map((week, wi) => {
@@ -207,14 +202,20 @@ export function ActivityHeatmap({
                   {week.map((day, di) => {
                     const level = day ? getLevel(day.count, maxCount) : 0;
                     const bg = colors[level] ?? colors[0]!;
-                    const title =
-                      showTooltip && day ? formatTooltip(day) : undefined;
                     return (
                       <div
                         key={di}
                         className={`w-[11px] h-[11px] rounded-sm ${clickable && day?.count ? "cursor-pointer" : "cursor-default"}`}
                         style={{ backgroundColor: bg }}
-                        title={title}
+                        onMouseEnter={(e) => {
+                          if (showTooltip && day) {
+                            setTooltip({ day, x: e.clientX, y: e.clientY });
+                          }
+                        }}
+                        onMouseMove={(e) => {
+                          if (tooltip) setTooltip((t) => t && { ...t, x: e.clientX, y: e.clientY });
+                        }}
+                        onMouseLeave={() => setTooltip(null)}
                         onClick={day ? () => handleClick(day) : undefined}
                       />
                     );
@@ -225,6 +226,30 @@ export function ActivityHeatmap({
           </div>
         </div>
       </div>
+
+      {tooltip && (
+        <div
+          style={{
+            position: "fixed",
+            left: tooltip.x + 12,
+            top: tooltip.y + 12,
+            backgroundColor: "var(--card, var(--background))",
+            color: "var(--foreground)",
+            fontFamily: "var(--font-sans)",
+            fontSize: "12px",
+            borderWidth: 0,
+            borderRadius: "4px",
+            padding: "8px 12px",
+            minWidth: "180px",
+            boxShadow: "0 4px 6px -1px rgba(0,0,0,.1), 0 2px 4px -2px rgba(0,0,0,.1)",
+            pointerEvents: "none",
+            zIndex: 9999,
+          }}
+        >
+          <div><strong>{formatTooltipHeader(tooltip.day)}</strong></div>
+          <div>{formatTooltipValue(tooltip.day)}</div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/tooltipUtils.ts
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/tooltipUtils.ts
@@ -1,0 +1,18 @@
+import { Activity } from "./types";
+
+const preferredLanguage = navigator.languages.length ? navigator.languages : navigator.language;
+const monthFormatter = new Intl.DateTimeFormat(preferredLanguage, { month: "short" });
+export const MONTH_NAMES = Array.from({ length: 12 }, (_, i) => monthFormatter.format(new Date(0, i)));
+
+export function formatTooltipHeader(day: Activity): string {
+  const date = new Date(day.date + "T00:00:00");
+  const month = MONTH_NAMES[date.getMonth()];
+  const dayNum = date.getDate();
+  const year = date.getFullYear();
+  return `${month} ${dayNum}, ${year}`;
+}
+
+export function formatTooltipValue(day: Activity): string {
+  const label = day.count === 1 ? "contribution" : "contributions";
+  return `${day.count} ${label}`;
+}

--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/tooltipUtils.ts
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/tooltipUtils.ts
@@ -16,3 +16,11 @@ export function formatTooltipValue(day: Activity): string {
   const label = day.count === 1 ? "contribution" : "contributions";
   return `${day.count} ${label}`;
 }
+
+export function getTooltipTransform(tooltipDiv: HTMLDivElement | null, tooltipCoordinates: { x: number; y: number }, gridContainer: HTMLDivElement | null): string {
+  if (!tooltipDiv || !gridContainer) return "translate(0px, 0px)";
+  const gridRect = gridContainer.getBoundingClientRect();
+  const xOffset = tooltipCoordinates.x > gridRect.left + gridRect.width / 2 ? -(tooltipDiv.offsetWidth + 20) : 20;
+  const yOffset = tooltipCoordinates.y > window.innerHeight / 2 ? -(tooltipDiv.offsetHeight + 20) : 20;
+  return `translate(${xOffset}px, ${yOffset}px)`;
+}


### PR DESCRIPTION
## Summary
Replaces the Activity Heatmap’s native title tooltips with a custom React tooltip that matches Ivy chart widgets: card background, shared shadow/min-width styling, bold date header, color swatch marker, and contribution count.

- Styled tooltip — Fixed overlay with `bg-card`, 180px min-width, chart-matching box shadow, fade transitions, and locale-aware date/value formatting moved to `tooltipUtils.ts`.
- Smoother interaction — Grid-level mouse handlers position the tooltip from cursor coordinates with flip logic (left/right of grid midpoint, top/bottom of viewport).
- Visual alignment — Heatmap container and day-label column use `bg-card` (was `bg-background`) so the widget sits cleanly inside `Card` wrappers like charts.
- Sample updates — Demo wraps heatmaps in `Card` instead of hand-rolled bordered layouts.

**Before:**
<img width="418" height="188" alt="activity-heatmap-tooltip-before" src="https://github.com/user-attachments/assets/f563fe74-720f-449d-9c4a-bc87537a07df" />

**After (light mode):**
<img width="717" height="184" alt="activity-heatmap-tooltip-light" src="https://github.com/user-attachments/assets/bbac74c7-4930-417a-85a6-3fa1b4b08e55" />

**After (dark mode):**
<img width="717" height="184" alt="activity-heatmap-tooltip-dark" src="https://github.com/user-attachments/assets/ede7bd11-fd40-4fa4-86ca-2b32ddf2066e" />


## Changes
- `ActivityHeatmap.tsx`: Custom tooltip overlay; grid onMouseEnter / onMouseMove / onMouseLeave; getTooltipTransform for smart offsets; cell hover scale; stable keys (day.date)
- `tooltipUtils.ts`:  `getTooltipTransform`, `formatTooltipHeader`, `formatTooltipValue`, shared `MONTH_NAMES`
- `.samples/Program.cs`: Demo uses Card for heatmap previews

