### PR TITLE
security: update dompurify and SQLitePCLRaw packages

### DIFF
--- a/src/Ivy.Agent.EfQuery.Test/Ivy.Agent.EfQuery.Test.csproj
+++ b/src/Ivy.Agent.EfQuery.Test/Ivy.Agent.EfQuery.Test.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
-    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.0" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -147,7 +147,7 @@
       "uuid": "14.0.0",
       "@swc/helpers": "0.5.17",
       "axios": "1.16.1",
-      "dompurify": "3.4.9",
+      "dompurify": "3.4.11",
       "follow-redirects": ">=1.16.0",
       "lodash-es": "4.18.1",
       "minimatch": "9.0.7",

--- a/src/frontend/pnpm-lock.yaml
+++ b/src/frontend/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
   uuid: 14.0.0
   '@swc/helpers': 0.5.17
   axios: 1.16.1
-  dompurify: 3.4.9
+  dompurify: 3.4.11
   follow-redirects: '>=1.16.0'
   lodash-es: 4.18.1
   minimatch: 9.0.7
@@ -2347,8 +2347,8 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
-  dompurify@3.4.9:
-    resolution: {integrity: sha512-4dPSRMRDqHvs0V4YDFCsaIZo4if5u0xM+llyxiM2fwuZFdKArUBAF3VtI2+n8NKg9P870WMdYk0UhqQNoWXbfQ==}
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -5624,7 +5624,7 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  dompurify@3.4.9:
+  dompurify@3.4.11:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -6350,7 +6350,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.20
-      dompurify: 3.4.9
+      dompurify: 3.4.11
       es-toolkit: 1.46.1
       katex: 0.16.25
       khroma: 2.1.0


### PR DESCRIPTION
Updates dompurify and SQLitePCLRaw.bundle_e_sqlite3 dependencies to address security alerts.