### PR TITLE
[00425] Fix DataTable tooltip false truncation in grown last column

### DIFF
--- a/src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx
+++ b/src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx
@@ -191,11 +191,9 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
   } = useCellHoverTooltip({
     columns,
     columnOrder,
-    columnWidths,
     density,
     getCellContent,
     visibleRows,
-    headerFont,
   });
 
   // Table theme

--- a/src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx
+++ b/src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx
@@ -4,7 +4,6 @@ import {
   CompactSelection,
   CustomRenderer,
   DataEditorRef,
-  getDefaultTheme,
   GridMouseCellEventArgs,
   GridMouseEventArgs,
   Item,
@@ -175,11 +174,6 @@ export const DataTableEditor: React.FC<TableEditorProps> = ({
     containerRef,
     arrowTableRef,
   });
-
-  const headerFont = useMemo(() => {
-    const t = getDefaultTheme();
-    return `${t.headerFontStyle} ${t.fontFamily}`;
-  }, []);
 
   // Cell hover tooltips (truncated text + link hint)
   const {

--- a/src/frontend/src/widgets/dataTables/hooks/useCellHoverTooltip.test.ts
+++ b/src/frontend/src/widgets/dataTables/hooks/useCellHoverTooltip.test.ts
@@ -46,6 +46,11 @@ describe("useCellHoverTooltip", () => {
     expect(hookSource).toContain("cellTooltipStyle");
     expect(hookSource).toContain("getCellTooltipPlacementStyle");
   });
+
+  it("should use args.bounds.width for truncation detection instead of base column width", () => {
+    expect(hookSource).toContain("const columnWidth = args.bounds.width");
+    expect(hookSource).not.toContain("getVisibleColumnWidthAt");
+  });
 });
 
 describe("getCellTooltipPlacementStyle", () => {

--- a/src/frontend/src/widgets/dataTables/hooks/useCellHoverTooltip.ts
+++ b/src/frontend/src/widgets/dataTables/hooks/useCellHoverTooltip.ts
@@ -4,18 +4,15 @@ import { GridCell } from "@glideapps/glide-data-grid";
 import { Densities } from "@/types/density";
 import { getCellFont } from "../utils/canvasText";
 import { getTruncatedCellTooltip } from "../utils/cellTooltip";
-import { getVisibleColumnWidthAt } from "../utils/columnHelpers";
 import { DENSITY_CONFIG } from "../dataTableEditor/constants";
 import { DataColumn } from "../types/types";
 
 interface UseCellHoverTooltipProps {
   columns: DataColumn[];
   columnOrder: number[];
-  columnWidths: Record<string, number>;
   density: Densities;
   getCellContent: (cell: Item) => GridCell;
   visibleRows: number;
-  headerFont?: string;
 }
 
 export interface CellHoverTooltipState {
@@ -80,11 +77,9 @@ function canShowCellHoverTooltip(): boolean {
 export const useCellHoverTooltip = ({
   columns,
   columnOrder,
-  columnWidths,
   density,
   getCellContent,
   visibleRows,
-  headerFont,
 }: UseCellHoverTooltipProps) => {
   const tooltipSupported = useMemo(() => canShowCellHoverTooltip(), []);
   const cellFont = useMemo(() => getCellFont(density), [density]);
@@ -126,13 +121,7 @@ export const useCellHoverTooltip = ({
       }
 
       const cell = getCellContent(args.location);
-      const columnWidth = getVisibleColumnWidthAt(
-        col,
-        columns,
-        columnOrder,
-        columnWidths,
-        headerFont,
-      );
+      const columnWidth = args.bounds.width;
 
       const truncatedText = getTruncatedCellTooltip(
         cell,
@@ -168,8 +157,6 @@ export const useCellHoverTooltip = ({
       tooltipSupported,
       columns,
       columnOrder,
-      columnWidths,
-      headerFont,
       cellFont,
       cellHorizontalPadding,
       getCellContent,


### PR DESCRIPTION
Fixes #4553

## Summary

Fixed false truncation tooltips appearing on the last DataTable column. The tooltip system was using the base column width (from `getVisibleColumnWidthAt`) for truncation detection, which didn't account for `grow: 1` expansion on the last column. Replaced with `args.bounds.width` which reflects the actual rendered cell width from Glide Data Grid.

## API Changes

- `UseCellHoverTooltipProps` interface: removed `columnWidths` and `headerFont` properties (no longer needed since truncation detection uses actual rendered bounds)

## Files Modified

- **src/frontend/src/widgets/dataTables/hooks/useCellHoverTooltip.ts** — replaced `getVisibleColumnWidthAt()` call with `args.bounds.width`, removed unused import and props
- **src/frontend/src/widgets/dataTables/hooks/useCellHoverTooltip.test.ts** — added test verifying bounds-based truncation detection
- **src/frontend/src/widgets/dataTables/dataTableEditor/DataTableEditor.tsx** — removed unused `columnWidths`/`headerFont` props from hook call, removed unused `headerFont` variable and `getDefaultTheme` import

---

### Commits

- 476716f4e43a6db920914f40110af26d590cbc6b
- fb0d7bbe7bd434c19ebbd79ef737b5c5f4612d46