### PR TITLE
fix(ActivityHeatmap): Scope widget tailwind output to container

### DIFF
--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/ActivityHeatmap.tsx
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/ActivityHeatmap.tsx
@@ -156,8 +156,8 @@ export function ActivityHeatmap({
   };
 
   return (
-    <div className="flex w-full relative rounded border-secondary bg-card">
-      <div className=" overflow-x-auto p-0"
+    <div className="ivy-activity-heatmap-container">
+      <div className="overflow-x-auto p-0"
         style={{ direction: "rtl" }}>
         <div className="inline-flex flex-col gap-1 font-sans"
           style={{ direction: "ltr" }}>

--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/style.css
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/style.css
@@ -1,2 +1,9 @@
 @tailwind components;
 @tailwind utilities;
+
+.ivy-activity-heatmap-container {
+    width: 100%;
+    position: relative;
+    display: flex;
+    background-color: var(--card);
+}

--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/tailwind.config.ts
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/tailwind.config.ts
@@ -1,6 +1,7 @@
 import type { Config } from "tailwindcss";
 
 export default {
+  important: ".ivy-activity-heatmap-container",
   content: ["./src/**/*.{ts,tsx}"],
   theme: {
     extend: {},


### PR DESCRIPTION
## Summary

- Scope ActivityHeatmap Tailwind output to the widget container so generated utilities do not affect the surrounding host UI.
- Move the root wrapper styling into a dedicated container class so child utilities still work under Tailwind’s selector-based `important` mode.

## Test plan

- [ ] `cd src/widgets/Ivy.Widgets.ActivityHeatmap/frontend && pnpm build`
- [ ] Open an ActivityHeatmap sample and verify the grid, day labels, tooltip, and horizontal scrolling render correctly.