### PR TITLE
[00569] FullWidthDetailValueInMultilineMode

### DIFF
--- a/src/frontend/src/components/ui/detail.tsx
+++ b/src/frontend/src/components/ui/detail.tsx
@@ -61,7 +61,7 @@ const DetailItem = React.forwardRef<HTMLDivElement, DetailItemProps>(
             detailValueSizeVariant({ density }),
             multiline
               ? cn(
-                  "whitespace-normal break-words text-left",
+                  "w-full whitespace-normal break-words text-left",
                   detailValueMultiLinePaddingVariant({ density }),
                 )
               : "truncate text-right ml-auto",


### PR DESCRIPTION
# Summary

## Changes

Added `w-full` CSS class to multiline detail values in the Ivy Framework's DetailItem component. This ensures the value container stretches to full width, allowing child layouts using `justify-between` to properly position elements at opposite edges.

## API Changes

None.

## Files Modified

- **Ivy-Framework/src/frontend/src/components/ui/detail.tsx** — Added `w-full` to multiline detail value className

---

## Commits

- d8e49e4b1 Add full width to multiline detail values