### PR TITLE
fix: prevent premature text truncation in datatable grow columns

### DIFF
--- a/src/frontend/src/widgets/dataTables/dataTableEditor/hooks/useCellContent.ts
+++ b/src/frontend/src/widgets/dataTables/dataTableEditor/hooks/useCellContent.ts
@@ -4,7 +4,8 @@ import { GridCell, GridCellKind, Item } from "@glideapps/glide-data-grid";
 import { Densities } from "@/types/density";
 import { getCellContent as getCellContentUtil } from "../../utils/cellContent";
 import { getCellFont } from "../../utils/canvasText";
-import { getVisibleColumnWidthAt } from "../../utils/columnHelpers";
+import { getVisibleColumnWidthAt, getOrderedVisibleDataColumns } from "../../utils/columnHelpers";
+import { parseSizeGrow } from "../../dataTableContext/utils/columnSizing";
 import { DENSITY_CONFIG } from "../constants";
 import { DataColumn, DataRow } from "../../types/types";
 
@@ -19,7 +20,7 @@ interface UseCellContentProps {
 }
 
 /**
- * Hook for generating cell content
+ * Hook for managing grid cell content
  */
 export const useCellContent = ({
   columns,
@@ -50,10 +51,24 @@ export const useCellContent = ({
           allowOverlay: false,
         };
       }
+
+      const orderedColumns = getOrderedVisibleDataColumns(columns, columnOrder);
+      const column = orderedColumns[col];
+
+      let isGrowColumn = false;
+      if (column) {
+        const grow = parseSizeGrow(
+          column.originalWidth ?? (typeof column.width === "string" ? column.width : undefined),
+        );
+        const isLastColumn = col === orderedColumns.length - 1;
+        isGrowColumn = (grow !== undefined && grow > 0) || isLastColumn;
+      }
+
       return getCellContentUtil(cell, columns, columnOrder, editable, getRowData, {
         columnWidth: getVisibleColumnWidthAt(col, columns, columnOrder, columnWidths, headerFont),
         cellHorizontalPadding,
         cellFont,
+        isGrowColumn,
       });
     },
     [

--- a/src/frontend/src/widgets/dataTables/utils/cellContent.test.ts
+++ b/src/frontend/src/widgets/dataTables/utils/cellContent.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { GridCellKind } from "@glideapps/glide-data-grid";
 import {
   createEmptyCell,
@@ -922,6 +922,65 @@ describe("cellContent utilities", () => {
       const cell = getCellContent([0, 0], noWrapColumns, [], false, getNoWrapRowData);
       if (cell.kind === GridCellKind.Text) {
         expect(cell.allowWrapping).toBe(false);
+      }
+    });
+  });
+
+  describe("getCellContent with isGrowColumn option", () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    function mockCanvasMeasure(measure: (text: string) => number) {
+      const mockMeasureText = vi.fn((text: string) => ({ width: measure(text) }));
+      const mockGetContext = vi.fn().mockReturnValue({
+        font: "",
+        measureText: mockMeasureText,
+      });
+      vi.spyOn(document, "createElement").mockReturnValue({
+        getContext: mockGetContext,
+      } as unknown as HTMLCanvasElement);
+    }
+
+    it("should not truncate displayData when isGrowColumn is true", () => {
+      const columns: DataColumn[] = [{ name: "Name", type: ColType.Text, width: 50 }];
+      const rowData: DataRow[] = [
+        { values: ["Very long name that should normally be truncated at 50px width"] },
+      ];
+      const getRowData = (rowIndex: number): DataRow | null => {
+        return rowIndex >= 0 && rowIndex < rowData.length ? rowData[rowIndex] : null;
+      };
+
+      const cell = getCellContent([0, 0], columns, [], false, getRowData, {
+        columnWidth: 50,
+        isGrowColumn: true,
+      });
+      expect(cell.kind).toBe(GridCellKind.Text);
+      if (cell.kind === GridCellKind.Text) {
+        expect(cell.displayData).toBe(
+          "Very long name that should normally be truncated at 50px width",
+        );
+      }
+    });
+
+    it("should truncate displayData when isGrowColumn is false or not provided", () => {
+      mockCanvasMeasure((text) => text.length * 8);
+
+      const columns: DataColumn[] = [{ name: "Name", type: ColType.Text, width: 50 }];
+      const rowData: DataRow[] = [
+        { values: ["Very long name that should normally be truncated at 50px width"] },
+      ];
+      const getRowData = (rowIndex: number): DataRow | null => {
+        return rowIndex >= 0 && rowIndex < rowData.length ? rowData[rowIndex] : null;
+      };
+
+      const cell = getCellContent([0, 0], columns, [], false, getRowData, {
+        columnWidth: 50,
+        isGrowColumn: false,
+      });
+      expect(cell.kind).toBe(GridCellKind.Text);
+      if (cell.kind === GridCellKind.Text) {
+        expect(cell.displayData).toContain("…");
       }
     });
   });

--- a/src/frontend/src/widgets/dataTables/utils/cellContent.ts
+++ b/src/frontend/src/widgets/dataTables/utils/cellContent.ts
@@ -143,8 +143,9 @@ function truncateCellDisplayData(
   cellHorizontalPadding: number,
   cellFont: string,
   wrapText?: boolean,
+  isGrowColumn?: boolean,
 ): GridCell {
-  if (wrapText || columnWidth === undefined) return cell;
+  if (wrapText || columnWidth === undefined || isGrowColumn) return cell;
 
   const maxWidth = getMaxTextWidth(columnWidth, cellHorizontalPadding);
   if (maxWidth <= 0) return cell;
@@ -475,6 +476,7 @@ export interface GetCellContentOptions {
   columnWidth?: number;
   cellHorizontalPadding?: number;
   cellFont?: string;
+  isGrowColumn?: boolean;
 }
 
 export function getCellContent(
@@ -575,6 +577,7 @@ export function getCellContent(
     options.cellHorizontalPadding ?? DENSITY_CONFIG[Densities.Medium].cellHorizontalPadding,
     options.cellFont ?? getCellFont(),
     column.wrapText,
+    options.isGrowColumn,
   );
   if (column.hasCellAction) {
     return { ...withTruncation, cursor: "pointer" };


### PR DESCRIPTION
Fixes #4619. This PR bypasses the cell text pre-truncation logic for columns that grow/stretch (such as Auto-sized columns or the last column in the table), letting glide-data-grid clip/draw text dynamically. This prevents status/timer strings from being cut off early inside stretched columns.