### PR TITLE
Fix Table Column Sizing and Optimize Resize Performance

### DIFF
--- a/src/Ivy.Samples.Shared/Apps/Widgets/TableApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/TableApp.cs
@@ -85,10 +85,10 @@ public class TableSizesExample : ViewBase
                 .Multiline(e => e.Name)
                 // Add explicit column widths to test overflow
                 .ColumnWidth(e => e.Sku, Size.Fraction(0.15f))      // 15% for SKU
-                .ColumnWidth(e => e.Foo, Size.Fraction(0.1f))       // 10% for Foo  
-                .ColumnWidth(e => e.Name, Size.Fraction(0.3f))      // 30% for Name
+                .ColumnWidth(e => e.Foo, Size.Fit())                // Fit for Foo  
+                .ColumnWidth(e => e.Name, Size.Fraction(0.35f))     // 35% for Name
                 .ColumnWidth(e => e.Price, Size.Fraction(0.15f))    // 15% for Price
-                .ColumnWidth(e => e.Url, Size.Fraction(0.3f)),      // 30% for URL
+                .ColumnWidth(e => e.Url, Size.Fraction(0.35f)),     // 35% for URL
 
             Text.Label("Medium Size:"),
             products
@@ -98,10 +98,10 @@ public class TableSizesExample : ViewBase
                 .Multiline(e => e.Name)
                 // Add explicit column widths to test overflow
                 .ColumnWidth(e => e.Sku, Size.Fraction(0.15f))      // 15% for SKU
-                .ColumnWidth(e => e.Foo, Size.Fraction(0.1f))       // 10% for Foo  
-                .ColumnWidth(e => e.Name, Size.Fraction(0.3f))      // 30% for Name
+                .ColumnWidth(e => e.Foo, Size.Fit())                // Fit for Foo  
+                .ColumnWidth(e => e.Name, Size.Fraction(0.35f))     // 35% for Name
                 .ColumnWidth(e => e.Price, Size.Fraction(0.15f))    // 15% for Price
-                .ColumnWidth(e => e.Url, Size.Fraction(0.3f)),      // 30% for URL
+                .ColumnWidth(e => e.Url, Size.Fraction(0.35f)),     // 35% for URL
 
             Text.Label("Large Size:"),
             products
@@ -111,14 +111,14 @@ public class TableSizesExample : ViewBase
                 .Multiline(e => e.Name)
                 // Add explicit column widths to test overflow
                 .ColumnWidth(e => e.Sku, Size.Fraction(0.15f))      // 15% for SKU
-                .ColumnWidth(e => e.Foo, Size.Fraction(0.1f))       // 10% for Foo  
-                .ColumnWidth(e => e.Name, Size.Fraction(0.3f))      // 30% for Name
+                .ColumnWidth(e => e.Foo, Size.Fit())                // Fit for Foo  
+                .ColumnWidth(e => e.Name, Size.Fraction(0.35f))     // 35% for Name
                 .ColumnWidth(e => e.Price, Size.Fraction(0.15f))    // 15% for Price
-                .ColumnWidth(e => e.Url, Size.Fraction(0.3f)),      // 30% for URL
+                .ColumnWidth(e => e.Url, Size.Fraction(0.35f)),     // 35% for URL
 
 
             Text.H3("Long Headers Table (Test Overflow & Tooltips)"),
-            longHeaderTable.Width(Size.Full())
+            longHeaderTable.Width(Size.Units(120)).Layout("Fixed")
         );
     }
 }

--- a/src/Ivy.Test/TableBuilderTests.cs
+++ b/src/Ivy.Test/TableBuilderTests.cs
@@ -481,5 +481,15 @@ public class TableBuilderTests
         Assert.Equal("avatar", result.Alt);
         Assert.Equal(ImageFit.Cover, result.ObjectFit);
     }
+
+    [Fact]
+    public void Table_Width_SerializesCorrectly()
+    {
+        var table = new Table().Width(Size.Units(120)) with { Id = "test" };
+        var node = Ivy.Core.WidgetSerializer.Serialize(table);
+        Assert.Equal("Units:120", node["props"]?["width"]?.ToString());
+    }
+
 }
+
 

