### PR TITLE
Fix dropdown trigger forcing full width and wrapping in toolbars

### DIFF
--- a/src/frontend/src/widgets/dropDownMenu/DropDownMenuWidget.tsx
+++ b/src/frontend/src/widgets/dropDownMenu/DropDownMenuWidget.tsx
@@ -208,7 +208,7 @@ export const DropDownMenuWidget: React.FC<DropDownMenuWidgetProps> = ({
   return (
     <DropdownMenu open={open} onOpenChange={handleOpenChange}>
       <DropdownMenuTrigger ref={triggerRef} asChild>
-        <div style={{ width: "100%", minWidth: 0 }}>{slots.Trigger}</div>
+        <div style={{ maxWidth: "100%", minWidth: 0 }}>{slots.Trigger}</div>
       </DropdownMenuTrigger>
       <DropdownMenuContent
         onClick={(e) => e.stopPropagation()}


### PR DESCRIPTION
## Problem

In Ivy Tendril, the action-buttons footer in the **draft** and **review** views has a `...` (ellipsis) "more actions" button rendered via `Button().WithDropDown(...)`. That dropdown trigger was stretching to **full width**, pushing it onto its own line inside the `Layout.Horizontal().Wrap()` footer.

## Root cause

The trigger isn't styled in Tendril — the full width is forced in the framework. In #4581 (CollapsibleOnMobile / mobile-responsive work), the `DropDownMenu` trigger wrapper was changed:

```diff
- <div>{slots.Trigger}</div>
+ <div style={{ width: "100%", minWidth: 0 }}>{slots.Trigger}</div>
```

That was meant so a header dropdown could fill a sidebar drawer on mobile, but it applied to **every** dropdown trigger, making standalone toolbar dropdown buttons stretch full width and wrap.

## Fix

Use `maxWidth: 100%` instead of `width: 100%` so the trigger sizes to its content by default (no spurious wrapping) while staying constrained to its container. Consumers that genuinely want a full-width trigger can set the width on the trigger button itself. `minWidth: 0` is kept for flex-shrink safety.

```diff
- <div style={{ width: "100%", minWidth: 0 }}>{slots.Trigger}</div>
+ <div style={{ maxWidth: "100%", minWidth: 0 }}>{slots.Trigger}</div>
```

## Verification

- `npx tsc --noEmit` passes.
- The fix is framework-side; the affected Tendril call sites (`Apps/Drafts/ActionBarView.cs`, `Apps/Review/ContentView.cs`) need no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)