### PR TITLE
fix: use Cascadia Mono as default Xterm font

### DIFF
--- a/src/widgets/Ivy.Widgets.Xterm/frontend/src/Terminal.tsx
+++ b/src/widgets/Ivy.Widgets.Xterm/frontend/src/Terminal.tsx
@@ -102,7 +102,7 @@ export const Terminal: React.FC<TerminalProps> = ({
   subscribeToStream,
   cols,
   rows,
-  fontFamily = "Geist Mono, Menlo, Monaco, 'Courier New', monospace, 'Segoe UI Emoji', 'Apple Color Emoji', 'Noto Color Emoji'",
+  fontFamily = "'Cascadia Mono', Geist Mono, Menlo, Monaco, 'Courier New', monospace, 'Segoe UI Emoji', 'Apple Color Emoji', 'Noto Color Emoji'",
   lineHeight = 1.0,
   cursorBlink = true,
   cursorStyle = "Block",


### PR DESCRIPTION
Matches Windows Terminal's default font for better rendering of Unicode block characters and general terminal output.