### PR TITLE
Fix xterm rendering to match Windows Terminal

### DIFF
--- a/src/widgets/Ivy.Widgets.Xterm/.samples/Apps/ClaudeCodeApp.cs
+++ b/src/widgets/Ivy.Widgets.Xterm/.samples/Apps/ClaudeCodeApp.cs
@@ -1,0 +1,38 @@
+using Ivy;
+using Ivy.Hooks.Pty;
+using Ivy.Widgets.Xterm;
+using Terminal = Ivy.Widgets.Xterm.Terminal;
+
+namespace XtermSamples.Apps;
+
+[App(title: "Claude Code", icon: Icons.Bot, group: ["Agents"], allowDuplicateTabs: true)]
+class ClaudeCodeApp : ViewBase
+{
+    public override object Build()
+    {
+        var workDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
+        var pty = Context.UsePty(
+            // Resolve "claude" through the shell so npm shims (.cmd) work on Windows
+            OperatingSystem.IsWindows() ? ["cmd", "/c", "claude"] : ["claude"],
+            workDir,
+            new PtyOptions
+            {
+                Environment = new Dictionary<string, string>
+                {
+                    ["FORCE_COLOR"] = "1",
+                }
+            }
+        );
+
+        return new Terminal()
+            .Stream(pty.Stream)
+            .OnInput(pty.HandleInput)
+            .OnResize(pty.HandleResize)
+            .Closed(pty.Closed)
+            .AllowClipboard()
+            .WithLayout()
+            .Full()
+            .RemoveParentPadding();
+    }
+}

--- a/src/widgets/Ivy.Widgets.Xterm/.samples/Apps/HelloConsoleApp.cs
+++ b/src/widgets/Ivy.Widgets.Xterm/.samples/Apps/HelloConsoleApp.cs
@@ -1,0 +1,34 @@
+using Ivy;
+using Ivy.Hooks.Pty;
+using Ivy.Widgets.Xterm;
+using AppContext = System.AppContext;
+using Terminal = Ivy.Widgets.Xterm.Terminal;
+
+namespace XtermSamples.Apps;
+
+[App(title: "Hello Console", icon: Icons.SquareTerminal, group: ["Terminal"], allowDuplicateTabs: true)]
+class HelloConsoleApp : ViewBase
+{
+    public override object Build()
+    {
+        var client = UseService<IClientProvider>();
+        var helloAppPath = Path.GetFullPath(
+            Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".console", "HelloApp"));
+
+        var pty = Context.UsePty(
+            ["dotnet", "run", "--project", helloAppPath],
+            helloAppPath
+        );
+
+        return new Terminal()
+            .Stream(pty.Stream)
+            .OnInput(pty.HandleInput)
+            .OnResize(pty.HandleResize)
+            .OnLinkClick(url => client.Toast(url, "Link clicked").Info())
+            .Closed(pty.Closed)
+            .AllowClipboard()
+            .WithLayout()
+            .Full()
+            .RemoveParentPadding();
+    }
+}

--- a/src/widgets/Ivy.Widgets.Xterm/.samples/Apps/ShellApp.cs
+++ b/src/widgets/Ivy.Widgets.Xterm/.samples/Apps/ShellApp.cs
@@ -1,0 +1,34 @@
+using Ivy;
+using Ivy.Hooks.Pty;
+using Ivy.Widgets.Xterm;
+using AppContext = System.AppContext;
+using Terminal = Ivy.Widgets.Xterm.Terminal;
+
+namespace XtermSamples.Apps;
+
+[App(title: "Shell", icon: Icons.Terminal, group: ["Terminal"], allowDuplicateTabs: true)]
+class ShellApp : ViewBase
+{
+    public override object Build()
+    {
+        var client = UseService<IClientProvider>();
+        var helloAppPath = Path.GetFullPath(
+            Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".console", "HelloApp"));
+
+        var pty = Context.UsePty(
+            OperatingSystem.IsWindows() ? ["cmd"] : ["bash"],
+            helloAppPath
+        );
+
+        return new Terminal()
+            .Stream(pty.Stream)
+            .OnInput(pty.HandleInput)
+            .OnResize(pty.HandleResize)
+            .OnLinkClick(url => client.Toast(url, "Link clicked").Info())
+            .Closed(pty.Closed)
+            .AllowClipboard()
+            .WithLayout()
+            .Full()
+            .RemoveParentPadding();
+    }
+}

--- a/src/widgets/Ivy.Widgets.Xterm/.samples/Program.cs
+++ b/src/widgets/Ivy.Widgets.Xterm/.samples/Program.cs
@@ -1,31 +1,6 @@
 using Ivy;
