### PR TITLE
(datatable): position cell hover tooltips above cells

### DIFF
--- a/src/Ivy.Samples.Shared/Apps/Widgets/DataTableApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/DataTableApp.cs
@@ -11,7 +11,6 @@ public class DataTableApp : SampleBase
             new Tab("Footer", new DataTableFooterSample()),
             new Tab("Multi Agg", new DataTableMultiAggSample()),
             new Tab("Density", new DataTableDensitySample()),
-            new Tab("Cell Tooltip", new DataTableCellTooltipSample()),
             new Tab("Million Rows", new DataTablesMillionRowsSample())
         ).Variant(TabsVariant.Content);
     }
@@ -394,74 +393,6 @@ public class DataTableDensitySample : ViewBase
                 | new Button("Large").OnClick(_ => density.Set(Density.Large))
                     .Variant(density.Value == Density.Large ? ButtonVariant.Primary : ButtonVariant.Outline).Small()
             | table;
-    }
-}
-
-public record CellTooltipRow(
-    string Status,
-    string Plan,
-    string Prompt,
-    string Type,
-    string Project,
-    string Timer,
-    string DocsLink
-);
-
-public class DataTableCellTooltipSample : ViewBase
-{
-    private const string LongPrompt =
-        "You are an expert assistant. Summarize the following in three bullet points, cite sources, "
-        + "and keep the tone professional. Do not invent facts. If context is missing, ask clarifying "
-        + "questions before answering. Prefer concise paragraphs over walls of text.";
-
-    private const string LongPlan =
-        "Enterprise tier — unlimited seats, SSO, audit logs, dedicated support SLA, custom retention policies";
-
-    public override object? Build()
-    {
-        var rows = Enumerable.Range(1, 40)
-            .Select(i => new CellTooltipRow(
-                Status: i % 3 == 0 ? "In progress" : i % 3 == 1 ? "Done" : "Blocked",
-                Plan: LongPlan,
-                Prompt: $"{LongPrompt} (row {i})",
-                Type: i % 2 == 0 ? "Completion" : "Chat",
-                Project: $"Project {(char)('A' + (i % 5))} — quarterly rollout and migration checklist",
-                Timer: $"{(i * 3) % 60:D2}:{(i * 7) % 60:D2}",
-                DocsLink: "https://docs.ivy.app/widgets/advanced/data-table"
-            ))
-            .AsQueryable();
-
-        return Layout.Vertical().Width(Size.Full()).Height(Size.Full()).Gap(3)
-            | Text.P(
-                "Hover truncated cells to preview the full value. Tooltips flip based on viewport space: "
-                    + "cells near the top of the window show the tooltip below the cell; cells near the bottom show it above. "
-                    + "Scroll the table and try both areas — the cell stays clickable in either case.")
-                .Muted()
-            | rows.ToDataTable()
-                .Header(x => x.Status, "Status")
-                .Header(x => x.Plan, "Plan")
-                .Header(x => x.Prompt, "Prompt")
-                .Header(x => x.Type, "Type")
-                .Header(x => x.Project, "Project")
-                .Header(x => x.Timer, "Timer")
-                .Header(x => x.DocsLink, "Docs")
-                .Width(x => x.Status, Size.Px(90))
-                .Width(x => x.Plan, Size.Px(140))
-                .Width(x => x.Prompt, Size.Px(160))
-                .Width(x => x.Type, Size.Px(100))
-                .Width(x => x.Project, Size.Px(180))
-                .Width(x => x.Timer, Size.Px(70))
-                .Width(x => x.DocsLink, Size.Px(120))
-                .Renderer(x => x.DocsLink, new LinkDisplayRenderer { Type = LinkDisplayType.Url })
-                .Config(config =>
-                {
-                    config.AllowColumnResizing = true;
-                    config.ShowSearch = false;
-                    config.ShowGroups = false;
-                    config.ShowIndexColumn = true;
-                })
-                .Width(Size.Full())
-                .Height(Size.Full());
     }
 }
 

--- a/src/Ivy.Samples.Shared/Apps/Widgets/DataTableApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/DataTableApp.cs
@@ -11,6 +11,7 @@ public class DataTableApp : SampleBase
             new Tab("Footer", new DataTableFooterSample()),
             new Tab("Multi Agg", new DataTableMultiAggSample()),
             new Tab("Density", new DataTableDensitySample()),
+            new Tab("Cell Tooltip", new DataTableCellTooltipSample()),
             new Tab("Million Rows", new DataTablesMillionRowsSample())
         ).Variant(TabsVariant.Content);
     }
