### PR TITLE
[00513] Fix dropdown menu overflow to the right with long item names

### DIFF
--- a/src/frontend/src/components/ui/dropdown-menu.tsx
+++ b/src/frontend/src/components/ui/dropdown-menu.tsx
@@ -61,8 +61,9 @@ const DropdownMenuSubContent = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DropdownMenuPrimitive.SubContent
     ref={ref}
+    collisionPadding={8}
     className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-box border bg-popover p-1 text-popover-foreground shadow-lg flex flex-col gap-0.5 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      "z-50 min-w-[8rem] max-w-[calc(100vw-16px)] overflow-hidden rounded-box border bg-popover p-1 text-popover-foreground shadow-lg flex flex-col gap-0.5 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
       className,
     )}
     {...props}
@@ -77,8 +78,9 @@ const DropdownMenuContent = React.forwardRef<
   <DropdownMenuPrimitive.Portal>
     <DropdownMenuPrimitive.Content
       ref={ref}
+      collisionPadding={8}
       className={cn(
-        "z-50 min-w-[8rem] overflow-hidden rounded-box border bg-popover p-1 text-popover-foreground shadow-md flex flex-col gap-0.5",
+        "z-50 min-w-[8rem] max-w-[calc(100vw-16px)] overflow-hidden rounded-box border bg-popover p-1 text-popover-foreground shadow-md flex flex-col gap-0.5",
         "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className,
       )}


### PR DESCRIPTION
Fixes #4589

# Summary

## Changes

Added collision padding and maximum width constraints to dropdown menu components to prevent overflow past the viewport edge. Both `DropdownMenuContent` and `DropdownMenuSubContent` now include `collisionPadding={8}` prop to maintain 8px spacing from viewport edges, and `max-w-[calc(100vw-16px)]` class to constrain menu width.

## API Changes

- **`DropdownMenuContent`** — Added `collisionPadding={8}` prop and `max-w-[calc(100vw-16px)]` to className
- **`DropdownMenuSubContent`** — Added `collisionPadding={8}` prop and `max-w-[calc(100vw-16px)]` to className

## Files Modified

- **UI Components**
  - `src/frontend/src/components/ui/dropdown-menu.tsx` — Added collision padding and max-width constraints to both dropdown menu content components

---

## Commits

- 9bb017afb Fix dropdown menu overflow with collisionPadding and max-width