### PR TITLE
[00549] Text widget: thread id prop through all non-heading variants

### DIFF
--- a/src/frontend/src/widgets/primitives/TextBlockWidget.test.tsx
+++ b/src/frontend/src/widgets/primitives/TextBlockWidget.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { renderToString } from "react-dom/server";
 import { TextBlockWidget } from "./TextBlockWidget";
 
 describe("TextBlockWidget id attribute", () => {
@@ -20,49 +21,47 @@ describe("TextBlockWidget id attribute", () => {
     "Display",
   ] as const;
 
-  test.each(variants)("%s variant renders id attribute", (variant) => {
-    const testId = `test-anchor-${variant.toLowerCase()}`;
-    const { container } = render(
-      <TextBlockWidget
-        id="test-widget"
-        content="Test content"
-        variant={variant}
-        anchor={testId}
-      />
-    );
+  variants.forEach((variant) => {
+    it(`${variant} variant renders id attribute`, () => {
+      const testId = `test-anchor-${variant.toLowerCase()}`;
+      const html = renderToString(
+        <TextBlockWidget
+          id="test-widget"
+          content="Test content"
+          variant={variant}
+          anchor={testId}
+        />,
+      );
 
-    const element = container.querySelector(`#${testId}`);
-    expect(element).not.toBeNull();
-    expect(element?.id).toBe(testId);
+      expect(html).toContain(`id="${testId}"`);
+    });
   });
 
-  test("heading variants also render id attribute", () => {
+  it("heading variants render id attribute", () => {
     const headingVariants = ["H1", "H2", "H3", "H4", "H5", "H6"] as const;
 
     headingVariants.forEach((variant) => {
       const testId = `test-anchor-${variant.toLowerCase()}`;
-      const { container } = render(
+      const html = renderToString(
         <TextBlockWidget
           id="test-widget"
           content="Test heading"
           variant={variant}
           anchor={testId}
-        />
+        />,
       );
 
-      const element = container.querySelector(`#${testId}`);
-      expect(element).not.toBeNull();
-      expect(element?.id).toBe(testId);
+      expect(html).toContain(`id="${testId}"`);
     });
   });
 
-  test("no id attribute when anchor is not provided", () => {
-    const { container } = render(
-      <TextBlockWidget id="test-widget" content="Test content" variant="P" />
+  it("no id attribute when anchor is not provided", () => {
+    const html = renderToString(
+      <TextBlockWidget id="test-widget" content="Test content" variant="P" />,
     );
 
-    const paragraph = container.querySelector("p");
-    expect(paragraph).not.toBeNull();
-    expect(paragraph?.id).toBe("");
+    const paragraph = html.match(/<p[^>]*>/)?.[0];
+    expect(paragraph).toBeDefined();
+    expect(paragraph).not.toContain('id="');
   });
 });

--- a/src/frontend/src/widgets/primitives/TextBlockWidget.test.tsx
+++ b/src/frontend/src/widgets/primitives/TextBlockWidget.test.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { TextBlockWidget } from "./TextBlockWidget";
+
+describe("TextBlockWidget id attribute", () => {
+  const variants = [
+    "Literal",
+    "Block",
+    "P",
+    "Inline",
+    "Blockquote",
+    "Monospaced",
+    "Lead",
+    "Muted",
+    "Danger",
+    "Warning",
+    "Success",
+    "Label",
+    "Strong",
+    "Display",
+  ] as const;
+
+  test.each(variants)("%s variant renders id attribute", (variant) => {
+    const testId = `test-anchor-${variant.toLowerCase()}`;
+    const { container } = render(
+      <TextBlockWidget
+        id="test-widget"
+        content="Test content"
+        variant={variant}
+        anchor={testId}
+      />
+    );
+
+    const element = container.querySelector(`#${testId}`);
+    expect(element).not.toBeNull();
+    expect(element?.id).toBe(testId);
+  });
+
+  test("heading variants also render id attribute", () => {
+    const headingVariants = ["H1", "H2", "H3", "H4", "H5", "H6"] as const;
+
+    headingVariants.forEach((variant) => {
+      const testId = `test-anchor-${variant.toLowerCase()}`;
+      const { container } = render(
+        <TextBlockWidget
+          id="test-widget"
+          content="Test heading"
+          variant={variant}
+          anchor={testId}
+        />
+      );
+
+      const element = container.querySelector(`#${testId}`);
+      expect(element).not.toBeNull();
+      expect(element?.id).toBe(testId);
+    });
+  });
+
+  test("no id attribute when anchor is not provided", () => {
+    const { container } = render(
+      <TextBlockWidget id="test-widget" content="Test content" variant="P" />
+    );
+
+    const paragraph = container.querySelector("p");
+    expect(paragraph).not.toBeNull();
+    expect(paragraph?.id).toBe("");
+  });
+});

--- a/src/frontend/src/widgets/primitives/TextBlockWidget.tsx
+++ b/src/frontend/src/widgets/primitives/TextBlockWidget.tsx
@@ -56,8 +56,8 @@ interface VariantMap {
   }>;
 }
 const variantMap: VariantMap = {
-  Literal: ({ children, className, style }) => (
-    <span className={className} style={style}>
+  Literal: ({ children, className, style, id }) => (
+    <span id={id} className={className} style={style}>
       {children}
     </span>
   ),
@@ -91,7 +91,7 @@ const variantMap: VariantMap = {
       {children}
     </h6>
   ),
-  Block: ({ children, className, style }) => {
+  Block: ({ children, className, style, id }) => {
     const spanRef = React.useRef<HTMLSpanElement>(null);
     const [isTruncated, setIsTruncated] = React.useState(false);
     const [showTooltip, setShowTooltip] = React.useState(false);
@@ -105,7 +105,7 @@ const variantMap: VariantMap = {
     };
 
     return (
-      <div className={cn(typography.block, className)} style={style}>
+      <div id={id} className={cn(typography.block, className)} style={style}>
         <TooltipProvider>
           <Tooltip>
             <TooltipTrigger asChild>
@@ -128,63 +128,63 @@ const variantMap: VariantMap = {
       </div>
     );
   },
-  P: ({ children, className, style }) => (
-    <p className={cn(typography.p, className)} style={style}>
+  P: ({ children, className, style, id }) => (
+    <p id={id} className={cn(typography.p, className)} style={style}>
       {children}
     </p>
   ),
-  Inline: ({ children, className, style }) => (
-    <span className={cn(className)} style={style}>
+  Inline: ({ children, className, style, id }) => (
+    <span id={id} className={cn(className)} style={style}>
       {children}
     </span>
   ),
-  Blockquote: ({ children, className, style }) => (
-    <blockquote className={cn(typography.blockquote, className)} style={style}>
+  Blockquote: ({ children, className, style, id }) => (
+    <blockquote id={id} className={cn(typography.blockquote, className)} style={style}>
       {children}
     </blockquote>
   ),
-  Monospaced: ({ children, className, style }) => (
-    <code className={cn(typography.code, className)} style={style}>
+  Monospaced: ({ children, className, style, id }) => (
+    <code id={id} className={cn(typography.code, className)} style={style}>
       {children}
     </code>
   ),
-  Lead: ({ children, className, style }) => (
-    <div className={cn(typography.lead, className)} style={style}>
+  Lead: ({ children, className, style, id }) => (
+    <div id={id} className={cn(typography.lead, className)} style={style}>
       <MarkdownRenderer content={children} />
     </div>
   ),
-  Muted: ({ children, className, style }) => (
-    <div className={cn(typography.muted, className)} style={style}>
+  Muted: ({ children, className, style, id }) => (
+    <div id={id} className={cn(typography.muted, className)} style={style}>
       {children}
     </div>
   ),
-  Danger: ({ children, className, style }) => (
-    <div className={cn(typography.danger, className)} style={style}>
+  Danger: ({ children, className, style, id }) => (
+    <div id={id} className={cn(typography.danger, className)} style={style}>
       {children}
     </div>
   ),
-  Warning: ({ children, className, style }) => (
-    <div className={cn(typography.warning, className)} style={style}>
+  Warning: ({ children, className, style, id }) => (
+    <div id={id} className={cn(typography.warning, className)} style={style}>
       {children}
     </div>
   ),
-  Success: ({ children, className, style }) => (
-    <div className={cn(typography.success, className)} style={style}>
+  Success: ({ children, className, style, id }) => (
+    <div id={id} className={cn(typography.success, className)} style={style}>
       {children}
     </div>
   ),
-  Label: ({ children, className, style }) => (
-    <div className={cn(typography.label, className)} style={style}>
+  Label: ({ children, className, style, id }) => (
+    <div id={id} className={cn(typography.label, className)} style={style}>
       {children}
     </div>
   ),
-  Strong: ({ children, className, style }) => (
-    <strong className={cn(typography.strong, className)} style={style}>
+  Strong: ({ children, className, style, id }) => (
+    <strong id={id} className={cn(typography.strong, className)} style={style}>
       {children}
     </strong>
   ),
-  Display: ({ children, className, style }) => (
-    <div className={cn(typography.display, className)} style={style}>
+  Display: ({ children, className, style, id }) => (
+    <div id={id} className={cn(typography.display, className)} style={style}>
       {children}
     </div>
   ),


### PR DESCRIPTION
Fixes #4623

# Summary

## Changes

Added the `id` prop to all 14 non-heading text widget variants (Literal, Block, P, Inline, Blockquote, Monospaced, Lead, Muted, Danger, Warning, Success, Label, Strong, Display) so that `Text.Block("...").Anchor("foo")` correctly renders the `id` attribute on the DOM element. Added comprehensive test coverage for id attribute rendering across all variants.

## API Changes

All non-heading variant components now accept and render the `id` prop:
- `Literal`, `P`, `Inline`, `Blockquote`, `Monospaced`, `Lead`, `Muted`, `Danger`, `Warning`, `Success`, `Label`, `Strong`, `Display`: Added `id` parameter to component signature and applied to rendered element
- `Block`: Added `id` parameter and applied to outer `<div>` wrapper

## Files Modified

- `src/frontend/src/widgets/primitives/TextBlockWidget.tsx` — Added `id` prop to 14 variant component signatures and rendered elements
- `src/frontend/src/widgets/primitives/TextBlockWidget.test.tsx` — New test file with comprehensive coverage for id attribute rendering

---

## Commits

- 316529925
- b41006c4f8d74e8c651a5d72c8cebe06083d59f7