### PR TITLE
[00430] Add top and bottom margin to code blocks in Markdown widget

### DIFF
--- a/src/frontend/src/components/markdown/CodeBlock.tsx
+++ b/src/frontend/src/components/markdown/CodeBlock.tsx
@@ -30,7 +30,7 @@ function CodeBlockChromeWithCopy({
   children: React.ReactNode;
 }) {
   return (
-    <div className="relative w-full">
+    <div className="markdown-code-block relative w-full">
       <div className="absolute top-2 right-2 z-30">
         <CopyToClipboardButton textToCopy={textToCopy} />
       </div>

--- a/src/frontend/src/styles/markdown-spacing.css
+++ b/src/frontend/src/styles/markdown-spacing.css
@@ -21,9 +21,10 @@
   margin-top: 1rem;
 }
 
-/* Tighter spacing around code blocks */
-:where(.markdown-widget > pre + p, .markdown-widget > p + pre) {
-  margin-top: 0.375rem;
+/* Spacing around code blocks */
+:where(.markdown-widget > .markdown-code-block) {
+  margin-top: 0.75rem;
+  margin-bottom: 0.25rem;
 }
 
 /* When a heading immediately follows another heading (e.g. an h2 directly


### PR DESCRIPTION
## Summary

Added vertical spacing to code blocks in the Markdown widget by introducing a `markdown-code-block` marker class on the code block wrapper and replacing the broken `pre`-based CSS rule with a new rule targeting that class. Code blocks now have `0.75rem` top margin and `0.25rem` bottom margin.

## API Changes

None.

## Files Modified

- **src/frontend/src/components/markdown/CodeBlock.tsx** — Added `markdown-code-block` class to the outer wrapper div in `CodeBlockChromeWithCopy`
- **src/frontend/src/styles/markdown-spacing.css** — Replaced broken `pre + p` / `p + pre` rule with `.markdown-code-block` margin rule

---

### Commits

- a6c0d0ad9 [00430] Add top and bottom margin to code blocks in Markdown widget