### PR TITLE
fix: replace backslashes with forward slashes in csproj files

### DIFF
--- a/src/Ivy.Agent.Filter/Ivy.Agent.Filter.csproj
+++ b/src/Ivy.Agent.Filter/Ivy.Agent.Filter.csproj
@@ -54,7 +54,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="README.md" Pack="true" PackagePath="\" />
+    <None Include="README.md" Pack="true" PackagePath="/" />
   </ItemGroup>
 
 </Project>

--- a/src/Ivy.Analyser/Ivy.Analyser.csproj
+++ b/src/Ivy.Analyser/Ivy.Analyser.csproj
@@ -37,8 +37,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="tools\*.ps1" CopyToOutputDirectory="Always" Pack="true" PackagePath="" />
-    <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+    <None Update="tools/*.ps1" CopyToOutputDirectory="Always" Pack="true" PackagePath="" />
+    <None Include="$(OutputPath)/$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ivy.Benchmarks.E2E/Ivy.Benchmarks.E2E.csproj
+++ b/src/Ivy.Benchmarks.E2E/Ivy.Benchmarks.E2E.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <RootNamespace>Ivy.Benchmarks.E2E</RootNamespace>
-    <DefaultItemExcludes>$(DefaultItemExcludes);Host.Native\**;Host.Legacy\**</DefaultItemExcludes>
+    <DefaultItemExcludes>$(DefaultItemExcludes);Host.Native/**;Host.Legacy/**</DefaultItemExcludes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Ivy.Desktop/Ivy.Desktop.csproj
+++ b/src/Ivy.Desktop/Ivy.Desktop.csproj
@@ -46,7 +46,7 @@
   <Import Project="build/Ivy.Desktop.targets" />
 
   <ItemGroup>
-    <None Include="README.md" Pack="true" PackagePath="\" />
+    <None Include="README.md" Pack="true" PackagePath="/" />
   </ItemGroup>
 
 </Project>

--- a/src/Ivy.Plugin.Abstractions/Ivy.Plugin.Abstractions.csproj
+++ b/src/Ivy.Plugin.Abstractions/Ivy.Plugin.Abstractions.csproj
@@ -42,6 +42,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="README.md" Pack="true" PackagePath="\" />
+    <None Include="README.md" Pack="true" PackagePath="/" />
   </ItemGroup>
 </Project>

--- a/src/auth/Ivy.Auth.Clerk/Ivy.Auth.Clerk.csproj
+++ b/src/auth/Ivy.Auth.Clerk/Ivy.Auth.Clerk.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../../../../Ivy/Directory.Build.props" Condition="Exists('../../../../Ivy/Directory.Build.props')" />
 
@@ -31,7 +31,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="README.md" Pack="true" PackagePath="\" />
+    <None Include="README.md" Pack="true" PackagePath="/" />
   </ItemGroup>
 
 </Project>

--- a/src/auth/Ivy.Auth.GitHub/Ivy.Auth.GitHub.csproj
+++ b/src/auth/Ivy.Auth.GitHub/Ivy.Auth.GitHub.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="README.md" Pack="true" PackagePath="\" />
+    <None Include="README.md" Pack="true" PackagePath="/" />
   </ItemGroup>
 
 </Project>

--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/Ivy.Widgets.ActivityHeatmap.csproj
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/Ivy.Widgets.ActivityHeatmap.csproj
@@ -40,12 +40,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Remove=".samples\**\*.cs" />
-    <Compile Remove="frontend\node_modules\**" />
-    <Compile Remove="Tests\**\*.cs" />
-    <None Include=".samples\**\*" CopyToOutputDirectory="Never" />
+    <Compile Remove=".samples/**/*.cs" />
+    <Compile Remove="frontend/node_modules/**" />
+    <Compile Remove="Tests/**/*.cs" />
+    <None Include=".samples/**/*" CopyToOutputDirectory="Never" />
   </ItemGroup>
 
-  <Import Project="..\..\Ivy\Build\Ivy.ExternalWidget.targets" />
+  <Import Project="../../Ivy/Build/Ivy.ExternalWidget.targets" />
 
 </Project>

--- a/src/widgets/Ivy.Widgets.AnimatedStatusLabel/Ivy.Widgets.AnimatedStatusLabel.csproj
+++ b/src/widgets/Ivy.Widgets.AnimatedStatusLabel/Ivy.Widgets.AnimatedStatusLabel.csproj
@@ -40,10 +40,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Remove=".samples\**\*.cs" />
-    <None Include=".samples\**\*" CopyToOutputDirectory="Never" />
+    <Compile Remove=".samples/**/*.cs" />
+    <None Include=".samples/**/*" CopyToOutputDirectory="Never" />
   </ItemGroup>
 
-  <Import Project="..\..\Ivy\Build\Ivy.ExternalWidget.targets" />
+  <Import Project="../../Ivy/Build/Ivy.ExternalWidget.targets" />
 
 </Project>