--- a/src/Ivy/Shared/Size.cs
+++ b/src/Ivy/Shared/Size.cs
@@ -48,6 +48,11 @@ public record Size
     private SizeType Type { get; set; }
     private float? Value { get; set; }
 
+    public bool IsContentSized => Type == SizeType.Fit ||
+                                  Type == SizeType.Auto ||
+                                  Type == SizeType.MinContent ||
+                                  Type == SizeType.MaxContent;
+
     public Size? Min { get; init; }
 
     public Size? Max { get; init; }

--- a/src/Ivy/Views/Tables/TableBuilder.cs
+++ b/src/Ivy/Views/Tables/TableBuilder.cs
@@ -386,11 +386,11 @@ public class TableBuilder<TModel> : ViewBase, IStateless
         {
             var tableWidth = _width ?? Size.Full();
             var table = new Table(tableRows).Width(tableWidth).Density(_density);
-            
+
             bool hasContentSizedColumn = _columns.Values
                 .Where(e => !e.Removed)
                 .Any(c => c.Width == null || c.Width.IsContentSized);
-                
+
             table = table.Layout(hasContentSizedColumn ? "Auto" : "Fixed");
             return table;
         }

--- a/src/Ivy/Views/Tables/TableBuilder.cs
+++ b/src/Ivy/Views/Tables/TableBuilder.cs
@@ -156,7 +156,6 @@ public class TableBuilder<TModel> : ViewBase, IStateless
             var removed = field.Name.StartsWith("_") && field.Name.Length > 1 && char.IsLetter(field.Name[1]);
 
             var column = new TableBuilderColumn(field.Name, order++, cellBuilder, cellAlignment, field.FieldInfo, field.PropertyInfo, removed, cellBuilder, removed, cellAlignment);
-            column.Width = CalculateSmartDefaultWidth(column);
             _columns[field.Name] = column;
         }
     }
@@ -174,7 +173,6 @@ public class TableBuilder<TModel> : ViewBase, IStateless
             foreach (var key in dictObj.Keys)
             {
                 var column = new TableBuilderColumn(key, order++, builder, Ivy.Align.Left, null!, null, false, builder, false, Ivy.Align.Left);
-                column.Width = CalculateSmartDefaultWidth(column);
                 _columns[key] = column;
             }
         }
@@ -183,7 +181,6 @@ public class TableBuilder<TModel> : ViewBase, IStateless
             foreach (var key in dictStr.Keys)
             {
                 var column = new TableBuilderColumn(key, order++, builder, Ivy.Align.Left, null!, null, false, builder, false, Ivy.Align.Left);
-                column.Width = CalculateSmartDefaultWidth(column);
                 _columns[key] = column;
             }
         }
@@ -192,30 +189,10 @@ public class TableBuilder<TModel> : ViewBase, IStateless
             foreach (var key in dict.Keys.Cast<object>().Select(k => k.ToString()!))
             {
                 var column = new TableBuilderColumn(key, order++, builder, Ivy.Align.Left, null!, null, false, builder, false, Ivy.Align.Left);
-                column.Width = CalculateSmartDefaultWidth(column);
                 _columns[key] = column;
             }
         }
     }
-
-    private int CalculateColumnWidth(TableBuilderColumn column)
-    {
-        var baseWidth = Math.Max(15, column.Header.Length + 2);
-
-        baseWidth = column.Type switch
-        {
-            var t when t?.IsNumeric() == true => Math.Max(baseWidth, 25),
-            var t when t == typeof(DateTime) || t == typeof(DateOnly) => Math.Max(baseWidth, 25),
-            var t when t == typeof(bool) => Math.Max(baseWidth, 10),
-            var t when t == typeof(string) => Math.Max(baseWidth, 25),
-            _ => baseWidth
-        };
-
-        return Math.Min(baseWidth, 50);
-    }
-
-    private Size CalculateSmartDefaultWidth(TableBuilderColumn column) =>
-        Size.Units(CalculateColumnWidth(column));
 
     public TableBuilder<TModel> Width(Size width)
     {
@@ -263,7 +240,6 @@ public class TableBuilder<TModel> : ViewBase, IStateless
             var builder = _builderFactory.Default();
             column = new TableBuilderColumn(name, order, builder, Ivy.Align.Left, null!, null, false, builder, false, Ivy.Align.Left);
             column.ExpressionAccessor = field.Compile();
-            column.Width = CalculateSmartDefaultWidth(column);
             _columns[name] = column;
         }
         return column;