-using Ivy.Hooks.Pty;
-using Ivy.Widgets.Xterm;
 
 var server = new Server();
-server.AddApp<TerminalView>();
+server.UseAppShell();
+server.AddAppsFromAssembly();
 await server.RunAsync();
-
-[App]
-class TerminalView : ViewBase
-{
-    public override object Build()
-    {
-        var helloAppPath = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".console", "HelloApp");
-
-        var pty = this.Context.UsePty(
-            ["cmd"],
-            Path.GetFullPath(helloAppPath)
-        );
-
-        return new Terminal()
-            .Stream(pty.Stream)
-            .OnInput(pty.HandleInput)
-            .OnResize(pty.HandleResize)
-            .OnLinkClick(url => Console.WriteLine($"Link clicked: {url}"))
-            .Closed(pty.Closed)
-            .WithLayout()
-            .Full()
-            .RemoveParentPadding();
-    }
-}

--- a/src/widgets/Ivy.Widgets.Xterm/README.md
+++ b/src/widgets/Ivy.Widgets.Xterm/README.md
@@ -122,8 +122,14 @@ All color properties accept CSS color strings (hex, rgb, rgba):
 
 ```bash
 cd .samples
-dotnet run Terminal.cs
+dotnet run
 ```
+
+The sample server uses an app shell with multiple demo apps (in `.samples/Apps/`):
+
+- **Shell** — an interactive system shell (`cmd` on Windows, `bash` otherwise)
+- **Hello Console** — runs the Spectre.Console demo app from `.console/HelloApp`
+- **Claude Code** — runs the `claude` CLI in the terminal (requires Claude Code to be installed and on `PATH`)
 
 ## Creating New Widgets
 

