### PR TITLE
(ci): fix E2E jobs timing out during Playwright browser install

### DIFF
--- a/.github/workflows/e2e-docs-tests.yml
+++ b/.github/workflows/e2e-docs-tests.yml
@@ -35,16 +35,32 @@ jobs:
       - name: Build backend
         run: dotnet build src/Ivy.Docs/Ivy.Docs.csproj
 
+      # Only Chromium is used (see playwright.config.ts). Cache browsers to avoid
+      # re-downloading ~500MB and slow apt installs on every run.
+      - name: Get Playwright version
+        id: playwright-version
+        working-directory: ./src/frontend
+        run: echo "version=$(node -p "require('./package.json').devDependencies['@playwright/test']")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-chromium-${{ steps.playwright-version.outputs.version }}
+
+      - name: Install Playwright Browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        timeout-minutes: 15
+        working-directory: ./src/frontend
+        run: pnpm exec playwright install chromium --with-deps
+
       - name: Start backend server
         run: |
           dotnet run --project src/Ivy.Docs/Ivy.Docs.csproj -- --port 5010 --silent &
           echo $! > backend.pid
           # Wait for server to be ready
           timeout 30 bash -c 'until curl -fk https://localhost:5010/ > /dev/null 2>&1; do sleep 1; done'
-
-      - name: Install Playwright Browsers
-        working-directory: ./src/frontend
-        run: npx playwright install --with-deps
 
       - name: Run Playwright tests for Docs
         working-directory: ./src/frontend

--- a/.github/workflows/e2e-samples-tests.yml
+++ b/.github/workflows/e2e-samples-tests.yml
@@ -35,16 +35,32 @@ jobs:
       - name: Build backend
         run: dotnet build src/Ivy.Samples/Ivy.Samples.csproj
 
+      # Only Chromium is used (see playwright.config.ts). Cache browsers to avoid
+      # re-downloading ~500MB and slow apt installs on every run.
+      - name: Get Playwright version
+        id: playwright-version
+        working-directory: ./src/frontend
+        run: echo "version=$(node -p "require('./package.json').devDependencies['@playwright/test']")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-chromium-${{ steps.playwright-version.outputs.version }}
+
+      - name: Install Playwright Browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        timeout-minutes: 15
+        working-directory: ./src/frontend
+        run: pnpm exec playwright install chromium --with-deps
+
       - name: Start backend server
         run: |
           dotnet run --project src/Ivy.Samples/Ivy.Samples.csproj -- --port 5010 --silent &
           echo $! > backend.pid
           # Wait for server to be ready
           timeout 30 bash -c 'until curl -fk https://localhost:5010/ > /dev/null 2>&1; do sleep 1; done'
-
-      - name: Install Playwright Browsers
-        working-directory: ./src/frontend
-        run: npx playwright install --with-deps
 
       - name: Run Playwright tests for Samples
         working-directory: ./src/frontend


### PR DESCRIPTION
## Summary

E2E Docs and E2E Samples jobs have been cancelling at the 60-minute job timeout because `playwright install --with-deps` was taking ~58 minutes (vs ~37s when healthy). Tests never ran — unrelated PRs were affected.

This updates both E2E workflows to:

- Install **Chromium only** (matches `playwright.config.ts`; avoids Firefox/WebKit downloads)
- **Cache** `~/.cache/ms-playwright` keyed by Playwright version
- Run browser install **before** starting the backend server
- Use `pnpm exec playwright` instead of `npx`
- Add a **15-minute step timeout** on browser install so slow CDN/apt failures fail clearly instead of burning the full job timeout

## Context

- Last successful install: ~37s (May 21 ~10:54 UTC)
- Broken runs since ~May 21 16:30 UTC: install step ~58m → job cancelled at 60m
- Not caused by individual PR changes

## Test plan

- [ ] Open PR and confirm E2E Docs + E2E Samples complete in normal time
- [ ] Re-run workflow on same PR to confirm cache hit (install step skipped)
- [ ] Verify Playwright tests actually execute (not skipped/cancelled)