### PR TITLE
[00423] Add top margin to paragraphs after h2/h3 in Markdown widget

### DIFF
--- a/src/frontend/src/styles/markdown-spacing.css
+++ b/src/frontend/src/styles/markdown-spacing.css
@@ -18,7 +18,7 @@
 
 /* Larger spacing for a non-heading element that follows a heading */
 :where(.markdown-widget > :is(h1, h2, h3) + *:not(:is(h1, h2, h3, h4, h5, h6))) {
-  margin-top: 0.75rem;
+  margin-top: 1rem;
 }
 
 /* Tighter spacing around code blocks */


### PR DESCRIPTION
# Summary

## Changes

Increased the `margin-top` for non-heading elements following h1/h2/h3 headings in the Markdown widget from `0.75rem` to `1rem`. This provides better visual breathing room between headings and their following content.

## API Changes

None.

## Files Modified

- `src/frontend/src/styles/markdown-spacing.css` — Updated post-heading spacing rule

---

## Commits

- 0dc076146 Increase post-heading margin from 0.75rem to 1rem in Markdown widget