### PR TITLE
Add UseBreakpoint hook for server-side responsive branching

### DIFF
--- a/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/BreakpointListenerApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/BreakpointListenerApp.cs
@@ -7,14 +7,10 @@ public class BreakpointListenerApp : SampleBase
 {
     protected override object? BuildSample()
     {
-        // UseBreakpoint round-trips the browser's active breakpoint into server state. The returned
-        // listener widget is invisible and must be rendered for updates to arrive — see the Fragment below.
         var (breakpoint, listener) = Context.UseBreakpoint();
 
         var log = UseState(ImmutableArray<string>.Empty);
 
-        // Append a log line whenever the resolved breakpoint changes. Resize the browser window across
-        // 640 / 768 / 1024px to watch the widget fire OnChange and the value update server-side.
         UseEffect(() =>
         {
             log.Set(log.Value.Add($"[{DateTime.Now:HH:mm:ss}] Breakpoint → {breakpoint.Value}"));
@@ -34,7 +30,6 @@ public class BreakpointListenerApp : SampleBase
         ).Title("OnChange events");
 
         return new Fragment(
-            // The invisible listener — without it, breakpoint.Value never updates.
             listener,
             Layout.Vertical()
             | Text.H1("BreakpointListener")

--- a/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/BreakpointListenerApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/BreakpointListenerApp.cs
@@ -1,0 +1,52 @@
+using System.Collections.Immutable;
+
+namespace Ivy.Samples.Shared.Apps.Widgets.Primitives;
+
+[App(icon: Icons.MonitorSmartphone, group: ["Widgets", "Primitives"], searchHints: ["breakpoint", "responsive", "mobile", "resize", "screen", "media query"])]
+public class BreakpointListenerApp : SampleBase
+{
+    protected override object? BuildSample()
+    {
+        // UseBreakpoint round-trips the browser's active breakpoint into server state. The returned
+        // listener widget is invisible and must be rendered for updates to arrive — see the Fragment below.
+        var (breakpoint, listener) = Context.UseBreakpoint();
+
+        var log = UseState(ImmutableArray<string>.Empty);
+
+        // Append a log line whenever the resolved breakpoint changes. Resize the browser window across
+        // 640 / 768 / 1024px to watch the widget fire OnChange and the value update server-side.
+        UseEffect(() =>
+        {
+            log.Set(log.Value.Add($"[{DateTime.Now:HH:mm:ss}] Breakpoint → {breakpoint.Value}"));
+        }, breakpoint);
+
+        var currentCard = new Card(
+            Layout.Vertical()
+            | Text.Muted("Current breakpoint")
+            | Text.H2(breakpoint.Value.ToString())
+            | Text.Muted("Thresholds: Mobile < 640px ≤ Tablet < 768px ≤ Desktop < 1024px ≤ Wide").Small()
+        ).Title("Live value");
+
+        var logCard = new Card(
+            AutoScroll.FromChildren(log.Value.Select(line => Text.Muted(line)))
+                .Height(Size.Px(180))
+                .Width(Size.Full())
+        ).Title("OnChange events");
+
+        return new Fragment(
+            // The invisible listener — without it, breakpoint.Value never updates.
+            listener,
+            Layout.Vertical()
+            | Text.H1("BreakpointListener")
+            | Text.P(
+                "Reports the browser's active responsive breakpoint back to the server so C# code can branch "
+                + "on screen size. Drag the window narrower and wider — crossing 640px, 768px, or 1024px fires "
+                + "an OnChange event and updates the value below.")
+            | Text.P("Usage: var (breakpoint, listener) = Context.UseBreakpoint(); render listener, read breakpoint.Value.")
+                .Small()
+            | (Layout.Horizontal().Wrap()
+               | currentCard
+               | logCard)
+        );
+    }
+}

--- a/src/Ivy.Test/Widgets/BreakpointListenerTests.cs
+++ b/src/Ivy.Test/Widgets/BreakpointListenerTests.cs
@@ -22,7 +22,6 @@ public class BreakpointListenerTests
     [InlineData("Wide", Breakpoint.Wide)]
     public async Task OnChange_RoundTripsBreakpointFromFrontendName(string wireName, Breakpoint expected)
     {
-        // Arrange: a listener whose handler captures the breakpoint the frontend reports.
         Breakpoint? captured = null;
         var widget = new BreakpointListener
         {
@@ -33,11 +32,9 @@ public class BreakpointListenerTests
             })
         };
 
-        // Act: simulate the frontend firing OnChange with the PascalCase enum name it sends on the wire.
         var args = new JsonArray { JsonValue.Create(wireName) };
         var handled = await widget.InvokeEventAsync("OnChange", args);
 
-        // Assert: the event resolves to the matching Breakpoint value.
         Assert.True(handled);
         Assert.Equal(expected, captured);
     }

--- a/src/Ivy.Test/Widgets/BreakpointListenerTests.cs
+++ b/src/Ivy.Test/Widgets/BreakpointListenerTests.cs
@@ -1,0 +1,44 @@
+using System.Text.Json.Nodes;
+
+namespace Ivy.Test.Widgets;
+
+public class BreakpointListenerTests
+{
+    [Fact]
+    public void OnChange_Event_IsExposedOnWidget()
+    {
+        var widget = new BreakpointListener
+        {
+            OnChange = new(_ => ValueTask.CompletedTask)
+        };
+
+        Assert.NotNull(widget.OnChange);
+    }
+
+    [Theory]
+    [InlineData("Mobile", Breakpoint.Mobile)]
+    [InlineData("Tablet", Breakpoint.Tablet)]
+    [InlineData("Desktop", Breakpoint.Desktop)]
+    [InlineData("Wide", Breakpoint.Wide)]
+    public async Task OnChange_RoundTripsBreakpointFromFrontendName(string wireName, Breakpoint expected)
+    {
+        // Arrange: a listener whose handler captures the breakpoint the frontend reports.
+        Breakpoint? captured = null;
+        var widget = new BreakpointListener
+        {
+            OnChange = new(e =>
+            {
+                captured = e.Value;
+                return ValueTask.CompletedTask;
+            })
+        };
+
+        // Act: simulate the frontend firing OnChange with the PascalCase enum name it sends on the wire.
+        var args = new JsonArray { JsonValue.Create(wireName) };
+        var handled = await widget.InvokeEventAsync("OnChange", args);
+
+        // Assert: the event resolves to the matching Breakpoint value.
+        Assert.True(handled);
+        Assert.Equal(expected, captured);
+    }
+}

--- a/src/Ivy/Hooks/UseBreakpoint.cs
+++ b/src/Ivy/Hooks/UseBreakpoint.cs
@@ -1,26 +1,8 @@
 // ReSharper disable once CheckNamespace
 namespace Ivy;
 
-/// <summary>
-/// Hook for reading the browser's current responsive <see cref="Breakpoint"/> from server-side code.
-/// </summary>
 public static class UseBreakpointExtensions
 {
-    /// <summary>
-    /// Tracks the browser's active responsive <see cref="Breakpoint"/> so server-side code can branch
-    /// its layout on screen size (for example, rendering a bottom <c>Sheet</c> on mobile and a
-    /// <c>Dialog</c> otherwise).
-    /// </summary>
-    /// <param name="context">The view context.</param>
-    /// <param name="initial">
-    /// The breakpoint assumed before the browser reports its first measurement. Defaults to
-    /// <see cref="Breakpoint.Desktop"/>, so the first render behaves like a wide layout until the
-    /// frontend corrects it (typically within the same paint).
-    /// </param>
-    /// <returns>
-    /// A tuple of the current breakpoint state and a listener widget. The listener <b>must be rendered
-    /// somewhere in the returned tree</b> (it is invisible) for the breakpoint to update.
-    /// </returns>
     public static (IState<Breakpoint> breakpoint, object listener) UseBreakpoint(
         this IViewContext context,
         Breakpoint initial = Breakpoint.Desktop)

--- a/src/Ivy/Hooks/UseBreakpoint.cs
+++ b/src/Ivy/Hooks/UseBreakpoint.cs
@@ -1,0 +1,41 @@
+// ReSharper disable once CheckNamespace
+namespace Ivy;
+
+/// <summary>
+/// Hook for reading the browser's current responsive <see cref="Breakpoint"/> from server-side code.
+/// </summary>
+public static class UseBreakpointExtensions
+{
+    /// <summary>
+    /// Tracks the browser's active responsive <see cref="Breakpoint"/> so server-side code can branch
+    /// its layout on screen size (for example, rendering a bottom <c>Sheet</c> on mobile and a
+    /// <c>Dialog</c> otherwise).
+    /// </summary>
+    /// <param name="context">The view context.</param>
+    /// <param name="initial">
+    /// The breakpoint assumed before the browser reports its first measurement. Defaults to
+    /// <see cref="Breakpoint.Desktop"/>, so the first render behaves like a wide layout until the
+    /// frontend corrects it (typically within the same paint).
+    /// </param>
+    /// <returns>
+    /// A tuple of the current breakpoint state and a listener widget. The listener <b>must be rendered
+    /// somewhere in the returned tree</b> (it is invisible) for the breakpoint to update.
+    /// </returns>
+    public static (IState<Breakpoint> breakpoint, object listener) UseBreakpoint(
+        this IViewContext context,
+        Breakpoint initial = Breakpoint.Desktop)
+    {
+        var breakpoint = context.UseState(initial);
+
+        var listener = new BreakpointListener
+        {
+            OnChange = new(e =>
+            {
+                breakpoint.Set(e.Value);
+                return ValueTask.CompletedTask;
+            })
+        };
+
+        return (breakpoint, listener);
+    }
+}

--- a/src/Ivy/Widgets/BreakpointListener.cs
+++ b/src/Ivy/Widgets/BreakpointListener.cs
@@ -1,22 +1,11 @@
 // ReSharper disable once CheckNamespace
 namespace Ivy;
 
-/// <summary>
-/// An invisible widget that reports the browser's current responsive <see cref="Breakpoint"/>
-/// back to the server. Rendered into the tree by <see cref="UseBreakpointExtensions.UseBreakpoint"/>;
-/// it produces no visible UI and exists solely to round-trip the active breakpoint so server-side
-/// code can branch its layout on screen size.
-/// </summary>
 public record BreakpointListener : WidgetBase<BreakpointListener>
 {
-    /// <summary>Initializes a new <see cref="BreakpointListener"/>.</summary>
     public BreakpointListener()
     {
     }
 
-    /// <summary>
-    /// Raised by the frontend whenever the active breakpoint changes (and once on mount), carrying
-    /// the newly resolved <see cref="Breakpoint"/>.
-    /// </summary>
     [Event] public EventHandler<Event<BreakpointListener, Breakpoint>>? OnChange { get; set; }
 }

--- a/src/Ivy/Widgets/BreakpointListener.cs
+++ b/src/Ivy/Widgets/BreakpointListener.cs
@@ -1,0 +1,22 @@
+// ReSharper disable once CheckNamespace
+namespace Ivy;
+
+/// <summary>
+/// An invisible widget that reports the browser's current responsive <see cref="Breakpoint"/>
+/// back to the server. Rendered into the tree by <see cref="UseBreakpointExtensions.UseBreakpoint"/>;
+/// it produces no visible UI and exists solely to round-trip the active breakpoint so server-side
+/// code can branch its layout on screen size.
+/// </summary>
+public record BreakpointListener : WidgetBase<BreakpointListener>
+{
+    /// <summary>Initializes a new <see cref="BreakpointListener"/>.</summary>
+    public BreakpointListener()
+    {
+    }
+
+    /// <summary>
+    /// Raised by the frontend whenever the active breakpoint changes (and once on mount), carrying
+    /// the newly resolved <see cref="Breakpoint"/>.
+    /// </summary>
+    [Event] public EventHandler<Event<BreakpointListener, Breakpoint>>? OnChange { get; set; }
+}

--- a/src/frontend/src/widgets/primitives/BreakpointListenerWidget.tsx
+++ b/src/frontend/src/widgets/primitives/BreakpointListenerWidget.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useRef } from "react";
+import { useEventHandler } from "@/components/event-handler/hooks";
+import { type BreakpointName, useBreakpoint } from "@/hooks/use-responsive";
+
+interface BreakpointListenerWidgetProps {
+  id: string;
+  events?: string[];
+}
+
+// The C# `Breakpoint` enum serializes by name (PascalCase). Map the frontend's lowercase
+// breakpoint name to the matching enum name so the round-tripped value deserializes server-side.
+const ENUM_NAME: Record<BreakpointName, string> = {
+  mobile: "Mobile",
+  tablet: "Tablet",
+  desktop: "Desktop",
+  wide: "Wide",
+};
+
+/**
+ * Invisible widget that reports the active responsive breakpoint back to the server. Renders
+ * nothing; it observes the breakpoint via {@link useBreakpoint} and fires the `OnChange` event
+ * on mount and whenever the breakpoint changes, letting server-side code branch on screen size.
+ */
+export const BreakpointListenerWidget: React.FC<BreakpointListenerWidgetProps> = ({
+  id,
+  events,
+}) => {
+  const eventHandler = useEventHandler();
+  const breakpoint = useBreakpoint();
+  const lastSent = useRef<BreakpointName | undefined>(undefined);
+
+  useEffect(() => {
+    if (!events?.includes("OnChange")) return;
+    if (lastSent.current === breakpoint) return;
+    lastSent.current = breakpoint;
+    eventHandler("OnChange", id, [ENUM_NAME[breakpoint]]);
+  }, [breakpoint, eventHandler, id, events]);
+
+  return null;
+};
+
+BreakpointListenerWidget.displayName = "BreakpointListenerWidget";

--- a/src/frontend/src/widgets/primitives/BreakpointListenerWidget.tsx
+++ b/src/frontend/src/widgets/primitives/BreakpointListenerWidget.tsx
@@ -7,8 +7,6 @@ interface BreakpointListenerWidgetProps {
   events?: string[];
 }
 
-// The C# `Breakpoint` enum serializes by name (PascalCase). Map the frontend's lowercase
-// breakpoint name to the matching enum name so the round-tripped value deserializes server-side.
 const ENUM_NAME: Record<BreakpointName, string> = {
   mobile: "Mobile",
   tablet: "Tablet",
@@ -16,11 +14,6 @@ const ENUM_NAME: Record<BreakpointName, string> = {
   wide: "Wide",
 };
 
-/**
- * Invisible widget that reports the active responsive breakpoint back to the server. Renders
- * nothing; it observes the breakpoint via {@link useBreakpoint} and fires the `OnChange` event
- * on mount and whenever the breakpoint changes, letting server-side code branch on screen size.
- */
 export const BreakpointListenerWidget: React.FC<BreakpointListenerWidgetProps> = ({
   id,
   events,

--- a/src/frontend/src/widgets/primitives/__tests__/BreakpointListenerWidget.test.tsx
+++ b/src/frontend/src/widgets/primitives/__tests__/BreakpointListenerWidget.test.tsx
@@ -2,13 +2,11 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { act } from "react";
 import { createRoot, Root } from "react-dom/client";
 
-// Control the breakpoint the widget observes.
 const mockBreakpoint = vi.fn().mockReturnValue("mobile");
 vi.mock("@/hooks/use-responsive", () => ({
   useBreakpoint: () => mockBreakpoint(),
 }));
 
-// Capture events the widget sends back to the server.
 const sentEvents: Array<{ name: string; id: string; args: unknown[] }> = [];
 vi.mock("@/components/event-handler/hooks", () => ({
   useEventHandler: () => (name: string, id: string, args: unknown[]) =>
@@ -53,14 +51,14 @@ describe("BreakpointListenerWidget", () => {
     render();
     sentEvents.length = 0;
     mockBreakpoint.mockReturnValue("desktop");
-    render(); // re-render with the new breakpoint
+    render();
     expect(sentEvents).toEqual([{ name: "OnChange", id: "bp", args: ["Desktop"] }]);
   });
 
   it("does not re-fire when the breakpoint is unchanged", () => {
     render();
     sentEvents.length = 0;
-    render(); // same breakpoint
+    render();
     expect(sentEvents).toHaveLength(0);
   });
 

--- a/src/frontend/src/widgets/primitives/__tests__/BreakpointListenerWidget.test.tsx
+++ b/src/frontend/src/widgets/primitives/__tests__/BreakpointListenerWidget.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+
+// Control the breakpoint the widget observes.
+const mockBreakpoint = vi.fn().mockReturnValue("mobile");
+vi.mock("@/hooks/use-responsive", () => ({
+  useBreakpoint: () => mockBreakpoint(),
+}));
+
+// Capture events the widget sends back to the server.
+const sentEvents: Array<{ name: string; id: string; args: unknown[] }> = [];
+vi.mock("@/components/event-handler/hooks", () => ({
+  useEventHandler: () => (name: string, id: string, args: unknown[]) =>
+    sentEvents.push({ name, id, args }),
+}));
+
+import { BreakpointListenerWidget } from "../BreakpointListenerWidget";
+
+describe("BreakpointListenerWidget", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    sentEvents.length = 0;
+    mockBreakpoint.mockReturnValue("mobile");
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  const render = () =>
+    act(() => {
+      root.render(<BreakpointListenerWidget id="bp" events={["OnChange"]} />);
+    });
+
+  it("renders nothing visible", () => {
+    render();
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("reports the active breakpoint as the PascalCase enum name on mount", () => {
+    render();
+    expect(sentEvents).toEqual([{ name: "OnChange", id: "bp", args: ["Mobile"] }]);
+  });
+
+  it("re-fires when the breakpoint changes", () => {
+    render();
+    sentEvents.length = 0;
+    mockBreakpoint.mockReturnValue("desktop");
+    render(); // re-render with the new breakpoint
+    expect(sentEvents).toEqual([{ name: "OnChange", id: "bp", args: ["Desktop"] }]);
+  });
+
+  it("does not re-fire when the breakpoint is unchanged", () => {
+    render();
+    sentEvents.length = 0;
+    render(); // same breakpoint
+    expect(sentEvents).toHaveLength(0);
+  });
+
+  it("stays silent when OnChange is not subscribed", () => {
+    act(() => {
+      root.render(<BreakpointListenerWidget id="bp" events={[]} />);
+    });
+    expect(sentEvents).toHaveLength(0);
+  });
+});

--- a/src/frontend/src/widgets/widgetMap.ts
+++ b/src/frontend/src/widgets/widgetMap.ts
@@ -62,6 +62,7 @@ import { LoadingWidget } from "@/widgets/primitives/LoadingWidget";
 import { LogoLoadingWidget } from "@/widgets/primitives/LogoLoadingWidget";
 import { AppHostWidget } from "@/widgets/primitives/AppHostWidget";
 import { AutoScrollWidget } from "@/widgets/primitives/AutoScrollWidget";
+import { BreakpointListenerWidget } from "@/widgets/primitives/BreakpointListenerWidget";
 import { TableWidget, TableRowWidget, TableCellWidget } from "@/widgets/tables";
 import { SmartSearch } from "@/docs-internal/SmartSearch";
 import { lazyWithRetry } from "@/lib/lazyWithRetry";
@@ -102,6 +103,7 @@ export const widgetMap = {
   "Ivy.LogoLoading": LogoLoadingWidget,
   "Ivy.AppHost": AppHostWidget,
   "Ivy.AutoScroll": AutoScrollWidget,
+  "Ivy.BreakpointListener": BreakpointListenerWidget,
   "Ivy.AudioPlayer": lazyWithRetry(() =>
     import("@/widgets/primitives/AudioPlayerWidget").then((m) => ({
       default: m.AudioPlayerWidget,


### PR DESCRIPTION


https://github.com/user-attachments/assets/a6331fb7-0c00-457b-826f-25f6014c8f75



## Summary

Adds a `UseBreakpoint()` hook that lets server-side C# code read the browser's active responsive breakpoint and branch its layout on screen size (e.g. render a bottom `Sheet` on mobile and a `Dialog` otherwise).

Until now `Responsive<T>` was **send-only** (`ResponsiveJsonConverter.Read` throws), so the active breakpoint never reached the server and C# could not conditionally render based on viewport. This adds a minimal round-trip channel.

## What's included

- **`BreakpointListener`** — an invisible widget carrying an `[Event] OnChange` that reports the active `Breakpoint`.
- **`UseBreakpoint()`** — returns `(IState<Breakpoint> breakpoint, object listener)`. The caller renders the (invisible) `listener` somewhere in the tree and reads `breakpoint.Value`. Defaults to `Breakpoint.Desktop` until the browser reports its first measurement (typically within the same paint).
- **`BreakpointListenerWidget`** (frontend) — reuses the existing `useBreakpoint()` and fires `OnChange` with the PascalCase enum name on mount and whenever the breakpoint changes, deduping repeats. Renders nothing.
- **`BreakpointListenerApp`** sample — live breakpoint value + an event log that updates as you resize the window across the 640/768/1024px thresholds.

## Usage

```csharp
var (breakpoint, listener) = Context.UseBreakpoint();

return new Fragment(
    listener, // invisible — required for updates
    breakpoint.Value == Breakpoint.Mobile
        ? new Sheet(...).Side(SheetSide.Bottom)
        : new Dialog(...)
);
```

## Notes

- Purely **additive** to the public API (new widget, hook, sample) — no existing signatures change, so plugin binary compatibility is preserved.
- The enum crosses the wire by name (`JsonEnumConverter`); the frontend maps its lowercase `BreakpointName` to the matching PascalCase name.

## Testing

- C# (`BreakpointListenerTests`): round-trips `"Mobile"`/`"Tablet"`/`"Desktop"`/`"Wide"` → `Breakpoint` via the real `InvokeEventAsync` plumbing. ✅ 5/5
- Frontend (`BreakpointListenerWidget.test.tsx`): renders null, fires on mount, re-fires on change, dedupes, and stays silent when unsubscribed. ✅ 5/5
- `dotnet build` (Ivy + Samples), `tsc --noEmit`, `vp lint`, `vp fmt` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)