### PR TITLE
[Staging]: extract version label into internal helper 

### DIFF
--- a/src/Ivy.Docs.Shared/DocsServer.cs
+++ b/src/Ivy.Docs.Shared/DocsServer.cs
@@ -23,19 +23,7 @@ public static class DocsServer
         server.Services.AddHttpClient<IvyDocsQuestionsClient>();
         server.Services.AddTransient<IIvyDocsQuestionsClient>(sp => sp.GetRequiredService<IvyDocsQuestionsClient>());
 
-        var version = typeof(Server).Assembly.GetName().Version!.ToString().EatRight(".0");
-
-        // For staging deployments (version = "0"): show build date from DLL timestamp
-        string versionLabel;
-        if (version == "0")
-        {
-            var buildDate = DateTime.UtcNow.ToString("MMM d · HH:mm UTC");
-            versionLabel = $"Deployed {buildDate}";
-        }
-        else
-        {
-            versionLabel = $"Version {version}";
-        }
+        var versionLabel = ServerVersionHelper.GetVersionLabel();
 
         server.SetMetaTitle($"Ivy Docs {versionLabel}");
 

--- a/src/Ivy.Docs.Shared/DocsServer.cs
+++ b/src/Ivy.Docs.Shared/DocsServer.cs
@@ -1,3 +1,4 @@
+using Ivy.Helpers;
 using Ivy.Docs.Shared.Middleware;
 using Ivy.Docs.Shared.Services;
 

--- a/src/Ivy.Samples.Shared/SamplesServer.cs
+++ b/src/Ivy.Samples.Shared/SamplesServer.cs
@@ -16,19 +16,7 @@ public static class SamplesServer
         server.UseHotReload();
         server.AddAppsFromAssembly(typeof(SamplesServer).Assembly);
 
-        var version = typeof(Server).Assembly.GetName().Version!.ToString().EatRight(".0");
-
-        // For staging deployments (version = "0"): show build date from DLL timestamp
-        string versionLabel;
-        if (version == "0")
-        {
-            var buildDate = DateTime.UtcNow.ToString("MMM d · HH:mm UTC");
-            versionLabel = $"Deployed {buildDate}";
-        }
-        else
-        {
-            versionLabel = $"Version {version}";
-        }
+        var versionLabel = ServerVersionHelper.GetVersionLabel();
 
         server.SetMetaTitle($"Ivy Samples {versionLabel}");
 

--- a/src/Ivy.Samples.Shared/SamplesServer.cs
+++ b/src/Ivy.Samples.Shared/SamplesServer.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using Ivy.Helpers;
 using Ivy.Samples.Shared.Helpers;
 using Ivy.Samples.Shared.Apps.Demos;
 using Microsoft.Extensions.AI;

--- a/src/Ivy/Helpers/ServerVersionHelper.cs
+++ b/src/Ivy/Helpers/ServerVersionHelper.cs
@@ -1,0 +1,22 @@
+namespace Ivy.Helpers;
+
+internal static class ServerVersionHelper
+{
+    /// <summary>
+    /// Returns a display label for the server version.
+    /// On staging builds (assembly version = "0"), returns "Deployed MMM d · HH:mm UTC"
+    /// using the current startup time. On release builds, returns "Version X.Y.Z".
+    /// </summary>
+    internal static string GetVersionLabel()
+    {
+        var version = typeof(Server).Assembly.GetName().Version!.ToString().EatRight(".0");
+
+        if (version == "0")
+        {
+            var deployedAt = DateTime.UtcNow.ToString("MMM d · HH:mm UTC");
+            return $"Deployed {deployedAt}";
+        }
+
+        return $"Version {version}";
+    }
+}

--- a/src/Ivy/Helpers/ServerVersionHelper.cs
+++ b/src/Ivy/Helpers/ServerVersionHelper.cs
@@ -1,3 +1,8 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Ivy.Samples.Shared")]
+[assembly: InternalsVisibleTo("Ivy.Docs.Shared")]
+
 namespace Ivy.Helpers;
 
 internal static class ServerVersionHelper

--- a/src/Ivy/Ivy.csproj
+++ b/src/Ivy/Ivy.csproj
@@ -79,6 +79,8 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Ivy.Test" />
     <InternalsVisibleTo Include="Ivy.Docs" />
+    <InternalsVisibleTo Include="Ivy.Docs.Shared" />
+    <InternalsVisibleTo Include="Ivy.Samples.Shared" />
     <InternalsVisibleTo Include="Ivy.XamlBuilder" />
     <InternalsVisibleTo Include="Ivy.XamlBuilder.Test" />
     <InternalsVisibleTo Include="Ivy.Integration.Tests" />

--- a/src/Ivy/Ivy.csproj
+++ b/src/Ivy/Ivy.csproj
@@ -79,8 +79,6 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Ivy.Test" />
     <InternalsVisibleTo Include="Ivy.Docs" />
-    <InternalsVisibleTo Include="Ivy.Docs.Shared" />
-    <InternalsVisibleTo Include="Ivy.Samples.Shared" />
     <InternalsVisibleTo Include="Ivy.XamlBuilder" />
     <InternalsVisibleTo Include="Ivy.XamlBuilder.Test" />
     <InternalsVisibleTo Include="Ivy.Integration.Tests" />


### PR DESCRIPTION
## What

Extracted duplicated version label logic from `SamplesServer` and `DocsServer` 
into a shared internal helper `ServerVersionHelper.GetVersionLabel()`.

## Why

The same logic existed in two places. Any future change (e.g. format, 
fallback behaviour) would need to be applied twice.

## Changes

- `src/Ivy/Helpers/ServerVersionHelper.cs` — new internal helper
- `src/Ivy/Ivy.csproj` — added `InternalsVisibleTo` for `Ivy.Docs.Shared` 
  and `Ivy.Samples.Shared` so they can access the internal helper
- `src/Ivy.Samples.Shared/SamplesServer.cs` — replaced inline logic with 
  `ServerVersionHelper.GetVersionLabel()`
- `src/Ivy.Docs.Shared/DocsServer.cs` — replaced inline logic with 
  `ServerVersionHelper.GetVersionLabel()`
