### PR TITLE
Treat empty collections as empty content in IsEmptyContent

### DIFF
--- a/src/Ivy.Test/Helpers/ValidationHelperTests.cs
+++ b/src/Ivy.Test/Helpers/ValidationHelperTests.cs
@@ -77,6 +77,24 @@ public class ValidationHelperTests
         Assert.False(ValidationHelper.IsEmptyContent(42));
     }
 
+    [Fact]
+    public void IsEmptyContent_EmptyList_ReturnsTrue()
+    {
+        Assert.True(ValidationHelper.IsEmptyContent(new List<string>()));
+    }
+
+    [Fact]
+    public void IsEmptyContent_EmptyArray_ReturnsTrue()
+    {
+        Assert.True(ValidationHelper.IsEmptyContent(Array.Empty<int>()));
+    }
+
+    [Fact]
+    public void IsEmptyContent_NonEmptyList_ReturnsFalse()
+    {
+        Assert.False(ValidationHelper.IsEmptyContent(new List<string> { "a" }));
+    }
+
     #endregion
 
     #region ValidateRedirectUrl

--- a/src/Ivy/Helpers/ValidationHelper.cs
+++ b/src/Ivy/Helpers/ValidationHelper.cs
@@ -35,6 +35,15 @@ public static class ValidationHelper
             return !b;
         }
 
+        // Treat empty collections (lists, arrays, etc.) as empty content. Strings are also
+        // IEnumerable but are handled above, so they never reach here.
+        if (obj is System.Collections.IEnumerable enumerable)
+        {
+            foreach (var _ in enumerable)
+                return false;
+            return true;
+        }
+
         return false;
     }
 


### PR DESCRIPTION
## What

`ValidationHelper.IsEmptyContent` — used by `Details.RemoveEmpty()` — only treated `null`, blank strings, and `false` bools as empty. Any other object, including an **empty `List<T>`/array**, counted as non-empty, so Details rows backed by empty collections (e.g. a plan's empty 'Related Plans' / 'Depends On') were never removed.

## Fix

Added an `IEnumerable` branch that treats any empty collection as empty content. Strings are `IEnumerable` too but are handled earlier in the method, so they never reach this branch.

```csharp
if (obj is System.Collections.IEnumerable enumerable)
{
    foreach (var _ in enumerable)
        return false;
    return true;
}
```

## Tests

Added unit tests for empty list, empty array, and non-empty list. All 68 `ValidationHelperTests` pass.

Fixes `RemoveEmpty()` for every Details view, not just the one that surfaced it (Tendril's plan Details tab).