### PR TITLE
[00550] Remove Top Border From Tabs Layout Tab Buttons

### DIFF
--- a/src/frontend/src/widgets/layouts/tabs/components/Variants.tsx
+++ b/src/frontend/src/widgets/layouts/tabs/components/Variants.tsx
@@ -306,7 +306,7 @@ export const TabsVariant: React.FC<TabsVariantProps> = ({
                         handleMouseDown(e, tabOrder.indexOf(id))
                       }
                       className={cn(
-                        "group overflow-hidden h-full data-[state=active]:z-10 data-[state=active]:shadow-none border-x border-t border-b border-border flex-shrink-0",
+                        "group overflow-hidden h-full data-[state=active]:z-10 data-[state=active]:shadow-none border-x border-b border-border flex-shrink-0",
                         // Inactive tab styling - pure black in dark mode
                         "bg-background hover:bg-muted-foreground/10 dark:hover:bg-muted-foreground/20",
                         // Active tab styling (overrides inactive)


### PR DESCRIPTION
# Summary

## Changes

Removed the top border from all tab buttons in the tabs layout by removing the `border-t` Tailwind class from the button's className string. This is a purely visual change that affects the styling of tabs in both active and inactive states.

## API Changes

None.

## Files Modified

- **src/frontend/src/widgets/layouts/tabs/components/Variants.tsx** — Removed `border-t` class from tab button styling

---

## Commits

- bf6bad4ef Remove top border from tabs layout tab buttons