### PR TITLE
fix: stop root connection reconnect storm when navigating with appArgs

### DIFF
--- a/src/Ivy/AppShell/DefaultSidebarAppShell.cs
+++ b/src/Ivy/AppShell/DefaultSidebarAppShell.cs
@@ -140,7 +140,7 @@ public class DefaultSidebarAppShell(AppShellSettings settings) : ViewBase
         void RedirectToAppIfNotError(NavigateArgs navigateArgs, bool replaceHistory = false, string? tabId = null)
         {
             if (IsErrorApp(navigateArgs.AppId)) return;
-            client.Redirect(navigateArgs.GetUrl(), replaceHistory, tabId: tabId);
+            client.Redirect(navigateArgs.GetUrl(includeArgs: settings.IncludeArgsInUrl), replaceHistory, tabId: tabId);
         }
 
         void OpenApp(NavigateArgs navigateArgs, bool replaceHistory = false)

--- a/src/Ivy/AppShell/Shared.cs
+++ b/src/Ivy/AppShell/Shared.cs
@@ -18,6 +18,14 @@ public record AppShellSettings
     public string? DefaultAppId { get; init; }
     public string? WallpaperAppId { get; init; }
     public bool PreventTabDuplicates { get; init; }
+
+    /// <summary>
+    /// When <c>true</c> (default), navigation args are appended to the browser URL as <c>appArgs=…</c>,
+    /// which lets a full page reload restore them. When <c>false</c>, args are still delivered to the
+    /// target app through its hosting connection but are kept out of the URL.
+    /// </summary>
+    public bool IncludeArgsInUrl { get; init; } = true;
+
     public AppShellNavigation Navigation { get; init; }
     public Size? Width { get; init; }
     public bool SidebarOpen { get; init; } = true;
@@ -54,6 +62,8 @@ public static class AppShellSettingsExtensions
     public static AppShellSettings UseFooterMenuItemsTransformer(this AppShellSettings settings, Func<IEnumerable<MenuItem>, INavigator, IEnumerable<MenuItem>> transformer) => settings with { FooterMenuItemsTransformer = transformer };
     public static AppShellSettings Width(this AppShellSettings settings, Size width) => settings with { Width = width };
     public static AppShellSettings SidebarOpen(this AppShellSettings settings, bool open) => settings with { SidebarOpen = open };
+    public static AppShellSettings IncludeArgsInUrl(this AppShellSettings settings, bool include) => settings with { IncludeArgsInUrl = include };
+    public static AppShellSettings HideArgsInUrl(this AppShellSettings settings) => settings with { IncludeArgsInUrl = false };
 }
 
 [Signal(BroadcastType.AppShell)]
@@ -77,7 +87,7 @@ public record NavigateArgs(string? AppId, object? AppArgs = null, string? TabId 
         return new AppHost(this.AppId, this.AppArgs != null ? JsonSerializer.Serialize(this.AppArgs, JsonHelper.DefaultOptions) : null, parentId);
     }
 
-    public string GetUrl(string? parentId = null)
+    public string GetUrl(string? parentId = null, bool includeArgs = true)
     {
         // Validate AppId to prevent injection attacks
         if (!ValidationHelper.IsSafeAppId(this.AppId))
@@ -96,7 +106,7 @@ public record NavigateArgs(string? AppId, object? AppArgs = null, string? TabId 
             queryParams.Add($"parentId={parentId}");
         }
 
-        if (this.AppArgs != null)
+        if (includeArgs && this.AppArgs != null)
         {
             var jsonArgs = JsonSerializer.Serialize(this.AppArgs, JsonHelper.DefaultOptions);
             var encodedArgs = System.Web.HttpUtility.UrlEncode(jsonArgs);

--- a/src/frontend/src/hooks/use-backend.tsx
+++ b/src/frontend/src/hooks/use-backend.tsx
@@ -372,6 +372,7 @@ export const useBackend = (
   // Stable values used in dependency arrays - only updated when we want to reconnect
   const [stableAppId, setStableAppId] = useState(appId);
   const [stableAppShell, setStableAppShell] = useState(appShell);
+  const [stableAppArgs, setStableAppArgs] = useState(appArgs);
 
   // Refs to always have latest values in callbacks, without needing to add them to dependency arrays
   const latestAppIdRef = useRef(appId);
@@ -397,6 +398,7 @@ export const useBackend = (
     if (!isRootConnection) {
       setStableAppId(appId);
       setStableAppShell(appShell);
+      setStableAppArgs(appArgs);
       return;
     }
 
@@ -407,8 +409,9 @@ export const useBackend = (
     if (shouldReconnect) {
       setStableAppId(appId);
       setStableAppShell(appShell);
+      setStableAppArgs(appArgs);
     }
-  }, [appId, appShell, isRootConnection]);
+  }, [appId, appArgs, appShell, isRootConnection]);
 
   useEffect(() => {
     syncStableAppValues();
@@ -742,7 +745,7 @@ export const useBackend = (
     const connectedAccountLogin = pageParams.get("connectedAccountLogin");
 
     // Build SignalR connection URL
-    let signalRUrl = `${getIvyHost()}/ivy/messages?appId=${latestAppIdRef.current ?? ""}&appArgs=${appArgs ?? ""}&machineId=${machineId}&parentId=${parentId ?? ""}&shell=${latestAppShellRef.current}`;
+    let signalRUrl = `${getIvyHost()}/ivy/messages?appId=${latestAppIdRef.current ?? ""}&appArgs=${stableAppArgs ?? ""}&machineId=${machineId}&parentId=${parentId ?? ""}&shell=${latestAppShellRef.current}`;
     if (oauthLogin) {
       signalRUrl += `&oauthLogin=${oauthLogin}`;
     }
@@ -803,7 +806,7 @@ export const useBackend = (
         rootAppIdRef.current = undefined;
       }
     };
-  }, [appArgs, stableAppId, machineId, parentId, stableAppShell, isRootConnection]);
+  }, [stableAppArgs, stableAppId, machineId, parentId, stableAppShell, isRootConnection]);
 
   useEffect(() => {
     return setupConnection();


### PR DESCRIPTION
The root (shell) SignalR connection used raw appArgs in its connection URL
and effect deps, so navigating to an app carrying appArgs (e.g. the agent
app via "Continue with Agent") tore down and rebuilt the live root
connection mid-handshake, producing a 'WebSocket is not in the OPEN state'
reconnect loop and a stuck 'Connection lost' modal.

- use-backend: add stableAppArgs gated by syncStableAppValues (mirroring
  stableAppId/stableAppShell) so the root no longer reconnects when only
  appArgs change; child app-hosts still receive args immediately.
- AppShell: add AppShellSettings.IncludeArgsInUrl (default true) with
  HideArgsInUrl()/IncludeArgsInUrl(bool) and a GetUrl(includeArgs) overload
  to keep navigation args out of the browser URL; DefaultSidebarAppShell
  honors it.
