### PR TITLE
[00591] Fix scroll shade showing when content is not scrollable

### DIFF
--- a/src/frontend/src/hooks/use-scroll-shadow.test.ts
+++ b/src/frontend/src/hooks/use-scroll-shadow.test.ts
@@ -82,6 +82,10 @@ describe("useScrollShadow direction parameter", () => {
   it("should disconnect ResizeObserver on cleanup", () => {
     expect(hookSource).toContain("resizeObserver?.disconnect()");
   });
+
+  it("should check for overflow before showing shadow for top direction", () => {
+    expect(hookSource).toContain("scrollHeight > clientHeight");
+  });
 });
 
 describe("useScrollShadow MutationObserver for dynamic content", () => {

--- a/src/frontend/src/hooks/use-scroll-shadow.ts
+++ b/src/frontend/src/hooks/use-scroll-shadow.ts
@@ -24,7 +24,8 @@ export function useScrollShadow(
         setIsScrolled(viewport.scrollTop > 0);
       } else {
         const { scrollTop, scrollHeight, clientHeight } = viewport;
-        setIsScrolled(scrollTop < scrollHeight - clientHeight - 1);
+        const isOverflowing = scrollHeight > clientHeight + 1;
+        setIsScrolled(isOverflowing && scrollTop < scrollHeight - clientHeight - 1);
       }
     };
 


### PR DESCRIPTION
Fixes #4642

# Summary

## Changes

Fixed the `useScrollShadow` hook to prevent scroll shadows from appearing when content is not scrollable. The hook now checks for overflow before showing the shadow for the "top" direction.

## API Changes

None.

## Files Modified

**Frontend hooks:**
- `src/frontend/src/hooks/use-scroll-shadow.ts` — Added overflow check to prevent shadow when content fits
- `src/frontend/src/hooks/use-scroll-shadow.test.ts` — Added test verifying overflow check exists

---

## Commits
- 66e9d581d Fix scroll shade showing when content is not scrollable