### PR TITLE
(multiselect): fix border ring

### DIFF
--- a/src/frontend/src/widgets/inputs/SelectInputWidget/styles.ts
+++ b/src/frontend/src/widgets/inputs/SelectInputWidget/styles.ts
@@ -1,7 +1,7 @@
 import { cva } from "class-variance-authority";
 
 export const selectContainerVariant = cva(
-  "relative border border-input bg-transparent rounded-box shadow-sm focus-within:ring-1 focus-within:ring-ring dark:border-white/10",
+  "relative border border-input bg-transparent rounded-box focus-within:outline-none focus-within:border-ring dark:border-white/10",
   {
     variants: {
       density: {

--- a/src/frontend/src/widgets/inputs/SelectInputWidget/variants/ToggleOptionItem.tsx
+++ b/src/frontend/src/widgets/inputs/SelectInputWidget/variants/ToggleOptionItem.tsx
@@ -43,7 +43,7 @@ export const ToggleOptionItem: React.FC<ToggleOptionItemProps> = ({
       aria-label={option.label || option.value.toString()}
       title={option.label}
       className={cn(
-        "hover:text-foreground gap-2",
+        "hover:text-foreground gap-2 shadow-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring focus-visible:ring-offset-0",
         sizeClasses[density],
         isInvalid
           ? cn(inputStyles.invalidInput, "bg-destructive/10 border-destructive text-destructive")

--- a/src/frontend/src/widgets/inputs/SelectInputWidget/variants/ToggleVariant.tsx
+++ b/src/frontend/src/widgets/inputs/SelectInputWidget/variants/ToggleVariant.tsx
@@ -179,7 +179,7 @@ export const ToggleVariant: React.FC<SelectInputWidgetProps> = ({
     <div
       className={cn(
         selectContainerVariant({ density }),
-        invalid && "border-destructive focus-within:ring-destructive",
+        invalid && "border-destructive focus-within:border-destructive",
         ghost &&
           "border-transparent shadow-none bg-transparent dark:border-transparent dark:bg-transparent",
       )}


### PR DESCRIPTION
Issue:
<img width="1212" height="408" alt="image" src="https://github.com/user-attachments/assets/6866274e-16ff-43ff-8bcc-0ab990941dc1" />

Fixed border for multiselect:
<img width="481" height="321" alt="Screenshot 2026-06-01 at 00 29 07" src="https://github.com/user-attachments/assets/19b6fd6c-4b6d-46b3-99ed-966af440bbc0" />
<img width="495" height="227" alt="Screenshot 2026-06-01 at 00 29 30" src="https://github.com/user-attachments/assets/1e9ecc2d-3c7a-4b22-a4ea-6717d2e6fa87" />