@@ -393,6 +394,74 @@ public class DataTableDensitySample : ViewBase
                 | new Button("Large").OnClick(_ => density.Set(Density.Large))
                     .Variant(density.Value == Density.Large ? ButtonVariant.Primary : ButtonVariant.Outline).Small()
             | table;
+    }
+}
+
+public record CellTooltipRow(
+    string Status,
+    string Plan,
+    string Prompt,
+    string Type,
+    string Project,
+    string Timer,
+    string DocsLink
+);
+
+public class DataTableCellTooltipSample : ViewBase
+{
+    private const string LongPrompt =
+        "You are an expert assistant. Summarize the following in three bullet points, cite sources, "
+        + "and keep the tone professional. Do not invent facts. If context is missing, ask clarifying "
+        + "questions before answering. Prefer concise paragraphs over walls of text.";
+
+    private const string LongPlan =
+        "Enterprise tier — unlimited seats, SSO, audit logs, dedicated support SLA, custom retention policies";
+
+    public override object? Build()
+    {
+        var rows = Enumerable.Range(1, 40)
+            .Select(i => new CellTooltipRow(
+                Status: i % 3 == 0 ? "In progress" : i % 3 == 1 ? "Done" : "Blocked",
+                Plan: LongPlan,
+                Prompt: $"{LongPrompt} (row {i})",
+                Type: i % 2 == 0 ? "Completion" : "Chat",
+                Project: $"Project {(char)('A' + (i % 5))} — quarterly rollout and migration checklist",
+                Timer: $"{(i * 3) % 60:D2}:{(i * 7) % 60:D2}",
+                DocsLink: "https://docs.ivy.app/widgets/advanced/data-table"
+            ))
+            .AsQueryable();
+
+        return Layout.Vertical().Width(Size.Full()).Height(Size.Full()).Gap(3)
+            | Text.P(
+                "Hover truncated cells to preview the full value. Tooltips flip based on viewport space: "
+                    + "cells near the top of the window show the tooltip below the cell; cells near the bottom show it above. "
+                    + "Scroll the table and try both areas — the cell stays clickable in either case.")
+                .Muted()
+            | rows.ToDataTable()
+                .Header(x => x.Status, "Status")
+                .Header(x => x.Plan, "Plan")
+                .Header(x => x.Prompt, "Prompt")
+                .Header(x => x.Type, "Type")
+                .Header(x => x.Project, "Project")
+                .Header(x => x.Timer, "Timer")
+                .Header(x => x.DocsLink, "Docs")
+                .Width(x => x.Status, Size.Px(90))
+                .Width(x => x.Plan, Size.Px(140))
+                .Width(x => x.Prompt, Size.Px(160))
+                .Width(x => x.Type, Size.Px(100))
+                .Width(x => x.Project, Size.Px(180))
+                .Width(x => x.Timer, Size.Px(70))
+                .Width(x => x.DocsLink, Size.Px(120))
+                .Renderer(x => x.DocsLink, new LinkDisplayRenderer { Type = LinkDisplayType.Url })
+                .Config(config =>
+                {
+                    config.AllowColumnResizing = true;
+                    config.ShowSearch = false;
+                    config.ShowGroups = false;
+                    config.ShowIndexColumn = true;
+                })
+                .Width(Size.Full())
+                .Height(Size.Full());
     }
 }
 

--- a/src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx
+++ b/src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx
@@ -182,6 +182,7 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
   // Cell hover tooltips (truncated text + link hint)
   const {
     cellTooltip,
+    cellTooltipStyle,
     onItemHovered: onCellTooltipHovered,
     supportsHoverTooltip,
     clearCellHoverTooltip,
@@ -418,19 +419,13 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
     footer
   );
 
-  const cellTooltipGap = 8;
   const cellTooltipNode =
