### PR TITLE
Add loading overlay to Xterm Terminal widget

### DIFF
--- a/src/widgets/Ivy.Widgets.Xterm/.samples/Apps/ClaudeCodeApp.cs
+++ b/src/widgets/Ivy.Widgets.Xterm/.samples/Apps/ClaudeCodeApp.cs
@@ -31,6 +31,7 @@ class ClaudeCodeApp : ViewBase
             .OnResize(pty.HandleResize)
             .Closed(pty.Closed)
             .AllowClipboard()
+            .Loading("Starting Claude Code...")
             .WithLayout()
             .Full()
             .RemoveParentPadding();

--- a/src/widgets/Ivy.Widgets.Xterm/README.md
+++ b/src/widgets/Ivy.Widgets.Xterm/README.md
@@ -37,6 +37,12 @@ new Terminal()
 new Terminal()
     .InitialContent("Welcome!\r\n$ ")
 
+// Terminal with a loading overlay shown until the attached
+// process writes its first output to the stream
+new Terminal()
+    .Stream(pty.Stream)
+    .Loading("Starting Claude Code...")
+
 // Terminal with event handlers
 new Terminal()
     .HandleData(data => Console.WriteLine($"User typed: {data}"))
@@ -57,6 +63,8 @@ new Terminal()
 | `Scrollback` | `int` | `1000` | Lines to keep in scrollback buffer |
 | `Theme` | `TerminalTheme?` | Dark theme | Terminal color theme |
 | `InitialContent` | `string?` | `null` | Initial content to display |
+| `Loading` | `bool` | `false` | Show a loading overlay (spinner + text) until the first stream data arrives |
+| `LoadingText` | `string?` | `"Loading..."` | Text shown in the loading overlay |
 
 #### Events
 

--- a/src/widgets/Ivy.Widgets.Xterm/Terminal.cs
+++ b/src/widgets/Ivy.Widgets.Xterm/Terminal.cs
@@ -23,6 +23,8 @@ public record Terminal : WidgetBase<Terminal>
     [Prop] public string? InitialContent { get; init; }
     [Prop] public bool Closed { get; init; }
     [Prop] public bool AllowClipboard { get; init; } = true;
+    [Prop] public bool Loading { get; init; }
+    [Prop] public string? LoadingText { get; init; }
     [Prop] public Colors? Background { get; init; }
     [Prop] public Colors? Foreground { get; init; }
 
@@ -58,6 +60,12 @@ public static class TerminalExtensions
 
     public static Terminal AllowClipboard(this Terminal widget, bool allowClipboard = true) =>
         widget with { AllowClipboard = allowClipboard };
+
+    public static Terminal Loading(this Terminal widget, bool loading = true) =>
+        widget with { Loading = loading };
+
+    public static Terminal Loading(this Terminal widget, string loadingText) =>
+        widget with { Loading = true, LoadingText = loadingText };
 
     public static Terminal Background(this Terminal widget, Colors color) =>
         widget with { Background = color };

--- a/src/widgets/Ivy.Widgets.Xterm/frontend/src/Terminal.tsx
+++ b/src/widgets/Ivy.Widgets.Xterm/frontend/src/Terminal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useCallback } from "react";
+import React, { useEffect, useRef, useCallback, useState } from "react";
 import { Terminal as XTerm } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
@@ -54,6 +54,8 @@ interface TerminalProps {
   stream?: { id: string };
   closed?: boolean;
   allowClipboard?: boolean;
+  loading?: boolean;
+  loadingText?: string;
   background?: string;
   foreground?: string;
 }
