### PR TITLE
[charts]: Fix ToChordChart charts stuck on loading after deploy

### DIFF
--- a/src/Ivy/Views/Charts/ChordChartView.cs
+++ b/src/Ivy/Views/Charts/ChordChartView.cs
@@ -1,4 +1,3 @@
-using System.Collections.Immutable;
 using System.Runtime.CompilerServices;
 
 // ReSharper disable once CheckNamespace
@@ -89,44 +88,19 @@ public class ChordChartBuilder<TSource>(
 
     public override object? Build()
     {
-        var chartData = UseState(ImmutableArray.Create<ChordChartInput>);
-        var loading = UseState(true);
-        var exception = UseState<Exception?>((Exception?)null);
-
-        UseEffect(async () =>
+        ChordChartInput[] inputs;
+        try
         {
-            try
-            {
-                var inputs = await Task.Run(() =>
-                    data.Select(item => new ChordChartInput(
-                        sourceSelector(item),
-                        targetSelector(item),
-                        valueSelector(item)
-                    )).ToArray()
-                );
-                chartData.Set([.. inputs]);
-            }
-            catch (Exception e)
-            {
-                exception.Set(e);
-            }
-            finally
-            {
-                loading.Set(false);
-            }
-        }, [EffectTrigger.OnMount()]);
-
-        if (exception.Value is not null)
-        {
-            return new ErrorTeaserView(exception.Value);
+            inputs = data.Select(item => new ChordChartInput(
+                sourceSelector(item),
+                targetSelector(item),
+                valueSelector(item)
+            )).ToArray();
         }
-
-        if (loading.Value)
+        catch (Exception e)
         {
-            return new ChatLoading();
+            return new ErrorTeaserView(e);
         }
-
-        var inputs = chartData.Value;
 
         var nodeNames = inputs
             .SelectMany(i => new[] { i.Source, i.Target })

--- a/src/Ivy/Views/Charts/SankeyChartView.cs
+++ b/src/Ivy/Views/Charts/SankeyChartView.cs
@@ -1,4 +1,3 @@
-using System.Collections.Immutable;
 using System.Runtime.CompilerServices;
 
 // ReSharper disable once CheckNamespace
@@ -82,44 +81,19 @@ public class SankeyChartBuilder<TSource>(
 
     public override object? Build()
     {
-        var chartData = UseState(ImmutableArray.Create<SankeyChartInput>);
-        var loading = UseState(true);
-        var exception = UseState<Exception?>((Exception?)null);
-
-        UseEffect(async () =>
+        SankeyChartInput[] inputs;
+        try
         {
-            try
-            {
-                var inputs = await Task.Run(() =>
-                    data.Select(item => new SankeyChartInput(
-                        sourceSelector(item),
-                        targetSelector(item),
-                        valueSelector(item)
-                    )).ToArray()
-                );
-                chartData.Set([.. inputs]);
-            }
-            catch (Exception e)
-            {
-                exception.Set(e);
-            }
-            finally
-            {
-                loading.Set(false);
-            }
-        }, [EffectTrigger.OnMount()]);
-
-        if (exception.Value is not null)
-        {
-            return new ErrorTeaserView(exception.Value);
+            inputs = data.Select(item => new SankeyChartInput(
+                sourceSelector(item),
+                targetSelector(item),
+                valueSelector(item)
+            )).ToArray();
         }
-
-        if (loading.Value)
+        catch (Exception e)
         {
-            return new ChatLoading();
+            return new ErrorTeaserView(e);
         }
-
-        var inputs = chartData.Value;
 
         var nodeNames = inputs
             .SelectMany(i => new[] { i.Source, i.Target })


### PR DESCRIPTION
## Summary

- Remove async `UseEffect(OnMount)` + `ChatLoading` from `ChordChartBuilder` and `SankeyChartBuilder`
- Build chart data synchronously in `Build()`, matching direct `new ChordChart(data)` / `new SankeyChart(data)` usage
- Fixes ToChordChart sample cards (`Default`, `Sorted`, `Dashboard`) staying on `...` after branch deploy until a full page refresh

## Problem

The three `ToChordChart` examples in `ChordChartApp` showed a perpetual loading state (`ChatLoading` / `...`) after deploying to a preview branch. Other chord charts on the same page rendered immediately because they pass pre-built `ChordData` directly.

`ChordChartBuilder` deferred a trivial in-memory LINQ projection to a background `Task.Run` inside `UseEffect(OnMount)`. In some client-navigation / post-deploy scenarios the effect completion did not reliably trigger a re-render, so the UI never left the loading state. A hard refresh worked because it rebuilt the widget tree from scratch.

## Solution

Project source → target → value in `Build()` and return the styled chart in the same pass. No loading placeholder is needed for this lightweight transform (same pattern as the static chart views above).

Applied the same change to `SankeyChartBuilder`, which used the identical async pattern.
