### PR TITLE
[datatable]: preserve full cell text when copying truncated cells

### DIFF
--- a/src/frontend/src/widgets/dataTables/utils/cellContent.ts
+++ b/src/frontend/src/widgets/dataTables/utils/cellContent.ts
@@ -153,7 +153,7 @@ function truncateCellDisplayData(
     const displayData = cell.displayData;
     const truncated = truncateTextWithEllipsis(displayData, maxWidth, cellFont);
     if (truncated === displayData) return cell;
-    return { ...cell, displayData: truncated };
+    return { ...cell, displayData: truncated, copyData: displayData };
   }
 
   return cell;


### PR DESCRIPTION
## Problem

When cell text was too long to fit in the column, it was displayed with
an ellipsis (e.g. `"Some long tex…"`). Copying that cell produced the
truncated string — the `…` and all — instead of the actual full value.

## Fix

Cells now copy the full original text regardless of how they are displayed.
The visible ellipsis is only a display hint; the clipboard always gets the
real data.

## Root cause

`truncateCellDisplayData` was overwriting `displayData` with the clipped
string. glide-data-grid uses `displayData` as the clipboard source for
Text cells, so the truncated version ended up being copied.

The fix sets `copyData` to the original text before truncation.
glide-data-grid checks `copyData` first and uses it over `displayData`.

## Before / After

| | Displayed | Copied |
|---|---|---|
| Before | `Some long tex…` | `Some long tex…` |
| After | `Some long tex…` | `Some long text that did not fit` |