### PR TITLE
Add Localize prop to ActivityHeatmap

### DIFF
--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/.samples/Program.cs
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/.samples/Program.cs
@@ -22,6 +22,7 @@ class ActivityHeatmapDemo : ViewBase
         var selectedColor = UseState(Colors.Emerald);
         var showDayLabels = UseState(false);
         var showMonthLabels = UseState(false);
+        var localize = UseState(false);
         var nullableRange = UseState<(DateOnly?, DateOnly?)>(() =>
             (DateOnly.FromDateTime(DateTime.Today.AddDays(-364)),
              DateOnly.FromDateTime(DateTime.Today)));
@@ -35,6 +36,19 @@ class ActivityHeatmapDemo : ViewBase
         var dailyData = Enumerable
             .Range(0, 365)
             .Select(start.AddDays)
+            .Where(_ => rng.NextDouble() > 0.4)
+            .Select(d => new RepoStats(
+                Date: d,
+                Timestamp: d.ToDateTime(new TimeOnly()),
+                Downloads: rng.Next(1, 20),
+                Stars: 0))
+            .ToList();
+
+        // Basic usage just shows the last 90 days.
+        var basicStart = today.AddDays(-89);
+        var basicData = Enumerable
+            .Range(0, 90)
+            .Select(basicStart.AddDays)
             .Where(_ => rng.NextDouble() > 0.4)
             .Select(d => new RepoStats(
                 Date: d,
@@ -74,13 +88,14 @@ class ActivityHeatmapDemo : ViewBase
 
         | new Card(
         Layout.Vertical()
-                | dailyData.ToActivityHeatmap(
+                | basicData.ToActivityHeatmap(
                     dimension: e => e.Date,
                     measure: e => e.Downloads)
         );
 
         var showMonthLabelsValue = !showMonthLabels.Value ? "\n\t\t\t\t.showMonthLabels(false)" : "";
         var showDayLabelsValue = !showDayLabels.Value ? "\n\t\t\t\t.showDayLabels(false)" : "";
+        var localizeValue = localize.Value ? "\n\t\t\t\t.Localize()" : "";
         var optionalPropsExample = Layout.Vertical()
             | Text.H3("With Optional Properties").Anchor("optional-props")
             | new CodeBlock($$"""
@@ -95,7 +110,7 @@ class ActivityHeatmapDemo : ViewBase
                                             | dailyRepoStats
                                                 .ToActivityHeatmap(
                                                     dimension: e => e.Date,
-                                                    measure: e => e.Downloads){{showDayLabelsValue}}{{showMonthLabelsValue}}
+                                                    measure: e => e.Downloads){{showDayLabelsValue}}{{showMonthLabelsValue}}{{localizeValue}}
                                                 .StartDate(DateOnly.Parse({{$"\"{startDate}\""}}))
                                                 .EndDate(DateOnly.Parse({{$"\"{endDate}\""}}))
                                                 .ColorScheme(Colors.{{selectedColor.Value}})
@@ -111,6 +126,8 @@ class ActivityHeatmapDemo : ViewBase
                     .Width(Size.MaxContent())
                 | showMonthLabels.ToBoolInput().WithField().Label("Show months")
                     .Width(Size.MaxContent())
+                | localize.ToBoolInput().WithField().Label("Localize")
+                    .Width(Size.MaxContent())
                 | nullableRange.ToDateRangeInput().WithField().Label("Time period")
                     .Width(Size.Fit()))
 
@@ -123,6 +140,7 @@ class ActivityHeatmapDemo : ViewBase
                 .ColorScheme(selectedColor.Value)
                 .ShowDayLabels(showDayLabels.Value)
                 .ShowMonthLabels(showMonthLabels.Value)
+                .Localize(localize.Value)
                 .OnDayClick(day => client.Toast($"Clicked {day.Date}: {day.Count} downloads")));
 
         var start2 = DateTime.Now.AddDays(-30);

--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/ActivityHeatmap.cs
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/ActivityHeatmap.cs
@@ -19,6 +19,9 @@ public record ActivityHeatmap : WidgetBase<ActivityHeatmap>
 
     [Prop] public bool ShowDayLabels { get; init; } = true;
 
+    /// <summary>When false (default), dates and labels are rendered in English. When true, they follow the user's browser locale.</summary>
+    [Prop] public bool Localize { get; init; } = false;
+
     [Prop] public ActivityInterval Interval { get; init; } = ActivityInterval.Daily;
 
     [Prop] public string? ValueLabel { get; init; }
@@ -49,6 +52,9 @@ public static class ActivityHeatmapExtensions
 
     public static ActivityHeatmap ShowDayLabels(this ActivityHeatmap w, bool show = true) =>
         w with { ShowDayLabels = show };
+
+    public static ActivityHeatmap Localize(this ActivityHeatmap w, bool localize = true) =>
+        w with { Localize = localize };
 
     public static ActivityHeatmap Interval(this ActivityHeatmap w, ActivityInterval interval) =>
         w with { Interval = interval };

--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/ActivityHeatmapBuilder.cs
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/ActivityHeatmapBuilder.cs
@@ -14,6 +14,7 @@ public class ActivityHeatmapBuilder<TSource>(
     private bool _showTooltip = true;
     private bool _showMonthLabels = true;
     private bool _showDayLabels = true;
+    private bool _localize;
     private DateOnly? _startDate;
     private DateOnly? _endDate;
     private EventHandler<Event<ActivityHeatmap, Activity>>? _onDayClick;
@@ -86,6 +87,7 @@ public class ActivityHeatmapBuilder<TSource>(
             .ShowTooltip(_showTooltip)
             .ShowMonthLabels(_showMonthLabels)
             .ShowDayLabels(_showDayLabels)
+            .Localize(_localize)
             .Interval(resolvedInterval.Value)
             .ValueLabel(_measure.Name)
             .StartDate(_startDate)
@@ -107,6 +109,7 @@ public class ActivityHeatmapBuilder<TSource>(
     public ActivityHeatmapBuilder<TSource> ShowTooltip(bool show = true) { _showTooltip = show; return this; }
     public ActivityHeatmapBuilder<TSource> ShowMonthLabels(bool show = true) { _showMonthLabels = show; return this; }
     public ActivityHeatmapBuilder<TSource> ShowDayLabels(bool show = true) { _showDayLabels = show; return this; }
+    public ActivityHeatmapBuilder<TSource> Localize(bool localize = true) { _localize = localize; return this; }
     public ActivityHeatmapBuilder<TSource> StartDate(DateOnly? date) { _startDate = date; return this; }
     public ActivityHeatmapBuilder<TSource> EndDate(DateOnly? date) { _endDate = date; return this; }
 

--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/ActivityHeatmap.tsx
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/ActivityHeatmap.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import "./style.css";
 import { ActivityHeatmapProps, Activity } from "./types";
 import { computeMaxCount, getLevel } from "./levelUtils";
-import { formatDimensionLabel, formatTooltipHeader, getTooltipTransform } from "./tooltipUtils";
+import { formatDimensionLabel, formatTooltipHeader, getTooltipTransform, resolveLocale } from "./tooltipUtils";
 
 function buildColorScheme(baseColor: string): string[] {
   return [
@@ -13,15 +13,6 @@ function buildColorScheme(baseColor: string): string[] {
     baseColor,
   ];
 }
-
-const weekdayFormatter = new Intl.DateTimeFormat(
-  navigator.languages.length ? navigator.languages : navigator.language,
-  { weekday: "short" }
-);
-
-const MONDAY = weekdayFormatter.format(new Date('2025-01-06'));
-const WEDNESDAY = weekdayFormatter.format(new Date('2025-01-08'));
-const FRIDAY = weekdayFormatter.format(new Date('2025-01-10'));
 
 function formatLocalDateKey(date: Date): string {
   const year = date.getFullYear();
@@ -162,11 +153,23 @@ export function ActivityHeatmap({
   showTooltip = true,
   showMonthLabels = true,
   showDayLabels = true,
+  localize = false,
   interval = "Daily",
   valueLabel,
   startDate,
   endDate,
 }: ActivityHeatmapProps) {
+  const locale = useMemo(() => resolveLocale(localize), [localize]);
+
+  const weekdayLabels = useMemo(() => {
+    const weekdayFormatter = new Intl.DateTimeFormat(locale, { weekday: "short" });
+    return {
+      monday: weekdayFormatter.format(new Date("2025-01-06")),
+      wednesday: weekdayFormatter.format(new Date("2025-01-08")),
+      friday: weekdayFormatter.format(new Date("2025-01-10")),
+    };
+  }, [locale]);
+
   const isHourly = interval === "Hourly";
   const rowCount = isHourly ? 24 : 7;
   const cellSize = 16; // 50% larger than original 11px (11 * 1.5 ≈ 16)
@@ -189,7 +192,7 @@ export function ActivityHeatmap({
   // Row (y-axis) labels: weekdays for daily, hours for hourly.
   const rowLabels: string[] = isHourly
     ? Array.from({ length: 24 }, (_, h) => (h % 6 === 0 ? `${String(h).padStart(2, "0")}:00` : ""))
-    : ["", MONDAY, "", WEDNESDAY, "", FRIDAY, ""];
+    : ["", weekdayLabels.monday, "", weekdayLabels.wednesday, "", weekdayLabels.friday, ""];
 
   // Column (x-axis) labels: month name on month boundaries (daily) or a short date
   // on the first column / month boundaries (hourly).
@@ -201,17 +204,17 @@ export function ActivityHeatmap({
     if (isHourly) {
       // First column or first day of the month
       return ci === 0 || date.getDate() === 1
-        ? formatDimensionLabel(date, isHourly)
+        ? formatDimensionLabel(date, isHourly, locale)
         : "";
     }
 
     if (date.getDate() <= 7) {
       // First week of the month
       const prevColumnFirst = ci > 0 ? columns[ci - 1]?.[0] : null;
-      if (!prevColumnFirst) return formatDimensionLabel(date, isHourly);
+      if (!prevColumnFirst) return formatDimensionLabel(date, isHourly, locale);
       const prevDate = new Date(prevColumnFirst.date + "T00:00:00");
       if (prevDate.getMonth() !== date.getMonth()) {
-        return formatDimensionLabel(date, isHourly);
+        return formatDimensionLabel(date, isHourly, locale);
       }
     }
     return "";
@@ -235,7 +238,7 @@ export function ActivityHeatmap({
         ref={scrollXContainer}>
         <div className={`inline-flex flex-col gap-[${cellGapSize}px] font-sans h-100`}>
           {showMonthLabels && (
-            <div className="sticky top-0 flex gap-1 text-[#57606a] w-full bg-card">
+            <div className="sticky top-0 flex gap-1 pb-2 text-[#57606a] w-full bg-card">
               {showDayLabels && <div style={{ width: `${labelWidth}px` }} />}
               {columns.map((_, ci) => (
                 <div
@@ -352,7 +355,7 @@ export function ActivityHeatmap({
       >
         {tooltip &&
           <>
-            <div className="font-bold">{formatTooltipHeader(tooltip.day)}</div>
+            <div className="font-bold">{formatTooltipHeader(tooltip.day, locale)}</div>
             <p>
               <span
                 className="relative inline-flex"

--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/tooltipUtils.test.ts
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/tooltipUtils.test.ts
@@ -1,40 +1,51 @@
 import { describe, expect, it } from "vitest";
-import { formatTooltipHeader } from "./tooltipUtils";
+import { ENGLISH_LOCALE, formatTooltipHeader, resolveLocale } from "./tooltipUtils";
 import type { Activity } from "./types";
 
-describe("formatTooltipHeader", () => {
-  it("formats a daily entry as a localized date without a time suffix", () => {
+describe("formatTooltipHeader (English locale)", () => {
+  it("formats a daily entry as an English date without a time suffix", () => {
     const day: Activity = { date: "2025-01-15", count: 3 };
-    expect(formatTooltipHeader(day)).toBe("Jan 15, 2025");
+    expect(formatTooltipHeader(day, ENGLISH_LOCALE)).toBe("Jan 15, 2025");
   });
 
   it("renders the calendar day of the entry", () => {
-    expect(formatTooltipHeader({ date: "2025-01-01", count: 1 })).toBe("Jan 1, 2025");
-    expect(formatTooltipHeader({ date: "2025-12-31", count: 1 })).toBe("Dec 31, 2025");
+    expect(formatTooltipHeader({ date: "2025-01-01", count: 1 }, ENGLISH_LOCALE)).toBe("Jan 1, 2025");
+    expect(formatTooltipHeader({ date: "2025-12-31", count: 1 }, ENGLISH_LOCALE)).toBe("Dec 31, 2025");
   });
 
   it("appends a zero-padded hour suffix for hourly entries", () => {
     const day: Activity = { date: "2025-01-15", hour: 9, count: 3 };
-    expect(formatTooltipHeader(day)).toBe("Jan 15, 2025, 09:00");
+    expect(formatTooltipHeader(day, ENGLISH_LOCALE)).toBe("Jan 15, 2025, 09:00");
   });
 
   it("includes the suffix for hour 0 (treats 0 as a real hour, not null)", () => {
     const day: Activity = { date: "2025-01-15", hour: 0, count: 3 };
-    expect(formatTooltipHeader(day)).toBe("Jan 15, 2025, 00:00");
+    expect(formatTooltipHeader(day, ENGLISH_LOCALE)).toBe("Jan 15, 2025, 00:00");
   });
 
   it("formats the last hour of the day", () => {
     const day: Activity = { date: "2025-01-15", hour: 23, count: 3 };
-    expect(formatTooltipHeader(day)).toBe("Jan 15, 2025, 23:00");
+    expect(formatTooltipHeader(day, ENGLISH_LOCALE)).toBe("Jan 15, 2025, 23:00");
   });
 
   it("omits the time suffix when hour is null", () => {
     const day = { date: "2025-01-15", hour: null, count: 3 } as Activity;
-    expect(formatTooltipHeader(day)).toBe("Jan 15, 2025");
+    expect(formatTooltipHeader(day, ENGLISH_LOCALE)).toBe("Jan 15, 2025");
   });
 
   it("omits the time suffix when hour is undefined", () => {
     const day: Activity = { date: "2025-01-15", hour: undefined, count: 3 };
-    expect(formatTooltipHeader(day)).toBe("Jan 15, 2025");
+    expect(formatTooltipHeader(day, ENGLISH_LOCALE)).toBe("Jan 15, 2025");
+  });
+});
+
+describe("resolveLocale", () => {
+  it("defaults to English when localization is disabled", () => {
+    expect(resolveLocale(false)).toBe(ENGLISH_LOCALE);
+    expect(resolveLocale(undefined)).toBe(ENGLISH_LOCALE);
+  });
+
+  it("uses the browser locale when localization is enabled", () => {
+    expect(resolveLocale(true)).not.toBe(ENGLISH_LOCALE);
   });
 });

--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/tooltipUtils.ts
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/tooltipUtils.ts
@@ -1,10 +1,20 @@
 import { Activity } from "./types";
 
-const preferredLanguage = navigator.languages.length ? navigator.languages : navigator.language;
+export type LocaleArg = string | readonly string[];
 
-export function formatTooltipHeader(day: Activity): string {
+export const browserLocale: LocaleArg =
+  navigator.languages.length ? navigator.languages : navigator.language;
+
+// When localization is disabled we render everything in English.
+export const ENGLISH_LOCALE = "en-US";
+
+export function resolveLocale(localize?: boolean): LocaleArg {
+  return localize ? browserLocale : ENGLISH_LOCALE;
+}
+
+export function formatTooltipHeader(day: Activity, locale: LocaleArg = browserLocale): string {
   const dateString = new Date(day.date + "T00:00:00")
-    .toLocaleDateString(preferredLanguage, { month: "short", day: "numeric", year: "numeric" });
+    .toLocaleDateString(locale, { month: "short", day: "numeric", year: "numeric" });
 
   if (day.hour != null) {
     return `${dateString}, ${String(day.hour).padStart(2, "0")}:00`;
@@ -25,9 +35,9 @@ export function getTooltipTransform(tooltipDiv: HTMLDivElement | null, tooltipCo
   return `translate(${xOffset}px, ${yOffset}px)`;
 }
 
-export function formatDimensionLabel(date: Date, isHourly?: boolean): string {
+export function formatDimensionLabel(date: Date, isHourly?: boolean, locale: LocaleArg = browserLocale): string {
   if (isHourly) {
-    return date.toLocaleDateString(preferredLanguage, { month: "short", day: "numeric" });
+    return date.toLocaleDateString(locale, { month: "short", day: "numeric" });
   }
-  return date.toLocaleDateString(preferredLanguage, { month: "short" });
+  return date.toLocaleDateString(locale, { month: "short" });
 }

--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/types.ts
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/types.ts
@@ -22,6 +22,7 @@ export interface ActivityHeatmapProps {
   showTooltip?: boolean;
   showMonthLabels?: boolean;
   showDayLabels?: boolean;
+  localize?: boolean;
   interval?: ActivityInterval;
   startDate?: string; // "YYYY-MM-DD"
   endDate?: string;   // "YYYY-MM-DD"


### PR DESCRIPTION
## What

- Adds a `Localize` prop to `ActivityHeatmap` (default `false`). When `false`, dates, month/day labels, and tooltips render in **English**; when `true`, they follow the user's browser locale.
- Threads locale resolution through the frontend (`resolveLocale` / `ENGLISH_LOCALE` in `tooltipUtils`) and the React component (memoized weekday labels, month/dimension labels, tooltip header).
- Wires `Localize` through `ActivityHeatmapBuilder`.
- Makes the tooltip-header tests deterministic by asserting against the explicit English locale (these were previously machine-locale dependent).

## Samples

- **Basic Usage** now shows just the last 90 days.
- **Optional Properties** demo gains a **Localize** toggle (reflected in the live code block).

## UI

- Adds bottom spacing under the month labels to match the spacing beside the day labels.