### PR TITLE
refactor: remove IncludeMargin prop from QRCode widget

### DIFF
--- a/src/widgets/Ivy.Widgets.QRCode/.samples/Program.cs
+++ b/src/widgets/Ivy.Widgets.QRCode/.samples/Program.cs
@@ -16,14 +16,12 @@ class QRCodeDemo : ViewBase
         var pixelSize = UseState(300);
         var foregroundColor = UseState(Colors.Emerald);
         var backgroundColor = UseState(Colors.White);
-        var includeMargin = UseState(false);
         var errorCorrectionLevel = UseState(QrErrorCorrectionLevel.Low);
 
         var fullExampleToolbar = Layout.Horizontal().Gap(2).Width(Size.Fit())
             | foregroundColor.ToColorInput().Variant(ColorInputVariant.SwatchPicker).WithLabel("Foreground")
             | backgroundColor.ToColorInput().Variant(ColorInputVariant.SwatchPicker).WithLabel("Background")
             | pixelSize.ToNumberInput().Min(100).Max(1000).WithLabel("PixelSize")
-            | includeMargin.ToBoolInput().WithLabel("IncludeMargin")
             | errorCorrectionLevel.ToSelectInput().WithLabel("ErrorCorrectionLevel");
 
         return Layout.Vertical().Gap(16).Width(Size.Auto())
@@ -59,7 +57,6 @@ class QRCodeDemo : ViewBase
             .PixelSize({pixelSize.Value})
             .Foreground(Colors.{foregroundColor.Value})
             .Background(Colors.{backgroundColor.Value})
-            .IncludeMargin({includeMargin.Value.ToString().ToLower()})
             .ErrorCorrectionLevel(QrErrorCorrectionLevel.{errorCorrectionLevel.Value});
     }}
 }}")
@@ -69,7 +66,6 @@ class QRCodeDemo : ViewBase
                         .PixelSize(pixelSize.Value)
                         .Foreground(foregroundColor.Value)
                         .Background(backgroundColor.Value)
-                        .IncludeMargin(includeMargin.Value)
                         .ErrorCorrectionLevel(errorCorrectionLevel.Value)
                         .AlignSelf(Align.Center)
                     | fullExampleContent.ToTextInput()

--- a/src/widgets/Ivy.Widgets.QRCode/QRCode.cs
+++ b/src/widgets/Ivy.Widgets.QRCode/QRCode.cs
@@ -6,7 +6,6 @@ public record QRCode : WidgetBase<QRCode>
     [Prop] public string Value { get; init; } = "";
     [Prop] public int? PixelSize { get; init; }
     [Prop] public QrErrorCorrectionLevel ErrorCorrectionLevel { get; init; } = QrErrorCorrectionLevel.Low;
-    [Prop] public bool IncludeMargin { get; init; } = true;
     [Prop] public Colors? Background { get; init; }
     [Prop] public Colors? Foreground { get; init; }
 }
@@ -21,9 +20,6 @@ public static class QRCodeExtensions
 
     public static QRCode ErrorCorrectionLevel(this QRCode w, QrErrorCorrectionLevel level) =>
         w with { ErrorCorrectionLevel = level };
-
-    public static QRCode IncludeMargin(this QRCode w, bool includeMargin = true) =>
-        w with { IncludeMargin = includeMargin };
 
     public static QRCode Background(this QRCode w, Colors color) =>
         w with { Background = color };

--- a/src/widgets/Ivy.Widgets.QRCode/README.md
+++ b/src/widgets/Ivy.Widgets.QRCode/README.md
@@ -9,7 +9,6 @@ A QR code widget for the Ivy Framework, powered by [`qrcode.react`](https://gith
 | `Value` | `string` | `""` | The data to encode as a QR code |
 | `PixelSize` | `int?` | *(client default 256)* | Size of the QR code in pixels |
 | `ErrorCorrectionLevel` | `QrErrorCorrectionLevel` | `Low` | Error correction: `Low` (L), `Medium` (M), `Quartile` (Q), `High` (H) |
-| `IncludeMargin` | `bool` | `true` | Whether to include a quiet zone margin |
 | `Background` | `Colors?` | `null` | Module background (resolved from the active Ivy theme) |
 | `Foreground` | `Colors?` | `null` | Module foreground (resolved from the active Ivy theme) |
 

--- a/src/widgets/Ivy.Widgets.QRCode/Tests/QRCodeTests.cs
+++ b/src/widgets/Ivy.Widgets.QRCode/Tests/QRCodeTests.cs
@@ -16,14 +16,13 @@ public class QRCodeTests(ITestOutputHelper output)
     }
 
     [Fact]
