### PR TITLE
Fix IL3000 single-file publish error in PluginLoader

### DIFF
--- a/src/Ivy/Core/Plugins/PluginLoader.cs
+++ b/src/Ivy/Core/Plugins/PluginLoader.cs
@@ -221,7 +221,7 @@ public class PluginLoader : IPluginManager
         {
             _logger.LogError(
                 "Multiple [assembly: IvyPlugin] attributes found in {Directory} ({Assemblies}). Skipping.",
-                directory, string.Join(", ", found.Select(f => Path.GetFileName(f.Assembly.Location))));
+                directory, string.Join(", ", found.Select(f => f.Assembly.GetName().Name)));
             failureReason = "Multiple [IvyPlugin] attributes found";
             DeleteShadowDirectory(shadowDir);
             return null;


### PR DESCRIPTION
Resolves the IL3000 warning-as-error when publishing apps in single-file mode (such as Ivy Tendril). Changing f.Assembly.Location to f.Assembly.GetName().Name prevents the build error and gets correct assembly names for logging.