### PR TITLE
[00505] Add HideScrollbar API to StackLayout

### DIFF
--- a/src/Ivy/Views/LayoutView.cs
+++ b/src/Ivy/Views/LayoutView.cs
@@ -27,6 +27,7 @@ public class LayoutView : ViewBase, IStateless
     private Colors? _background = null;
     private Align? _alignment = null;
     private Scroll _scroll = Ivy.Scroll.None;
+    private bool _hideScrollbar = false;
     private bool _removeParentPadding = false;
     private Colors? _borderColor = null;
     private Ivy.BorderRadius _borderRadius = Ivy.BorderRadius.None;
@@ -441,6 +442,12 @@ public class LayoutView : ViewBase, IStateless
         return this;
     }
 
+    public LayoutView HideScrollbar(bool hide = true)
+    {
+        _hideScrollbar = hide;
+        return this;
+    }
+
     public LayoutView ScrollTarget(string? target)
     {
         _scrollTarget = target;
@@ -462,6 +469,7 @@ public class LayoutView : ViewBase, IStateless
             Height = _height
         };
 
+        if (_hideScrollbar) layout.HideScrollbar = true;
         if (_testId != null) layout.TestId = _testId;
         if (_scrollTarget != null) layout.ScrollTarget = _scrollTarget;
 

--- a/src/Ivy/Widgets/Layouts/StackLayout.cs
+++ b/src/Ivy/Widgets/Layouts/StackLayout.cs
@@ -46,6 +46,8 @@ internal record StackLayout : WidgetBase<StackLayout>
 
     [Prop] public Scroll Scroll { get; set; } = Scroll.None;
 
+    [Prop] public bool HideScrollbar { get; set; }
+
     [Prop] public string? ScrollTarget { get; set; }
 
     [Prop(attached: nameof(StackLayoutExtensions.AlignSelf))] public Align?[] ChildAlignSelf { get; set; } = null!;

--- a/src/frontend/src/components/ui/scroll-area.tsx
+++ b/src/frontend/src/components/ui/scroll-area.tsx
@@ -8,10 +8,19 @@ const ScrollArea = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root> & {
     viewportClassName?: string;
     viewportStyle?: React.CSSProperties;
+    hideScrollbar?: boolean;
   }
 >(
   (
-    { className, children, scrollHideDelay = 0, viewportClassName, viewportStyle, ...props },
+    {
+      className,
+      children,
+      scrollHideDelay = 0,
+      viewportClassName,
+      viewportStyle,
+      hideScrollbar,
+      ...props
+    },
     ref,
   ) => (
     <ScrollAreaPrimitive.Root
@@ -26,7 +35,7 @@ const ScrollArea = React.forwardRef<
       >
         {children}
       </ScrollAreaPrimitive.Viewport>
-      <ScrollBar />
+      <ScrollBar className={hideScrollbar ? "invisible-scrollbar" : undefined} />
       <ScrollAreaPrimitive.Corner />
     </ScrollAreaPrimitive.Root>
   ),

--- a/src/frontend/src/widgets/layouts/StackLayoutWidget.tsx
+++ b/src/frontend/src/widgets/layouts/StackLayoutWidget.tsx
@@ -52,6 +52,7 @@ interface StackLayoutWidgetProps {
   responsiveColumnGap?: Responsive<number>;
   responsivePadding?: Responsive<string>;
   scrollTarget?: string | null;
+  hideScrollbar?: boolean;
 }
 
 export const StackLayoutWidget: React.FC<StackLayoutWidgetProps> = ({
@@ -80,6 +81,7 @@ export const StackLayoutWidget: React.FC<StackLayoutWidgetProps> = ({
   responsiveColumnGap,
   responsivePadding,
   scrollTarget,
+  hideScrollbar,
 }) => {
   const bp = useCurrentBreakpoint();
 
@@ -170,6 +172,7 @@ export const StackLayoutWidget: React.FC<StackLayoutWidgetProps> = ({
           style={outerStyles}
           type="scroll"
           scrollHideDelay={600}
+          hideScrollbar={hideScrollbar}
         >
           <div style={flexStyles}>{wrappedChildren}</div>
         </ScrollArea>


### PR DESCRIPTION
# Summary

## Changes

Added a `HideScrollbar` boolean property to `StackLayout` that applies the existing `.invisible-scrollbar` CSS class to the Radix ScrollBar component. This allows scroll functionality to be preserved while hiding the visible scrollbar indicator, replacing the need for fragile CSS injection workarounds.

## API Changes

- **New property:** `StackLayout.HideScrollbar` (`[Prop] public bool`)
- **New fluent method:** `LayoutView.HideScrollbar(bool hide = true)` — chainable after `.Scroll()`
- **New prop:** `ScrollArea.hideScrollbar?: boolean` (TypeScript component)
- **New prop:** `StackLayoutWidgetProps.hideScrollbar?: boolean` (TypeScript interface)

Usage: `Layout.Vertical(items).Scroll().HideScrollbar()`

## Files Modified

- `src/Ivy/Widgets/Layouts/StackLayout.cs` — Added `HideScrollbar` property
- `src/Ivy/Views/LayoutView.cs` — Added field, fluent method, and Build() wiring
- `src/frontend/src/widgets/layouts/StackLayoutWidget.tsx` — Added prop and pass-through
- `src/frontend/src/components/ui/scroll-area.tsx` — Applied invisible-scrollbar class

---

## Commits

- `453c8b0` Add HideScrollbar API to StackLayout