--- a/src/widgets/Ivy.Widgets.DiffView/Ivy.Widgets.DiffView.csproj
+++ b/src/widgets/Ivy.Widgets.DiffView/Ivy.Widgets.DiffView.csproj
@@ -40,10 +40,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Remove=".samples\**\*.cs" />
-    <None Include=".samples\**\*" CopyToOutputDirectory="Never" />
+    <Compile Remove=".samples/**/*.cs" />
+    <None Include=".samples/**/*" CopyToOutputDirectory="Never" />
   </ItemGroup>
 
-  <Import Project="..\..\Ivy\Build\Ivy.ExternalWidget.targets" />
+  <Import Project="../../Ivy/Build/Ivy.ExternalWidget.targets" />
 
 </Project>

--- a/src/widgets/Ivy.Widgets.Leaflet/Ivy.Widgets.Leaflet.csproj
+++ b/src/widgets/Ivy.Widgets.Leaflet/Ivy.Widgets.Leaflet.csproj
@@ -44,10 +44,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Remove=".samples\**\*.cs" />
-    <None Include=".samples\**\*" CopyToOutputDirectory="Never" />
+    <Compile Remove=".samples/**/*.cs" />
+    <None Include=".samples/**/*" CopyToOutputDirectory="Never" />
   </ItemGroup>
 
-  <Import Project="..\..\Ivy\Build\Ivy.ExternalWidget.targets" />
+  <Import Project="../../Ivy/Build/Ivy.ExternalWidget.targets" />
 
 </Project>

--- a/src/widgets/Ivy.Widgets.QRCode/Ivy.Widgets.QRCode.csproj
+++ b/src/widgets/Ivy.Widgets.QRCode/Ivy.Widgets.QRCode.csproj
@@ -40,11 +40,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Remove=".samples\**\*.cs" />
-    <Compile Remove="Tests\**\*.cs" />
-    <None Include=".samples\**\*" CopyToOutputDirectory="Never" />
+    <Compile Remove=".samples/**/*.cs" />
+    <Compile Remove="Tests/**/*.cs" />
+    <None Include=".samples/**/*" CopyToOutputDirectory="Never" />
   </ItemGroup>
 
-  <Import Project="..\..\Ivy\Build\Ivy.ExternalWidget.targets" />
+  <Import Project="../../Ivy/Build/Ivy.ExternalWidget.targets" />
 
 </Project>

--- a/src/widgets/Ivy.Widgets.ScreenshotFeedback/Ivy.Widgets.ScreenshotFeedback.csproj
+++ b/src/widgets/Ivy.Widgets.ScreenshotFeedback/Ivy.Widgets.ScreenshotFeedback.csproj
@@ -39,10 +39,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Remove=".samples\**\*.cs" />
-    <None Include=".samples\**\*" CopyToOutputDirectory="Never" />
+    <Compile Remove=".samples/**/*.cs" />
+    <None Include=".samples/**/*" CopyToOutputDirectory="Never" />
   </ItemGroup>
 
-  <Import Project="..\..\Ivy\Build\Ivy.ExternalWidget.targets" />
+  <Import Project="../../Ivy/Build/Ivy.ExternalWidget.targets" />
 
 </Project>

--- a/src/widgets/Ivy.Widgets.Tiptap/Ivy.Widgets.Tiptap.csproj
+++ b/src/widgets/Ivy.Widgets.Tiptap/Ivy.Widgets.Tiptap.csproj
@@ -43,11 +43,11 @@
     <ProjectReference Include="..\..\Ivy\Ivy.csproj" />
   </ItemGroup>
 
-  <Import Project="..\..\Ivy\Build\Ivy.ExternalWidget.targets" />
+  <Import Project="../../Ivy/Build/Ivy.ExternalWidget.targets" />
 
   <ItemGroup>
-    <Compile Remove=".samples\**\*.cs" />
-    <None Include=".samples\**\*" CopyToOutputDirectory="Never" />
+    <Compile Remove=".samples/**/*.cs" />
+    <None Include=".samples/**/*" CopyToOutputDirectory="Never" />
   </ItemGroup>
   
 </Project>

--- a/src/widgets/Ivy.Widgets.Xterm/Ivy.Widgets.Xterm.csproj
+++ b/src/widgets/Ivy.Widgets.Xterm/Ivy.Widgets.Xterm.csproj
@@ -40,10 +40,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Remove=".samples\**\*.cs" />
-    <None Include=".samples\**\*" CopyToOutputDirectory="Never" />
+    <Compile Remove=".samples/**/*.cs" />
+    <None Include=".samples/**/*" CopyToOutputDirectory="Never" />
   </ItemGroup>
 
-  <Import Project="..\..\Ivy\Build\Ivy.ExternalWidget.targets" />
+  <Import Project="../../Ivy/Build/Ivy.ExternalWidget.targets" />
 
 </Project>


### PR DESCRIPTION
Replace Windows-style backslashes with cross-platform forward slashes in MSBuild glob patterns, imports, and template paths to ensure compatibility with macOS and Linux builders.