### PR TITLE
fix(ActivityHeatmap): dimension label localization and style adjustments for cell size change

### DIFF
--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/ActivityHeatmap.tsx
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/ActivityHeatmap.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import "./style.css";
 import { ActivityHeatmapProps, Activity } from "./types";
 import { computeMaxCount, getLevel } from "./levelUtils";
-import { MONTH_NAMES, formatTooltipHeader, getTooltipTransform } from "./tooltipUtils";
+import { formatDimensionLabel, formatTooltipHeader, getTooltipTransform } from "./tooltipUtils";
 
 function buildColorScheme(baseColor: string): string[] {
   return [
@@ -197,19 +197,19 @@ export function ActivityHeatmap({
     const date = new Date(firstCell.date + "T00:00:00");
 
     if (isHourly) {
-      if (ci === 0 || date.getDate() === 1) {
-        return `${MONTH_NAMES[date.getMonth()]} ${date.getDate()}`;
-      }
-      return "";
+      // First column or first day of the month
+      return ci === 0 || date.getDate() === 1
+        ? formatDimensionLabel(date, isHourly)
+        : "";
     }
 
     if (date.getDate() <= 7) {
       // First week of the month
       const prevColumnFirst = ci > 0 ? columns[ci - 1]?.[0] : null;
-      if (!prevColumnFirst) return MONTH_NAMES[date.getMonth()] ?? "";
+      if (!prevColumnFirst) return formatDimensionLabel(date, isHourly);
       const prevDate = new Date(prevColumnFirst.date + "T00:00:00");
       if (prevDate.getMonth() !== date.getMonth()) {
-        return MONTH_NAMES[date.getMonth()] ?? "";
+        return formatDimensionLabel(date, isHourly);
       }
     }
     return "";
@@ -238,7 +238,7 @@ export function ActivityHeatmap({
               {columns.map((_, ci) => (
                 <div
                   key={ci}
-                  className="text-center flex text-secondary-foreground opacity-50 last:hidden"
+                  className="text-center text-nowrap flex text-secondary-foreground opacity-50 last:hidden"
                   style={{ width: "11px", fontSize: "10px" }}
                 >
                   {columnLabels[ci]}

--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/ActivityHeatmap.tsx
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/ActivityHeatmap.tsx
@@ -170,6 +170,7 @@ export function ActivityHeatmap({
   const isHourly = interval === "Hourly";
   const rowCount = isHourly ? 24 : 7;
   const cellSize = 16; // 50% larger than original 11px (11 * 1.5 ≈ 16)
+  const cellGapSize = 3;
   const labelWidth = isHourly ? 50 : 42;
 
   const columns = isHourly
@@ -232,15 +233,15 @@ export function ActivityHeatmap({
     <div className="ivy-activity-heatmap-container">
       <div className="overflow-x-auto h-100 bg-card ivy-activity-heatmap-scroll"
         ref={scrollXContainer}>
-        <div className="inline-flex flex-col gap-1 font-sans h-100">
+        <div className={`inline-flex flex-col gap-[${cellGapSize}px] font-sans h-100`}>
           {showMonthLabels && (
-            <div className="sticky top-0 flex gap-0.5 text-[#57606a] w-full bg-card">
+            <div className="sticky top-0 flex gap-1 text-[#57606a] w-full bg-card">
               {showDayLabels && <div style={{ width: `${labelWidth}px` }} />}
               {columns.map((_, ci) => (
                 <div
                   key={ci}
                   className="text-center text-nowrap flex text-secondary-foreground opacity-50 last:hidden"
-                  style={{ width: "11px", fontSize: "10px" }}
+                  style={{ width: `${cellSize}px`, fontSize: "10px" }}
                 >
                   {columnLabels[ci]}
                 </div>
@@ -248,15 +249,28 @@ export function ActivityHeatmap({
             </div>
           )}
 
-          <div className="flex gap-1">
+          <div
+            className="flex"
+            style={{ gap: `${cellGapSize}px` }}
+          >
             {showDayLabels && (
               <div className="flex flex-col justify-end sticky left-0 top-0 bottom-0 bg-card">
                 <div
-                  className="grid gap-0.5 text-secondary-foreground opacity-50 *:pr-2 *:text-right"
-                  style={{ gridTemplateRows: `repeat(${rowCount}, ${cellSize}px)`, width: `${labelWidth}px` }}
+                  className="grid text-secondary-foreground opacity-50 *:pr-2 *:text-right"
+                  style={{
+                    gridTemplateRows: `repeat(${rowCount}, ${cellSize}px)`, width: `${labelWidth}px`,
+                    gap: `${cellGapSize}px`
+                  }}
                 >
                   {rowLabels.map((label, ri) => (
-                    <div key={ri} style={{ fontSize: "10px", lineHeight: `${cellSize}px` }}>
+                    <div
+                      key={ri}
+                      style={{
+                        fontSize: "10px",
+                        lineHeight: `${cellSize}px`,
+                        height: `${cellSize}px`
+                      }}
+                    >
                       {label}
                     </div>
                   ))}
@@ -264,7 +278,8 @@ export function ActivityHeatmap({
               </div>
             )}
 
-            <div className="flex gap-0.5"
+            <div className="flex"
+              style={{ gap: `${cellGapSize}px` }}
               ref={gridContainer}
               onMouseEnter={(e) => {
                 if (!showTooltip) return;
@@ -301,8 +316,11 @@ export function ActivityHeatmap({
               {columns.map((column, ci) => (
                 <div
                   key={ci}
-                  className="grid gap-0.5"
-                  style={{ gridTemplateRows: `repeat(${rowCount}, ${cellSize}px)` }}
+                  className="grid"
+                  style={{
+                    gridTemplateRows: `repeat(${rowCount}, ${cellSize}px)`,
+                    gap: `${cellGapSize}px`
+                  }}
                 >
                   {column.map((day, di) => {
                     const level = day ? getLevel(day.count, maxCount) : 0;
@@ -310,7 +328,7 @@ export function ActivityHeatmap({
                     return (
                       <div
                         key={day ? `${day.date}T${day.hour ?? "d"}` : `${di}-${ci}`}
-                        className={`rounded-sm hover:rounded-none hover:scale-110 ${clickable && day?.count ? "cursor-pointer" : "cursor-default"}`}
+                        className={`rounded-sm hover:rounded-xs hover:scale-110 ${clickable && day?.count ? "cursor-pointer" : "cursor-default"}`}
                         style={{ backgroundColor: bg, width: `${cellSize}px`, height: `${cellSize}px` }}
                         onMouseEnter={() => {
                           if (showTooltip && day) {
@@ -336,10 +354,21 @@ export function ActivityHeatmap({
           <>
             <div className="font-bold">{formatTooltipHeader(tooltip.day)}</div>
             <p>
-              <span className="relative pr-4 inline-flex" style={{ width: `${cellSize}px`, height: `${cellSize}px` }}>
+              <span
+                className="relative inline-flex"
+                style={{
+                  width: `${cellSize + cellGapSize}px`,
+                  height: `${cellSize}px`,
+                  gap: `${cellGapSize}px`,
+                }}
+              >
                 <span
-                  className="absolute top-[2px] left-0 rounded-full self-center"
-                  style={{ backgroundColor: colors[getLevel(tooltip.day.count, maxCount)] ?? colors[0]!, width: `${cellSize}px`, height: `${cellSize}px` }}
+                  className="absolute left-0 rounded-sm self-center"
+                  style={{
+                    top: `${cellGapSize}px`,
+                    backgroundColor: colors[getLevel(tooltip.day.count, maxCount)] ?? colors[0]!,
+                    width: `${cellSize}px`, height: `${cellSize}px`
+                  }}
                 />
               </span>
               <span>{`${valueLabel ?? "Count"}: `}</span>

--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/tooltipUtils.test.ts
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/tooltipUtils.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { formatTooltipHeader } from "./tooltipUtils";
+import type { Activity } from "./types";
+
+describe("formatTooltipHeader", () => {
+  it("formats a daily entry as a localized date without a time suffix", () => {
+    const day: Activity = { date: "2025-01-15", count: 3 };
+    expect(formatTooltipHeader(day)).toBe("Jan 15, 2025");
+  });
+
+  it("renders the calendar day of the entry", () => {
+    expect(formatTooltipHeader({ date: "2025-01-01", count: 1 })).toBe("Jan 1, 2025");
+    expect(formatTooltipHeader({ date: "2025-12-31", count: 1 })).toBe("Dec 31, 2025");
+  });
+
+  it("appends a zero-padded hour suffix for hourly entries", () => {
+    const day: Activity = { date: "2025-01-15", hour: 9, count: 3 };
+    expect(formatTooltipHeader(day)).toBe("Jan 15, 2025, 09:00");
+  });
+
+  it("includes the suffix for hour 0 (treats 0 as a real hour, not null)", () => {
+    const day: Activity = { date: "2025-01-15", hour: 0, count: 3 };
+    expect(formatTooltipHeader(day)).toBe("Jan 15, 2025, 00:00");
+  });
+
+  it("formats the last hour of the day", () => {
+    const day: Activity = { date: "2025-01-15", hour: 23, count: 3 };
+    expect(formatTooltipHeader(day)).toBe("Jan 15, 2025, 23:00");
+  });
+
+  it("omits the time suffix when hour is null", () => {
+    const day = { date: "2025-01-15", hour: null, count: 3 } as Activity;
+    expect(formatTooltipHeader(day)).toBe("Jan 15, 2025");
+  });
+
+  it("omits the time suffix when hour is undefined", () => {
+    const day: Activity = { date: "2025-01-15", hour: undefined, count: 3 };
+    expect(formatTooltipHeader(day)).toBe("Jan 15, 2025");
+  });
+});

--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/tooltipUtils.ts
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/tooltipUtils.ts
@@ -1,11 +1,9 @@
 import { Activity } from "./types";
 
 const preferredLanguage = navigator.languages.length ? navigator.languages : navigator.language;
-const monthFormatter = new Intl.DateTimeFormat(preferredLanguage, { month: "short" });
-export const MONTH_NAMES = Array.from({ length: 12 }, (_, i) => monthFormatter.format(new Date(0, i)));
 
 export function formatTooltipHeader(day: Activity): string {
-  const dateString = new Date(day.date)
+  const dateString = new Date(day.date + "T00:00:00")
     .toLocaleDateString(preferredLanguage, { month: "short", day: "numeric", year: "numeric" });
 
   if (day.hour != null) {
@@ -25,4 +23,11 @@ export function getTooltipTransform(tooltipDiv: HTMLDivElement | null, tooltipCo
   const xOffset = tooltipCoordinates.x > gridRect.left + gridRect.width / 2 ? -(tooltipDiv.offsetWidth + 20) : 20;
   const yOffset = tooltipCoordinates.y > window.innerHeight / 2 ? -(tooltipDiv.offsetHeight + 20) : 20;
   return `translate(${xOffset}px, ${yOffset}px)`;
+}
+
+export function formatDimensionLabel(date: Date, isHourly?: boolean): string {
+  if (isHourly) {
+    return date.toLocaleDateString(preferredLanguage, { month: "short", day: "numeric" });
+  }
+  return date.toLocaleDateString(preferredLanguage, { month: "short" });
 }

--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/tooltipUtils.ts
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/tooltipUtils.ts
@@ -5,15 +5,13 @@ const monthFormatter = new Intl.DateTimeFormat(preferredLanguage, { month: "shor
 export const MONTH_NAMES = Array.from({ length: 12 }, (_, i) => monthFormatter.format(new Date(0, i)));
 
 export function formatTooltipHeader(day: Activity): string {
-  const date = new Date(day.date + "T00:00:00");
-  const month = MONTH_NAMES[date.getMonth()];
-  const dayNum = date.getDate();
-  const year = date.getFullYear();
-  const header = `${month} ${dayNum}, ${year}`;
+  const dateString = new Date(day.date)
+    .toLocaleDateString(preferredLanguage, { month: "short", day: "numeric", year: "numeric" });
+
   if (day.hour != null) {
-    return `${header}, ${String(day.hour).padStart(2, "0")}:00`;
+    return `${dateString}, ${String(day.hour).padStart(2, "0")}:00`;
   }
-  return header;
+  return dateString;
 }
 
 export function formatTooltipValue(day: Activity): string {


### PR DESCRIPTION
## Summary

- Replace the hardcoded `MONTH_NAMES` array and manual `"Month Day, Year"` template with locale-aware `Intl`/`toLocaleDateString` formatting, so tooltip headers and column labels respect the user's locale:
**Before**
<img width="311" height="141" alt="ActivityHeatmap sv-SE tooltip header - before" src="https://github.com/user-attachments/assets/d36aa1bb-408e-4ade-903a-16a37ebacdb7" />

**After**
<img width="311" height="141" alt="ActivityHeatmap sv-SE tooltip header - after" src="https://github.com/user-attachments/assets/4c866817-20b0-4d1c-a4f3-8652de721d3a" />


- Fix a timezone off-by-one bug: tooltip header dates are now parsed with an explicit local-time component (`+ "T00:00:00"`) so single-day entries no longer render as the previous day for users in negative-UTC timezones.
- Consolidate label formatting into a single `formatDimensionLabel` helper that drives both daily (month) and hourly (month + day) x-axis labels, and add `text-nowrap` so wider labels don't wrap inside the fixed-width column cell.
- Add unit tests covering `formatTooltipHeader` (daily, hourly, hour 0/23 edge cases, and null/undefined hour handling).
- Adjust frontend component styles after cell size increase:

**Before:**
<img width="576" height="198" alt="ActivityHeatmap size adjustment - before" src="https://github.com/user-attachments/assets/c0f4be42-d66e-4b65-8167-d33f8309bffc" />


**After:**
<img width="576" height="198" alt="ActivityHeatmap size adjustment - after" src="https://github.com/user-attachments/assets/bbbe3bdf-56e0-49d6-98c3-2f9a07db22d0" />
