### PR TITLE
[00105] Add Heatmap Widget To Wallpaper App Showing Completed PRs

### DIFF
--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/ActivityHeatmap.tsx
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/ActivityHeatmap.tsx
@@ -169,7 +169,8 @@ export function ActivityHeatmap({
 }: ActivityHeatmapProps) {
   const isHourly = interval === "Hourly";
   const rowCount = isHourly ? 24 : 7;
-  const labelWidth = isHourly ? 34 : 28;
+  const cellSize = 16; // 50% larger than original 11px (11 * 1.5 ≈ 16)
+  const labelWidth = isHourly ? 50 : 42;
 
   const columns = isHourly
     ? buildHourlyGrid(data, startDate, endDate)
@@ -239,7 +240,7 @@ export function ActivityHeatmap({
                 <div
                   key={ci}
                   className="text-center flex text-secondary-foreground opacity-50 last:hidden"
-                  style={{ width: "11px", fontSize: "10px" }}
+                  style={{ width: `${cellSize}px`, fontSize: "10px" }}
                 >
                   {columnLabels[ci]}
                 </div>
@@ -252,10 +253,10 @@ export function ActivityHeatmap({
               <div className="flex flex-col justify-end sticky left-0 top-0 bottom-0 bg-card">
                 <div
                   className="grid gap-0.5 text-secondary-foreground opacity-50 *:pr-2 *:text-right"
-                  style={{ gridTemplateRows: `repeat(${rowCount}, 11px)`, width: `${labelWidth}px` }}
+                  style={{ gridTemplateRows: `repeat(${rowCount}, ${cellSize}px)`, width: `${labelWidth}px` }}
                 >
                   {rowLabels.map((label, ri) => (
-                    <div key={ri} style={{ fontSize: "10px", lineHeight: "11px" }}>
+                    <div key={ri} style={{ fontSize: "10px", lineHeight: `${cellSize}px` }}>
                       {label}
                     </div>
                   ))}
@@ -301,7 +302,7 @@ export function ActivityHeatmap({
                 <div
                   key={ci}
                   className="grid gap-0.5"
-                  style={{ gridTemplateRows: `repeat(${rowCount}, 11px)` }}
+                  style={{ gridTemplateRows: `repeat(${rowCount}, ${cellSize}px)` }}
                 >
                   {column.map((day, di) => {
                     const level = day ? getLevel(day.count, maxCount) : 0;
@@ -309,8 +310,8 @@ export function ActivityHeatmap({
                     return (
                       <div
                         key={day ? `${day.date}T${day.hour ?? "d"}` : `${di}-${ci}`}
-                        className={`w-[11px] h-[11px] rounded-sm hover:rounded-none hover:scale-110 ${clickable && day?.count ? "cursor-pointer" : "cursor-default"}`}
-                        style={{ backgroundColor: bg }}
+                        className={`rounded-sm hover:rounded-none hover:scale-110 ${clickable && day?.count ? "cursor-pointer" : "cursor-default"}`}
+                        style={{ backgroundColor: bg, width: `${cellSize}px`, height: `${cellSize}px` }}
                         onMouseEnter={() => {
                           if (showTooltip && day) {
                             setTooltip({ day });
@@ -335,10 +336,10 @@ export function ActivityHeatmap({
           <>
             <div className="font-bold">{formatTooltipHeader(tooltip.day)}</div>
             <p>
-              <span className="relative w-[11px] h-[11px] pr-4 inline-flex">
+              <span className="relative pr-4 inline-flex" style={{ width: `${cellSize}px`, height: `${cellSize}px` }}>
                 <span
-                  className="absolute top-[2px] left-0 w-[11px] h-[11px] rounded-full self-center"
-                  style={{ backgroundColor: colors[getLevel(tooltip.day.count, maxCount)] ?? colors[0]! }}
+                  className="absolute top-[2px] left-0 rounded-full self-center"
+                  style={{ backgroundColor: colors[getLevel(tooltip.day.count, maxCount)] ?? colors[0]!, width: `${cellSize}px`, height: `${cellSize}px` }}
                 />
               </span>
               <span>{`${valueLabel ?? "Count"}: `}</span>


### PR DESCRIPTION
# Summary

## Changes

Added an ActivityHeatmap widget to the wallpaper app displaying the count of completed PRs for each day over the last 30 days. The heatmap is rendered without month or day labels and shows the value label "PRs".

## API Changes

- **Added** `IPlanDatabaseService.GetCompletedPrsByDay(int days = 30)` — returns a list of (DateOnly Date, int Count) tuples representing completed PRs per day
- **Added** ActivityHeatmap widget dependency to Ivy.Tendril (both NuGet package and IvySource project reference)

## Files Modified

**Database Layer:**
- `src/Ivy.Tendril/Services/Plans/IPlanDatabaseService.cs` — added GetCompletedPrsByDay method signature
- `src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs` — implemented query joining PullRequests with Plans table

**UI Layer:**
- `src/Ivy.Tendril/Apps/WallpaperApp.cs` — injected IPlanDatabaseService, queried 30-day data, rendered ActivityHeatmap widget

**Project Configuration:**
- `src/Ivy.Tendril/Ivy.Tendril.csproj` — added Ivy.Widgets.ActivityHeatmap project reference and NuGet package

## Manual Testing

1. Run Tendril: `tendril`
2. The wallpaper screen should display automatically (or switch to it if another app is visible)
3. Observe the ActivityHeatmap widget rendered below the process view
4. The heatmap should show:
   - A 90-day calendar grid (no month/day labels), centered on the screen
   - Boxes that are 16px × 16px (50% larger than the original 11px)
   - Green intensity corresponding to PR completion count per day
   - Tooltip on hover showing date and "N PRs"
   - Days with no completed PRs appear as empty/gray cells
5. Verify the data is accurate by comparing against recent PR merge activity in your Tendril projects

## Fix: Extend to 90 days and enlarge boxes

Changed the heatmap to display 90 days of PR activity instead of 30 days, and increased the box size from 11px to 16px (approximately 50% larger) for better visibility.

### Files Modified

**Ivy-Tendril:**
- `src/Ivy.Tendril/Apps/WallpaperApp.cs` — changed query from 30 to 90 days, updated date range

**Ivy-Framework:**
- `src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/ActivityHeatmap.tsx` — parameterized cell size, increased from 11px to 16px, adjusted all related dimensions (labels, tooltips, grid layout)

---

## Commits

- 2139e079d Make ActivityHeatmap boxes 50% larger