### PR TITLE
ci: fix E2E tests timing out during Playwright browser installation

### DIFF
--- a/.github/workflows/e2e-docs-tests.yml
+++ b/.github/workflows/e2e-docs-tests.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install Playwright Browsers
         working-directory: ./src/frontend
-        run: npx playwright install --with-deps
+        run: npx playwright install chromium --with-deps
 
       - name: Run Playwright tests for Docs
         working-directory: ./src/frontend

--- a/.github/workflows/e2e-samples-tests.yml
+++ b/.github/workflows/e2e-samples-tests.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install Playwright Browsers
         working-directory: ./src/frontend
-        run: npx playwright install --with-deps
+        run: npx playwright install chromium --with-deps
 
       - name: Run Playwright tests for Samples
         working-directory: ./src/frontend


### PR DESCRIPTION
Fixes the E2E Docs and Samples tests getting stuck and timing out by limiting Playwright installation to Chromium only (as configured in playwright.config.ts), avoiding hanging downloads on Firefox/WebKit.