### PR TITLE
[DataTable]: fix grow column widths distribution and container flexbox shrinking

### DIFF
--- a/src/frontend/src/widgets/dataTables/DataTableWidget.test.ts
+++ b/src/frontend/src/widgets/dataTables/DataTableWidget.test.ts
@@ -18,8 +18,9 @@ describe("DataTableWidget - container style for height modes", () => {
     expect(source).toContain("containerStyle.flexGrow = 1");
   });
 
-  it("should cap explicit heights with min(preferred, 100%) so tables shrink in tabs", () => {
-    expect(source).toContain("containerStyle.height = `min(${containerStyle.height}, 100%)`");
+  it("should move explicit heights to flex-basis so tables shrink in tabs", () => {
+    expect(source).toContain("containerStyle.flexBasis = containerStyle.height");
+    expect(source).toContain("delete containerStyle.height");
   });
 
   it("should compute a density-aware minimum height before page scroll", () => {

--- a/src/frontend/src/widgets/dataTables/DataTableWidget.tsx
+++ b/src/frontend/src/widgets/dataTables/DataTableWidget.tsx
@@ -116,9 +116,9 @@ export const DataTable: React.FC<DataTableWidgetProps> = ({
     containerStyle.flexDirection = "column";
     containerStyle.flexShrink = 1;
     containerStyle.minHeight = minHeight;
-    containerStyle.maxHeight = "100%";
     if (containerStyle.height) {
-      containerStyle.height = `min(${containerStyle.height}, 100%)`;
+      containerStyle.flexBasis = containerStyle.height;
+      delete containerStyle.height;
     }
   }
 

--- a/src/frontend/src/widgets/dataTables/dataTableContext/hooks/useColumnManagement.ts
+++ b/src/frontend/src/widgets/dataTables/dataTableContext/hooks/useColumnManagement.ts
@@ -3,6 +3,7 @@ import { GridColumn, getDefaultTheme } from "@glideapps/glide-data-grid";
 import { DataColumn } from "../../types/types";
 import {
   parseSize,
+  parseSizeGrow,
   estimateHeaderWidth,
   estimateContentWidth,
   getSizeMode,
@@ -81,6 +82,10 @@ export const useColumnManagement = ({
         const headerFont = `${defaultTheme.headerFontStyle} ${defaultTheme.fontFamily}`;
         const contentFont = `${defaultTheme.baseFontStyle} ${defaultTheme.fontFamily}`;
         const widths: Record<string, number> = {};
+
+        const growColumnIndices: number[] = [];
+        let maxGrowBaseWidth = 0;
+
         mergedColumns.forEach((col, index) => {
           const explicitWidth = parseSize(col.width);
           const headerMinWidth = estimateHeaderWidth(col.header || col.name, headerFont);
@@ -96,9 +101,25 @@ export const useColumnManagement = ({
             }
           }
 
-          // For grow/fraction/auto/etc types, parseSize returns 0 — use header width as minimum
+          // Check if this column uses grow/fraction sizing
+          const sizeStr =
+            col.originalWidth ?? (typeof col.width === "string" ? col.width : undefined);
+          const growFactor = parseSizeGrow(sizeStr);
+          if (growFactor !== undefined) {
+            const baseWidth = Math.max(explicitWidth, headerMinWidth);
+            growColumnIndices.push(index);
+            maxGrowBaseWidth = Math.max(maxGrowBaseWidth, baseWidth);
+            widths[index.toString()] = baseWidth;
+            return;
+          }
+
+          // For fixed-width types, use explicit width or header width as minimum
           widths[index.toString()] = Math.max(explicitWidth, headerMinWidth);
         });
+
+        for (const idx of growColumnIndices) {
+          widths[idx.toString()] = maxGrowBaseWidth;
+        }
         return widths;
       });
     },

--- a/src/frontend/src/widgets/dataTables/hooks/useContainerSize.test.ts
+++ b/src/frontend/src/widgets/dataTables/hooks/useContainerSize.test.ts
@@ -53,8 +53,9 @@ describe("DataTableWidget - flex sizing for unconstrained parents", () => {
     expect(widgetSource).toContain("flexGrow = 1");
   });
 
-  it("should cap explicit heights with min(preferred, 100%)", () => {
-    expect(widgetSource).toContain("containerStyle.height = `min(${containerStyle.height}, 100%)`");
+  it("should move explicit height to flexBasis for proportional shrinking", () => {
+    expect(widgetSource).toContain("containerStyle.flexBasis = containerStyle.height");
+    expect(widgetSource).toContain("delete containerStyle.height");
   });
 
   it("should compute min height from density and table chrome via getDataTableMinHeight", () => {

--- a/src/frontend/src/widgets/dataTables/utils/columnHelpers.ts
+++ b/src/frontend/src/widgets/dataTables/utils/columnHelpers.ts
@@ -128,7 +128,9 @@ export function convertToGridColumns(
     const originalIndex = columns.indexOf(col);
     const numericBaseWidth = resolveColumnWidth(col, originalIndex, columnWidths, headerFont);
 
-    const grow = parseSizeGrow(col.originalWidth);
+    const grow = parseSizeGrow(
+      col.originalWidth ?? (typeof col.width === "string" ? col.width : undefined),
+    );
     const isLastColumn = index === orderedColumns.length - 1;
     const effectiveGrow = grow !== undefined ? grow : isLastColumn ? 1 : undefined;
 


### PR DESCRIPTION
## Overview
This PR addresses critical rendering bugs in the `DataTableWidget` where proportional columns (`Fraction` / `Grow`) failed to distribute space equally, and the table's height failed to shrink correctly inside Flexbox layouts.

## Issue 1: Uneven Column Width Distribution
**Problem:** 
Columns explicitly set to equal fractions (e.g., `Size.Fraction(1/8f)`) were rendered with slightly varying widths. In some scenarios, only the very last column would stretch to fill the remaining space.

**Root Causes:**
1. The `syncColumns` hook inadvertently wiped out the `originalWidth` metadata (which contains the raw `Fraction:0.125` string) by overwriting it with `columnsProp`. This caused `parseSizeGrow` to return `undefined`, forcing the table to apply the default fallback where only the last column gets `grow: 1`.
2. `glide-data-grid` calculates final column widths by first allocating a base width, then dividing the *remaining* space according to `grow` factors. Because base widths were derived from header text lengths, columns with longer text got a larger base width. Distributing equal grow factors over unequal base widths resulted in uneven final widths.

**The Fix:**
1. Modified `parseSizeGrow` in `columnHelpers.ts` to fall back to `col.width` (as a string) when `col.originalWidth` is missing. This ensures the grow factor is always preserved.
2. Implemented a two-pass initialization in `useColumnManagement.ts`. It now identifies all proportional columns, finds the maximum base width among them, and normalizes all of them to share that same base width. This forces `glide-data-grid` to distribute the remaining space perfectly evenly.

## Issue 2: Improper Flexbox Shrinking
**Problem:** 
When a DataTable had an explicitly defined height (e.g., `307px`), it would not shrink properly if its flex parent (like `Layout.Vertical()`) ran out of vertical space. 

**Root Cause:** 
The explicit `height` property created a rigid constraint. Previous workarounds attempting to use `maxHeight: 100%` and `min(height, 100%)` were brittle and failed to leverage native flexbox mechanics.

**The Fix:** 
Updated `DataTableWidget.tsx` to move explicit heights into the `flexBasis` property instead of `height`, while keeping `flexShrink: 1`. This correctly communicates the table's ideal size to the flex engine while allowing it to gracefully shrink when the parent container lacks space.

Fixes [Issue 843](https://github.com/Ivy-Interactive/Ivy-Tendril/issues/843)

Before:
<img width="1813" height="1128" alt="image" src="https://github.com/user-attachments/assets/374bcc05-ebd6-43e2-ad0a-72934b3f8d44" />


After:
<img width="1610" height="813" alt="image" src="https://github.com/user-attachments/assets/b25ff418-7ad6-499c-b887-2e71f556a7e2" />
