### PR TITLE
[00086] Checkbox labels should be clickable to toggle state

### DIFF
--- a/src/frontend/src/widgets/inputs/BoolInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/BoolInputWidget.tsx
@@ -73,11 +73,19 @@ const InputLabel: React.FC<{
   label?: string;
   description?: string;
   density?: Densities;
-}> = React.memo(({ id, label, description, density = Densities.Medium }) => {
+  onClick?: () => void;
+  disabled?: boolean;
+}> = React.memo(({ id, label, description, density = Densities.Medium, onClick, disabled }) => {
   if (!label && !description) return null;
 
+  const cursorClass = onClick
+    ? disabled
+      ? "cursor-not-allowed"
+      : "cursor-pointer"
+    : undefined;
+
   return (
-    <div>
+    <div onClick={onClick} className={cursorClass}>
       {label && (
         <Label htmlFor={id} className={labelSizeVariant({ density })}>
           {label}
@@ -126,6 +134,18 @@ const VariantComponents = {
       onCheckedChange,
       "data-testid": dataTestId,
     }: CheckboxVariantProps) => {
+      // Toggle cycle for label clicks: null → true → false → null (if nullable)
+      const handleLabelClick = () => {
+        if (disabled || loading) return;
+        if (nullable) {
+          if (value === null) onCheckedChange(true);
+          else if (value === true) onCheckedChange(false);
+          else onCheckedChange(null);
+        } else {
+          onCheckedChange(!value);
+        }
+      };
+
       const checkboxElement = (
         <div className="relative flex shrink-0">
           <Checkbox
@@ -158,7 +178,14 @@ const VariantComponents = {
           >
             {checkboxElement}
           </DivWithTooltip>
-          <InputLabel id={id} label={label} description={description} />
+          <InputLabel
+            id={id}
+            label={label}
+            description={description}
+            density={density}
+            onClick={handleLabelClick}
+            disabled={disabled || loading}
+          />
         </div>
       );
 
@@ -181,6 +208,11 @@ const VariantComponents = {
       onCheckedChange,
       "data-testid": dataTestId,
     }: SwitchVariantProps) => {
+      const handleLabelClick = () => {
+        if (disabled || loading) return;
+        onCheckedChange(!value);
+      };
+
       const switchElement = (
         <div className="relative flex shrink-0">
           <Switch
@@ -213,7 +245,14 @@ const VariantComponents = {
           >
             {switchElement}
           </DivWithTooltip>
-          <InputLabel id={id} label={label} description={description} />
+          <InputLabel
+            id={id}
+            label={label}
+            description={description}
+            density={density}
+            onClick={handleLabelClick}
+            disabled={disabled || loading}
+          />
         </div>
       );
 
@@ -236,6 +275,11 @@ const VariantComponents = {
       onPressedChange,
       "data-testid": dataTestId,
     }: ToggleVariantProps) => {
+      const handleLabelClick = () => {
+        if (disabled || loading) return;
+        onPressedChange(!value);
+      };
+
       const toggleElement = (
         <div className="relative flex shrink-0">
           <Toggle
@@ -270,7 +314,14 @@ const VariantComponents = {
           >
             {toggleElement}
           </DivWithTooltip>
-          <InputLabel id={id} label={label} description={description} />
+          <InputLabel
+            id={id}
+            label={label}
+            description={description}
+            density={density}
+            onClick={handleLabelClick}
+            disabled={disabled || loading}
+          />
         </div>
       );
 

--- a/src/frontend/src/widgets/inputs/BoolInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/BoolInputWidget.tsx
@@ -78,11 +78,7 @@ const InputLabel: React.FC<{
 }> = React.memo(({ id, label, description, density = Densities.Medium, onClick, disabled }) => {
   if (!label && !description) return null;
 
-  const cursorClass = onClick
-    ? disabled
-      ? "cursor-not-allowed"
-      : "cursor-pointer"
-    : undefined;
+  const cursorClass = onClick ? (disabled ? "cursor-not-allowed" : "cursor-pointer") : undefined;
 
   return (
     <div onClick={onClick} className={cursorClass}>


### PR DESCRIPTION
# Summary

## Changes

Updated the `BoolInputWidget` component to make labels and descriptions clickable for toggling checkbox, switch, and toggle inputs. Clicking the label or description text now toggles the input state, bringing the behavior in line with standard web UX.

The implementation correctly handles:
- Nullable checkbox cycle (null → true → false → null)
- Disabled and loading states (prevents clicks)
- Appropriate cursor styling (pointer when enabled, not-allowed when disabled)
- All three variants (Checkbox, Switch, Toggle)

## API Changes

None — this is a purely behavioral change. The `InputLabel` component is an internal implementation detail, not a public API. No exported interfaces or props were modified.

## Files Modified

- **src/frontend/src/widgets/inputs/BoolInputWidget.tsx**
  - Enhanced internal `InputLabel` component with `onClick` and `disabled` props
  - Added conditional cursor styling (`cursor-pointer` / `cursor-not-allowed`)
  - Implemented `handleLabelClick` in all three variants (Checkbox, Switch, Toggle)
  - Checkbox variant correctly replicates the nullable cycle logic from checkbox.tsx

---

## Commits

- 8783dbeca: Fix formatting in BoolInputWidget
- 515561105: Make checkbox, switch, and toggle labels clickable to toggle state
