### PR TITLE
[00556] Fix dialog scrollbar not aligned to right border

### DIFF
--- a/src/frontend/src/widgets/dialogs/DialogBodyWidget.tsx
+++ b/src/frontend/src/widgets/dialogs/DialogBodyWidget.tsx
@@ -11,11 +11,11 @@ export const DialogBodyWidget: React.FC<DialogBodyWidgetProps> = ({ id, children
   return (
     <section
       id={id}
-      className="flex-1 min-h-0 flex flex-col p-4"
+      className="flex-1 min-h-0 flex flex-col pl-4 py-4"
       role="document"
       aria-describedby={descriptionId}
     >
-      <div className="flex-1 min-h-0 overflow-y-auto" id={descriptionId}>
+      <div className="flex-1 min-h-0 overflow-y-auto pr-4" id={descriptionId}>
         {children}
       </div>
     </section>


### PR DESCRIPTION
Fixes #1302

# Summary

## Changes

Fixed dialog scrollbar positioning by moving right padding from the section wrapper to the inner scrollable div. The scrollbar now renders flush against the dialog's right border while content maintains proper padding on all sides.

## API Changes

None.

## Files Modified

- **src/frontend/src/widgets/dialogs/DialogBodyWidget.tsx** — Changed section className from `p-4` to `pl-4 py-4` and added `pr-4` to the inner scrollable div

---

## Commits

- ad4220328 Fix dialog scrollbar alignment to right border
- 7ce966c51 Fix TextBlockWidget color prop and test unused import