### PR TITLE
[00595] Fix inline code rendering in bullet points

### DIFF
--- a/src/frontend/src/lib/styles.ts
+++ b/src/frontend/src/lib/styles.ts
@@ -771,7 +771,7 @@ export const typography: Record<string, string> = {
   ul: "list-disc list-outside ps-5 flex flex-col gap-y-1",
   ol: "list-decimal list-outside ps-5 flex flex-col gap-y-1",
   li: "list-item",
-  liContent: "flex flex-col gap-y-1 [&>p]:my-0",
+  liContent: "[&>*+*]:mt-1 [&>p]:my-0",
 
   // Links
   a: "text-primary underline underline-offset-[3px] brightness-90 hover:brightness-100",


### PR DESCRIPTION
Fixes #4640

## Problem

Inline code (backtick text) inside bullet points renders as a full-width block element instead of inline with the surrounding text. In the "Local Changes Detected" dialog, text like "4 commits ahead of `origin/main`" renders with `origin/main` on its own line spanning the full width.

The root cause is in the `li` component rendering logic in MarkdownRenderer.tsx. When a list item contains block-level children, all children are wrapped in a `flex flex-col` container, causing inline content to stack vertically.

## Solution

**Ivy-Framework:** Changed the `liContent` typography class in `styles.ts` from `"flex flex-col gap-y-1 [&>p]:my-0"` to `"[&>*+*]:mt-1 [&>p]:my-0"`. This removes the flex column layout, allowing inline content to flow naturally while maintaining spacing between block-level children.

---

## Commits

- 96c8918b3 Fix inline code rendering in list items