### PR TITLE
[Ivy.Docs.Shared]: fix missing markdown embedded resources by correcting MSBuild target timing

### DIFF
--- a/src/Ivy.Docs.Shared/Ivy.Docs.Shared.csproj
+++ b/src/Ivy.Docs.Shared/Ivy.Docs.Shared.csproj
@@ -42,7 +42,7 @@
 
 
 
-  <Target Name="TransformMarkdown" BeforeTargets="CoreCompile">
+  <Target Name="TransformMarkdown" AfterTargets="ResolveProjectReferences" BeforeTargets="CoreCompile">
     <PropertyGroup>
       <DocsInputPath>$([System.IO.Path]::Combine($(MSBuildProjectDirectory), 'Docs'))</DocsInputPath>
       <DocsOutputPath>$([System.IO.Path]::Combine($(MSBuildProjectDirectory), 'Generated'))</DocsOutputPath>


### PR DESCRIPTION
## Description

This PR fixes a critical issue where the "Copy Page" functionality (`.md` raw file fetching) returned a 404 error on the deployed `docs.ivy.app` environment, despite working perfectly on `localhost`.

### The Issue
On the production deployment, attempting to fetch any raw markdown file (e.g., `https://docs.ivy.app/onboarding/getting-started/introduction.md`) resulted in a `404 Not Found` response generated by the `MarkdownMiddleware`. The middleware correctly intercepted the request but `Assembly.GetManifestResourceStream()` returned `null`, indicating that the embedded `.md` resources were missing from the compiled `Ivy.Docs.Shared.dll`.

### The Root Cause
The root cause was a subtle MSBuild pipeline timing issue introduced during a previous build pipeline simplification (PR #3477). 

In `Ivy.Docs.Shared.csproj`, the `TransformMarkdown` target was configured as:
```xml
<Target Name="TransformMarkdown" BeforeTargets="CoreCompile">
```

During a clean Docker build (where the `Generated/` directory does not exist because it is `.gitignore`d), MSBuild processes embedded resources (`AssignTargetPaths` and `PrepareResourceNames`) **before** `CoreCompile`. Because the `Generated/` folder was empty when MSBuild evaluated the `<EmbeddedResource>` items, it recorded 0 resources to embed. 
The `ivy-docs-cli` tool successfully generated the `.md` and `.g.cs` files moments later (which is why the C# UI pages worked), but it was too late for the resource pipeline, resulting in an assembly with no embedded markdown files.

Locally, this bug was masked because the `Generated/` directory persists between builds, allowing MSBuild to find the `.md` files from previous runs during its initial evaluation phase.

### The Fix
To fix this, the MSBuild target signature in `Ivy.Docs.Shared.csproj` was updated to explicitly run earlier in the pipeline, immediately after resolving project references (matching the working configuration in `Ivy.Tendril.Docs.csproj`):

```diff
- <Target Name="TransformMarkdown" BeforeTargets="CoreCompile">
+ <Target Name="TransformMarkdown" AfterTargets="ResolveProjectReferences" BeforeTargets="CoreCompile">
```

By adding `AfterTargets="ResolveProjectReferences"`, we force `TransformMarkdown` to execute **before** `AssignTargetPaths`. This guarantees that `ivy-docs-cli` generates the markdown files in time for the .NET SDK resource pipeline to detect and embed them into the final `.dll`, ensuring they are available in production.
