### PR TITLE
[Details]: page crash when model contains nested ToDetails()

### DIFF
--- a/src/Ivy.Test/Views/DetailsBuilderNavigationTests.cs
+++ b/src/Ivy.Test/Views/DetailsBuilderNavigationTests.cs
@@ -122,4 +122,36 @@ public class DetailsBuilderNavigationTests
         Assert.Equal("hello", defaultBuilder.Build("hello", new Product()));
         Assert.Equal(3.14m, defaultBuilder.Build(3.14m, new Product()));
     }
+
+    [Fact]
+    public void NavigationPropertyBuilder_Build_NestedDetailsBuilder_ReturnsView()
+    {
+        var address = new { Street = "123 Elm St", City = "Springfield" }.ToDetails();
+        var builder = new NavigationPropertyBuilder<object>();
+        var result = builder.Build(address, new object());
+        Assert.Same(address, result);
+    }
+
+    [Fact]
+    public void ToDetails_WithNestedToDetails_BuildsWithoutThrowing()
+    {
+        var record = new
+        {
+            FirstName = "John",
+            Address = new { Street = "123 Elm St", City = "Springfield" }.ToDetails(),
+            Employment = new { Company = "Acme" }.ToDetails(),
+        };
+
+        var details = record.ToDetails().RemoveEmpty().Build();
+
+        Assert.IsType<Details>(details);
+    }
+
+    [Fact]
+    public void ResolveDisplayValue_OnUninitializedViewBase_DoesNotThrow()
+    {
+        var builder = new DetailsBuilder<TestModel>(new TestModel());
+        var result = NavigationPropertyBuilder<object>.ResolveDisplayValue(builder);
+        Assert.Null(result);
+    }
 }

--- a/src/Ivy/Views/Builders/DetailsBuilder.cs
+++ b/src/Ivy/Views/Builders/DetailsBuilder.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.Linq.Expressions;
 using System.Reflection;
+using Ivy.Core;
 using Ivy.Views.Builders;
 
 // ReSharper disable once CheckNamespace
@@ -87,7 +88,10 @@ public class DetailsBuilder<TModel> : ViewBase, IStateless
             {
                 item.IsRemoved = true;
             }
-            else if (!TypeHelper.IsSimpleType(field.Type) && field.Type != typeof(string) && field.Type.IsClass)
+            else if (!TypeHelper.IsSimpleType(field.Type)
+                     && field.Type != typeof(string)
+                     && field.Type.IsClass
+                     && !typeof(IView).IsAssignableFrom(field.Type))
             {
                 item.Builder = new NavigationPropertyBuilder<TModel>();
             }

--- a/src/Ivy/Views/Builders/NavigationPropertyBuilder.cs
+++ b/src/Ivy/Views/Builders/NavigationPropertyBuilder.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using Ivy.Core;
 
 // ReSharper disable once CheckNamespace
 namespace Ivy.Views.Builders;
@@ -7,12 +8,19 @@ public class NavigationPropertyBuilder<TModel> : IBuilder<TModel>
 {
     public object? Build(object? value, TModel record)
     {
+        // Nested ToDetails() stores a DetailsBuilder in the model; render it as a view, not as text.
+        if (value is IView)
+            return value;
+
         return ResolveDisplayValue(value);
     }
 
     public static string? ResolveDisplayValue(object? value)
     {
         if (value == null) return null;
+
+        if (value is IView)
+            return null;
 
         var type = value.GetType();
 
@@ -34,12 +42,15 @@ public class NavigationPropertyBuilder<TModel> : IBuilder<TModel>
             return value.ToString();
         }
 
-        // Look for an Id property
-        var idProp = type.GetProperty("Id", BindingFlags.Public | BindingFlags.Instance);
-        if (idProp != null)
+        // Look for an Id property (skip ViewBase — Id is the runtime widget id, not a display key)
+        if (!typeof(ViewBase).IsAssignableFrom(type))
         {
-            var idValue = idProp.GetValue(value);
-            if (idValue != null) return $"Entity #{idValue}";
+            var idProp = type.GetProperty("Id", BindingFlags.Public | BindingFlags.Instance);
+            if (idProp != null)
+            {
+                var idValue = idProp.GetValue(value);
+                if (idValue != null) return $"Entity #{idValue}";
+            }
         }
 
         return value.ToString();


### PR DESCRIPTION
## Summary

Fixes a crash when opening the Details sample/docs page (`TargetInvocationException`). Nested `.ToDetails()` fields (e.g. `Address = new { ... }.ToDetails()`) were incorrectly handled as navigation properties, causing `NavigationPropertyBuilder` to read uninitialized `ViewBase.Id`.

## Problem

After navigation-property support in `DetailsBuilder._Scaffold()`, any complex class field got `NavigationPropertyBuilder`. Fields whose value is a nested `DetailsBuilder` (from `.ToDetails()` in an anonymous type) match that rule.

`NavigationPropertyBuilder` resolves display text via `Name` / `Title` / `Id`. `ViewBase.Id` is only set when the view is mounted in the widget tree. A `DetailsBuilder` stored only in the model has no id yet → `InvalidOperationException`, surfaced as `TargetInvocationException`.

This broke `DetailsApp` tabs that use nested details (Nested, Density) and failed immediately on app open because all tabs are built at once.

## Solution

- **DetailsBuilder**: skip `NavigationPropertyBuilder` when the field type implements `IView` (e.g. `DetailsBuilder<T>`).
- **NavigationPropertyBuilder**: return `IView` values as-is for rendering; do not read `Id` on `ViewBase` when resolving entity display strings.

https://github.com/user-attachments/assets/1a4a22e9-0f92-4039-8710-406ba827b20d


