### PR TITLE
fix(frontend): make DialogBody scrollable when contents overflow

### DIFF
--- a/src/frontend/src/widgets/dialogs/DialogBodyWidget.tsx
+++ b/src/frontend/src/widgets/dialogs/DialogBodyWidget.tsx
@@ -15,7 +15,7 @@ export const DialogBodyWidget: React.FC<DialogBodyWidgetProps> = ({ id, children
       role="document"
       aria-describedby={descriptionId}
     >
-      <div className="flex-1 min-h-0" id={descriptionId}>
+      <div className="flex-1 min-h-0 overflow-y-auto" id={descriptionId}>
         {children}
       </div>
     </section>


### PR DESCRIPTION
This PR fixes the DialogBody component by adding overflow-y-auto to its inner container. This allows dialogs with tall content (such as the Add Project verifications step) to scroll instead of being clipped.