### PR TITLE
[00124] ReduceMultilineGapInDetailsBuilder

### DIFF
--- a/src/frontend/src/components/ui/detail.tsx
+++ b/src/frontend/src/components/ui/detail.tsx
@@ -55,7 +55,7 @@ const DetailItem = React.forwardRef<HTMLDivElement, DetailItemProps>(
         )}
         {...props}
       >
-        <div className={cn(detailLabelSizeVariant({ density }))}>{label}</div>
+        <div className={cn(detailLabelSizeVariant({ density }), multiline && "pb-0")}>{label}</div>
         <div
           className={cn(
             detailValueSizeVariant({ density }),


### PR DESCRIPTION
# Summary

## Changes

Modified the Detail component to reduce vertical spacing between label and content in multiline mode by removing the label's bottom padding when `multiline` is true. This reduces the gap from ~16px to ~4px (Medium density).

## API Changes

None.

## Files Modified

- **src/frontend/src/components/ui/detail.tsx** — Added conditional `pb-0` class to label div in multiline mode

## Manual Testing

1. Run the Ivy Framework sample app
2. Navigate to a view that displays Detail components with the `multiline` prop set to true
3. Observe the vertical spacing between the detail label (header) and its content
4. The gap should be noticeably reduced compared to the previous implementation (~4px instead of ~16px for Medium density)
5. Verify that non-multiline Detail components remain unchanged with proper horizontal layout

---

## Commits

- 2c7bd500c [00124] Reduce gap between label and content in multiline Details

---
Created using [Ivy Tendril](https://ivy.app).