--- a/src/widgets/Ivy.Widgets.Xterm/frontend/package.json
+++ b/src/widgets/Ivy.Widgets.Xterm/frontend/package.json
@@ -9,6 +9,7 @@
     "preview": "vp preview"
   },
   "dependencies": {
+    "@xterm/addon-canvas": "0.7.0",
     "@xterm/addon-clipboard": "0.1.0",
     "@xterm/addon-fit": "0.10.0",
     "@xterm/addon-unicode11": "0.8.0",
@@ -18,13 +19,13 @@
   "devDependencies": {
     "@types/react": "19.2.8",
     "@types/react-dom": "19.2.3",
+    "@vitejs/plugin-react": "6.0.1",
     "autoprefixer": "10.4.23",
     "postcss": "8.5.10",
     "tailwindcss": "3.4.19",
     "typescript": "5.9.3",
     "vite": "npm:@voidzero-dev/vite-plus-core@0.1.20",
-    "vite-plus": "0.1.20",
-    "@vitejs/plugin-react": "6.0.1"
+    "vite-plus": "0.1.20"
   },
   "peerDependencies": {
     "react": "19.2.3",

--- a/src/widgets/Ivy.Widgets.Xterm/frontend/pnpm-lock.yaml
+++ b/src/widgets/Ivy.Widgets.Xterm/frontend/pnpm-lock.yaml
@@ -13,6 +13,9 @@ importers:
 
   .:
     dependencies:
+      '@xterm/addon-canvas':
+        specifier: 0.7.0
+        version: 0.7.0(@xterm/xterm@5.5.0)
       '@xterm/addon-clipboard':
         specifier: 0.1.0
         version: 0.1.0(@xterm/xterm@5.5.0)
@@ -553,6 +556,11 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
+
+  '@xterm/addon-canvas@0.7.0':
+    resolution: {integrity: sha512-LF5LYcfvefJuJ7QotNRdRSPc9YASAVDeoT5uyXS/nZshZXjYplGXRECBGiznwvhNL2I8bq1Lf5MzRwstsYQ2Iw==}
+    peerDependencies:
+      '@xterm/xterm': ^5.0.0
 
   '@xterm/addon-clipboard@0.1.0':
     resolution: {integrity: sha512-zdoM7p53T5sv/HbRTyp4hY0kKmEQ3MZvAvEtiXqNIHc/JdpqwByCtsTaQF5DX2n4hYdXRPO4P/eOS0QEhX1nPw==}
@@ -1330,6 +1338,10 @@ snapshots:
 
   '@voidzero-dev/vite-plus-win32-x64-msvc@0.1.20':
     optional: true
+
+  '@xterm/addon-canvas@0.7.0(@xterm/xterm@5.5.0)':
+    dependencies:
+      '@xterm/xterm': 5.5.0
 
   '@xterm/addon-clipboard@0.1.0(@xterm/xterm@5.5.0)':
     dependencies:

--- a/src/widgets/Ivy.Widgets.Xterm/frontend/src/Terminal.tsx
+++ b/src/widgets/Ivy.Widgets.Xterm/frontend/src/Terminal.tsx
@@ -4,6 +4,7 @@ import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { ClipboardAddon } from "@xterm/addon-clipboard";
 import { Unicode11Addon } from "@xterm/addon-unicode11";
+import { CanvasAddon } from "@xterm/addon-canvas";
 import xtermStyles from "@xterm/xterm/css/xterm.css?inline";
 import { EventHandler, StreamSubscriber } from "./types";
 import { getWidth, getHeight } from "./styles";
@@ -343,11 +344,60 @@ export const Terminal: React.FC<TerminalProps> = ({
 
     let disposed = false;
 
+    // Container padding (see .terminal-container CSS: "10px 0px 10px 10px").
+    const PAD_TOP = 10;
+    const PAD_BOTTOM = 10;
+
+    // FitAddon computes rows from the fractional cell height, but the canvas
+    // renderer rounds each row up to whole pixels. Over many rows that excess
+    // can exceed the bottom padding, pushing the last row past the container
+    // and clipping it. After fitting, if the rendered terminal overflows the
+    // available height, drop one row so the final line stays fully visible.
+    const doFit = () => {
+      const fa = fitAddonRef.current;
+      const t = terminalRef.current;
+      if (!fa || !t) return;
+      fa.fit();
+      const rendered = t.element?.offsetHeight ?? 0;
+      const available = container.clientHeight - PAD_TOP - PAD_BOTTOM;
+      if (rendered > available + 1 && t.rows > 1) {
+        t.resize(t.cols, t.rows - 1);
+      }
+    };
+
     // Defer opening until container has dimensions
     requestAnimationFrame(() => {
       if (disposed) return;
 
       term.open(container);
+
+      // Canvas renderer draws box-drawing and block-element glyphs procedurally
+      // (customGlyphs, on by default), so the Claude logo and other block art
+      // tile seamlessly like Windows Terminal instead of relying on font metrics.
+      // Must be loaded after open(); the canvas renderer works reliably inside
+      // the Shadow DOM (unlike WebGL). Fall back to the DOM renderer on failure.
+      try {
+        const canvasAddon = new CanvasAddon();
+        term.loadAddon(canvasAddon);
+
+        // The canvas renderer caches glyphs in a texture atlas on first paint.
+        // If a webfont (e.g. Geist Mono) hasn't finished loading yet, missing
+        // glyphs get cached as tofu until the cell is invalidated. Once fonts
+        // are ready, drop the atlas and repaint so those glyphs render correctly.
+        if (document.fonts?.ready) {
+          document.fonts.ready.then(() => {
+            if (disposed) return;
+            try {
+              canvasAddon.clearTextureAtlas();
+              term.refresh(0, term.rows - 1);
+            } catch {
+              // Addon disposed or refresh failed — ignore.
+            }
+          });
+        }
+      } catch {
+        // Canvas unsupported — DOM renderer remains in place.
+      }
 
       terminalRef.current = term;
       fitAddonRef.current = fitAddon;
@@ -357,7 +407,7 @@ export const Terminal: React.FC<TerminalProps> = ({
       term.onResize(handleResize);
 
       if (!cols && !rows) {
-        fitAddon.fit();
+        doFit();
         // Fire initial size since fit() may not trigger onResize if size matches default
         handleResize({ cols: term.cols, rows: term.rows });
       }
@@ -373,7 +423,7 @@ export const Terminal: React.FC<TerminalProps> = ({
 
     const handleWindowResize = () => {
       if (!cols && !rows && terminalReadyRef.current && fitAddonRef.current) {
-        fitAddonRef.current.fit();
+        doFit();
       }
     };
 
@@ -381,7 +431,7 @@ export const Terminal: React.FC<TerminalProps> = ({
 
     const resizeObserver = new ResizeObserver(() => {
       if (!cols && !rows && terminalReadyRef.current && fitAddonRef.current) {
-        fitAddonRef.current.fit();
+        doFit();
       }
     });
 


### PR DESCRIPTION
- Switch to the canvas renderer (@xterm/addon-canvas) so box-drawing and
  block-element glyphs (e.g. the Claude Code logo) tile seamlessly via
  customGlyphs instead of relying on font metrics.
- Clear the texture atlas once document.fonts are ready to avoid tofu from
  the webfont-load race.
- Add a doFit() correction so the canvas renderer's per-row pixel rounding
  no longer clips the last line in full-height terminals.
