### PR TITLE
Pin MessagePack 2.5.302 to clear NU1903 vulnerability advisory

### DIFF
--- a/src/Ivy/Ivy.csproj
+++ b/src/Ivy/Ivy.csproj
@@ -59,6 +59,8 @@
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.2.9" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="10.0.5" />
+    <!-- Lifts the transitive MessagePack 2.5.187 from SignalR.Protocols.MessagePack past GHSA-hv8m-jj95-wg3x (NU1903) -->
+    <PackageReference Include="MessagePack" Version="2.5.302" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.4.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.5" />

--- a/src/Ivy/packages.lock.json
+++ b/src/Ivy/packages.lock.json
@@ -74,6 +74,16 @@
         "resolved": "2.0.4",
         "contentHash": "NH59ZAAQrk+DJTzaZxSgJ4JOyw/b0pjX9qRxl9ao1YBhZmNinS9VlYf7smphsJ2nfwQlBakA/KG5mabDIJA7dg=="
       },
+      "MessagePack": {
+        "type": "Direct",
+        "requested": "[2.5.302, )",
+        "resolved": "2.5.302",
+        "contentHash": "5DZsKli4dMEpm/glcMAheuO8/IesfaTskbfsuvgnQwWFKS5FN7Z6yNx+5F+UW94E+9N2qt8Zs63/XVzpLsElgA==",
+        "dependencies": {
+          "MessagePack.Annotations": "2.5.302",
+          "Microsoft.NET.StringTools": "17.6.3"
+        }
+      },
       "Microsoft.AspNetCore.OpenApi": {
         "type": "Direct",
         "requested": "[10.0.5, )",
@@ -281,19 +291,10 @@
         "resolved": "2.0.0",
         "contentHash": "oWbRv/BTztKJxKFr3FBurWBBCgE1+nUTm3pwtA3Yg7Xeo4wDpaLstAwqx8HeQG3/b9yOs2qykpqfbNPJ40McIw=="
       },
-      "MessagePack": {
-        "type": "Transitive",
-        "resolved": "2.5.187",
-        "contentHash": "uW4j8m4Nc+2Mk5n6arOChavJ9bLjkis0qWASOj2h2OwmfINuzYv+mjCHUymrYhmyyKTu3N+ObtTXAY4uQ7jIhg==",
-        "dependencies": {
-          "MessagePack.Annotations": "2.5.187",
-          "Microsoft.NET.StringTools": "17.6.3"
-        }
-      },
       "MessagePack.Annotations": {
         "type": "Transitive",
-        "resolved": "2.5.187",
-        "contentHash": "/IvvMMS8opvlHjEJ/fR2Cal4Co726Kj77Z8KiohFhuHfLHHmb9uUxW5+tSCL4ToKFfkQlrS3HD638mRq83ySqA=="
+        "resolved": "2.5.302",
+        "contentHash": "PTHQHbMJzx1VtUUCpnvPavD7o5X9s2dAJ4uQHAP2kBCwJKICpPTZq0qxzbB4/6iJJiIxem8zlxyfldGAx1SjSQ=="
       },
       "Microsoft.AspNetCore.Authentication.Abstractions": {
         "type": "Transitive",


### PR DESCRIPTION
SignalR.Protocols.MessagePack 10.0.5 pulls in MessagePack 2.5.187
transitively, which has a known high-severity advisory
(GHSA-hv8m-jj95-wg3x). With TreatWarningsAsErrors the NU1903 audit
warning fails restore for Ivy, Ivy.Hooks.Pty, and Ivy.Desktop.
Add a direct reference to the patched 2.5.302 to lift the
transitive version.
