### PR TITLE
[Desktop]: fix taskbar icon missing

### DIFF
--- a/src/Ivy.Desktop/DesktopWindow.cs
+++ b/src/Ivy.Desktop/DesktopWindow.cs
@@ -339,6 +339,8 @@ public class DesktopWindow(Server server)
         if (!_mediaAutoplay) window.SetMediaAutoplayEnabled(false);
         foreach (var script in _initScripts) window.AddInitScript(script);
 
+        if (_appId != null) window.SetApplicationId(_appId);
+
         if (_iconFilePath != null)
         {
             window.SetIconFile(_iconFilePath);


### PR DESCRIPTION
## Problem

The Ivy Tendril application was missing its icon in the Windows taskbar. The window appeared with a generic/blank icon despite the application correctly calling `.AppId("Ivy Tendril")` and `.Icon(typeof(Program), "Ivy.Tendril.Assets.icon.ico")` on the `DesktopWindow` builder.

## Root Cause

In commit `9f8e15e`, `RustinoWindow.SetApplicationId()` was added to Rustino.NET to support proper Windows taskbar icon association via `SetCurrentProcessExplicitAppUserModelID`. However, `DesktopWindow.CreateWindow()` was never updated to pass the `_appId` value through to `RustinoWindow`.

The `_appId` field was being stored by the `AppId()` builder method (line 66), but in `CreateWindow()` it was silently ignored — the value never reached the underlying `RustinoWindow` instance. This meant the Windows AppUserModelID was not being set through the Rustino layer, causing Windows to fall back to a default icon association for the taskbar.

## Fix

Added a single line to `DesktopWindow.CreateWindow()` that forwards the `_appId` to `RustinoWindow.SetApplicationId()`:

```csharp
if (_appId != null) window.SetApplicationId(_appId);
```

This is placed after init script registration and before icon file handling, ensuring the application identity is established before the window is displayed.

## Related

- Closes Ivy-Interactive/Ivy-Tendril#962
- Follow-up to `9f8e15e` (Rustino: Fix taskbar and macOS Dock icon for global dotnet tools)
