### PR TITLE
Show fields with an explicit Builder() in DetailsBuilder

### DIFF
--- a/src/Ivy/Views/Builders/DetailsBuilder.cs
+++ b/src/Ivy/Views/Builders/DetailsBuilder.cs
@@ -146,6 +146,7 @@ public class DetailsBuilder<TModel> : ViewBase, IStateless
     {
         var column = GetField(field);
         column.Builder = builder(_builderFactory);
+        column.IsRemoved = false;
         return this;
     }
 
@@ -154,6 +155,7 @@ public class DetailsBuilder<TModel> : ViewBase, IStateless
         foreach (var column in _items.Values.Where(e => e.Type == typeof(TU)))
         {
             column.Builder = builder(_builderFactory);
+            column.IsRemoved = false;
         }
         return this;
     }
@@ -163,6 +165,7 @@ public class DetailsBuilder<TModel> : ViewBase, IStateless
         foreach (var column in _items.Values.Where(e => e.Type == typeof(TU)))
         {
             column.Builder = Outer(_builderFactory);
+            column.IsRemoved = false;
         }
         return this;
 
@@ -174,6 +177,7 @@ public class DetailsBuilder<TModel> : ViewBase, IStateless
         foreach (var column in _items.Values)
         {
             column.Builder = Outer(_builderFactory);
+            column.IsRemoved = false;
         }
         return this;
 


### PR DESCRIPTION
## Problem

Collection-typed fields (e.g. `List<Link>`) are auto-removed during `ToDetails()` scaffolding — `_Scaffold` sets `IsRemoved = true` for any collection type. Supplying a custom `.Builder(...)` for such a field only swapped the builder and left `IsRemoved` set, so `Build()` filtered it out and it never rendered.

This surfaced in Ivy.Tendril's `DetailsTabView`, where `RelatedPlans` and `DependsOn` (both `List<Link>`) were never shown despite having explicit builders.

## Fix

Reset `IsRemoved = false` in all four `Builder(...)` overloads. Explicitly giving a field a builder now re-includes it, so collection fields render as intended. No change needed in downstream callers.