### PR TITLE
fix(sidebar): prevent sidebar header stretching by default using h-fit

### DIFF
--- a/src/frontend/src/widgets/layouts/sidebar/SidebarLayoutWidget.tsx
+++ b/src/frontend/src/widgets/layouts/sidebar/SidebarLayoutWidget.tsx
@@ -236,7 +236,7 @@ export const SidebarLayoutWidget: React.FC<SidebarLayoutWidgetProps> = ({
         style={{ width: effectiveSidebarWidth }}
       >
         {hasContent(slots?.SidebarHeader) && (
-          <div className="flex flex-col shrink-0 p-2 gap-y-4">{slots?.SidebarHeader}</div>
+          <div className="flex flex-col shrink-0 p-2 gap-y-4 h-fit">{slots?.SidebarHeader}</div>
         )}
         {slots?.SidebarContent &&
           (sidebarContentScroll === "None" ? (


### PR DESCRIPTION
Sets h-fit on the sidebar header wrapper div to prevent header layouts (like Layout.Horizontal, which default to 100% height) from stretching the sidebar header to full height. Closes https://github.com/Ivy-Interactive/Ivy-Tendril/issues/925