### PR TITLE
Improve Kbd API: standalone icon-based key caps

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/11_Kbd.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/11_Kbd.md
@@ -17,13 +17,23 @@ Display keyboard shortcuts and key combinations with proper styling to help user
 
 The `Kbd` [widget](../../01_Onboarding/02_Concepts/03_Widgets.md) displays keyboard shortcuts or key combinations with proper styling. It helps users identify key commands and improves documentation clarity.
 
-Pass a full combination as a single string. Each key is rendered as its own standalone cap (so `"Ctrl+Enter"` shows two caps, not one), and modifier and navigation keys — `Ctrl`, `Cmd`/`Win`, `Shift`, `Alt`/`Option`, `Enter`, `Backspace`, and the arrow keys — are shown as platform-appropriate icons where available.
+Pass a full combination as a single string. Each key is rendered as its own standalone cap (so `"Ctrl+Enter"` shows two caps, not one), and modifier and navigation keys — `Ctrl`, `Cmd`/`Win`, `Shift`, `Alt`/`Option`, `Enter`, `Backspace`, and the arrow keys — are shown as platform-appropriate icons where available. Single-glyph caps are square; multi-character labels keep the same height and grow wider.
 
 ```csharp demo-below
 Layout.Horizontal() | 
     new Kbd("Ctrl+C") | 
     new Kbd("Shift+Ctrl+C") |
     new Kbd("Cmd+Enter")
+```
+
+## Ghost
+
+Use `.Ghost()` to drop the background and border, leaving just the key glyphs — useful for inline, low-emphasis shortcut hints.
+
+```csharp demo-below
+Layout.Horizontal() | 
+    new Kbd("Cmd+Enter").Ghost() | 
+    new Kbd("Esc").Ghost()
 ```
 
 <WidgetDocs Type="Ivy.Kbd" ExtensionTypes="Ivy.KbdExtensions"  SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Primitives/Kbd.cs"/>

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/11_Kbd.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/11_Kbd.md
@@ -17,10 +17,13 @@ Display keyboard shortcuts and key combinations with proper styling to help user
 
 The `Kbd` [widget](../../01_Onboarding/02_Concepts/03_Widgets.md) displays keyboard shortcuts or key combinations with proper styling. It helps users identify key commands and improves documentation clarity.
 
+Pass a full combination as a single string. Each key is rendered as its own standalone cap (so `"Ctrl+Enter"` shows two caps, not one), and modifier and navigation keys — `Ctrl`, `Cmd`/`Win`, `Shift`, `Alt`/`Option`, `Enter`, `Backspace`, and the arrow keys — are shown as platform-appropriate icons where available.
+
 ```csharp demo-below
 Layout.Horizontal() | 
-    new Kbd("Ctrl + C") | 
-    new Kbd("Shift + Ctrl + C")
+    new Kbd("Ctrl+C") | 
+    new Kbd("Shift+Ctrl+C") |
+    new Kbd("Cmd+Enter")
 ```
 
 <WidgetDocs Type="Ivy.Kbd" ExtensionTypes="Ivy.KbdExtensions"  SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Primitives/Kbd.cs"/>

--- a/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/KbdApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/KbdApp.cs
@@ -6,17 +6,22 @@ public class KbdApp : SampleBase
 {
     protected override object? BuildSample()
     {
-        // Each key in a combination is rendered as its own standalone cap,
-        // so a single Kbd describes the whole shortcut.
-        return Layout.Vertical().Gap(4)
-               | (Layout.Horizontal().Gap(2).AlignContent(Align.Center)
-                  | new Kbd("Ctrl+C")
-                  | new Kbd("Shift+Ctrl+C"))
+        // Each key in a combination renders as its own standalone cap. Modifier and
+        // navigation keys (Cmd, Ctrl, Shift, Alt, Enter, Backspace, arrows) are shown
+        // as platform-appropriate icons where available.
+        return Layout.Vertical().Gap(6)
+               | Text.H4("Default")
                | (Layout.Horizontal().Gap(2).AlignContent(Align.Center)
                   | new Kbd("Cmd+Enter")
+                  | new Kbd("Shift+Ctrl+C")
                   | new Kbd("Alt+Backspace")
-                  | new Kbd("Ctrl+ArrowUp"))
-               | new Kbd("A")
+                  | new Kbd("Ctrl+ArrowUp")
+                  | new Kbd("A"))
+               | Text.H4("Ghost")
+               | (Layout.Horizontal().Gap(2).AlignContent(Align.Center)
+                  | new Kbd("Cmd+Enter").Ghost()
+                  | new Kbd("Shift+Ctrl+C").Ghost()
+                  | new Kbd("Esc").Ghost())
             ;
     }
 }

--- a/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/KbdApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/KbdApp.cs
@@ -6,11 +6,17 @@ public class KbdApp : SampleBase
 {
     protected override object? BuildSample()
     {
-        return Layout.Horizontal().Gap(1).AlignContent(Align.Center)
-               | new Kbd("Ctrl")
-               | "+"
-               | new Kbd("C")
+        // Each key in a combination is rendered as its own standalone cap,
+        // so a single Kbd describes the whole shortcut.
+        return Layout.Vertical().Gap(4)
+               | (Layout.Horizontal().Gap(2).AlignContent(Align.Center)
+                  | new Kbd("Ctrl+C")
+                  | new Kbd("Shift+Ctrl+C"))
+               | (Layout.Horizontal().Gap(2).AlignContent(Align.Center)
+                  | new Kbd("Cmd+Enter")
+                  | new Kbd("Alt+Backspace")
+                  | new Kbd("Ctrl+ArrowUp"))
+               | new Kbd("A")
             ;
-
     }
 }

--- a/src/Ivy/Widgets/Primitives/Kbd.cs
+++ b/src/Ivy/Widgets/Primitives/Kbd.cs
@@ -2,51 +2,28 @@
 namespace Ivy;
 
 /// <summary>
