### PR TITLE
fix(ActivityHeatmap): handle undefined activity count

### DIFF
--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/package.json
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vp dev",
     "build": "tsc && vp build",
-    "preview": "vp preview"
+    "preview": "vp preview",
+    "test": "vp test"
   },
   "dependencies": {
     "@ivy-interactive/ivy-design-system": "1.1.18"
@@ -20,6 +21,7 @@
     "typescript": "5.9.3",
     "vite": "npm:@voidzero-dev/vite-plus-core@0.1.20",
     "vite-plus": "0.1.20",
+    "vitest": "npm:@voidzero-dev/vite-plus-test@0.1.20",
     "@vitejs/plugin-react": "6.0.1"
   },
   "peerDependencies": {

--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/pnpm-lock.yaml
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       vite-plus:
         specifier: 0.1.20
         version: 0.1.20(@voidzero-dev/vite-plus-core@0.1.20(jiti@1.21.7)(typescript@5.9.3))(jiti@1.21.7)(typescript@5.9.3)
+      vitest:
+        specifier: npm:@voidzero-dev/vite-plus-test@0.1.20
+        version: '@voidzero-dev/vite-plus-test@0.1.20(@voidzero-dev/vite-plus-core@0.1.20(jiti@1.21.7)(typescript@5.9.3))(jiti@1.21.7)(typescript@5.9.3)'
 
 packages:
 

--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/ActivityHeatmap.tsx
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/ActivityHeatmap.tsx
@@ -23,10 +23,11 @@ const WEDNESDAY = weekdayFormatter.format(new Date('2025-01-08'));
 const FRIDAY = weekdayFormatter.format(new Date('2025-01-10'));
 
 function getLevel(count: number | undefined, maxCount: number): number {
-  if (count === undefined || count === 0 || maxCount === 0) return 0;
-  if (count <= maxCount * 0.25) return 1;
-  if (count <= maxCount * 0.5) return 2;
-  if (count <= maxCount * 0.75) return 3;
+  const normalizedCount = count ?? 0;
+  if (normalizedCount === 0 || maxCount === 0) return 0;
+  if (normalizedCount <= maxCount * 0.25) return 1;
+  if (normalizedCount <= maxCount * 0.5) return 2;
+  if (normalizedCount <= maxCount * 0.75) return 3;
   return 4;
 }
 

--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/ActivityHeatmap.tsx
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/ActivityHeatmap.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from "react";
 import "./style.css";
 import { ActivityHeatmapProps, Activity } from "./types";
+import { computeMaxCount, getLevel } from "./levelUtils";
 import { MONTH_NAMES, formatTooltipHeader, formatTooltipValue, getTooltipTransform } from "./tooltipUtils";
 
 function buildColorScheme(baseColor: string): string[] {
@@ -21,15 +22,6 @@ const weekdayFormatter = new Intl.DateTimeFormat(
 const MONDAY = weekdayFormatter.format(new Date('2025-01-06'));
 const WEDNESDAY = weekdayFormatter.format(new Date('2025-01-08'));
 const FRIDAY = weekdayFormatter.format(new Date('2025-01-10'));
-
-function getLevel(count: number | undefined, maxCount: number): number {
-  const normalizedCount = count ?? 0;
-  if (normalizedCount === 0 || maxCount === 0) return 0;
-  if (normalizedCount <= maxCount * 0.25) return 1;
-  if (normalizedCount <= maxCount * 0.5) return 2;
-  if (normalizedCount <= maxCount * 0.75) return 3;
-  return 4;
-}
 
 function formatLocalDateKey(date: Date): string {
   const year = date.getFullYear();
@@ -124,7 +116,7 @@ export function ActivityHeatmap({
   endDate,
 }: ActivityHeatmapProps) {
   const weeks = buildGrid(data, startDate, endDate);
-  const maxCount = Math.max(0, ...data.map((d) => d.count ?? 0));
+  const maxCount = computeMaxCount(data);
   const colors = buildColorScheme(`var(--color-${colorScheme.toLowerCase()})`);
   const clickable = events.includes("OnDayClick");
   const gridContainer = useRef<HTMLDivElement>(null);

--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/ActivityHeatmap.tsx
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/ActivityHeatmap.tsx
@@ -22,8 +22,8 @@ const MONDAY = weekdayFormatter.format(new Date('2025-01-06'));
 const WEDNESDAY = weekdayFormatter.format(new Date('2025-01-08'));
 const FRIDAY = weekdayFormatter.format(new Date('2025-01-10'));
 
-function getLevel(count: number, maxCount: number): number {
-  if (count === 0 || maxCount === 0) return 0;
+function getLevel(count: number | undefined, maxCount: number): number {
+  if (count === undefined || count === 0 || maxCount === 0) return 0;
   if (count <= maxCount * 0.25) return 1;
   if (count <= maxCount * 0.5) return 2;
   if (count <= maxCount * 0.75) return 3;
@@ -123,7 +123,7 @@ export function ActivityHeatmap({
   endDate,
 }: ActivityHeatmapProps) {
   const weeks = buildGrid(data, startDate, endDate);
-  const maxCount = Math.max(0, ...data.map((d) => d.count));
+  const maxCount = Math.max(0, ...data.map((d) => d.count ?? 0));
   const colors = buildColorScheme(`var(--color-${colorScheme.toLowerCase()})`);
   const clickable = events.includes("OnDayClick");
   const gridContainer = useRef<HTMLDivElement>(null);

--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/levelUtils.test.ts
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/levelUtils.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { computeMaxCount, getLevel } from "./levelUtils";
+import type { Activity } from "./types";
+
+describe("computeMaxCount", () => {
+  it("returns 0 for empty data", () => {
+    expect(computeMaxCount([])).toBe(0);
+  });
+
+  it("does not return NaN when some counts are missing", () => {
+    const data: Activity[] = [
+      { date: "2025-01-01", count: 10 },
+      { date: "2025-01-02", count: undefined },
+      { date: "2025-01-03", count: 5 },
+    ];
+    const max = computeMaxCount(data);
+    expect(Number.isNaN(max)).toBe(false);
+    expect(max).toBe(10);
+  });
+
+  it("treats null counts as zero", () => {
+    const data = [
+      { date: "2025-01-01", count: 7 },
+      { date: "2025-01-02", count: null },
+    ] as Activity[];
+    expect(computeMaxCount(data)).toBe(7);
+  });
+});
+
+describe("getLevel", () => {
+  const max = 100;
+
+  it("returns 0 for undefined count", () => {
+    expect(getLevel(undefined, max)).toBe(0);
+  });
+
+  it("returns 0 for null count", () => {
+    expect(getLevel(null, max)).toBe(0);
+  });
+
+  it("returns 0 for zero count", () => {
+    expect(getLevel(0, max)).toBe(0);
+  });
+
+  it("returns 0 when maxCount is 0", () => {
+    expect(getLevel(50, 0)).toBe(0);
+  });
+
+  it("maps counts to expected levels", () => {
+    expect(getLevel(1, max)).toBe(1);
+    expect(getLevel(25, max)).toBe(1);
+    expect(getLevel(26, max)).toBe(2);
+    expect(getLevel(50, max)).toBe(2);
+    expect(getLevel(51, max)).toBe(3);
+    expect(getLevel(75, max)).toBe(3);
+    expect(getLevel(76, max)).toBe(4);
+    expect(getLevel(100, max)).toBe(4);
+  });
+
+  it("uses a finite maxCount so positive counts are not all level 4", () => {
+    const data: Activity[] = [
+      { date: "2025-01-01", count: 10 },
+      { date: "2025-01-02", count: undefined },
+    ];
+    const maxCount = computeMaxCount(data);
+    expect(getLevel(5, maxCount)).toBe(2);
+  });
+});

--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/levelUtils.ts
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/levelUtils.ts
@@ -1,0 +1,14 @@
+import type { Activity } from "./types";
+
+export function computeMaxCount(data: Pick<Activity, "count">[]): number {
+  return Math.max(0, ...data.map((d) => d.count ?? 0));
+}
+
+export function getLevel(count: Activity["count"] | null, maxCount: number): number {
+  const normalizedCount = count ?? 0;
+  if (normalizedCount === 0 || maxCount === 0) return 0;
+  if (normalizedCount <= maxCount * 0.25) return 1;
+  if (normalizedCount <= maxCount * 0.5) return 2;
+  if (normalizedCount <= maxCount * 0.75) return 3;
+  return 4;
+}

--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/tooltipUtils.ts
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/tooltipUtils.ts
@@ -14,7 +14,7 @@ export function formatTooltipHeader(day: Activity): string {
 
 export function formatTooltipValue(day: Activity): string {
   const label = day.count === 1 ? "contribution" : "contributions";
-  return `${day.count} ${label}`;
+  return `${day.count ?? 0} ${label}`;
 }
 
 export function getTooltipTransform(tooltipDiv: HTMLDivElement | null, tooltipCoordinates: { x: number; y: number }, gridContainer: HTMLDivElement | null): string {

--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/types.ts
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/types.ts
@@ -1,6 +1,6 @@
 export interface Activity {
   date: string; // "YYYY-MM-DD"
-  count: number;
+  count: number | undefined;
 }
 
 export type IvyEventHandler = (

--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/tsconfig.json
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/tsconfig.json
@@ -21,5 +21,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
 }


### PR DESCRIPTION
This PR addresses part of an issue with the ActivityHeatmap external widget seen in the [Ivy Insights dashboard](https://ivy-nuget-stats.sliplane.app/ivy-insights). Some `Count` values are being read as `undefined` in the widget frontend, causing the day cell color scaling to break:
<img width="546" height="312" alt="undefined-activity-count" src="https://github.com/user-attachments/assets/d0cada4f-d3c2-41fb-9b13-cf2914fed9ad" />

## Summary

- Fixes ActivityHeatmap rendering when daily `count` is missing or undefined: `maxCount` no longer becomes `NaN`, so cell colors and tooltips scale correctly instead of showing every day at the maximum intensity.
- Normalizes missing counts to zero in `computeMaxCount`, `getLevel`, and tooltip value formatting so undefined/null JSON values behave like empty days.
- Extracts level calculation into `levelUtils` and adds Vitest coverage for the regression, plus a `pnpm test` script on the widget frontend package.

## Steps to reproduce in sample app:
Reproducable in local dev environment by adding undefined activity count to `data` array in `ActivityHeatmap.tsx`:

```tsx
// ActivityHeatmap.tsx
export function ActivityHeatmap({
  id,
  events = [],
  eventHandler,
  data = [],
  ...
}: ActivityHeatmapProps) {
  data = [...data, { date: "2025-01-01", count: undefined! }]; // <- temporary mock data to reproduce bug
  const weeks = buildGrid(data, startDate, endDate);
  const maxCount = computeMaxCount(data);
  ...
```

**Before:**
<img width="821" height="246" alt="undefined-activity-count-reproduced-before" src="https://github.com/user-attachments/assets/9cfebffc-64bf-4489-92f5-1a46fe93231b" />

**After:**
<img width="821" height="246" alt="undefined-activity-count-reproduced-after" src="https://github.com/user-attachments/assets/5e77afa0-8e6b-4d2d-acf7-a43549f7b0d2" />
