### PR TITLE
[Select]: fix multiple selector clipping and flicker via Popover

### DIFF
--- a/src/frontend/src/components/ui/multiselect.tsx
+++ b/src/frontend/src/components/ui/multiselect.tsx
@@ -4,6 +4,7 @@ import { Badge } from "@/components/ui/badge";
 import { Command, CommandGroup, CommandItem } from "@/components/ui/command";
 import { Command as CommandPrimitive } from "cmdk";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 import {
   computeClearAllValues,
@@ -114,8 +115,6 @@ const MultipleSelector = React.forwardRef<
     const triggerWrapperRef = React.useRef<HTMLDivElement>(null);
     const dropdownRef = React.useRef<HTMLDivElement>(null);
     const [open, setOpen] = React.useState(false);
-    const [openUpward, setOpenUpward] = React.useState(false);
-    const [dropdownMaxHeight, setDropdownMaxHeight] = React.useState(300);
     const [inputValue, setInputValue] = React.useState("");
     const measureRef = React.useRef<HTMLDivElement>(null);
     const [visibleCount, setVisibleCount] = React.useState(maxVisibleBadges ?? 1);
@@ -142,6 +141,7 @@ const MultipleSelector = React.forwardRef<
       const handlePointerDownOutside = (event: MouseEvent) => {
         const target = event.target as Node;
         if (triggerWrapperRef.current?.contains(target)) return;
+        if (dropdownRef.current?.contains(target)) return;
         closeDropdown();
         inputRef.current?.blur();
       };
@@ -149,38 +149,6 @@ const MultipleSelector = React.forwardRef<
       document.addEventListener("mousedown", handlePointerDownOutside, true);
       return () => document.removeEventListener("mousedown", handlePointerDownOutside, true);
     }, [open, closeDropdown]);