-    supportsHoverTooltip && cellTooltip
+    supportsHoverTooltip && cellTooltip && cellTooltipStyle
       ? createPortal(
           <div
             role="tooltip"
             className="pointer-events-none fixed z-50 max-w-sm overflow-hidden rounded-selector border border-border bg-popover px-3 py-1.5 text-xs text-popover-foreground shadow-md whitespace-pre-wrap break-words"
-            style={{
-              left: cellTooltip.x,
-              top: cellTooltip.y - cellTooltipGap,
-              transform: "translate(-50%, -100%)",
-              maxHeight: Math.max(0, cellTooltip.y - cellTooltipGap),
-            }}
+            style={cellTooltipStyle}
           >
             <div className="overflow-y-auto break-words">{cellTooltip.content}</div>
             {cellTooltip.hint ? (

--- a/src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx
+++ b/src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef } from "react";
+import { createPortal } from "react-dom";
 import {
   CompactSelection,
   CustomRenderer,
@@ -8,7 +9,6 @@ import {
   GridMouseEventArgs,
   Item,
 } from "@glideapps/glide-data-grid";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useTable } from "../dataTableContext";
 import { getSelectionProps } from "../utils/selectionModes";
 import {
@@ -182,8 +182,6 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
   // Cell hover tooltips (truncated text + link hint)
   const {
     cellTooltip,
-    isCellTooltipOpen,
-    virtualRef,
     onItemHovered: onCellTooltipHovered,
     supportsHoverTooltip,
     clearCellHoverTooltip,
@@ -420,34 +418,28 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
     footer
   );
 
-  const cellTooltipNode = (
-    <TooltipProvider
-      key={cellTooltip ? `${cellTooltip.x},${cellTooltip.y},${cellTooltip.content}` : "hidden"}
-      delayDuration={300}
-    >
-      <Tooltip open={isCellTooltipOpen}>
-        <TooltipTrigger asChild>
+  const cellTooltipGap = 8;
+  const cellTooltipNode =
+    supportsHoverTooltip && cellTooltip
+      ? createPortal(
           <div
-            ref={(node) => {
-              if (node) {
-                node.getBoundingClientRect = virtualRef.getBoundingClientRect;
-              }
+            role="tooltip"
+            className="pointer-events-none fixed z-50 max-w-sm overflow-hidden rounded-selector border border-border bg-popover px-3 py-1.5 text-xs text-popover-foreground shadow-md whitespace-pre-wrap break-words"
+            style={{
+              left: cellTooltip.x,
+              top: cellTooltip.y - cellTooltipGap,
+              transform: "translate(-50%, -100%)",
+              maxHeight: Math.max(0, cellTooltip.y - cellTooltipGap),
             }}
-            style={{ position: "absolute", top: 0, left: 0, pointerEvents: "none" }}
-          />
-        </TooltipTrigger>
-        <TooltipContent
-          side="top"
-          className="pointer-events-none max-w-sm whitespace-pre-wrap break-words"
-        >
-          <div>{cellTooltip?.content}</div>
-          {cellTooltip?.hint ? (
-            <div className="mt-1 text-xs text-muted-foreground">{cellTooltip.hint}</div>
-          ) : null}
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
-  );
+          >
+            <div className="overflow-y-auto break-words">{cellTooltip.content}</div>
+            {cellTooltip.hint ? (
+              <div className="mt-1 text-xs text-muted-foreground">{cellTooltip.hint}</div>
+            ) : null}
+          </div>,
+          document.body,
+        )
+      : null;
 
   const cellActionIndicatorNode = cellActionIndicator ? (
     <div
@@ -532,7 +524,7 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
         footer={footerNode}
         hasEmptyRows={emptyRowsCount > 0}
       />
-      {supportsHoverTooltip ? cellTooltipNode : null}
+      {cellTooltipNode}
       {cellActionIndicatorNode}
     </>
   );

--- a/src/frontend/src/widgets/dataTables/hooks/useCellHoverTooltip.test.ts
+++ b/src/frontend/src/widgets/dataTables/hooks/useCellHoverTooltip.test.ts
@@ -25,14 +25,13 @@ describe("useCellHoverTooltip", () => {
     expect(kindCheck).not.toBeNull();
   });
 
-  it("should expose virtualRef and clearCellHoverTooltip", () => {
-    expect(hookSource).toContain("virtualRef");
+  it("should expose clearCellHoverTooltip", () => {
     expect(hookSource).toContain("clearCellHoverTooltip");
-    expect(hookSource).toContain("getBoundingClientRect");
   });
 
-  it("should position tooltip at the center-top of the hovered cell", () => {
+  it("should position tooltip anchor at the center-top of the hovered cell", () => {
     expect(hookSource).toContain("args.bounds.x + args.bounds.width / 2");
     expect(hookSource).toContain("y: args.bounds.y");
+    expect(hookSource).not.toContain("args.bounds.y + args.bounds.height");
   });
 });

--- a/src/frontend/src/widgets/dataTables/hooks/useCellHoverTooltip.test.ts
+++ b/src/frontend/src/widgets/dataTables/hooks/useCellHoverTooltip.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect } from "vitest";
 import * as fs from "fs";
 import * as path from "path";
+import { getCellTooltipPlacementStyle, type CellHoverTooltipState } from "./useCellHoverTooltip";
+
+const layout = { cellGap: 8, viewportInset: 8 };
+
+function tooltipAt(y: number, cellHeight = 32): CellHoverTooltipState {
+  return { x: 100, y, cellHeight, content: "Full value" };
+}
 
 describe("useCellHoverTooltip", () => {
   const hookSource = fs.readFileSync(path.resolve(__dirname, "./useCellHoverTooltip.ts"), "utf-8");
@@ -32,6 +39,50 @@ describe("useCellHoverTooltip", () => {
   it("should position tooltip anchor at the center-top of the hovered cell", () => {
     expect(hookSource).toContain("args.bounds.x + args.bounds.width / 2");
     expect(hookSource).toContain("y: args.bounds.y");
-    expect(hookSource).not.toContain("args.bounds.y + args.bounds.height");
+    expect(hookSource).toContain("cellHeight: args.bounds.height");
+  });
+
+  it("should compute cellTooltipStyle from tooltip state", () => {
+    expect(hookSource).toContain("cellTooltipStyle");
+    expect(hookSource).toContain("getCellTooltipPlacementStyle");
+  });
+});
+
+describe("getCellTooltipPlacementStyle", () => {
+  it("places tooltip above when more space is available above the cell", () => {
+    const cellTop = 400;
+    const cellHeight = 32;
+    const style = getCellTooltipPlacementStyle(tooltipAt(cellTop, cellHeight), 800, layout);
+    expect(style).toMatchObject({
+      left: 100,
+      top: cellTop - layout.cellGap,
+      transform: "translate(-50%, -100%)",
+    });
+    expect(style.maxHeight).toBe(cellTop - layout.cellGap - layout.viewportInset);
+  });
+
+  it("places tooltip below when more space is available under the cell", () => {
+    const cellTop = 40;
+    const cellHeight = 32;
+    const cellBottom = cellTop + cellHeight;
+    const style = getCellTooltipPlacementStyle(tooltipAt(cellTop, cellHeight), 800, layout);
+    expect(style).toMatchObject({
+      left: 100,
+      top: cellBottom + layout.cellGap,
+      transform: "translate(-50%, 0)",
+    });
+    expect(style.maxHeight).toBe(800 - cellBottom - layout.cellGap - layout.viewportInset);
+  });
+
+  it("prefers above when space above and below are equal", () => {
+    const viewportHeight = 200;
+    const cellHeight = 32;
+    const cellTop = (viewportHeight - cellHeight) / 2;
+    const style = getCellTooltipPlacementStyle(
+      tooltipAt(cellTop, cellHeight),
+      viewportHeight,
+      layout,
+    );
+    expect(style.transform).toBe("translate(-50%, -100%)");
   });
 });

--- a/src/frontend/src/widgets/dataTables/hooks/useCellHoverTooltip.ts
+++ b/src/frontend/src/widgets/dataTables/hooks/useCellHoverTooltip.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useState, type CSSProperties } from "react";
 import { GridCellKind, GridMouseEventArgs, Item } from "@glideapps/glide-data-grid";
 import { GridCell } from "@glideapps/glide-data-grid";
 import { Densities } from "@/types/density";
@@ -21,9 +21,52 @@ interface UseCellHoverTooltipProps {
 export interface CellHoverTooltipState {
   x: number;
   y: number;
+  cellHeight: number;
   content: string;
   /** Secondary line (e.g. link open hint) */
   hint?: string;
+}
+
+type CellTooltipPlacement = "above" | "below";
+
+interface CellTooltipLayout {
+  cellGap: number;
+  viewportInset: number;
+}
+
+const defaultTooltipLayout: CellTooltipLayout = {
+  cellGap: 8,
+  viewportInset: 8,
+};
+
+/** Positions tooltip above or below the cell based on available viewport space. */
+export function getCellTooltipPlacementStyle(
+  tooltip: CellHoverTooltipState,
+  viewportHeight: number,
+  layout: CellTooltipLayout = defaultTooltipLayout,
+): CSSProperties {
+  const { cellGap, viewportInset } = layout;
+  const cellBottom = tooltip.y + tooltip.cellHeight;
+  const availableAbove = tooltip.y - cellGap - viewportInset;
+  const availableBelow = viewportHeight - cellBottom - cellGap - viewportInset;
+
+  const placement: CellTooltipPlacement = availableAbove >= availableBelow ? "above" : "below";
+
+  if (placement === "above") {
+    return {
+      left: tooltip.x,
+      top: tooltip.y - cellGap,
+      transform: "translate(-50%, -100%)",
+      maxHeight: Math.max(0, availableAbove),
+    };
+  }
+
+  return {
+    left: tooltip.x,
+    top: cellBottom + cellGap,
+    transform: "translate(-50%, 0)",
+    maxHeight: Math.max(0, availableBelow),
+  };
 }
 
 /** Tooltip hover relies on real hover; skip on touch / coarse pointers where it mispositions */
@@ -48,6 +91,12 @@ export const useCellHoverTooltip = ({
   const cellHorizontalPadding = DENSITY_CONFIG[density].cellHorizontalPadding;
 
   const [tooltip, setTooltip] = useState<CellHoverTooltipState | null>(null);
+
+  const cellTooltipStyle = useMemo(() => {
+    if (!tooltip) return null;
+    const viewportHeight = typeof window !== "undefined" ? window.innerHeight : 0;
+    return getCellTooltipPlacementStyle(tooltip, viewportHeight);
+  }, [tooltip]);
 
   const onItemHovered = useCallback(
     (args: GridMouseEventArgs) => {
@@ -110,6 +159,7 @@ export const useCellHoverTooltip = ({
       setTooltip({
         x: args.bounds.x + args.bounds.width / 2,
         y: args.bounds.y,
+        cellHeight: args.bounds.height,
         content: truncatedText ?? (isLinkCell ? linkHint : ""),
         hint: truncatedText && isLinkCell ? linkHint : undefined,
       });
@@ -133,6 +183,7 @@ export const useCellHoverTooltip = ({
 
   return {
     cellTooltip: tooltip,
+    cellTooltipStyle,
     supportsHoverTooltip: tooltipSupported,
     onItemHovered,
     clearCellHoverTooltip,

--- a/src/frontend/src/widgets/dataTables/hooks/useCellHoverTooltip.ts
+++ b/src/frontend/src/widgets/dataTables/hooks/useCellHoverTooltip.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { GridCellKind, GridMouseEventArgs, Item } from "@glideapps/glide-data-grid";
 import { GridCell } from "@glideapps/glide-data-grid";
 import { Densities } from "@/types/density";
@@ -48,8 +48,6 @@ export const useCellHoverTooltip = ({
   const cellHorizontalPadding = DENSITY_CONFIG[density].cellHorizontalPadding;
 
   const [tooltip, setTooltip] = useState<CellHoverTooltipState | null>(null);
-  const tooltipRef = useRef(tooltip);
-  tooltipRef.current = tooltip;
 
   const onItemHovered = useCallback(
     (args: GridMouseEventArgs) => {
@@ -129,27 +127,13 @@ export const useCellHoverTooltip = ({
     ],
   );
 
-  const virtualRef = useMemo(
-    () => ({
-      getBoundingClientRect: () => {
-        const pos = tooltipRef.current;
-        const x = pos?.x ?? 0;
-        const y = pos?.y ?? 0;
-        return new DOMRect(x, y, 0, 0);
-      },
-    }),
-    [],
-  );
-
   const clearCellHoverTooltip = useCallback(() => {
     setTooltip(null);
   }, []);
 
   return {
     cellTooltip: tooltip,
-    isCellTooltipOpen: tooltipSupported && tooltip !== null,
     supportsHoverTooltip: tooltipSupported,
-    virtualRef,
     onItemHovered,
     clearCellHoverTooltip,
   };


### PR DESCRIPTION
## Summary
- Fixes DataTable cell hover tooltips that covered the entire cell when content was long, making clicks hard or impossible.
- Replaces Radix-based positioning with a fixed portal anchored to the top-center of the cell (`translate(-50%, -100%)`) so the tooltip grows upward and stays out of the cell.
- Adds a **Cell Tooltip** sample tab with columns and mock rows (Status, Plan, Prompt/Title, Type, Project, Timer, etc.) to reproduce and verify the behavior.

Issue:
<img width="690" height="346" alt="Screenshot 2026-05-24 at 01 04 15" src="https://github.com/user-attachments/assets/8a2c1f56-54a9-4100-a5e1-d73da4f24e81" />

Fixed:

https://github.com/user-attachments/assets/49c1b5f6-d795-403c-bb33-a55b8c4a7563

