### PR TITLE
(markdown): enhance gaps in lists

### DIFF
--- a/src/frontend/src/components/MarkdownRenderer.tsx
+++ b/src/frontend/src/components/MarkdownRenderer.tsx
@@ -294,7 +294,11 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
       )),
       li: memo(({ children, className }: { children: React.ReactNode; className?: string }) => {
         const isTaskItem = className?.includes("task-list-item");
-        return <li className={cn(typography.li, isTaskItem && "list-none")}>{children}</li>;
+        return (
+          <li className={cn(typography.li, isTaskItem && "list-none")}>
+            {isTaskItem ? children : <div className={typography.liContent}>{children}</div>}
+          </li>
+        );
       }),
       strong: memo(({ children }: { children: React.ReactNode }) => (
         <strong className={typography.strong}>{children}</strong>
@@ -442,6 +446,7 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
       typography.ul,
       typography.ol,
       typography.li,
+      typography.liContent,
       typography.strong,
       typography.em,
       typography.blockquote,

--- a/src/frontend/src/lib/styles.ts
+++ b/src/frontend/src/lib/styles.ts
@@ -771,7 +771,7 @@ export const typography: Record<string, string> = {
   ul: "list-disc list-outside ps-8 flex flex-col gap-y-4",
   ol: "list-decimal list-outside ps-8 flex flex-col gap-y-4",
   li: "list-item",
-  liContent: "flex flex-col gap-y-3.5 [&>p]:my-0",
+  liContent: "flex flex-col gap-y-4 [&>p]:my-0",
 
   // Links
   a: "text-primary underline underline-offset-[3px] brightness-90 hover:brightness-100",
@@ -811,9 +811,8 @@ export const articleTypography: Record<string, string> = {
 
   // Slightly increased line height for article body text (readability)
   p: `${typography.p} leading-relaxed`,
-  ul: "list-disc list-outside ps-9 flex flex-col gap-y-5",
-  ol: "list-decimal list-outside ps-9 flex flex-col gap-y-5",
+  ul: "list-disc list-outside ps-9 flex flex-col gap-y-4",
+  ol: "list-decimal list-outside ps-9 flex flex-col gap-y-4",
   li: "list-item leading-relaxed",
-  liContent: "flex flex-col gap-y-4 [&>p]:my-0",
   blockquote: `${typography.blockquote} leading-relaxed`,
 };

--- a/src/frontend/src/lib/styles.ts
+++ b/src/frontend/src/lib/styles.ts
@@ -767,10 +767,11 @@ export const typography: Record<string, string> = {
   label: "text-large-label font-medium leading-none flex items-center",
   block: "flex items-center min-w-0",
 
-  // Lists
-  ul: "list-disc ml-6 gap-y-1.5 [&_li>ul]:mt-1.5 [&_li>ol]:mt-1.5",
-  ol: "list-decimal ml-6 gap-y-1.5 [&_li>ul]:mt-1.5 [&_li>ol]:mt-1.5",
-  li: "",
+  // Lists — gap on ol/ul; markers need list-item on li (flex on li hides numbers/bullets)
+  ul: "list-disc list-outside ps-8 flex flex-col gap-y-4",
+  ol: "list-decimal list-outside ps-8 flex flex-col gap-y-4",
+  li: "list-item",
+  liContent: "flex flex-col gap-y-3.5 [&>p]:my-0",
 
   // Links
   a: "text-primary underline underline-offset-[3px] brightness-90 hover:brightness-100",
@@ -810,6 +811,9 @@ export const articleTypography: Record<string, string> = {
 
   // Slightly increased line height for article body text (readability)
   p: `${typography.p} leading-relaxed`,
-  li: `${typography.li} leading-relaxed`,
+  ul: "list-disc list-outside ps-9 flex flex-col gap-y-5",
+  ol: "list-decimal list-outside ps-9 flex flex-col gap-y-5",
+  li: "list-item leading-relaxed",
+  liContent: "flex flex-col gap-y-4 [&>p]:my-0",
   blockquote: `${typography.blockquote} leading-relaxed`,
 };


### PR DESCRIPTION
Issue:
<img width="1003" height="323" alt="Screenshot 2026-05-29 at 13 06 41" src="https://github.com/user-attachments/assets/9782c594-62f0-4697-99df-90a2232cfbed" />

Made gaps a bit bigger:

<img width="1258" height="526" alt="Screenshot 2026-05-29 at 13 04 21" src="https://github.com/user-attachments/assets/db973ca8-0fb5-4b9c-9789-c4d40ba2e78b" />

<img width="553" height="553" alt="Screenshot 2026-05-29 at 13 04 33" src="https://github.com/user-attachments/assets/3cb3c0eb-2680-4e96-a66f-347b2e788a01" />

<img width="502" height="552" alt="Screenshot 2026-05-29 at 13 04 39" src="https://github.com/user-attachments/assets/c9e6d71b-1e39-48ec-ab34-e2da17cec784" />
