### PR TITLE
[Datatable]: fix header slots bad spacing and density scaling

### DIFF
--- a/src/Ivy.Samples.Shared/Apps/Widgets/DataTableApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/DataTableApp.cs
@@ -254,10 +254,10 @@ public class DataTableHeaderSlotsSample : ViewBase
                 .Icon(x => x.Team, Icons.Layers)
                 .Icon(x => x.Priority, Icons.Flag)
                 .Icon(x => x.LastUpdate, Icons.Clock)
-                .HeaderLeft(_ => Layout.Horizontal().Gap(2)
+                .HeaderLeft(_ => new Fragment()
                     | new Button("Export", icon: Icons.Download).Small()
                     | new Badge("Live").Color(Colors.Blue).Small())
-                .HeaderRight(_ => Layout.Horizontal().Gap(2)
+                .HeaderRight(_ => new Fragment()
                     | new Badge($"{data.Count()} rows").Color(Colors.Green).Small()
                     | new Button("Settings", icon: Icons.Settings).Primary().Small())
                 .Config(config =>

--- a/src/frontend/src/widgets/dataTables/DataTableOption.tsx
+++ b/src/frontend/src/widgets/dataTables/DataTableOption.tsx
@@ -2,6 +2,8 @@ import React, { ReactNode, useState, useRef } from "react";
 import { LucideIcon } from "lucide-react";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
+import { Densities } from "@/types/density";
+import { controlHeight, controlSize } from "@/components/ui/density-scale";
 
 /**
  * Display modes for DataTableOption
@@ -35,6 +37,7 @@ export interface DataTableOptionProps {
 
   // Button configuration
   showLabel?: boolean;
+  density?: Densities;
 }
 
 /**
@@ -56,6 +59,7 @@ export const DataTableOption: React.FC<DataTableOptionProps> = ({
   inlineDirection = "right",
   defaultExpanded: propDefaultExpanded = false,
   showLabel = true,
+  density = Densities.Medium,
 }) => {
   const [expanded, setExpanded] = useState(() => propDefaultExpanded);
   const prevDefaultExpandedRef = useRef(propDefaultExpanded);
@@ -65,6 +69,11 @@ export const DataTableOption: React.FC<DataTableOptionProps> = ({
     setExpanded(propDefaultExpanded);
   }
   const containerRef = useRef<HTMLDivElement>(null);
+
+  const heightClass = controlHeight[density] || controlHeight.Medium;
+  const sizeClass = controlSize[density] || controlSize.Medium;
+  const pxClass =
+    density === Densities.Small ? "px-2" : density === Densities.Large ? "px-4" : "px-3";
 
   // Handle click outside to collapse
   // useEffect(() => {
@@ -93,7 +102,7 @@ export const DataTableOption: React.FC<DataTableOptionProps> = ({
           <button
             className={cn(
               "inline-flex items-center justify-center rounded-md text-sm font-medium",
-              "h-9 px-3 gap-2 cursor-pointer",
+              `${heightClass} ${pxClass} gap-2 cursor-pointer`,
               "bg-transparent hover:bg-accent hover:text-accent-foreground",
               "border border-input",
               "transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
@@ -130,7 +139,7 @@ export const DataTableOption: React.FC<DataTableOptionProps> = ({
       <div
         ref={containerRef}
         className={cn(
-          "inline-flex items-center mb-3",
+          "inline-flex items-center",
           "rounded-field border border-input bg-transparent shadow-sm",
           "dark:border-white/10 dark:bg-white/5",
           "focus-within:outline-none focus-within:ring-1 focus-within:ring-ring",
@@ -141,7 +150,7 @@ export const DataTableOption: React.FC<DataTableOptionProps> = ({
         <button
           className={cn(
             "inline-flex items-center justify-center text-sm font-medium",
-            "size-9 shrink-0 gap-2 cursor-pointer",
+            `${sizeClass} shrink-0 gap-2 cursor-pointer`,
             "bg-transparent rounded-l-fields",
             "transition-colors focus-visible:outline-none",
             expanded
@@ -157,7 +166,7 @@ export const DataTableOption: React.FC<DataTableOptionProps> = ({
         {/* Content container - fixed dimensions when expanded */}
         <div
           className={cn(
-            "border-l h-9",
+            `border-l ${heightClass}`,
             "transition-all duration-300 ease-in-out",
             expanded ? "w-[450px] opacity-100 border-input" : "w-0 opacity-0 border-transparent",
           )}
@@ -185,7 +194,7 @@ export const DataTableOption: React.FC<DataTableOptionProps> = ({
       <div
         ref={containerRef}
         className={cn(
-          "inline-flex items-center mb-3",
+          "inline-flex items-center",
           "border rounded-field",
           "transition-all duration-300 ease-in-out",
           "bg-transparent",
@@ -203,7 +212,7 @@ export const DataTableOption: React.FC<DataTableOptionProps> = ({
               : "max-w-0 opacity-0 border-transparent",
           )}
         >
-          <div className={cn("h-9 flex items-center", contentClassName)}>
+          <div className={cn(`${heightClass} flex items-center`, contentClassName)}>
             {React.isValidElement(children)
               ? React.cloneElement(children as React.ReactElement<{ isExpanded?: boolean }>, {
                   isExpanded: expanded,
@@ -215,7 +224,7 @@ export const DataTableOption: React.FC<DataTableOptionProps> = ({
         <button
           className={cn(
             "inline-flex items-center justify-center text-sm font-medium",
-            "h-9 px-3 gap-2 cursor-pointer",
+            `${heightClass} ${pxClass} gap-2 cursor-pointer`,
             "bg-transparent hover:bg-accent hover:text-accent-foreground rounded-r-md",
             "transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
             expanded && "bg-accent",
@@ -234,7 +243,7 @@ export const DataTableOption: React.FC<DataTableOptionProps> = ({
     <div
       ref={containerRef}
       className={cn(
-        "inline-flex flex-col mb-3",
+        "inline-flex flex-col",
         "border rounded-field",
         "transition-all duration-300 ease-in-out",
         "bg-transparent",
@@ -245,7 +254,7 @@ export const DataTableOption: React.FC<DataTableOptionProps> = ({
       <button
         className={cn(
           "inline-flex items-center justify-center text-sm font-medium",
-          "h-9 px-3 gap-2 w-full cursor-pointer",
+          `${heightClass} ${pxClass} gap-2 w-full cursor-pointer`,
           "bg-transparent hover:bg-accent hover:text-accent-foreground",
           "transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
           expanded && "bg-accent border-b border-input/30 rounded-t-md",

--- a/src/frontend/src/widgets/dataTables/DataTableWidget.tsx
+++ b/src/frontend/src/widgets/dataTables/DataTableWidget.tsx
@@ -122,6 +122,13 @@ export const DataTable: React.FC<DataTableWidgetProps> = ({
     }
   }
 
+  const densityMode = density ?? Densities.Medium;
+  const spacing = {
+    [Densities.Small]: { mb: "mb-1", gapOuter: "gap-1", gapInner: "gap-1" },
+    [Densities.Medium]: { mb: "mb-2", gapOuter: "gap-2", gapInner: "gap-2" },
+    [Densities.Large]: { mb: "mb-4", gapOuter: "gap-4", gapInner: "gap-3" },
+  }[densityMode];
+
   return (
     <div style={containerStyle} data-testid={dataTestId}>
       <TableProvider
@@ -133,9 +140,9 @@ export const DataTable: React.FC<DataTableWidgetProps> = ({
         updateStream={updateStream}
       >
         <TableLayout>
-          <DataTableHeader>
-            <div className="flex items-center gap-2 w-full">
-              <div className="flex items-center gap-1">
+          <DataTableHeader className={spacing.mb}>
+            <div className={`flex items-center w-full ${spacing.gapOuter}`}>
+              <div className={`flex items-center ${spacing.gapInner}`}>
                 {finalConfig.allowFiltering && (
                   <DataTableOption
                     icon={FilterIcon}
@@ -144,6 +151,7 @@ export const DataTable: React.FC<DataTableWidgetProps> = ({
                     displayMode="inline"
                     inlineDirection="right"
                     showLabel={false}
+                    density={densityMode}
                   >
                     <DataTableFilterOption allowLlmFiltering={finalConfig.allowLlmFiltering} />
                   </DataTableOption>
@@ -151,7 +159,7 @@ export const DataTable: React.FC<DataTableWidgetProps> = ({
                 {slots?.HeaderLeft}
               </div>
               <div className="flex-1" />
-              <div className="flex items-center gap-1">{slots?.HeaderRight}</div>
+              <div className={`flex items-center ${spacing.gapInner}`}>{slots?.HeaderRight}</div>
             </div>
           </DataTableHeader>
 


### PR DESCRIPTION
## Issue

The DataTable header slots (`HeaderLeft` and `HeaderRight`) had poor spacing and vertical alignment issues:
1. The header toolbar lacked a bottom margin, causing it to stick flush against the table columns.
2. The elements inside the slots were crowded due to static gaps, and the filter button was visually misaligned (its baseline was pushed up relative to the slot items).
3. The spacing and sizes of the built-in header elements (like the filter button) did not respond to the DataTable's `density` property, looking out of proportion in `Small` and `Large` scales.

## What Needed to be Done
- Fix the vertical misalignment between the built-in filter button and custom slot elements.
- Introduce dynamic spacing (margins and gaps) for the header toolbar that accurately scales with the DataTable's `density` setting.
- Ensure the filter button's size scales appropriately alongside standard buttons.
- Update the sample code to demonstrate the correct usage of slots without hardcoded layout wrappers.

## What I Did and Why
- **`DataTableOption.tsx`**: 
  - **Why**: The filter button was misaligned because it had a hardcoded `mb-3` class pushing its visual center up within the `items-center` flex container. It also had a fixed `size-9` dimensions.
  - **What**: Removed the parasitic `mb-3` class to restore perfect baseline alignment. Replaced hardcoded sizes with dynamic variables (`controlHeight`, `controlSize`) from `density-scale.ts` based on the injected `density` prop.
- **`DataTableWidget.tsx`**: 
  - **Why**: The entire header needed to react to the density scale.
  - **What**: Created a dynamic density-to-spacing mapping (`mb-1/2/4` and `gap-1/2/4`). Passed the `density` prop down to `DataTableOption` and applied the dynamic gaps to the `DataTableHeader` containers so they scale proportionally.
- **`DataTableApp.cs` (Samples)**: 
  - **Why**: The `HeaderLeft` and `HeaderRight` slots were wrapped in `Layout.Horizontal().Gap(2)`. This forced a static 8px gap onto the elements, overriding the responsive gaps provided by the frontend.
  - **What**: Replaced `Layout.Horizontal().Gap(2)` with `new Fragment()`. This allows the injected slot elements to directly join the frontend's flex container and seamlessly inherit the dynamic `gapInner` scaling.
  

https://github.com/user-attachments/assets/b2decb51-2411-493a-a4a2-89117656e8ce