@@ -410,6 +386,12 @@ public class TableBuilder<TModel> : ViewBase, IStateless
         {
             var tableWidth = _width ?? Size.Full();
             var table = new Table(tableRows).Width(tableWidth).Density(_density);
+            
+            bool hasContentSizedColumn = _columns.Values
+                .Where(e => !e.Removed)
+                .Any(c => c.Width == null || c.Width.IsContentSized);
+                
+            table = table.Layout(hasContentSizedColumn ? "Auto" : "Fixed");
             return table;
         }
 
@@ -427,7 +409,7 @@ public class TableBuilder<TModel> : ViewBase, IStateless
 
             if (isHeader)
             {
-                cell = cell.Width(column.Width);
+                cell = cell.Width(column.Width ?? Size.Fit());
             }
 
             if (!isHeader && isEmptyColumn[index])

--- a/src/Ivy/Widgets/Tables/Table.cs
+++ b/src/Ivy/Widgets/Tables/Table.cs
@@ -1,5 +1,3 @@
-using Ivy.Core;
-
 // ReSharper disable once CheckNamespace
 namespace Ivy;
 

--- a/src/Ivy/Widgets/Tables/Table.cs
+++ b/src/Ivy/Widgets/Tables/Table.cs
@@ -1,3 +1,5 @@
+using Ivy.Core;
+
 // ReSharper disable once CheckNamespace
 namespace Ivy;
 
@@ -12,6 +14,8 @@ public record Table : WidgetBase<Table>
 
     internal Table() { }
 
