### PR TITLE
fix: code input copy button position and hover visibility

### DIFF
--- a/src/frontend/src/widgets/inputs/code/CodeInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/code/CodeInputWidget.tsx
@@ -7,7 +7,7 @@ import { getHeight, getWidth } from "@/lib/styles";
 import { InvalidIcon } from "@/components/InvalidIcon";
 import { Densities } from "@/types/density";
 import { boolInputRowMinHeightVariant } from "@/components/ui/input/bool-input-variant";
-import { X, Copy, Loader2 } from "lucide-react";
+import { X, Copy, Loader2, Check } from "lucide-react";
 import {
   normalizeInputDensity,
   textInputAffixCellClasses,
@@ -142,6 +142,18 @@ export const CodeInputWidget: React.FC<CodeInputWidgetProps> = ({
   const serverValue = value || "";
   const [localValue, setLocalValue] = useOptimisticValue(serverValue, isFocused);
 
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await copyToClipboard(localValue);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error("Copy failed:", err);
+    }
+  }, [localValue]);
+
   const debouncedOnChange = useDebouncedCallback((value: string) => {
     if (events.includes("OnChange")) {
       eventHandler("OnChange", id, [value]);
@@ -242,14 +254,19 @@ export const CodeInputWidget: React.FC<CodeInputWidgetProps> = ({
       {showCopy && (
         <button
           type="button"
-          onClick={() => copyToClipboard(localValue)}
+          onClick={handleCopy}
           aria-label="Copy to clipboard"
           className={cn(
             textInputTrailingIconButtonClasses(overlay, density),
             "opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity duration-200",
+            copied && "opacity-100 text-primary hover:text-primary",
           )}
         >
-          <Copy className={textInputTrailingIconSizeVariant({ density: densityKey })} />
+          {copied ? (
+            <Check className={textInputTrailingIconSizeVariant({ density: densityKey })} />
+          ) : (
+            <Copy className={textInputTrailingIconSizeVariant({ density: densityKey })} />
+          )}
         </button>
       )}
       {showClear && (

--- a/src/frontend/src/widgets/inputs/code/CodeInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/code/CodeInputWidget.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useMemo, Suspense, lazy, useEffect } from "react";
+import React, { useState, useCallback, useMemo, Suspense, lazy, useEffect, useRef } from "react";
 import { useOptimisticValue } from "../shared/useOptimisticValue";
 import { useEventHandler } from "@/components/event-handler";
 import { cn } from "@/lib/utils";
@@ -21,6 +21,7 @@ import {
   textInputTrailingIconButtonClasses,
   textInputTrailingIconSizeVariant,
   textInputTrailingInvalidSlotClasses,
+  textInputTrailingOverlayClasses,
   textareaTrailingOverlayClasses,
 } from "@/components/ui/input/text-input-variant";
 import {
@@ -123,6 +124,20 @@ export const CodeInputWidget: React.FC<CodeInputWidgetProps> = ({
   const eventHandler = useEventHandler();
   const [isFocused, setIsFocused] = useState(false);
   const densityKey = normalizeInputDensity(density);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [isTall, setIsTall] = useState(false);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        setIsTall(entry.contentRect.height > 50);
+      }
+    });
+    observer.observe(containerRef.current);
+    return () => observer.disconnect();
+  }, []);
 
   const serverValue = value || "";
   const [localValue, setLocalValue] = useOptimisticValue(serverValue, isFocused);
@@ -265,7 +280,15 @@ export const CodeInputWidget: React.FC<CodeInputWidgetProps> = ({
   const codeEditor = () => (
     <div className="relative h-full min-h-0 w-full overflow-hidden">
       {trailingInOverlay && (
-        <div className={textareaTrailingOverlayClasses(density)}>{trailingCluster(true)}</div>
+        <div
+          className={
+            isTall
+              ? textareaTrailingOverlayClasses(density)
+              : textInputTrailingOverlayClasses(density)
+          }
+        >
+          {trailingCluster(true)}
+        </div>
       )}
       <Suspense
         fallback={
@@ -313,6 +336,7 @@ export const CodeInputWidget: React.FC<CodeInputWidgetProps> = ({
   if (!hasAffixes) {
     return (
       <div
+        ref={containerRef}
         style={styles}
         className={cn(
           "relative flex w-full flex-col overflow-hidden group",
@@ -326,6 +350,7 @@ export const CodeInputWidget: React.FC<CodeInputWidgetProps> = ({
 
   return (
     <div
+      ref={containerRef}
       style={styles}
       className={cn(
         textInputFieldShellClasses({

--- a/src/frontend/src/widgets/inputs/code/CodeInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/code/CodeInputWidget.tsx
@@ -21,7 +21,7 @@ import {
   textInputTrailingIconButtonClasses,
   textInputTrailingIconSizeVariant,
   textInputTrailingInvalidSlotClasses,
-  textInputTrailingOverlayClasses,
+  textareaTrailingOverlayClasses,
 } from "@/components/ui/input/text-input-variant";
 import {
   keymap,
@@ -229,7 +229,10 @@ export const CodeInputWidget: React.FC<CodeInputWidgetProps> = ({
           type="button"
           onClick={() => copyToClipboard(localValue)}
           aria-label="Copy to clipboard"
-          className={textInputTrailingIconButtonClasses(overlay, density)}
+          className={cn(
+            textInputTrailingIconButtonClasses(overlay, density),
+            "opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity duration-200",
+          )}
         >
           <Copy className={textInputTrailingIconSizeVariant({ density: densityKey })} />
         </button>
@@ -260,15 +263,9 @@ export const CodeInputWidget: React.FC<CodeInputWidgetProps> = ({
   );
 
   const codeEditor = () => (
-    <div
-      className={cn(
-        "relative h-full min-h-0 w-full overflow-hidden",
-        trailingInOverlay && "pr-8",
-        trailingInOverlay && (showClear || invalid) && "pr-16",
-      )}
-    >
+    <div className="relative h-full min-h-0 w-full overflow-hidden">
       {trailingInOverlay && (
-        <div className={textInputTrailingOverlayClasses(density)}>{trailingCluster(true)}</div>
+        <div className={textareaTrailingOverlayClasses(density)}>{trailingCluster(true)}</div>
       )}
       <Suspense
         fallback={
@@ -297,6 +294,10 @@ export const CodeInputWidget: React.FC<CodeInputWidgetProps> = ({
             "h-full overflow-hidden",
             "[&_.cm-editor]:border-0 [&_.cm-editor]:bg-transparent! [&_.cm-editor]:shadow-none",
             "[&_.cm-scroller]:bg-transparent! [&_.cm-content]:bg-transparent! [&_.cm-gutters]:bg-transparent!",
+            trailingInOverlay && "[&_.cm-content]:pr-8 [&_.cm-placeholder]:pr-8",
+            trailingInOverlay &&
+              (showClear || invalid) &&
+              "[&_.cm-content]:pr-16 [&_.cm-placeholder]:pr-16",
             hasAffixes && "[&_.cm-editor]:rounded-none",
             hasAffixes && hasPrefix && "[&_.cm-editor]:rounded-l-none",
             hasAffixes && (hasSuffix || trailingInAffixCell) && "[&_.cm-editor]:rounded-r-none",
@@ -314,7 +315,7 @@ export const CodeInputWidget: React.FC<CodeInputWidgetProps> = ({
       <div
         style={styles}
         className={cn(
-          "relative flex w-full flex-col overflow-hidden",
+          "relative flex w-full flex-col overflow-hidden group",
           textInputFieldShellClasses({ focused: isFocused, invalid, disabled }),
         )}
       >
@@ -326,11 +327,14 @@ export const CodeInputWidget: React.FC<CodeInputWidgetProps> = ({
   return (
     <div
       style={styles}
-      className={textInputFieldShellClasses({
-        focused: isFocused,
-        invalid,
-        disabled,
-      })}
+      className={cn(
+        textInputFieldShellClasses({
+          focused: isFocused,
+          invalid,
+          disabled,
+        }),
+        "group",
+      )}
     >
       {hasPrefix && (
         <div className={codeInputAffixCellClasses("prefix", density, prefixContent)}>

--- a/src/frontend/src/widgets/inputs/code/theme.ts
+++ b/src/frontend/src/widgets/inputs/code/theme.ts
@@ -21,6 +21,18 @@ export function createIvyCodeTheme(density: Densities = Densities.Medium): Exten
     }
   };
 
+  // Get padding based on density
+  const getPadding = (density: Densities) => {
+    switch (density) {
+      case Densities.Small:
+        return "4px 6px";
+      case Densities.Large:
+        return "8px 10px";
+      default:
+        return "6px 8px";
+    }
+  };
+
   // Base editor styles using CSS variables
   const baseTheme = EditorView.theme({
     "&": {
@@ -44,7 +56,7 @@ export function createIvyCodeTheme(density: Densities = Densities.Medium): Exten
       backgroundColor: "transparent",
     },
     ".cm-content": {
-      padding: "10px",
+      padding: getPadding(density),
       wordWrap: "break-word",
       whiteSpace: "pre-wrap",
       width: "fit-content",


### PR DESCRIPTION
This PR fixes the layout and hover behavior of the copy code button in CodeInputWidget:

1. Moves the copy button to the top right using textareaTrailingOverlayClasses.
2. Shows the copy button only on hover over the input container (using group-hover).
3. Moves scroll padding to the CodeMirror content element so the scrollbar remains at the far right edge of the container.