@@ -113,6 +115,8 @@ export const Terminal: React.FC<TerminalProps> = ({
   stream,
   closed = false,
   allowClipboard = true,
+  loading = false,
+  loadingText = "Loading...",
   background,
   foreground,
 }) => {
@@ -123,6 +127,28 @@ export const Terminal: React.FC<TerminalProps> = ({
   const fitAddonRef = useRef<FitAddon | null>(null);
   const initialContentWrittenRef = useRef(false);
   const terminalReadyRef = useRef(false);
+
+  // Loading overlay: visible while `loading` is set, auto-hidden once visible
+  // output arrives on the stream. ConPTY and shells emit escape-sequence
+  // preambles (window title, cursor homing, mode sets) within milliseconds of
+  // spawn — long before the process prints anything — so control sequences
+  // and whitespace must not count as output.
+  const streamDataReceivedRef = useRef(false);
+  const [streamDataReceived, setStreamDataReceived] = useState(false);
+
+  const markStreamDataIfVisible = useCallback((text: string) => {
+    if (streamDataReceivedRef.current) return;
+    const visible = text
+      .replace(/\x1b\][\s\S]*?(\x07|\x1b\\|$)/g, "") // OSC (e.g. title set)
+      .replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, "") // CSI
+      .replace(/\x1b[\s\S]/g, "") // other ESC sequences
+      .replace(/[\x00-\x1f\x7f]/g, "") // remaining control chars
+      .trim();
+    if (visible.length > 0) {
+      streamDataReceivedRef.current = true;
+      setStreamDataReceived(true);
+    }
+  }, []);
 
   const isReadOnly = closed || !events.includes("OnInput");
 
@@ -232,6 +258,8 @@ export const Terminal: React.FC<TerminalProps> = ({
     container.innerHTML = "";
     initialContentWrittenRef.current = false;
     terminalReadyRef.current = false;
+    streamDataReceivedRef.current = false;
+    setStreamDataReceived(false);
 
     const mergedTheme = { ...defaultTheme, ...theme };
 
@@ -490,12 +518,14 @@ export const Terminal: React.FC<TerminalProps> = ({
               text: text.slice(0, 50),
             });
           }
+          markStreamDataIfVisible(text);
           terminalRef.current.write(text);
         } catch (e) {
           // Fallback for non-base64 data
           console.warn("[Terminal] base64 decode failed, using raw data:", e, {
             data: data.slice(0, 50),
           });
+          markStreamDataIfVisible(data);
           terminalRef.current.write(data);
         }
       } else {
@@ -504,13 +534,59 @@ export const Terminal: React.FC<TerminalProps> = ({
     });
 
     return unsubscribe;
-  }, [stream?.id, subscribeToStream]);
+  }, [stream?.id, subscribeToStream, markStreamDataIfVisible]);
 
   const style: React.CSSProperties = {
     ...getWidth(width),
     ...getHeight(height),
     overflow: "hidden",
+    position: "relative",
   };
 
-  return <div ref={hostRef} style={style} />;
+  const showLoading = loading && !streamDataReceived && !closed;
+
+  const overlayForeground = foreground
+    ? `var(--${foreground.toLowerCase()})`
+    : defaultTheme.foreground;
+
+  return (
+    <div style={style}>
+      <div ref={hostRef} style={{ width: "100%", height: "100%" }} />
+      {showLoading && (
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: "12px",
+            pointerEvents: "none",
+          }}
+        >
+          <style>{`@keyframes ivy-xterm-loading-spin { to { transform: rotate(360deg); } }`}</style>
+          <div
+            style={{
+              width: "24px",
+              height: "24px",
+              borderRadius: "50%",
+              border: "3px solid rgba(128, 128, 128, 0.3)",
+              borderTopColor: overlayForeground,
+              animation: "ivy-xterm-loading-spin 0.8s linear infinite",
+            }}
+          />
+          <span
+            style={{
+              color: overlayForeground,
+              fontFamily,
+              fontSize: "13px",
+            }}
+          >
+            {loadingText}
+          </span>
+        </div>
+      )}
+    </div>
+  );
 };


### PR DESCRIPTION
New Loading/LoadingText props show a spinner overlay until the first
visible output arrives on the PTY stream. ANSI escape preambles from
ConPTY (title set, cursor homing) are filtered out so the overlay
stays up until the process actually prints something.
