### PR TITLE
[00097] Format dates better in frontmatter rendering

### DIFF
--- a/src/frontend/src/components/MarkdownRenderer.tsx
+++ b/src/frontend/src/components/MarkdownRenderer.tsx
@@ -80,6 +80,9 @@ const FrontmatterDisplay: React.FC<{ data: FrontmatterData }> = memo(({ data }) 
   const formatValue = (value: any): string => {
     if (value === null || value === undefined) return "null";
     if (typeof value === "boolean") return value ? "true" : "false";
+    if (value instanceof Date) {
+      return value.toLocaleString();
+    }
     if (typeof value === "string") {
       // Format ISO dates nicely
       if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/.test(value)) {


### PR DESCRIPTION
# Summary

## Changes

Added a `Date` instance check to the `formatValue` function in `FrontmatterDisplay` component to properly format `Date` objects parsed by `js-yaml`. This fixes the issue where dates in YAML frontmatter displayed as raw quoted ISO strings (e.g., `"2026-06-03T17:55:59.000Z"`) instead of human-readable formats.

## API Changes

None. Internal display logic change only.

## Files Modified

- `src/frontend/src/components/MarkdownRenderer.tsx` — Added `if (value instanceof Date)` check before string handling to format Date objects using `toLocaleString()`

---

## Commits

- 553ca1940