### PR TITLE
[00420] Add bottom margin to Markdown h1

### DIFF
--- a/src/frontend/src/lib/styles.ts
+++ b/src/frontend/src/lib/styles.ts
@@ -739,7 +739,7 @@ export const convertSizeToGridValue = (size?: string): string => {
 // Typography classes - shadcn typography with Ivy spacing
 export const typography: Record<string, string> = {
   // Headings
-  h1: `text-4xl font-semibold scroll-m-20`,
+  h1: `text-4xl font-semibold scroll-m-20 mb-3`,
   h2: `text-3xl font-medium scroll-m-20`,
   h3: `text-2xl font-medium scroll-m-20`,
   h4: `text-xl font-medium scroll-m-20`,
@@ -801,7 +801,7 @@ export const typography: Record<string, string> = {
 
 export const articleTypography: Record<string, string> = {
   ...typography,
-  h1: `text-4xl font-semibold scroll-m-20 mt-6`,
+  h1: `text-4xl font-semibold scroll-m-20 mt-6 mb-3`,
   h2: `text-3xl font-medium scroll-m-20 mt-5 pb-2 border-b border-border`,
   h3: `text-2xl font-medium scroll-m-20 mt-4`,
   h4: `text-xl font-medium scroll-m-20 mt-3`,


### PR DESCRIPTION
## Summary

Added `mb-3` (0.75rem bottom margin) to the h1 heading class in both the standard `typography` and `articleTypography` objects in `styles.ts`. This ensures consistent spacing below h1 headings in the Markdown widget.

## Files Modified

- `src/frontend/src/lib/styles.ts` — Added `mb-3` to h1 class in both typography configurations

---

**Commits:**
- 80ed3eae1 — [00420] Add bottom margin to Markdown h1 heading