+    [Prop] public string Layout { get; set; } = "Auto";
+
     public static Table operator |(Table table, TableRow child)
     {
         return table with { Children = [.. table.Children, child] };
@@ -20,4 +24,8 @@ public record Table : WidgetBase<Table>
 
 public static partial class TableExtensions
 {
+    public static Table Layout(this Table table, string layout)
+    {
+        return table with { Layout = layout };
+    }
 }

--- a/src/frontend/src/components/DevTools.tsx
+++ b/src/frontend/src/components/DevTools.tsx
@@ -16,6 +16,10 @@ interface WidgetInfo {
 const TEXT_EDITABLE_TYPES = ["Ivy.TextBlock", "Ivy.Markdown"];
 
 function getWidgetBounds(wrapperElement: HTMLElement): DOMRect {
+  if (wrapperElement.tagName !== "IVY-WIDGET") {
+    return wrapperElement.getBoundingClientRect();
+  }
+
   const children = wrapperElement.children;
   if (children.length === 0) return new DOMRect(0, 0, 0, 0);
 
@@ -106,8 +110,9 @@ export function DevTools() {
   const dialogRef = useRef<HTMLDivElement>(null);
 
   const getWidgetInfo = useCallback((element: HTMLElement): WidgetInfo => {
-    const widgetId = element.getAttribute("id")!;
-    const widgetType = element.getAttribute("type")!;
+    const widgetId = element.getAttribute("data-ivy-widget-id") || element.getAttribute("id")!;
+    const widgetType =
+      element.getAttribute("data-ivy-widget-type") || element.getAttribute("type")!;
     const bounds = getWidgetBounds(element);
     const callSite = widgetCallSiteRegistry.get(widgetId);
     return { id: widgetId, type: widgetType, element, bounds, callSite };
@@ -170,7 +175,9 @@ export function DevTools() {
 
       e.stopPropagation();
 
-      const widgetWrapper = target.closest("ivy-widget") as HTMLElement | null;
+      const widgetWrapper = target.closest(
+        "ivy-widget, [data-ivy-widget-id]",
+      ) as HTMLElement | null;
       if (!widgetWrapper) {
         dispatchDev({ highlightedWidget: null, widgetStack: [] });
         return;
@@ -180,7 +187,9 @@ export function DevTools() {
       let current: HTMLElement | null = widgetWrapper;
       while (current) {
         stack.push(current);
-        current = current.parentElement?.closest("ivy-widget") as HTMLElement | null;
+        current = current.parentElement?.closest(
+          "ivy-widget, [data-ivy-widget-id]",
+        ) as HTMLElement | null;
       }
       dispatchDev({
         widgetStack: stack,

--- a/src/frontend/src/components/ui/table/table-variant.ts
+++ b/src/frontend/src/components/ui/table/table-variant.ts
@@ -2,7 +2,7 @@ import { cva } from "class-variance-authority";
 import { densityHeight, densityText } from "../density-scale";
 
 // Size variants for TableHead padding
-export const tableHeadSizeVariant = cva("w-full caption-bottom", {
+export const tableHeadSizeVariant = cva("", {
   variants: {
     density: {
       Small: `${densityHeight.Small} px-1 ${densityText.Small}`,

--- a/src/frontend/src/widgets/primitives/TextBlockWidget.tsx
+++ b/src/frontend/src/widgets/primitives/TextBlockWidget.tsx
@@ -95,19 +95,15 @@ const variantMap: VariantMap = {
     const spanRef = React.useRef<HTMLSpanElement>(null);
     const [isTruncated, setIsTruncated] = React.useState(false);
     const [showTooltip, setShowTooltip] = React.useState(false);
-    React.useEffect(() => {
-      const checkTruncation = () => {
-        const el = spanRef.current;
-        if (el) {
-          setIsTruncated(el.scrollWidth > el.clientWidth);
-        }
-      };
-      checkTruncation();
-      window.addEventListener("resize", checkTruncation);
-      return () => {
-        window.removeEventListener("resize", checkTruncation);
-      };
-    }, [children, style]);
+
+    const handleMouseEnter = () => {
+      const el = spanRef.current;
+      if (el) {
+        setIsTruncated(el.scrollWidth > el.clientWidth);
+      }
+      setShowTooltip(true);
+    };
+
     return (
       <div className={cn(typography.block, className)} style={style}>
         <TooltipProvider>
@@ -116,7 +112,7 @@ const variantMap: VariantMap = {
               <span
                 ref={spanRef}
                 className="overflow-hidden text-ellipsis"
-                onMouseEnter={() => setShowTooltip(true)}
+                onMouseEnter={handleMouseEnter}
                 onMouseLeave={() => setShowTooltip(false)}
               >
                 {children}

--- a/src/frontend/src/widgets/tables/TableCellWidget.tsx
+++ b/src/frontend/src/widgets/tables/TableCellWidget.tsx
@@ -38,7 +38,8 @@ const getTextAlign = (align: Align): React.CSSProperties => {
   }
 };
 
-export const TableCellWidget: React.FC<TableCellWidgetProps> = ({
+export const TableCellWidget: React.FC<TableCellWidgetProps> & { skipWidgetWrapper?: boolean } = ({
+  id,
   children,
   isHeader,
   isFooter,
@@ -75,24 +76,49 @@ export const TableCellWidget: React.FC<TableCellWidgetProps> = ({
     </div>
   );
 
+  // Check if width is a content-based sizing type (Fit, MinContent, MaxContent, Auto)
+  // or undefined. Content-sized columns should size naturally and not be truncated.
+  const isContentSized =
+    !width ||
+    width.toLowerCase().startsWith("fit") ||
+    width.toLowerCase().startsWith("mincontent") ||
+    width.toLowerCase().startsWith("maxcontent") ||
+    width.toLowerCase().startsWith("auto");
+
   // Apply max-w-0 overflow-hidden for truncation when:
-  // 1. We have an explicit width (for column width control), OR
-  // 2. It's a header cell (headers should truncate)
-  // Don't apply to data cells without widths - they need to size naturally
-  const shouldTruncate = width || isHeader;
+  // 1. We have an explicit fixed width (not content-sized), OR
+  // 2. It's a header cell of a non-content-sized column
+  const shouldTruncate = width ? !isContentSized : isHeader && !isContentSized;
 
   // Only show tooltip for string/number children to avoid "[object Object]" issues
   const shouldShowTooltip =
     !multiline && (typeof children === "string" || typeof children === "number");
 
+  const isRightAligned =
+    alignContent === "Right" || alignContent === "TopRight" || alignContent === "BottomRight";
+
+  const isCenterAligned =
+    alignContent === "Center" || alignContent === "TopCenter" || alignContent === "BottomCenter";
+
+  const isLeftAligned =
+    alignContent === "Left" || alignContent === "TopLeft" || alignContent === "BottomLeft";
+
   const cellClasses = cn("border border-border force-text-inherit", {
     "header-cell bg-muted font-bold": isHeader,
     "footer-cell bg-muted font-semibold": isFooter,
     "max-w-0 overflow-hidden": shouldTruncate,
+    "text-right": isRightAligned,
+    "text-center": isCenterAligned,
+    "text-left": isLeftAligned,
   });
 
   return (
-    <TableCell className={cellClasses} style={cellStyles}>
+    <TableCell
+      className={cellClasses}
+      style={cellStyles}
+      data-ivy-widget-id={id}
+      data-ivy-widget-type="Ivy.TableCell"
+    >
       {shouldShowTooltip ? (
         <TooltipProvider>
           <Tooltip>
@@ -108,3 +134,4 @@ export const TableCellWidget: React.FC<TableCellWidgetProps> = ({
     </TableCell>
   );
 };
+TableCellWidget.skipWidgetWrapper = true;

--- a/src/frontend/src/widgets/tables/TableRowWidget.tsx
+++ b/src/frontend/src/widgets/tables/TableRowWidget.tsx
@@ -10,8 +10,17 @@ interface TableRowWidgetProps {
   children?: React.ReactNode;
 }
 
-export const TableRowWidget: React.FC<TableRowWidgetProps> = ({ children, isHeader = false }) => (
-  <TableRow className={`border border-border ${isHeader ? "font-medium bg-background" : ""}`}>
+export const TableRowWidget: React.FC<TableRowWidgetProps> & { skipWidgetWrapper?: boolean } = ({
+  children,
+  isHeader = false,
+  id,
+}) => (
+  <TableRow
+    className={`border border-border ${isHeader ? "font-medium bg-background" : ""}`}
+    data-ivy-widget-id={id}
+    data-ivy-widget-type="Ivy.TableRow"
+  >
     {children}
   </TableRow>
 );
+TableRowWidget.skipWidgetWrapper = true;

--- a/src/frontend/src/widgets/tables/TableWidget.tsx
+++ b/src/frontend/src/widgets/tables/TableWidget.tsx
@@ -9,27 +9,28 @@ interface TableWidgetProps {
   children?: React.ReactNode;
   width?: string;
   density?: Densities;
+  layout?: string;
 }
 
 export const TableWidget: React.FC<TableWidgetProps> = ({
   children,
   width,
   density = Densities.Medium,
+  layout = "Auto",
 }) => {
   const widthStyles = getWidth(width || "Full");
 
   return (
-    <Table
-      density={density}
-      className={cn("w-full caption-bottom border-collapse border border-border")}
-      style={{
-        ...widthStyles,
-        ...(widthStyles.width === "100%"
-          ? { maxWidth: "100%", tableLayout: "fixed" as const }
-          : { tableLayout: "auto" as const }),
-      }}
-    >
-      <TableBody>{children}</TableBody>
-    </Table>
+    <div style={widthStyles} className="w-full">
+      <Table
+        density={density}
+        className={cn("w-full caption-bottom border-collapse border border-border")}
+        style={{
+          tableLayout: layout.toLowerCase() === "fixed" ? "fixed" : "auto",
+        }}
+      >
+        <TableBody>{children}</TableBody>
+      </Table>
+    </div>
   );
 };

--- a/src/frontend/src/widgets/tables/table.css
+++ b/src/frontend/src/widgets/tables/table.css
@@ -2,3 +2,22 @@
 .force-text-inherit * {
   font-size: inherit !important;
 }
+
+/* Align flex containers inside table cells based on cell text alignment classes */
+.text-right .flex,
+.text-right ivy-widget > div {
+  justify-content: flex-end !important;
+  text-align: right !important;
+}
+
+.text-center .flex,
+.text-center ivy-widget > div {
+  justify-content: center !important;
+  text-align: center !important;
+}
+
+.text-left .flex,
+.text-left ivy-widget > div {
+  justify-content: flex-start !important;
+  text-align: left !important;
+}

--- a/src/frontend/src/widgets/tree/TreeItem.tsx
+++ b/src/frontend/src/widgets/tree/TreeItem.tsx
@@ -14,17 +14,13 @@ const TreeItemLabel: React.FC<{ label: string; tooltip?: string }> = ({ label, t
   const [isTruncated, setIsTruncated] = React.useState(false);
   const [showTooltip, setShowTooltip] = React.useState(false);
 
-  React.useEffect(() => {
-    const checkTruncation = () => {
-      const el = spanRef.current;
-      if (el) {
-        setIsTruncated(el.scrollWidth > el.clientWidth);
-      }
-    };
-    checkTruncation();
-    window.addEventListener("resize", checkTruncation);
-    return () => window.removeEventListener("resize", checkTruncation);
-  }, []);
+  const handleMouseEnter = () => {
+    const el = spanRef.current;
+    if (el) {
+      setIsTruncated(el.scrollWidth > el.clientWidth);
+    }
+    setShowTooltip(true);
+  };
 
   return (
     <TooltipProvider>
@@ -33,7 +29,7 @@ const TreeItemLabel: React.FC<{ label: string; tooltip?: string }> = ({ label, t
           <span
             ref={spanRef}
             className="truncate flex-1"
-            onMouseEnter={() => setShowTooltip(true)}
+            onMouseEnter={handleMouseEnter}
             onMouseLeave={() => setShowTooltip(false)}
           >
             {label}

--- a/src/frontend/src/widgets/widgetRenderer.tsx
+++ b/src/frontend/src/widgets/widgetRenderer.tsx
@@ -67,7 +67,7 @@ export const MemoizedWidget = React.memo(
 
     const Component = widgetMap[node.type as keyof typeof widgetMap] as React.ComponentType<
       Record<string, unknown>
-    >;
+    > & { skipWidgetWrapper?: boolean };
 
     if (!Component) {
       return <div>{`Unknown component type: ${node.type}`}</div>;
@@ -121,7 +121,13 @@ export const MemoizedWidget = React.memo(
       ? (node.props.content as string) || (node.props.text as string) || ""
       : undefined;
 
-    const content = (
+    const skipWrapper = Component.skipWidgetWrapper === true;
+
+    const content = skipWrapper ? (
+      <Component {...props} slots={slots}>
+        {slots.default}
+      </Component>
+    ) : (
       <ivy-widget id={node.id} type={node.type} data-content={rawContent}>
         <Component {...props} slots={slots}>
           {slots.default}


### PR DESCRIPTION
## Summary

This PR resolves table column collapsing issues (e.g. `Size.Fit()` columns disappearing) and eliminates window resize lag/performance overhead.

### How Tables Got Faster (Performance Optimization)
- **Eliminated Window Resize Listeners**: Removed synchronous `resize` event listeners from `TextBlockWidget.tsx` and `TreeItem.tsx`. Previously, window resize events triggered immediate layout measurements for every single text block/tree item, leading to layout thrashing.
- **Lazy Measurements**: Moved truncation measurements to run **lazily on hover (`onMouseEnter`)\**. This prevents lag during window resize and significantly speeds up page responsiveness.

### Behavior Changes (Column Sizing & Table Layout)
- **Dynamic Table Layout Selection**:
  - Added a `Layout` property to `Table` (defaulting to `"Auto"`).
  - `TableBuilder` now dynamically selects the table layout. If any column is content-sized (like `Size.Fit()`, `Size.Auto()`, or `null` which defaults to `Fit`), the table uses `Auto` layout to allow the browser to naturally size columns to their content (preventing checkmarks, icons, or actions columns from collapsing to 0px).
  - If all columns use fixed/fractional sizes (no content-sized columns), the builder defaults to `Fixed` layout, enabling correct truncation/ellipsis on text columns and preventing horizontal scrollbars.
  - Manual tables default to `Auto` for flexibility, with the ability to chain `.Layout("Fixed")` (applied to the `longHeaderTable` example to preserve its overflow truncation test case).
- **Cleaned Up Frontend Cell Sizing**: Reverted manual client-side `fit-content` overrides in `TableCellWidget.tsx` since layout selection is now natively handled on the backend.