### PR TITLE
[00492] Make DataTable HeaderRight slot mobile responsive

### DIFF
--- a/src/frontend/src/widgets/dataTables/DataTableWidget.tsx
+++ b/src/frontend/src/widgets/dataTables/DataTableWidget.tsx
@@ -141,7 +141,7 @@ export const DataTable: React.FC<DataTableWidgetProps> = ({
       >
         <TableLayout>
           <DataTableHeader className={spacing.mb}>
-            <div className={`flex items-center w-full ${spacing.gapOuter}`}>
+            <div className={`flex flex-wrap items-center w-full ${spacing.gapOuter}`}>
               <div className={`flex items-center ${spacing.gapInner}`}>
                 {finalConfig.allowFiltering && (
                   <DataTableOption


### PR DESCRIPTION
Fixes Ivy-Interactive/Ivy-Tendril#1146

## Summary

Added `flex-wrap` to the DataTable header's outer flex container so that `HeaderRight` slot content wraps to a new row on narrow screens instead of overflowing or squeezing against the filter component.

## API Changes

None.

## Files Modified

- **src/frontend/src/widgets/dataTables/DataTableWidget.tsx** — Added `flex-wrap` class to header container div (line 144)

---

## Commits

- fbcfeb7d5 Add flex-wrap to DataTable header for mobile responsiveness
- dfb8826e5 Pass processed slots to external widget props