-    public void Defaults_ValueEmpty_LowCorrection_IncludeMarginTrue_OptionalNull()
+    public void Defaults_ValueEmpty_LowCorrection_OptionalNull()
     {
         var qr = new QRCode();
 
         Assert.Equal("", qr.Value);
         Assert.Null(qr.PixelSize);
         Assert.Equal(QrErrorCorrectionLevel.Low, qr.ErrorCorrectionLevel);
-        Assert.True(qr.IncludeMargin);
         Assert.Null(qr.Background);
         Assert.Null(qr.Foreground);
     }
@@ -53,14 +52,6 @@ public class QRCodeTests(ITestOutputHelper output)
     }
 
     [Fact]
-    public void IncludeMargin_Extension_SetsIncludeMargin()
-    {
-        var qr = new QRCode().IncludeMargin(false);
-
-        Assert.False(qr.IncludeMargin);
-    }
-
-    [Fact]
     public void Background_Foreground_Extensions_SetColors()
     {
         var qr = new QRCode()
@@ -78,18 +69,15 @@ public class QRCodeTests(ITestOutputHelper output)
         var chained = original
             .Value("x")
             .PixelSize(64)
-            .ErrorCorrectionLevel(QrErrorCorrectionLevel.Medium)
-            .IncludeMargin(false);
+            .ErrorCorrectionLevel(QrErrorCorrectionLevel.Medium);
 
         Assert.Equal("", original.Value);
         Assert.Null(original.PixelSize);
         Assert.Equal(QrErrorCorrectionLevel.Low, original.ErrorCorrectionLevel);
-        Assert.True(original.IncludeMargin);
 
         Assert.Equal("x", chained.Value);
         Assert.Equal(64, chained.PixelSize);
         Assert.Equal(QrErrorCorrectionLevel.Medium, chained.ErrorCorrectionLevel);
-        Assert.False(chained.IncludeMargin);
         Assert.NotSame(original, chained);
     }
 
@@ -116,7 +104,6 @@ public class QRCodeTests(ITestOutputHelper output)
         Assert.Null(props["value"]);
         Assert.Null(props["pixelSize"]);
         Assert.Null(props["errorCorrectionLevel"]);
-        Assert.Null(props["includeMargin"]);
         Assert.Null(props["background"]);
         Assert.Null(props["foreground"]);
     }
@@ -128,7 +115,6 @@ public class QRCodeTests(ITestOutputHelper output)
             .Value("https://example.com")
             .PixelSize(96)
             .ErrorCorrectionLevel(QrErrorCorrectionLevel.Quartile)
-            .IncludeMargin(false)
             .Background(Colors.Slate)
             .Foreground(Colors.Rose);
 
@@ -140,7 +126,6 @@ public class QRCodeTests(ITestOutputHelper output)
         Assert.Equal("https://example.com", props["value"]!.GetValue<string>());
         Assert.Equal(96, props["pixelSize"]!.GetValue<int>());
         Assert.Equal("Quartile", props["errorCorrectionLevel"]!.GetValue<string>());
-        Assert.False(props["includeMargin"]!.GetValue<bool>());
         Assert.Equal("Slate", props["background"]!.GetValue<string>());
         Assert.Equal("Rose", props["foreground"]!.GetValue<string>());
     }

--- a/src/widgets/Ivy.Widgets.QRCode/frontend/src/QRCode.tsx
+++ b/src/widgets/Ivy.Widgets.QRCode/frontend/src/QRCode.tsx
@@ -18,7 +18,6 @@ interface QRCodeProps {
   value?: string;
   pixelSize?: number;
   errorCorrectionLevel?: QrErrorCorrectionLevel;
-  includeMargin?: boolean;
   background?: string;
   foreground?: string;
   eventHandler?: EventHandler;
@@ -30,7 +29,6 @@ export const QRCode: React.FC<QRCodeProps> = ({
   value = "",
   pixelSize = 256,
   errorCorrectionLevel = "Low",
-  includeMargin = true,
   background,
   foreground,
 }) => {
@@ -43,7 +41,7 @@ export const QRCode: React.FC<QRCodeProps> = ({
       value={value || " "}
       size={pixelSize}
       level={level}
-      marginSize={includeMargin ? 4 : 0}
+      marginSize={0}
       {...(bgColor !== undefined ? { bgColor } : {})}
       {...(fgColor !== undefined ? { fgColor } : {})}
     />


### PR DESCRIPTION
## Summary
- Remove `IncludeMargin` prop from QRCode widget entirely
- Hardcode `marginSize=0` in the React component — QR codes always render without margin
- Update tests, samples, and README

## Test plan
- [x] Frontend builds cleanly
- [x] All 9 C# tests pass