-
-    const updateOpenDirection = React.useCallback(() => {
-      const trigger = triggerWrapperRef.current;
-      if (!trigger) return;
-
-      const triggerRect = trigger.getBoundingClientRect();
-      const dropdownHeight = dropdownRef.current?.offsetHeight ?? 0;
-
-      const sectionBoundary = trigger.closest<HTMLElement>("[role='document']");
-      const dialogBoundary = trigger.closest<HTMLElement>("[role='dialog']");
-      const boundaryEl = sectionBoundary ?? dialogBoundary;
-      const boundaryRect = boundaryEl?.getBoundingClientRect();
-      const boundaryTop = boundaryRect?.top ?? 0;
-      const boundaryBottom = boundaryRect?.bottom ?? window.innerHeight;
-
-      const spaceBelow = Math.max(0, boundaryBottom - triggerRect.bottom - 8);
-      const spaceAbove = Math.max(0, triggerRect.top - boundaryTop - 8);
-
-      const shouldOpenUpward = spaceBelow < dropdownHeight + 8;
-      setOpenUpward(shouldOpenUpward);
-      setDropdownMaxHeight(Math.min(300, shouldOpenUpward ? spaceAbove : spaceBelow));
-    }, []);
-
-    React.useLayoutEffect(() => {
-      if (!open) {
-        setOpenUpward(false);
-        return;
-      }
-      updateOpenDirection();
-      const id = requestAnimationFrame(updateOpenDirection);
-      return () => cancelAnimationFrame(id);
-    }, [open, updateOpenDirection, defaultOptions.length, showActions]);
 
     React.useEffect(() => {
       if (open && dropdownRef.current) {
@@ -378,274 +346,281 @@ const MultipleSelector = React.forwardRef<
         {...commandProps}
         shouldFilter={false}
       >
-        <div ref={triggerWrapperRef} className="relative w-full">
-          {maxVisibleBadges === undefined && value.length > 0 && (
-            <div
-              ref={measureRef}
-              aria-hidden="true"
-              style={{
-                position: "absolute",
-                visibility: "hidden",
-                pointerEvents: "none",
-                display: "flex",
-                gap: "4px",
-                top: 0,
-                left: 0,
-              }}
-            >
-              {value.map((option) => (
-                <Badge
-                  key={`measure-${option.value}`}
-                  variant="secondary"
-                  className={cn(badgeVariant({ density }), "shrink-0")}
+        <Popover open={open} onOpenChange={setOpen} modal={true}>
+          <PopoverAnchor asChild>
+            <div ref={triggerWrapperRef} className="relative w-full">
+              {maxVisibleBadges === undefined && value.length > 0 && (
+                <div
+                  ref={measureRef}
+                  aria-hidden="true"
+                  style={{
+                    position: "absolute",
+                    visibility: "hidden",
+                    pointerEvents: "none",
+                    display: "flex",
+                    gap: "4px",
+                    top: 0,
+                    left: 0,
+                  }}
                 >
-                  {option.label}
-                  <span className="ml-1 p-1 h-3" style={{ display: "inline-flex" }}>
-                    <X className={xIconVariant({ density })} />
-                  </span>
-                </Badge>
-              ))}
-              <Badge
-                variant="outline"
-                className={cn(badgeVariant({ density }), "bg-muted text-muted-foreground shrink-0")}
-              >
-                +{Math.max(1, value.length - 1)}
-              </Badge>
-            </div>
-          )}
-          <div
-            className={cn(
-              selectMultiTriggerVariant({ density }),
-              disabled && "cursor-not-allowed opacity-50",
-              (!value || value.length === 0) && "text-muted-foreground",
-              invalid
-                ? "border-destructive text-destructive-foreground focus-within:ring-destructive focus-within:border-destructive"
-                : undefined,
-              ghost &&
-                "border-transparent shadow-none bg-transparent hover:bg-accent hover:text-accent-foreground dark:border-transparent dark:bg-transparent dark:hover:bg-accent dark:hover:text-accent-foreground",
-            )}
-          >
-            <span
-              ref={containerRef}
-              className="flex gap-1 items-center flex-1 min-w-0 overflow-hidden"
-            >
-              {value.slice(0, visibleCount).map((option) => (
-                <Badge
-                  key={option.value}
-                  variant="secondary"
-                  className={cn(
-                    badgeVariant({ density }),
-                    "shrink-0",
-                    invalid && "bg-destructive/10 border-destructive text-destructive",
-                  )}
-                >
-                  {option.label}
-                  <button
-                    type="button"
-                    tabIndex={-1}
-                    aria-label="Remove"
-                    className="ml-1 p-0.5 rounded-sm hover:bg-black/10 dark:hover:bg-white/10 focus:outline-none cursor-pointer flex items-center justify-center opacity-70 hover:opacity-100 transition-opacity"
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter" || e.key === " ") {
-                        e.preventDefault();
-                        handleUnselect(option);
-                      }
-                    }}
-                    onMouseDown={(e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                    }}
-                    onClick={() => handleUnselect(option)}
-                  >
-                    <X className={xIconVariant({ density })} />
-                  </button>
-                </Badge>
-              ))}
-              {value.length > visibleCount && (
-                <Badge
-                  variant="outline"
-                  className={cn(
-                    badgeVariant({ density }),
-                    "bg-muted text-muted-foreground shrink-0",
-                  )}
-                >
-                  +{value.length - visibleCount}
-                </Badge>
-              )}
-              <CommandPrimitive.Input
-                ref={inputRef}
-                value={inputValue}
-                onValueChange={setInputValue}
-                onBlur={(e) => {
-                  window.requestAnimationFrame(() => {
-                    window.requestAnimationFrame(() => {
-                      if (triggerWrapperRef.current?.contains(document.activeElement)) return;
-                      closeDropdown();
-                      onBlur?.(e);
-                    });
-                  });
-                }}
-                onFocus={(e) => {
-                  setOpen(true);
-                  requestAnimationFrame(() => {
-                    if (containerRef.current) {
-                      containerRef.current.scrollLeft = 0;
-                    }
-                  });
-                  onFocus?.(e);
-                }}
-                placeholder={
-                  hidePlaceholderWhenSelected && value.length > 0 ? undefined : placeholder
-                }
-                disabled={disabled}
-                className="ml-2 bg-transparent outline-none placeholder:text-muted-foreground flex-1 min-w-[120px] cursor-pointer"
-              />
-            </span>
-            <div className={selectTriggerEndActionsVariant()}>
-              {rightSlot}
-              <ChevronDown
-                className={cn(
-                  "size-4 opacity-50 shrink-0 cursor-pointer pointer-events-auto",
-                  disabled && "cursor-not-allowed opacity-50",
-                )}
-                onClick={(e) => {
-                  if (disabled) return;
-                  e.preventDefault();
-                  e.stopPropagation();
-                  if (inputRef.current) {
-                    if (open) {
-                      inputRef.current.blur();
-                    } else {
-                      inputRef.current.focus();
-                    }
-                  }
-                }}
-                onKeyDown={(e) => {
-                  if (disabled) return;
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    if (inputRef.current) {
-                      if (open) {
-                        inputRef.current.blur();
-                      } else {
-                        inputRef.current.focus();
-                      }
-                    }
-                  }
-                }}
-                role="button"
-                tabIndex={disabled ? -1 : 0}
-                aria-label="Toggle dropdown"
-              />
-            </div>
-          </div>
-          {open && (
-            <div
-              ref={dropdownRef}
-              className={cn(
-                "absolute w-full z-50 rounded-box border bg-popover text-popover-foreground shadow-md outline-none animate-in",
-                openUpward ? "bottom-full mb-1" : "top-full mt-1",
-              )}
-            >
-              {defaultOptions.length > 0 ? (
-                <>
-                  <CommandGroup
-                    className="h-full overflow-auto slim-scrollbar"
-                    style={{ maxHeight: dropdownMaxHeight }}
-                  >
-                    {defaultOptions.map((option) => {
-                      const selected = isSelected(option);
-                      return (
-                        <CommandItem
-                          key={option.value}
-                          onMouseDown={(e) => {
-                            e.preventDefault();
-                            e.stopPropagation();
-                          }}
-                          onSelect={() => {
-                            setInputValue("");
-                            toggleOption(option);
-                          }}
-                          className={cn(
-                            menuItemVariant({ density }),
-                            "flex items-center justify-between",
-                          )}
-                          disabled={option.disable}
-                        >
-                          {option.tooltip ? (
-                            <TooltipProvider>
-                              <Tooltip delayDuration={300}>
-                                <TooltipTrigger asChild>
-                                  <div className="flex items-center justify-between w-full">
-                                    <span>{option.label}</span>
-                                    {selected && (
-                                      <X
-                                        className={cn(
-                                          xIconVariant({ density }),
-                                          "text-muted-foreground hover:text-foreground",
-                                        )}
-                                      />
-                                    )}
-                                  </div>
-                                </TooltipTrigger>
-                                <TooltipContent>{option.tooltip}</TooltipContent>
-                              </Tooltip>
-                            </TooltipProvider>
-                          ) : (
-                            <>
-                              <span>{option.label}</span>
-                              {selected && (
-                                <X
-                                  className={cn(
-                                    xIconVariant({ density }),
-                                    "text-muted-foreground hover:text-foreground",
-                                  )}
-                                />
-                              )}
-                            </>
-                          )}
-                        </CommandItem>
-                      );
-                    })}
-                  </CommandGroup>
-                  {showActions && (
-                    <div
-                      className="border-t border-border p-2 flex justify-between items-center gap-2 text-sm shrink-0"
-                      role="group"
-                      aria-label="Bulk selection"
+                  {value.map((option) => (
+                    <Badge
+                      key={`measure-${option.value}`}
+                      variant="secondary"
+                      className={cn(badgeVariant({ density }), "shrink-0")}
                     >
-                      <button
-                        type="button"
-                        className="text-primary hover:underline underline-offset-2 disabled:opacity-50 disabled:cursor-not-allowed disabled:no-underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-sm px-0.5"
-                        disabled={bulkSelectAllDisabled || disabled}
-                        onMouseDown={(e) => e.preventDefault()}
-                        onClick={() => handleBulkSelectAll()}
-                      >
-                        Select All
-                      </button>
-                      <button
-                        type="button"
-                        className="text-primary hover:underline underline-offset-2 disabled:opacity-50 disabled:cursor-not-allowed disabled:no-underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-sm px-0.5"
-                        disabled={bulkClearAllDisabled || disabled}
-                        onMouseDown={(e) => e.preventDefault()}
-                        onClick={() => handleBulkClearAll()}
-                      >
-                        Clear All
-                      </button>
-                    </div>
-                  )}
-                </>
-              ) : emptyIndicator ? (
-                <div className="p-2">{emptyIndicator}</div>
-              ) : (
-                <div className="px-2 py-3 text-sm text-muted-foreground text-center">
-                  No options available
+                      {option.label}
+                      <span className="ml-1 p-1 h-3" style={{ display: "inline-flex" }}>
+                        <X className={xIconVariant({ density })} />
+                      </span>
+                    </Badge>
+                  ))}
+                  <Badge
+                    variant="outline"
+                    className={cn(
+                      badgeVariant({ density }),
+                      "bg-muted text-muted-foreground shrink-0",
+                    )}
+                  >
+                    +{Math.max(1, value.length - 1)}
+                  </Badge>
                 </div>
               )}
+              <div
+                className={cn(
+                  selectMultiTriggerVariant({ density }),
+                  disabled && "cursor-not-allowed opacity-50",
+                  (!value || value.length === 0) && "text-muted-foreground",
+                  invalid
+                    ? "border-destructive text-destructive-foreground focus-within:ring-destructive focus-within:border-destructive"
+                    : undefined,
+                  ghost &&
+                    "border-transparent shadow-none bg-transparent hover:bg-accent hover:text-accent-foreground dark:border-transparent dark:bg-transparent dark:hover:bg-accent dark:hover:text-accent-foreground",
+                )}
+              >
+                <span
+                  ref={containerRef}
+                  className="flex gap-1 items-center flex-1 min-w-0 overflow-hidden"
+                >
+                  {value.slice(0, visibleCount).map((option) => (
+                    <Badge
+                      key={option.value}
+                      variant="secondary"
+                      className={cn(
+                        badgeVariant({ density }),
+                        "shrink-0",
+                        invalid && "bg-destructive/10 border-destructive text-destructive",
+                      )}
+                    >
+                      {option.label}
+                      <button
+                        type="button"
+                        tabIndex={-1}
+                        aria-label="Remove"
+                        className="ml-1 p-0.5 rounded-sm hover:bg-black/10 dark:hover:bg-white/10 focus:outline-none cursor-pointer flex items-center justify-center opacity-70 hover:opacity-100 transition-opacity"
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter" || e.key === " ") {
+                            e.preventDefault();
+                            handleUnselect(option);
+                          }
+                        }}
+                        onMouseDown={(e) => {
+                          e.preventDefault();
+                          e.stopPropagation();
+                        }}
+                        onClick={() => handleUnselect(option)}
+                      >
+                        <X className={xIconVariant({ density })} />
+                      </button>
+                    </Badge>
+                  ))}
+                  {value.length > visibleCount && (
+                    <Badge
+                      variant="outline"
+                      className={cn(
+                        badgeVariant({ density }),
+                        "bg-muted text-muted-foreground shrink-0",
+                      )}
+                    >
+                      +{value.length - visibleCount}
+                    </Badge>
+                  )}
+                  <CommandPrimitive.Input
+                    ref={inputRef}
+                    value={inputValue}
+                    onValueChange={setInputValue}
+                    onBlur={(e) => {
+                      window.requestAnimationFrame(() => {
+                        window.requestAnimationFrame(() => {
+                          if (triggerWrapperRef.current?.contains(document.activeElement)) return;
+                          if (dropdownRef.current?.contains(document.activeElement)) return;
+                          closeDropdown();
+                          onBlur?.(e);
+                        });
+                      });
+                    }}
+                    onFocus={(e) => {
+                      setOpen(true);
+                      requestAnimationFrame(() => {
+                        if (containerRef.current) {
+                          containerRef.current.scrollLeft = 0;
+                        }
+                      });
+                      onFocus?.(e);
+                    }}
+                    placeholder={
+                      hidePlaceholderWhenSelected && value.length > 0 ? undefined : placeholder
+                    }
+                    disabled={disabled}
+                    className="ml-2 bg-transparent outline-none placeholder:text-muted-foreground flex-1 min-w-[120px] cursor-pointer"
+                  />
+                </span>
+                <div className={selectTriggerEndActionsVariant()}>
+                  {rightSlot}
+                  <ChevronDown
+                    className={cn(
+                      "size-4 opacity-50 shrink-0 cursor-pointer pointer-events-auto",
+                      disabled && "cursor-not-allowed opacity-50",
+                    )}
+                    onClick={(e) => {
+                      if (disabled) return;
+                      e.preventDefault();
+                      e.stopPropagation();
+                      if (inputRef.current) {
+                        if (open) {
+                          inputRef.current.blur();
+                        } else {
+                          inputRef.current.focus();
+                        }
+                      }
+                    }}
+                    onKeyDown={(e) => {
+                      if (disabled) return;
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        if (inputRef.current) {
+                          if (open) {
+                            inputRef.current.blur();
+                          } else {
+                            inputRef.current.focus();
+                          }
+                        }
+                      }
+                    }}
+                    role="button"
+                    tabIndex={disabled ? -1 : 0}
+                    aria-label="Toggle dropdown"
+                  />
+                </div>
+              </div>
             </div>