-/// Represents keyboard input. Each key in a combination is rendered as its own
-/// standalone cap, so a single <see cref="Kbd"/> describes a whole shortcut — for
-/// example <c>new Kbd("Ctrl+Enter")</c> renders two caps. Modifier and navigation
-/// keys are shown as platform-appropriate icons where available.
+/// Represents keyboard input.
 /// </summary>
 public record Kbd : WidgetBase<Kbd>
 {
-    /// <summary>
-    /// Initializes a new <see cref="Kbd"/> from a shortcut string such as
-    /// "Ctrl+Enter". The string is split on "+" and each key is rendered as its
-    /// own standalone cap.
-    /// </summary>
-    /// <param name="content">The shortcut string (e.g. "Shift+Ctrl+C").</param>
     public Kbd(string content)
     {
         Keys = content;
     }
 
-    /// <summary>
-    /// Initializes a new <see cref="Kbd"/> from arbitrary content, rendered inside a
-    /// single key cap. Prefer the string overload for keyboard shortcuts.
-    /// </summary>
-    /// <param name="content">The content to render inside a single cap.</param>
     public Kbd(object content) : base(content)
     {
     }
 
     internal Kbd() { }
 
-    /// <summary>The shortcut string to render as standalone key caps (e.g. "Ctrl+Enter").</summary>
     [Prop] public string? Keys { get; set; }
 
-    /// <summary>When true, renders caps without a background or border.</summary>
     [Prop] public bool Ghost { get; set; }
 }
 
-/// <summary>
-/// Extension methods for <see cref="Kbd"/>.
-/// </summary>
 public static class KbdExtensions
 {
-    /// <summary>
-    /// Renders the key caps without a background or border, leaving just the key
-    /// glyphs — useful for inline, low-emphasis shortcut hints.
-    /// </summary>
     public static Kbd Ghost(this Kbd kbd, bool ghost = true)
     {
         return kbd with { Ghost = ghost };

--- a/src/Ivy/Widgets/Primitives/Kbd.cs
+++ b/src/Ivy/Widgets/Primitives/Kbd.cs
@@ -2,13 +2,53 @@
 namespace Ivy;
 
 /// <summary>
-/// Represents keyboard input.
+/// Represents keyboard input. Each key in a combination is rendered as its own
+/// standalone cap, so a single <see cref="Kbd"/> describes a whole shortcut — for
+/// example <c>new Kbd("Ctrl+Enter")</c> renders two caps. Modifier and navigation
+/// keys are shown as platform-appropriate icons where available.
 /// </summary>
 public record Kbd : WidgetBase<Kbd>
 {
+    /// <summary>
+    /// Initializes a new <see cref="Kbd"/> from a shortcut string such as
+    /// "Ctrl+Enter". The string is split on "+" and each key is rendered as its
+    /// own standalone cap.
+    /// </summary>
+    /// <param name="content">The shortcut string (e.g. "Shift+Ctrl+C").</param>
+    public Kbd(string content)
+    {
+        Keys = content;
+    }
+
+    /// <summary>
+    /// Initializes a new <see cref="Kbd"/> from arbitrary content, rendered inside a
+    /// single key cap. Prefer the string overload for keyboard shortcuts.
+    /// </summary>
+    /// <param name="content">The content to render inside a single cap.</param>
     public Kbd(object content) : base(content)
     {
     }
 
     internal Kbd() { }
+
+    /// <summary>The shortcut string to render as standalone key caps (e.g. "Ctrl+Enter").</summary>
+    [Prop] public string? Keys { get; set; }
+
+    /// <summary>When true, renders caps without a background or border.</summary>
+    [Prop] public bool Ghost { get; set; }
+}
+
+/// <summary>
+/// Extension methods for <see cref="Kbd"/>.
+/// </summary>
+public static class KbdExtensions
+{
+    /// <summary>
+    /// Renders the key caps without a background or border, leaving just the key
+    /// glyphs — useful for inline, low-emphasis shortcut hints.
+    /// </summary>
+    public static Kbd Ghost(this Kbd kbd, bool ghost = true)
+    {
+        return kbd with { Ghost = ghost };
+    }
 }

--- a/src/Ivy/Widgets/Primitives/Kbd.cs
+++ b/src/Ivy/Widgets/Primitives/Kbd.cs
@@ -8,7 +8,7 @@ public record Kbd : WidgetBase<Kbd>
 {
     public Kbd(string content)
     {
-        Keys = content;
+        Content = content;
     }
 
     public Kbd(object content) : base(content)
@@ -17,7 +17,7 @@ public record Kbd : WidgetBase<Kbd>
 
     internal Kbd() { }
 
-    [Prop] public string? Keys { get; set; }
+    [Prop] public string? Content { get; set; }
 
     [Prop] public bool Ghost { get; set; }
 }

--- a/src/frontend/e2e/samples/widgets/button.spec.ts
+++ b/src/frontend/e2e/samples/widgets/button.spec.ts
@@ -302,7 +302,8 @@ test.describe("Button Widget Tests", () => {
       // Verify shortcut badges are rendered on buttons
       const searchButton = page.getByRole("button", { name: /Search/ }).first();
       await searchButton.scrollIntoViewIfNeeded();
-      const kbd = searchButton.locator("kbd");
+      // Each key in a shortcut renders as its own standalone <kbd> cap.
+      const kbd = searchButton.locator("kbd").first();
       await expect(kbd).toBeVisible();
     });
   });

--- a/src/frontend/src/components/Kbd.test.tsx
+++ b/src/frontend/src/components/Kbd.test.tsx
@@ -81,6 +81,36 @@ describe("Kbd", () => {
     expect(caps).toHaveLength(1);
     expect(caps[0].querySelector('[data-testid="custom"]')).not.toBeNull();
   });
