### PR TITLE
[Layout]: Fix greedy flex behavior in Spacer and margin wrappers

### DIFF
--- a/src/Ivy/Views/Layout.cs
+++ b/src/Ivy/Views/Layout.cs
@@ -69,17 +69,17 @@ public static class LayoutExtensions
 {
     public static LayoutView WithMargin(this object anything, int margin)
     {
-        return Layout.Horizontal(anything).Margin(margin);
+        return new LayoutView().Horizontal(anything).Margin(margin);
     }
 
     public static LayoutView WithMargin(this object anything, int marginX, int marginY)
     {
-        return Layout.Horizontal(anything).Margin(marginX, marginY);
+        return new LayoutView().Horizontal(anything).Margin(marginX, marginY);
     }
 
     public static LayoutView WithMargin(this object anything, int left, int top, int right, int bottom)
     {
-        return Layout.Horizontal(anything).Margin(left, top, right, bottom);
+        return new LayoutView().Horizontal(anything).Margin(left, top, right, bottom);
     }
 
     public static LayoutView WithLayout(this object anything)

--- a/src/frontend/src/widgets/primitives/SpacerWidget.tsx
+++ b/src/frontend/src/widgets/primitives/SpacerWidget.tsx
@@ -9,9 +9,6 @@ export const SpacerWidget: React.FC<SpacerWidgetProps> = ({ width, height }) => 
   return (
     <div
       style={{
-        flexGrow: 1,
-        flexShrink: 1,
-        flexBasis: "0%",
         ...getWidth(width),
         ...getHeight(height),
       }}


### PR DESCRIPTION
## Overview
This pull request resolves two closely related flexbox layout issues that caused unintended visual alignments and elements being pushed to the bottom of centered vertical layouts. 

## Issue 1: `.WithMargin()` Alignment Bug (#4511)
**What happened:** 
When applying a margin using the `.WithMargin()` extension method on an element inside a centered vertical layout, the element would unexpectedly break the center alignment and push itself (or other content) to the edges of the container.

**Why it happened:** 
The `LayoutExtensions.WithMargin(...)` method was implicitly wrapping the target element in a `Layout.Horizontal()` container. By default, `Layout.Horizontal()` explicitly assigns `.Height(Size.Full())` to itself. In CSS flexbox, when a vertical container is set to center its content, placing a child with `height: 100%` inside it forces the child to expand to the parent's full height, completely ruining the intended centering behavior and pushing content apart.

**How we fixed it:** 
Modified `Layout.cs` so that `WithMargin` instantiates a raw `new LayoutView().Horizontal()` directly, completely avoiding the default `Size.Full()` height injection. The wrapper now acts purely as an invisible margin container without greedily affecting the layout's height constraints.

## Issue 2: `Spacer` Height Bug (#4510)
**What happened:** 
When using a `Spacer` component and explicitly assigning it a fixed height (e.g., `new Spacer().Height(Size.Units(4))`), the spacer would ignore the constraint and greedily expand to consume all remaining vertical space in the flex container, pushing elements to the very top and bottom of the screen.

**Why it happened:** 
In the frontend React renderer, the `SpacerWidget.tsx` component had `flexGrow: 1` and `flexBasis: "0%"` hardcoded directly into its inline styles. Because of this, no matter what height constraint or width token was sent from the C# backend, the browser was forced to unconditionally apply `flex-grow` to the spacer, making it absorb all free space in the column layout.

**How we fixed it:** 
Removed the hardcoded `flexGrow: 1`, `flexShrink: 1`, and `flexBasis: "0%"` from the inline styles in `SpacerWidget.tsx`. The component now fully relies on the responsive size properties (`getWidth` and `getHeight`) passed dynamically from the C# backend. This allows the spacer to respect fixed heights properly.

## Verification
Both fixes have been tested locally. A clean build of the framework and frontend guarantees that `Spacer` and `WithMargin` now behave predictably within centered vertical layouts without leaking greedy flex properties.

<img width="2559" height="1439" alt="image" src="https://github.com/user-attachments/assets/6f1776bb-52a6-4ce6-84c7-9bceced21313" />
<img width="2559" height="1439" alt="image" src="https://github.com/user-attachments/assets/ae29e4d8-0e50-4bfb-8991-8521dfb0f163" />
