### PR TITLE
fix(ActivityHeatmap): Remove width property from container CSS

### DIFF
--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/style.css
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/style.css
@@ -2,7 +2,6 @@
 @tailwind utilities;
 
 .ivy-activity-heatmap-container {
-    width: 100%;
     height: 100%;
     overflow-y: auto;
     direction: ltr;

--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/style.css
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/style.css
@@ -4,7 +4,6 @@
 .ivy-activity-heatmap-container {
     height: 100%;
     overflow-y: auto;
-    direction: ltr;
     position: relative;
     display: flex;
     background-color: var(--card);


### PR DESCRIPTION
## Summary

- Removes `width` property that was set in the `.ivy-activity-heatmap-container` CSS class causing the widget not to respect the Layout set in the backend.
- Removes left over `direction` property that was left in `.ivy-activity-heatmap-container` (no visual impact)

**Issue Reproduction:**
```csharp
public class LayoutIssueReproduction : ViewBase
{
    public override object Build()
    {
        return Layout.Center()
            | (Layout.Vertical().Gap(2).AlignContent(Align.Center)
            | dailyData.ToActivityHeatmap(
                    dimension: e => e.Date,
                    measure: e => e.Downloads)
                .StartDate(DateOnly.FromDateTime(DateTime.Now.AddDays(-60))));
    }
}
```

**Before:**
<img width="1022" height="471" alt="ActivityHeatmap width issue - before" src="https://github.com/user-attachments/assets/f2a4f357-710e-45c7-925d-8c4125cc894f" />


**After:**
<img width="1017" height="455" alt="ActivityHeatmap width issue - after" src="https://github.com/user-attachments/assets/9cf3a0f1-61b3-4e19-ac18-5ad00118be70" />
