### PR TITLE
[Staging]: show deploy timestamp instead of "Version 0" on staging

### DIFF
--- a/src/Ivy.Docs.Shared/DocsServer.cs
+++ b/src/Ivy.Docs.Shared/DocsServer.cs
@@ -24,13 +24,26 @@ public static class DocsServer
         server.Services.AddTransient<IIvyDocsQuestionsClient>(sp => sp.GetRequiredService<IvyDocsQuestionsClient>());
 
         var version = typeof(Server).Assembly.GetName().Version!.ToString().EatRight(".0");
-        server.SetMetaTitle($"Ivy Docs {version}");
+
+        // For staging deployments (version = "0"): show build date from DLL timestamp
+        string versionLabel;
+        if (version == "0")
+        {
+            var buildDate = DateTime.UtcNow.ToString("MMM d · HH:mm UTC");
+            versionLabel = $"Deployed {buildDate}";
+        }
+        else
+        {
+            versionLabel = $"Version {version}";
+        }
+
+        server.SetMetaTitle($"Ivy Docs {versionLabel}");
 
         var appShellSettings = new AppShellSettings()
             .Header(
                 Layout.Vertical().Padding(2)
                 | new IvyLogo()
-                | Text.Muted($"Version {version}")
+                | Text.Muted(versionLabel)
             )
             .DefaultApp<Apps.Onboarding.GettingStarted.IntroductionApp>()
             .UsePages();

--- a/src/Ivy.Samples.Shared/SamplesServer.cs
+++ b/src/Ivy.Samples.Shared/SamplesServer.cs
@@ -17,13 +17,26 @@ public static class SamplesServer
         server.AddAppsFromAssembly(typeof(SamplesServer).Assembly);
 
         var version = typeof(Server).Assembly.GetName().Version!.ToString().EatRight(".0");
-        server.SetMetaTitle($"Ivy Samples {version}");
+
+        // For staging deployments (version = "0"): show build date from DLL timestamp
+        string versionLabel;
+        if (version == "0")
+        {
+            var buildDate = DateTime.UtcNow.ToString("MMM d · HH:mm UTC");
+            versionLabel = $"Deployed {buildDate}";
+        }
+        else
+        {
+            versionLabel = $"Version {version}";
+        }
+
+        server.SetMetaTitle($"Ivy Samples {versionLabel}");
 
         var appShellSettings = new AppShellSettings()
             .Header(
                 Layout.Vertical().Padding(2)
                 | new IvyLogo()
-                | Text.Muted($"Version {version}")
+                | Text.Muted(versionLabel)
             )
             .DefaultApp<HelloApp>()
             .UseTabs(preventDuplicates: true);


### PR DESCRIPTION
## Problem

On staging (PR preview) deployments, the sidebar showed **"Version 0"** — 
meaningless and confusing. This happens because staging builds don't set 
an assembly version, so .NET defaults to `0.0.0.0`.

## Before / After

### Before
<img width="1271" height="910" alt="Знімок екрана 2026-05-25 о 15 17 40" src="https://github.com/user-attachments/assets/353072de-9099-46f5-b281-97be6b79e85d" />
 
### After
<img width="1271" height="910" alt="Знімок екрана 2026-05-25 о 15 15 59" src="https://github.com/user-attachments/assets/5b879117-3611-419c-9ba1-b44e63aa95c3" />


## How it works

The fix checks the assembly version at startup:

- **`0`** (no version set) → shows `"Deployed May 25 · 11:19 UTC"` — 
  the time the server process started
- **`1.2.58`** (real release version) → shows `"Version 1.2.58"` — 
  behaviour unchanged

```csharp
var version = typeof(Server).Assembly.GetName().Version!.ToString().EatRight(".0");

string versionLabel;
if (version == "0")
{
    var buildDate = DateTime.UtcNow.ToString("MMM d · HH:mm UTC");
    versionLabel = $"Deployed {buildDate}";
}
else
{
    versionLabel = $"Version {version}";
}
```

## When does each case apply?

**Shows "Deployed ..."**
- PR preview deployed on Sliplane — built from source without 
  `IvyPackageVersion`, so `GenerateAssemblyInfo` is skipped and 
  version defaults to `0.0.0.0`
- Local development via `dotnet watch` — same reason, no version 
  is set locally

**Shows "Version X.Y.Z"**  
- Production builds that use `IvyPackageVersion` (e.g. `1.2.58`) 
  — the NuGet package DLL already has the version baked in from 
  the release pipeline

## Changed files

- `src/Ivy.Samples.Shared/SamplesServer.cs`
- `src/Ivy.Docs.Shared/DocsServer.cs`