-          )}
-        </div>
+          </PopoverAnchor>
+          <PopoverContent
+            ref={dropdownRef}
+            className="w-[var(--radix-popover-trigger-width)] p-0 z-50 rounded-box border bg-popover text-popover-foreground shadow-md outline-none overflow-hidden"
+            sideOffset={4}
+            onOpenAutoFocus={(e) => e.preventDefault()}
+            onCloseAutoFocus={(e) => e.preventDefault()}
+            onInteractOutside={(e) => e.preventDefault()}
+          >
+            {defaultOptions.length > 0 ? (
+              <>
+                <CommandGroup
+                  className="h-full overflow-auto slim-scrollbar"
+                  style={{ maxHeight: "min(300px, var(--radix-popover-content-available-height))" }}
+                >
+                  {defaultOptions.map((option) => {
+                    const selected = isSelected(option);
+                    return (
+                      <CommandItem
+                        key={option.value}
+                        onMouseDown={(e) => {
+                          e.preventDefault();
+                          e.stopPropagation();
+                        }}
+                        onSelect={() => {
+                          setInputValue("");
+                          toggleOption(option);
+                        }}
+                        className={cn(
+                          menuItemVariant({ density }),
+                          "flex items-center justify-between",
+                        )}
+                        disabled={option.disable}
+                      >
+                        {option.tooltip ? (
+                          <TooltipProvider>
+                            <Tooltip delayDuration={300}>
+                              <TooltipTrigger asChild>
+                                <div className="flex items-center justify-between w-full">
+                                  <span>{option.label}</span>
+                                  {selected && (
+                                    <X
+                                      className={cn(
+                                        xIconVariant({ density }),
+                                        "text-muted-foreground hover:text-foreground",
+                                      )}
+                                    />
+                                  )}
+                                </div>
+                              </TooltipTrigger>
+                              <TooltipContent>{option.tooltip}</TooltipContent>
+                            </Tooltip>
+                          </TooltipProvider>
+                        ) : (
+                          <>
+                            <span>{option.label}</span>
+                            {selected && (
+                              <X
+                                className={cn(
+                                  xIconVariant({ density }),
+                                  "text-muted-foreground hover:text-foreground",
+                                )}
+                              />
+                            )}
+                          </>
+                        )}
+                      </CommandItem>
+                    );
+                  })}
+                </CommandGroup>
+                {showActions && (
+                  <div
+                    className="border-t border-border p-2 flex justify-between items-center gap-2 text-sm shrink-0"
+                    role="group"
+                    aria-label="Bulk selection"
+                  >
+                    <button
+                      type="button"
+                      className="text-primary hover:underline underline-offset-2 disabled:opacity-50 disabled:cursor-not-allowed disabled:no-underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-sm px-0.5"
+                      disabled={bulkSelectAllDisabled || disabled}
+                      onMouseDown={(e) => e.preventDefault()}
+                      onClick={() => handleBulkSelectAll()}
+                    >
+                      Select All
+                    </button>
+                    <button
+                      type="button"
+                      className="text-primary hover:underline underline-offset-2 disabled:opacity-50 disabled:cursor-not-allowed disabled:no-underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-sm px-0.5"
+                      disabled={bulkClearAllDisabled || disabled}
+                      onMouseDown={(e) => e.preventDefault()}
+                      onClick={() => handleBulkClearAll()}
+                    >
+                      Clear All
+                    </button>
+                  </div>
+                )}
+              </>
+            ) : emptyIndicator ? (
+              <div className="p-2">{emptyIndicator}</div>
+            ) : (
+              <div className="px-2 py-3 text-sm text-muted-foreground text-center">
+                No options available
+              </div>
+            )}
+          </PopoverContent>
+        </Popover>
       </Command>
     );
   },