+
+  it("tokenizes the `keys` prop into standalone caps", () => {
+    mount(<Kbd keys="Ctrl+Shift+C" />);
+    const caps = container.querySelectorAll("kbd");
+    expect(caps).toHaveLength(3);
+  });
+
+  it("prefers the `keys` prop over children", () => {
+    mount(<Kbd keys="Ctrl+K">ignored</Kbd>);
+    const caps = container.querySelectorAll("kbd");
+    expect(caps).toHaveLength(2);
+    expect(caps[0].textContent).toBe("Ctrl");
+    expect(caps[1].textContent).toBe("K");
+  });
+
+  it("keeps caps square via a fixed height and matching minimum width", () => {
+    mount(<Kbd keys="A" />);
+    const cap = container.querySelector("kbd")!;
+    // h-5 fixes the height and min-w-5 matches it, so a single-glyph cap is square.
+    expect(cap.className).toContain("h-5");
+    expect(cap.className).toContain("min-w-5");
+  });
+
+  it("renders a ghost cap without background or border", () => {
+    mount(<Kbd keys="A" ghost />);
+    const cap = container.querySelector("kbd")!;
+    expect(cap.className).toContain("border-0");
+    expect(cap.className).toContain("bg-transparent");
+    expect(cap.className).not.toContain("bg-muted");
+  });
 });
 
 describe("ShortcutKeys", () => {

--- a/src/frontend/src/components/Kbd.test.tsx
+++ b/src/frontend/src/components/Kbd.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { Kbd, ShortcutKeys } from "./Kbd";
+
+// Note: jsdom reports a non-Mac userAgent, so `isMac` is false here. Modifier keys
+// therefore render as text ("Ctrl", "Alt") rather than the Mac symbols (⌘, ⌥).
+
+let container: HTMLDivElement;
+let root: Root;
+
+function mount(element: React.ReactElement) {
+  act(() => {
+    root.render(element);
+  });
+}
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+describe("Kbd", () => {
+  it("renders each key in a combination as its own standalone cap", () => {
+    mount(<Kbd>Ctrl+Shift+C</Kbd>);
+    const caps = container.querySelectorAll("kbd");
+    expect(caps).toHaveLength(3);
+  });
+
+  it("renders a single key as a single cap", () => {
+    mount(<Kbd>A</Kbd>);
+    const caps = container.querySelectorAll("kbd");
+    expect(caps).toHaveLength(1);
+    expect(caps[0].textContent).toBe("A");
+  });
+
+  it("uppercases a single-letter key", () => {
+    mount(<Kbd>c</Kbd>);
+    expect(container.querySelector("kbd")!.textContent).toBe("C");
+  });
+
+  it("renders modifier keys as text on non-Mac platforms", () => {
+    mount(<Kbd>Ctrl+C</Kbd>);
+    const caps = container.querySelectorAll("kbd");
+    expect(caps[0].textContent).toBe("Ctrl");
+    expect(caps[1].textContent).toBe("C");
+  });
+
+  it("renders an icon (svg) for navigation keys like Enter", () => {
+    mount(<Kbd>Ctrl+Enter</Kbd>);
+    const caps = container.querySelectorAll("kbd");
+    expect(caps).toHaveLength(2);
+    // The Enter cap should contain an icon, not text.
+    const enterCap = caps[1];
+    expect(enterCap.querySelector("svg")).not.toBeNull();
+    expect(enterCap.getAttribute("aria-label")).toBe("Enter");
+  });
+
+  it("renders arrow keys as icons", () => {
+    mount(<Kbd>ArrowUp</Kbd>);
+    const cap = container.querySelector("kbd")!;
+    expect(cap.querySelector("svg")).not.toBeNull();
+    expect(cap.getAttribute("aria-label")).toBe("Arrow Up");
+  });
+
+  it("renders non-string children inside a single cap unchanged", () => {
+    mount(
+      <Kbd>
+        <span data-testid="custom">x</span>
+      </Kbd>,
+    );
+    const caps = container.querySelectorAll("kbd");
+    expect(caps).toHaveLength(1);
+    expect(caps[0].querySelector('[data-testid="custom"]')).not.toBeNull();
+  });
+});
+
+describe("ShortcutKeys", () => {
+  it("tokenizes a shortcut string into standalone caps", () => {
+    mount(<ShortcutKeys shortcut="Ctrl+K" />);
+    const caps = container.querySelectorAll("kbd");
+    expect(caps).toHaveLength(2);
+    expect(caps[0].textContent).toBe("Ctrl");
+    expect(caps[1].textContent).toBe("K");
+  });
+
+  it("renders nothing for an empty shortcut", () => {
+    mount(<ShortcutKeys shortcut="" />);
+    expect(container.querySelectorAll("kbd")).toHaveLength(0);
+  });
+
+  it("applies a custom className to the wrapper", () => {
+    mount(<ShortcutKeys shortcut="A" className="ml-auto" />);
+    const wrapper = container.querySelector("span");
+    expect(wrapper!.className).toContain("ml-auto");
+  });
+});

--- a/src/frontend/src/components/Kbd.tsx
+++ b/src/frontend/src/components/Kbd.tsx
@@ -24,10 +24,11 @@ const tokenForKey = (raw: string): KeyToken => {
   const key = raw.trim();
   const k = key.toLowerCase();
 
-  // Platform modifiers
+  // Platform modifiers. On macOS each modifier has its own glyph (⌃ ⌘ ⇧ ⌥); on other
+  // platforms only Shift has a conventional symbol, so the rest render as short text.
   if (k === "ctrl" || k === "control") {
     return isMac
-      ? { icon: "Command", label: "⌘", aria: "Command" }
+      ? { icon: "ChevronUp", label: "⌃", aria: "Control" }
       : { label: "Ctrl", aria: "Control" };
   }
   if (k === "cmd" || k === "command" || k === "meta" || k === "win" || k === "super") {
@@ -36,7 +37,7 @@ const tokenForKey = (raw: string): KeyToken => {
       : { label: "Win", aria: "Windows" };
   }
   if (k === "shift") {
-    return { icon: "ArrowBigUp", label: "Shift", aria: "Shift" };
+    return { icon: "ArrowBigUp", label: "⇧", aria: "Shift" };
   }
   if (k === "alt" || k === "option") {
     return isMac ? { icon: "Option", label: "⌥", aria: "Option" } : { label: "Alt", aria: "Alt" };
@@ -84,27 +85,40 @@ const tokenForKey = (raw: string): KeyToken => {
   return { label, aria: label };
 };
 
-/** Shared base styling for a single key cap. */
+/**
+ * Base styling for a key cap. The height is fixed and the minimum width equals the
+ * height, so a cap holding a single glyph or letter is a perfect square; multi-character
+ * labels keep that height and simply grow wider. `box-border` keeps the border inside
+ * the square so single-glyph caps stay exactly square.
+ */
 const keyCapBase =
-  "inline-flex h-5 min-w-5 items-center justify-center rounded-selector px-1.5 text-[0.7rem] font-medium leading-none";
+  "box-border inline-flex h-5 min-w-5 items-center justify-center rounded-selector px-1 text-[0.7rem] font-medium leading-none";
 
 /**
- * Color styling for a key cap. `inherit` adopts the surrounding text color (for use
- * on colored surfaces such as a primary button); otherwise the standard muted look.
+ * Color/fill styling for a key cap.
+ * - `ghost`   → no background or border, just the glyph.
+ * - `inherit` → adopts the surrounding text color (for colored surfaces such as a primary button).
+ * - default   → the standard muted key-cap look.
  */
-const keyCapColor = (inherit?: boolean) =>
-  inherit
+const keyCapColor = ({ inherit, ghost }: { inherit?: boolean; ghost?: boolean }) => {
+  if (ghost) return "border-0 bg-transparent text-current";
+  return inherit
     ? "border border-current/30 bg-transparent text-current"
     : "border border-border bg-muted/40 text-foreground";
+};
 
 /**
- * Renders a single standalone key box.
+ * Renders a single standalone key cap.
  */
-const KeyCap: React.FC<{ token: KeyToken; inherit?: boolean }> = ({ token, inherit }) => (
+const KeyCap: React.FC<{ token: KeyToken; inherit?: boolean; ghost?: boolean }> = ({
+  token,
+  inherit,
+  ghost,
+}) => (
   <kbd
     title={token.icon ? token.aria : undefined}
     aria-label={token.icon ? token.aria : undefined}
-    className={cn(keyCapBase, keyCapColor(inherit))}
+    className={cn(keyCapBase, keyCapColor({ inherit, ghost }))}
   >
     {token.icon ? <Icon name={token.icon} size={12} aria-hidden /> : token.label}
   </kbd>
@@ -121,27 +135,41 @@ const tokenizeShortcut = (value: string): KeyToken[] =>
     .map(tokenForKey);
 
 /**
- * Displays a keyboard shortcut. Each key is rendered as its own standalone box —
+ * Displays a keyboard shortcut. Each key is rendered as its own standalone cap —
  * "Ctrl+Enter" becomes [⌘][↵] rather than a single [Ctrl+Enter] cap. Modifier and
  * navigation keys are shown as icons where available.
+ *
+ * Pass `keys` (a shortcut string) for the tokenized, standalone-cap rendering; pass
+ * `children` for arbitrary composed content inside a single cap. Set `ghost` to drop
+ * the background and border.
  */
-export function Kbd({ children }: { children: React.ReactNode }) {
-  // Plain string shortcuts get tokenized into standalone, icon-aware key caps.
-  if (typeof children === "string" && children.trim().length > 0) {
-    const tokens = tokenizeShortcut(children);
+export function Kbd({
+  children,
+  keys,
+  ghost,
+}: {
+  children?: React.ReactNode;
+  keys?: string;
+  ghost?: boolean;
+}) {
+  // Prefer the keys string; otherwise fall back to a string child (legacy call sites).
+  const shortcut = keys ?? (typeof children === "string" ? children : undefined);
+
+  if (shortcut && shortcut.trim().length > 0) {
+    const tokens = tokenizeShortcut(shortcut);
     return (
       <span className="inline-flex items-center gap-0.5 align-middle">
         {tokens.map((token, i) => (
-          <KeyCap key={i} token={token} />
+          <KeyCap key={i} token={token} ghost={ghost} />
         ))}
       </span>
     );
   }
 
-  // Non-string content (composed nodes) renders unchanged inside a single key box.
+  // Non-string content (composed nodes) renders unchanged inside a single cap.
   return (
     <span className="inline-flex items-center gap-0.5 align-middle">
-      <kbd className={cn(keyCapBase, keyCapColor())}>{children}</kbd>
+      <kbd className={cn(keyCapBase, keyCapColor({ ghost }))}>{children}</kbd>
     </span>
   );
 }
@@ -155,17 +183,19 @@ export function ShortcutKeys({
   shortcut,
   className,
   inherit,
+  ghost,
 }: {
   shortcut: string;
   className?: string;
   inherit?: boolean;
+  ghost?: boolean;
 }) {
   const tokens = tokenizeShortcut(shortcut);
   if (tokens.length === 0) return null;
   return (
     <span className={cn("inline-flex items-center gap-0.5 align-middle", className)}>
       {tokens.map((token, i) => (
-        <KeyCap key={i} token={token} inherit={inherit} />
+        <KeyCap key={i} token={token} inherit={inherit} ghost={ghost} />
       ))}
     </span>
   );

--- a/src/frontend/src/components/Kbd.tsx
+++ b/src/frontend/src/components/Kbd.tsx
@@ -1,9 +1,172 @@
+import Icon from "@/components/Icon";
+import { cn } from "@/lib/utils";
+import { isMac } from "@/lib/shortcut";
 import React from "react";
 
+/**
+ * A single key to render inside a <Kbd>. Either an icon (lucide name) or a text label.
+ */
+interface KeyToken {
+  /** Lucide icon name to render for this key, when one is available. */
+  icon?: string;
+  /** Text label to render when no icon is used. */
+  label: string;
+  /** Accessible label, used as the title/aria for icon-only keys. */
+  aria: string;
+}
+
+/**
+ * Maps a normalized key name to an icon-based or text-based token.
+ * Modifier and navigation keys resolve to platform-appropriate icons; everything
+ * else falls back to an uppercased text label.
+ */
+const tokenForKey = (raw: string): KeyToken => {
+  const key = raw.trim();
+  const k = key.toLowerCase();
+
+  // Platform modifiers
+  if (k === "ctrl" || k === "control") {
+    return isMac
+      ? { icon: "Command", label: "⌘", aria: "Command" }
+      : { label: "Ctrl", aria: "Control" };
+  }
+  if (k === "cmd" || k === "command" || k === "meta" || k === "win" || k === "super") {
+    return isMac
+      ? { icon: "Command", label: "⌘", aria: "Command" }
+      : { label: "Win", aria: "Windows" };
+  }
+  if (k === "shift") {
+    return { icon: "ArrowBigUp", label: "Shift", aria: "Shift" };
+  }
+  if (k === "alt" || k === "option") {
+    return isMac ? { icon: "Option", label: "⌥", aria: "Option" } : { label: "Alt", aria: "Alt" };
+  }
+
+  // Navigation / editing keys
+  const iconKeys: Record<string, { icon: string; aria: string }> = {
+    enter: { icon: "CornerDownLeft", aria: "Enter" },
+    return: { icon: "CornerDownLeft", aria: "Enter" },
+    backspace: { icon: "Delete", aria: "Backspace" },
+    arrowup: { icon: "ArrowUp", aria: "Arrow Up" },
+    up: { icon: "ArrowUp", aria: "Arrow Up" },
+    arrowdown: { icon: "ArrowDown", aria: "Arrow Down" },
+    down: { icon: "ArrowDown", aria: "Arrow Down" },
+    arrowleft: { icon: "ArrowLeft", aria: "Arrow Left" },
+    left: { icon: "ArrowLeft", aria: "Arrow Left" },
+    arrowright: { icon: "ArrowRight", aria: "Arrow Right" },
+    right: { icon: "ArrowRight", aria: "Arrow Right" },
+  };
+  if (k in iconKeys) {
+    const { icon, aria } = iconKeys[k];
+    return { icon, label: aria, aria };
+  }
+
+  // Text-only special keys (rendered as words, not single chars)
+  const textKeys: Record<string, string> = {
+    esc: "Esc",
+    escape: "Esc",
+    tab: "Tab",
+    space: "Space",
+    delete: "Del",
+    del: "Del",
+    home: "Home",
+    end: "End",
+    pageup: "PgUp",
+    pagedown: "PgDn",
+    insert: "Ins",
+  };
+  if (k in textKeys) {
+    return { label: textKeys[k], aria: textKeys[k] };
+  }
+
+  // Single character → uppercase; longer tokens keep their casing capitalized.
+  const label = key.length === 1 ? key.toUpperCase() : key.charAt(0).toUpperCase() + key.slice(1);
+  return { label, aria: label };
+};
+
+/** Shared base styling for a single key cap. */
+const keyCapBase =
+  "inline-flex h-5 min-w-5 items-center justify-center rounded-selector px-1.5 text-[0.7rem] font-medium leading-none";
+
+/**
+ * Color styling for a key cap. `inherit` adopts the surrounding text color (for use
+ * on colored surfaces such as a primary button); otherwise the standard muted look.
+ */
+const keyCapColor = (inherit?: boolean) =>
+  inherit
+    ? "border border-current/30 bg-transparent text-current"
+    : "border border-border bg-muted/40 text-foreground";
+
+/**
+ * Renders a single standalone key box.
+ */
+const KeyCap: React.FC<{ token: KeyToken; inherit?: boolean }> = ({ token, inherit }) => (
+  <kbd
+    title={token.icon ? token.aria : undefined}
+    aria-label={token.icon ? token.aria : undefined}
+    className={cn(keyCapBase, keyCapColor(inherit))}
+  >
+    {token.icon ? <Icon name={token.icon} size={12} aria-hidden /> : token.label}
+  </kbd>
+);
+
+/**
+ * Splits a shortcut string such as "Ctrl+Enter" into its individual key tokens.
+ */
+const tokenizeShortcut = (value: string): KeyToken[] =>
+  value
+    .split("+")
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0)
+    .map(tokenForKey);
+
+/**
+ * Displays a keyboard shortcut. Each key is rendered as its own standalone box —
+ * "Ctrl+Enter" becomes [⌘][↵] rather than a single [Ctrl+Enter] cap. Modifier and
+ * navigation keys are shown as icons where available.
+ */
 export function Kbd({ children }: { children: React.ReactNode }) {
+  // Plain string shortcuts get tokenized into standalone, icon-aware key caps.
+  if (typeof children === "string" && children.trim().length > 0) {
+    const tokens = tokenizeShortcut(children);
+    return (
+      <span className="inline-flex items-center gap-0.5 align-middle">
+        {tokens.map((token, i) => (
+          <KeyCap key={i} token={token} />
+        ))}
+      </span>
+    );
+  }
+
+  // Non-string content (composed nodes) renders unchanged inside a single key box.
   return (
-    <kbd className="rounded text-xs text-foreground border border-border px-1 py-0.5">
-      {children}
-    </kbd>
+    <span className="inline-flex items-center gap-0.5 align-middle">
+      <kbd className={cn(keyCapBase, keyCapColor())}>{children}</kbd>
+    </span>
+  );
+}
+
+/**
+ * Renders the tokens for a shortcut string as standalone key caps. Exposed for
+ * widgets (e.g. Button) that already hold a shortcut string and want the same look.
+ * Set `inherit` when rendering on a colored surface so the caps adopt its text color.
+ */
+export function ShortcutKeys({
+  shortcut,
+  className,
+  inherit,
+}: {
+  shortcut: string;
+  className?: string;
+  inherit?: boolean;
+}) {
+  const tokens = tokenizeShortcut(shortcut);
+  if (tokens.length === 0) return null;
+  return (
+    <span className={cn("inline-flex items-center gap-0.5 align-middle", className)}>
+      {tokens.map((token, i) => (
+        <KeyCap key={i} token={token} inherit={inherit} />
+      ))}
+    </span>
   );
 }

--- a/src/frontend/src/widgets/button/ButtonWidget.tsx
+++ b/src/frontend/src/widgets/button/ButtonWidget.tsx
@@ -17,8 +17,9 @@ import { Loader2 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { BorderRadius, getColor, getWidth } from "@/lib/styles";
 import { Densities } from "@/types/density";
-import { parseShortcut, formatShortcutForDisplay } from "@/lib/shortcut";
+import { parseShortcut } from "@/lib/shortcut";
 import { useShortcut } from "@/lib/useShortcut";
+import { ShortcutKeys } from "@/components/Kbd";
 
 const ButtonWithTooltip = withTooltip(Button);
 
@@ -113,7 +114,6 @@ export const ButtonWidget: React.FC<ButtonWidgetProps> = ({
   "data-testid": dataTestId,
 }) => {
   const eventHandler = useEventHandler();
-  const shortcutDisplay = formatShortcutForDisplay(shortcutKey);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const hasAutoFocusedRef = useRef(false);
 
@@ -261,9 +261,7 @@ export const ButtonWidget: React.FC<ButtonWidgetProps> = ({
             </Badge>
           )}
           {shortcutKey && title && (
-            <kbd className="ml-1 px-1 py-0.5 text-[0.65rem] font-medium border border-current/20 rounded-selector opacity-70">
-              {shortcutDisplay}
-            </kbd>
+            <ShortcutKeys shortcut={shortcutKey} className="ml-1.5 opacity-80" inherit />
           )}
           {iconPosition == "Right" && loading && (
             <Loader2 className="animate-spin" style={iconStyles} />

--- a/src/frontend/src/widgets/dropDownMenu/DropDownMenuWidget.tsx
+++ b/src/frontend/src/widgets/dropDownMenu/DropDownMenuWidget.tsx
@@ -19,7 +19,7 @@ import { MenuItem } from "@/types/widgets";
 import Icon from "@/components/Icon";
 import { camelCase } from "@/lib/utils";
 import { getColor } from "@/lib/styles";
-import { formatShortcutForDisplay } from "@/lib/shortcut";
+import { ShortcutKeys } from "@/components/Kbd";
 import { Densities } from "@/types/density";
 
 const EMPTY_ARRAY: never[] = [];
@@ -93,7 +93,9 @@ const DropDownMenuItemGroup = ({
           {item.label}
           {item.checked && <span className="ml-auto">✓</span>}
           {item.shortcut && (
-            <DropdownMenuShortcut>{formatShortcutForDisplay(item.shortcut)}</DropdownMenuShortcut>
+            <DropdownMenuShortcut>
+              <ShortcutKeys shortcut={item.shortcut} />
+            </DropdownMenuShortcut>
           )}
         </DropdownMenuItem>
       );
@@ -113,7 +115,9 @@ const DropDownMenuItemGroup = ({
           {item.label}
           {item.checked && <span className="ml-auto">●</span>}
           {item.shortcut && (
-            <DropdownMenuShortcut>{formatShortcutForDisplay(item.shortcut)}</DropdownMenuShortcut>
+            <DropdownMenuShortcut>
+              <ShortcutKeys shortcut={item.shortcut} />
+            </DropdownMenuShortcut>
           )}
         </DropdownMenuItem>
       );
@@ -127,7 +131,9 @@ const DropDownMenuItemGroup = ({
             {item.icon && <Icon name={item.icon} size={iconSize} style={colorStyle} />}
             {item.label}
             {item.shortcut && (
-              <DropdownMenuShortcut>{formatShortcutForDisplay(item.shortcut)}</DropdownMenuShortcut>
+              <DropdownMenuShortcut>
+                <ShortcutKeys shortcut={item.shortcut} />
+              </DropdownMenuShortcut>
             )}
           </DropdownMenuSubTrigger>
           <DropdownMenuPortal>
@@ -156,7 +162,9 @@ const DropDownMenuItemGroup = ({
         {item.icon && <Icon name={item.icon} size={iconSize} style={colorStyle} />}
         {item.label}
         {item.shortcut && (
-          <DropdownMenuShortcut>{formatShortcutForDisplay(item.shortcut)}</DropdownMenuShortcut>
+          <DropdownMenuShortcut>
+            <ShortcutKeys shortcut={item.shortcut} />
+          </DropdownMenuShortcut>
         )}
       </DropdownMenuItem>
     );

--- a/src/frontend/src/widgets/inputs/ContentInputWidget/ContentInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/ContentInputWidget/ContentInputWidget.tsx
@@ -12,7 +12,7 @@ import { useFileAttachments } from "./useFileAttachments";
 import { FileAttachmentList } from "./FileAttachmentList";
 import { ContentInputWidgetProps } from "./types";
 import { EMPTY_ARRAY } from "@/lib/constants";
-import { formatShortcutForDisplay } from "@/lib/shortcut";
+import { ShortcutKeys } from "@/components/Kbd";
 import { useShortcut } from "@/lib/useShortcut";
 
 const toolbarVariant = cva("flex items-center gap-1", {
@@ -58,20 +58,6 @@ const dropTextVariant = cva("text-primary ml-1", {
   },
   defaultVariants: { density: "Medium" },
 });
-
-const shortcutBadgeVariant = cva(
-  "ml-auto font-medium text-muted-foreground bg-muted border border-border rounded-field",
-  {
-    variants: {
-      density: {
-        Small: "text-[10px] px-0.5 py-0",
-        Medium: "text-xs px-1 py-0.5",
-        Large: "text-sm px-1.5 py-0.5",
-      },
-    },
-    defaultVariants: { density: "Medium" },
-  },
-);
 
 export const ContentInputWidget: React.FC<ContentInputWidgetProps> = ({
   id,
@@ -182,8 +168,6 @@ export const ContentInputWidget: React.FC<ContentInputWidgetProps> = ({
     }
   }, [autoFocus]);
 
-  const shortcutDisplay = formatShortcutForDisplay(shortcutKey);
-
   useShortcut(
     id,
     shortcutKey,
@@ -275,7 +259,7 @@ export const ContentInputWidget: React.FC<ContentInputWidgetProps> = ({
           <div className={toolbarVariant({ density })}>
             {isDragging && <span className={dropTextVariant({ density })}>Drop files here</span>}
             {shortcutKey && !isFocused && (
-              <kbd className={shortcutBadgeVariant({ density })}>{shortcutDisplay}</kbd>
+              <ShortcutKeys shortcut={shortcutKey} className="ml-auto" />
             )}
           </div>
         )}

--- a/src/frontend/src/widgets/inputs/TextInputWidget/variants/DefaultVariant.tsx
+++ b/src/frontend/src/widgets/inputs/TextInputWidget/variants/DefaultVariant.tsx
@@ -19,12 +19,8 @@ import {
   textInputTrailingShortcutWrapperClasses,
 } from "@/components/ui/input/text-input-variant";
 import { TextInputWidgetProps } from "../types";
-import {
-  useCursorPosition,
-  useEnterKeyBlur,
-  usePasteHandler,
-  formatShortcutForDisplay,
-} from "../hooks";
+import { useCursorPosition, useEnterKeyBlur, usePasteHandler } from "../hooks";
+import { ShortcutKeys } from "@/components/Kbd";
 import { Mic, X } from "lucide-react";
 
 interface DefaultVariantProps {
@@ -75,7 +71,6 @@ export const DefaultVariant: React.FC<DefaultVariantProps> = ({
     ...getWidth(props.width),
   };
 
-  const shortcutDisplay = formatShortcutForDisplay(props.shortcutKey);
   const hasValue = props.value && props.value.toString().trim() !== "";
   const prefixContent = props.slots?.Prefix;
   const suffixContent = props.slots?.Suffix;
@@ -144,9 +139,7 @@ export const DefaultVariant: React.FC<DefaultVariantProps> = ({
                     textInputTrailingShortcutWrapperClasses(density),
                   )}
                 >
-                  <kbd className="rounded-selector border border-border bg-muted px-1 py-0.5 text-xs font-medium text-foreground">
-                    {shortcutDisplay}
-                  </kbd>
+                  <ShortcutKeys shortcut={props.shortcutKey ?? ""} />
                 </div>
               )}
               {showClear && (
@@ -200,11 +193,7 @@ export const DefaultVariant: React.FC<DefaultVariantProps> = ({
           >
             {trailingBesideSuffix && showTrailing && (
               <>
-                {showShortcut && (
-                  <kbd className="rounded-selector border border-border bg-muted px-1 py-0.5 text-xs font-medium text-foreground">
-                    {shortcutDisplay}
-                  </kbd>
-                )}
+                {showShortcut && <ShortcutKeys shortcut={props.shortcutKey ?? ""} />}
                 {showClear && (
                   <button
                     type="button"

--- a/src/frontend/src/widgets/inputs/TextInputWidget/variants/PasswordVariant.tsx
+++ b/src/frontend/src/widgets/inputs/TextInputWidget/variants/PasswordVariant.tsx
@@ -19,12 +19,8 @@ import {
   textInputTrailingShortcutWrapperClasses,
 } from "@/components/ui/input/text-input-variant";
 import { TextInputWidgetProps } from "../types";
-import {
-  useCursorPosition,
-  useEnterKeyBlur,
-  usePasteHandler,
-  formatShortcutForDisplay,
-} from "../hooks";
+import { useCursorPosition, useEnterKeyBlur, usePasteHandler } from "../hooks";
+import { ShortcutKeys } from "@/components/Kbd";
 
 interface PasswordVariantProps {
   props: Omit<TextInputWidgetProps, "variant">;
@@ -89,7 +85,6 @@ export const PasswordVariant: React.FC<PasswordVariantProps> = ({
     ...getWidth(props.width),
   };
 
-  const shortcutDisplay = formatShortcutForDisplay(props.shortcutKey);
   const hasValue = props.value && props.value.toString().trim() !== "";
   const showClear = props.nullable && !props.disabled && hasValue;
   const ghostTight = Boolean(props.ghost);
@@ -137,14 +132,10 @@ export const PasswordVariant: React.FC<PasswordVariantProps> = ({
             overlay && "pointer-events-auto",
           )}
         >
-          <kbd
-            className={cn(
-              "rounded-field border border-border bg-muted px-1 py-0.5 text-xs font-medium text-foreground",
-              !ghostTight && overlay && "ml-2",
-            )}
-          >
-            {shortcutDisplay}
-          </kbd>
+          <ShortcutKeys
+            shortcut={props.shortcutKey ?? ""}
+            className={cn(!ghostTight && overlay && "ml-2")}
+          />
         </div>
       )}
       {props.invalid && (

--- a/src/frontend/src/widgets/inputs/TextInputWidget/variants/SearchVariant.tsx
+++ b/src/frontend/src/widgets/inputs/TextInputWidget/variants/SearchVariant.tsx
@@ -22,7 +22,8 @@ import {
   searchInputPaddingVariant,
 } from "@/components/ui/input/text-input-variant";
 import { TextInputWidgetProps } from "../types";
-import { useCursorPosition, usePasteHandler, formatShortcutForDisplay } from "../hooks";
+import { useCursorPosition, usePasteHandler } from "../hooks";
+import { ShortcutKeys } from "@/components/Kbd";
 
 interface SearchVariantProps {
   props: Omit<TextInputWidgetProps, "variant">;
@@ -90,7 +91,6 @@ export const SearchVariant: React.FC<SearchVariantProps> = ({
     ...getWidth(props.width),
   };
 
-  const shortcutDisplay = formatShortcutForDisplay(props.shortcutKey);
   const hasValue = Boolean(props.value && String(props.value).trim() !== "");
   const prefixContent = props.slots?.Prefix;
   const suffixContent = props.slots?.Suffix;
@@ -115,11 +115,7 @@ export const SearchVariant: React.FC<SearchVariantProps> = ({
     [focusRef, inputRef],
   );
 
-  const kbd = (
-    <kbd className="rounded-selector border border-border bg-muted px-1 py-0.25 text-xs text-foreground">
-      {shortcutDisplay}
-    </kbd>
-  );
+  const kbd = props.shortcutKey ? <ShortcutKeys shortcut={props.shortcutKey} /> : null;
 
   const trailingCluster = (overlay: boolean) => (
     <>

--- a/src/frontend/src/widgets/inputs/TextInputWidget/variants/TextareaVariant.tsx
+++ b/src/frontend/src/widgets/inputs/TextInputWidget/variants/TextareaVariant.tsx
@@ -17,7 +17,8 @@ import {
   textInputTrailingInvalidSlotClasses,
 } from "@/components/ui/input/text-input-variant";
 import { TextInputWidgetProps } from "../types";
-import { useCursorPosition, usePasteHandler, formatShortcutForDisplay } from "../hooks";
+import { useCursorPosition, usePasteHandler } from "../hooks";
+import { ShortcutKeys } from "@/components/Kbd";
 import { Mic, X } from "lucide-react";
 
 interface TextareaVariantProps {
@@ -87,7 +88,6 @@ export const TextareaVariant: React.FC<TextareaVariantProps> = ({
     ...getHeight(props.height),
   };
 
-  const shortcutDisplay = formatShortcutForDisplay(props.shortcutKey);
   const hasValue = props.value && props.value.toString().trim() !== "";
   const showClear = props.nullable && !props.disabled && hasValue;
   const prefixContent = props.slots?.Prefix;
@@ -135,9 +135,7 @@ export const TextareaVariant: React.FC<TextareaVariantProps> = ({
       )}
       {showShortcut && (
         <div className={cn("flex shrink-0 items-center", overlay && "pointer-events-auto")}>
-          <kbd className="rounded-field border border-border bg-muted px-1 py-0.5 text-xs font-medium text-foreground">
-            {shortcutDisplay}
-          </kbd>
+          <ShortcutKeys shortcut={props.shortcutKey ?? ""} />
         </div>
       )}
       {props.invalid && (

--- a/src/frontend/src/widgets/primitives/KbdWidget.tsx
+++ b/src/frontend/src/widgets/primitives/KbdWidget.tsx
@@ -4,18 +4,18 @@ import React from "react";
 
 interface KbdWidgetProps {
   children: React.ReactNode;
-  keys?: string;
+  content?: string;
   ghost?: boolean;
   density?: Densities;
 }
 
 export const KbdWidget: React.FC<KbdWidgetProps> = ({
   children,
-  keys,
+  content,
   ghost = false,
   density: _density = Densities.Medium,
 }) => (
-  <Kbd keys={keys} ghost={ghost}>
+  <Kbd keys={content} ghost={ghost}>
     {children}
   </Kbd>
 );

--- a/src/frontend/src/widgets/primitives/KbdWidget.tsx
+++ b/src/frontend/src/widgets/primitives/KbdWidget.tsx
@@ -4,10 +4,18 @@ import React from "react";
 
 interface KbdWidgetProps {
   children: React.ReactNode;
+  keys?: string;
+  ghost?: boolean;
   density?: Densities;
 }
 
 export const KbdWidget: React.FC<KbdWidgetProps> = ({
   children,
+  keys,
+  ghost = false,
   density: _density = Densities.Medium,
-}) => <Kbd>{children}</Kbd>;
+}) => (
+  <Kbd keys={keys} ghost={ghost}>
+    {children}
+  </Kbd>
+);


### PR DESCRIPTION

<img width="381" height="93" alt="Screenshot 2026-06-25 at 11 46 39" src="https://github.com/user-attachments/assets/58111d02-d955-4019-a8a3-f40db7585cce" />
<img width="588" height="106" alt="Screenshot 2026-06-25 at 11 46 37" src="https://github.com/user-attachments/assets/50b5ea70-d606-438e-9111-59c5824aa5e8" />
<img width="738" height="149" alt="Screenshot 2026-06-25 at 11 46 33" src="https://github.com/user-attachments/assets/b497736a-350d-42bc-a21d-0e3a77588f7b" />

## Summary

Reworks the `Kbd` widget so each key in a combination renders as its own **standalone cap** instead of one combined box — `new Kbd("Ctrl+Enter")` now shows `[Ctrl][↵]` rather than `[Ctrl+Enter]`. Modifier and navigation keys render as **icons** where available (Mac: ⌘ ⌥ ⇧; cross-platform: enter, backspace, arrows), which is much more compact than spelled-out text.

All key-cap styling now lives in one place (`Kbd.tsx`) and is shared via a new `ShortcutKeys` component. The Button, text input variants (Default/Search/Password/Textarea), ContentInput, and DropDownMenu shortcut displays all route through it instead of duplicating inline `<kbd>` markup.

This shrinks the shortcut indicator on buttons (e.g. the "Create" button's `CTRL+ENTER` badge that motivated this), addressing **Ivy-Interactive/Ivy-Tendril#1373**.

## Changes

- **`Kbd.tsx`** — tokenizes a shortcut string (`"Ctrl+Shift+C"` → 3 caps), maps modifier/navigation keys to platform-appropriate lucide icons, and exposes a reusable `ShortcutKeys` component. Adds an `inherit` mode so caps adopt the surrounding text color on colored surfaces (e.g. a primary button).
- **`ButtonWidget.tsx`** — shortcut badge now uses `<ShortcutKeys inherit />` (compact, legible on any button variant).
- **TextInput variants, ContentInput, DropDownMenu** — converted from inline `<kbd>` + `formatShortcutForDisplay` to the shared `ShortcutKeys`. Removed the now-redundant local `shortcutBadgeVariant` cva in ContentInput.
- **Sample + docs** — `KbdApp.cs` and `11_Kbd.md` updated to demonstrate the single-string, standalone-cap API.
- **Tests** — new `Kbd.test.tsx` (tokenization, icon rendering, non-string fallback, `ShortcutKeys`); fixed `button.spec.ts` to use `.first()` now that a shortcut renders multiple `<kbd>` caps.

## Verification

- `tsc -b` ✅ · `vp lint .` ✅ · `vp fmt --check` ✅
- `npm run build` ✅
- `vp test` — `shortcut.test.ts` (9) + new `Kbd.test.tsx` (10) ✅
- `dotnet build Ivy.Samples.Shared` ✅ (0 warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)