### PR TITLE
[TextInputVariant]: force foreground color on embedded buttons

### DIFF
--- a/src/frontend/src/components/ui/input/text-input-variant.ts
+++ b/src/frontend/src/components/ui/input/text-input-variant.ts
@@ -8,7 +8,7 @@ import { cn } from "@/lib/utils";
  * `size-7`/`size-9` target is larger than the glyph, which reads as extra padding.
  */
 export const affixEmbeddedButtonClasses =
-  "[&_button]:!px-0 [&_button]:shadow-none [&_button]:rounded [&_button]:hover:bg-accent [&_button]:cursor-pointer [&_button]:transition-colors [&_button.size-7]:!size-4 [&_button.size-9]:!size-6";
+  "[&_button]:!px-0 [&_button]:text-foreground [&_button]:shadow-none [&_button]:rounded [&_button]:hover:bg-accent [&_button]:cursor-pointer [&_button]:transition-colors [&_button.size-7]:!size-4 [&_button.size-9]:!size-6";
 
 /** Tighter affix cell padding when the slot only contains an icon-sized button. */
 export const affixIconOnlyCellPaddingClasses =


### PR DESCRIPTION
## Problem

Buttons placed inside `.Suffix()` / `.Prefix()` slots of a `TextInput` inherited the `text-muted-foreground` color from the affix container. This caused button labels and icons to appear gray/muted instead of using the standard foreground color, making them look disabled or de-emphasized — even though they are fully interactive.

This was especially noticeable for `.Ghost()` buttons, which have a transparent background and rely entirely on text color for visual presence.

## What needed to be done

Ensure that any button rendered inside an affix cell always uses the normal foreground color (`text-foreground`), regardless of the muted color applied to the surrounding container (which is intentional for non-interactive content like icons or unit labels).

## What was changed and why

Added `[&_button]:text-foreground` to the `affixEmbeddedButtonClasses` constant in `text-input-variant.ts`.

This CSS selector targets any `<button>` element nested inside the affix cell and overrides the inherited `text-muted-foreground` with `text-foreground`. The override is scoped specifically to buttons, so non-button affix content (e.g. plain text labels, icons used as indicators) still renders in the muted color as designed.

### Changed file

- `src/frontend/src/components/ui/input/text-input-variant.ts`

Before:
<img width="827" height="494" alt="image" src="https://github.com/user-attachments/assets/6d8d20a1-93c8-4925-9133-eafaad3b6e1d" />

After:
<img width="818" height="472" alt="image" src="https://github.com/user-attachments/assets/84daea8a-6e51-44f1-b1cc-8d4d45e7c792" />