### PR DESCRIPTION
##  The Problem

The `MultipleSelector` component (used for selecting Assignees and Labels) suffered from several UX issues when used inside constrained containers, such as the `ImportIssuesDialog`:

1. **Dropdown Clipping**: The dropdown menu was rendered using standard `absolute` positioning relative to its container. Consequently, it was cropped by the `overflow: hidden` / `overflow: auto` constraints of the parent modal window, forcing users to scroll the entire modal just to see the options.
2. **Flicker (Jump) Effect**: The component manually calculated whether to open upward or downward using `getBoundingClientRect()` inside a `useLayoutEffect` and `requestAnimationFrame`. This caused a visible frame delay where the dropdown would briefly render downwards before instantly snapping upwards.
3. **Scroll Lock Issues**: Due to conflicting native scrolling handling inside modals, scrolling the dropdown with the mouse wheel didn't work unless the user dragged the scrollbar manually.


https://github.com/user-attachments/assets/2049e3ff-32e1-41b5-81e1-3459e1de95f6



## What was done

To resolve these issues, we fundamentally changed how the dropdown renders:

- **Migrated to Radix Popover (Portals)**: Wrapped the dropdown menu in Radix UI's `<Popover>` and `<PopoverContent>`. This properly portals the dropdown directly to the `<body>`, allowing it to break out of the modal's overflow boundaries and render on top of all other elements.
- **Removed Manual Calculations**: Deleted the legacy `updateOpenDirection`, `dropdownMaxHeight`, and the accompanying `useLayoutEffect`. Radix Popover leverages Floating UI internally to synchronously calculate the optimal placement (up/down) without any flickering.
- **Responsive Max Height**: Replaced the fixed height style with `style={{ maxHeight: "min(300px, var(--radix-popover-content-available-height))" }}`. This elegantly limits the dropdown to a clean 300px, but dynamically shrinks it if it gets too close to the edge of the monitor, preventing it from overflowing the screen.
- **Fixed Mouse Wheel Scrolling**: Passed `modal={true}` to the Popover instance. This properly integrates the Popover with the Dialog's `react-remove-scroll` context, unlocking native mouse wheel scrolling for the options list.


https://github.com/user-attachments/assets/79880f72-8922-4422-a560-f2ee30c8d02c

