### PR TITLE
fix(efquery-test): fix SQLitePCLRaw.lib.e_sqlite3 vulnerability in EfQuery.Test

### DIFF
--- a/src/Ivy.Agent.EfQuery.Test/Ivy.Agent.EfQuery.Test.csproj
+++ b/src/Ivy.Agent.EfQuery.Test/Ivy.Agent.EfQuery.Test.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
This PR adds SQLitePCLRaw.bundle_e_sqlite3 version 3.0.0 to Ivy.Agent.EfQuery.Test.csproj to resolve the warning-as-error build issue in GitHub Actions (due to SQLitePCLRaw.lib.e_sqlite3 2.1.11 vulnerability GHSA-2m69-gcr7-jv3q).