### PR TITLE
[00421] Reduce list item gap in Markdown widget

### DIFF
--- a/src/frontend/src/lib/styles.ts
+++ b/src/frontend/src/lib/styles.ts
@@ -768,10 +768,10 @@ export const typography: Record<string, string> = {
   block: "flex items-center min-w-0",
 
   // Lists — gap on ol/ul; markers need list-item on li (flex on li hides numbers/bullets)
-  ul: "list-disc list-outside ps-8 flex flex-col gap-y-2",
-  ol: "list-decimal list-outside ps-8 flex flex-col gap-y-2",
+  ul: "list-disc list-outside ps-8 flex flex-col gap-y-1",
+  ol: "list-decimal list-outside ps-8 flex flex-col gap-y-1",
   li: "list-item",
-  liContent: "flex flex-col gap-y-2 [&>p]:my-0",
+  liContent: "flex flex-col gap-y-1 [&>p]:my-0",
 
   // Links
   a: "text-primary underline underline-offset-[3px] brightness-90 hover:brightness-100",
@@ -811,8 +811,8 @@ export const articleTypography: Record<string, string> = {
 
   // Slightly increased line height for article body text (readability)
   p: `${typography.p} leading-relaxed`,
-  ul: "list-disc list-outside ps-9 flex flex-col gap-y-2",
-  ol: "list-decimal list-outside ps-9 flex flex-col gap-y-2",
+  ul: "list-disc list-outside ps-9 flex flex-col gap-y-1",
+  ol: "list-decimal list-outside ps-9 flex flex-col gap-y-1",
   li: "list-item leading-relaxed",
   blockquote: `${typography.blockquote} leading-relaxed`,
 };


### PR DESCRIPTION
## Summary

Reduced the vertical gap between list items in the Markdown widget from `gap-y-2` (8px) to `gap-y-1` (4px). Applied to both the base typography definitions (`ul`, `ol`, `liContent`) and the article typography variant.

## Files Modified

- **src/frontend/src/lib/styles.ts** — Reduced `gap-y-2` to `gap-y-1` on `ul`, `ol`, and `liContent` in base typography, and on `ul`/`ol` in article typography.

---

- c4fdcabd2 [00421] Reduce list item gap in Markdown widget