### PR TITLE
(tabs): increase gaps

### DIFF
--- a/src/frontend/src/widgets/layouts/tabs/components/Variants.tsx
+++ b/src/frontend/src/widgets/layouts/tabs/components/Variants.tsx
@@ -99,11 +99,7 @@ export const ContentVariant: React.FC<ContentVariantProps> = ({
     <div
       className={cn("flex flex-col h-full w-full", removeParentPadding && "remove-parent-padding")}
     >
-      <div
-        ref={containerRef}
-        className="relative pl-2 pt-2 pb-[6px] w-full"
-        style={getWidth(width)}
-      >
+      <div ref={containerRef} className="relative pl-2 pt-2 pb-4 w-full" style={getWidth(width)}>
         {/* Tabs */}
         <div
           ref={tabsListRef}
@@ -118,10 +114,9 @@ export const ContentVariant: React.FC<ContentVariantProps> = ({
               pointerEvents: "none",
             }}
           />
-          {/* Active Indicator */}
           <div
             className={cn(
-              "absolute bottom-[0px] h-[2px] bg-foreground",
+              "absolute bottom-[-6px] h-[2px] bg-foreground",
               !isInitialRender && "transition-all duration-300 ease-out",
               activeTabId && !visibleTabs.includes(activeTabId) && "opacity-0",
             )}


### PR DESCRIPTION
How it was:
<img width="1068" height="224" alt="Screenshot 2026-05-29 at 00 31 51" src="https://github.com/user-attachments/assets/4d2fd049-9182-453e-b820-1fe33db9ada0" />

Now:

<img width="1034" height="254" alt="Screenshot 2026-05-29 at 00 31 42" src="https://github.com/user-attachments/assets/8d0844ee-ac83-451b-8f92-db320e508fd7" />

In docs:
How it was:

<img width="858" height="188" alt="Screenshot 2026-05-29 at 00 34 13" src="https://github.com/user-attachments/assets/bd71f0c3-e791-42df-85f9-e1f99600925e" />

Now:

<img width="968" height="224" alt="Screenshot 2026-05-29 at 00 34 07" src="https://github.com/user-attachments/assets/748747f5-5f49-4fab-85c5-c6b95048c8dd" />
