### PR TITLE
fix(button): use shadow-sm for primary button variant

### DIFF
--- a/src/frontend/src/components/ui/button/variant.ts
+++ b/src/frontend/src/components/ui/button/variant.ts
@@ -7,7 +7,7 @@ export const buttonVariant = cva(
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground shadow hover:brightness-90",
+        default: "bg-primary text-primary-foreground shadow-sm hover:brightness-90",
         destructive: "bg-destructive text-destructive-foreground shadow-sm hover:brightness-90",
         outline:
           "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",


### PR DESCRIPTION
## Summary
The default button variant was missing a `shadow-sm` class, which caused `ring-*` classes to have no effect when it is focused.

**Before:**
<img width="953" height="638" alt="primary button focus - before" src="https://github.com/user-attachments/assets/fc30b81c-119e-4376-8891-d3e27ce383d1" />


**After:**
<img width="953" height="638" alt="primary button focus - after" src="https://github.com/user-attachments/assets/65024b5c-ba3e-42df-a03b-a640714a4e14" />

**Dark mode:**
<img width="953" height="638" alt="primary button focus - after - dark" src="https://github.com/user-attachments/assets/9e9882e2-aa73-4635-a03b-0e26a1750673" />
