### PR TITLE
feat(Xterm): add AutoFocus prop to Terminal

### DIFF
--- a/src/widgets/Ivy.Widgets.Xterm/README.md
+++ b/src/widgets/Ivy.Widgets.Xterm/README.md
@@ -63,6 +63,7 @@ new Terminal()
 | `Scrollback` | `int` | `1000` | Lines to keep in scrollback buffer |
 | `Theme` | `TerminalTheme?` | Dark theme | Terminal color theme |
 | `InitialContent` | `string?` | `null` | Initial content to display |
+| `AutoFocus` | `bool` | `true` | Automatically focus the terminal on mount so it receives keyboard input |
 | `Loading` | `bool` | `false` | Show a loading overlay (spinner + text) until the first stream data arrives |
 | `LoadingText` | `string?` | `"Loading..."` | Text shown in the loading overlay |
 

--- a/src/widgets/Ivy.Widgets.Xterm/Terminal.cs
+++ b/src/widgets/Ivy.Widgets.Xterm/Terminal.cs
@@ -23,6 +23,7 @@ public record Terminal : WidgetBase<Terminal>
     [Prop] public string? InitialContent { get; init; }
     [Prop] public bool Closed { get; init; }
     [Prop] public bool AllowClipboard { get; init; } = true;
+    [Prop] public bool AutoFocus { get; init; } = true;
     [Prop] public bool Loading { get; init; }
     [Prop] public string? LoadingText { get; init; }
     [Prop] public Colors? Background { get; init; }
@@ -60,6 +61,9 @@ public static class TerminalExtensions
 
     public static Terminal AllowClipboard(this Terminal widget, bool allowClipboard = true) =>
         widget with { AllowClipboard = allowClipboard };
+
+    public static Terminal AutoFocus(this Terminal widget, bool autoFocus = true) =>
+        widget with { AutoFocus = autoFocus };
 
     public static Terminal Loading(this Terminal widget, bool loading = true) =>
         widget with { Loading = loading };

--- a/src/widgets/Ivy.Widgets.Xterm/frontend/src/Terminal.tsx
+++ b/src/widgets/Ivy.Widgets.Xterm/frontend/src/Terminal.tsx
@@ -54,6 +54,7 @@ interface TerminalProps {
   stream?: { id: string };
   closed?: boolean;
   allowClipboard?: boolean;
+  autoFocus?: boolean;
   loading?: boolean;
   loadingText?: string;
   background?: string;
@@ -115,6 +116,7 @@ export const Terminal: React.FC<TerminalProps> = ({
   stream,
   closed = false,
   allowClipboard = true,
+  autoFocus = true,
   loading = false,
   loadingText = "Loading...",
   background,
@@ -447,6 +449,12 @@ export const Terminal: React.FC<TerminalProps> = ({
 
       // Mark terminal as ready after initialization is complete
       terminalReadyRef.current = true;
+
+      // Automatically focus the terminal on mount so it receives keyboard
+      // input immediately, unless read-only or auto focus is disabled.
+      if (autoFocus && !isReadOnly) {
+        term.focus();
+      }
     });
 
     const handleWindowResize = () => {


### PR DESCRIPTION
Adds an `AutoFocus` prop (default `true`) to the Terminal widget so the xterm automatically receives keyboard input on mount.

## Changes
- **C# (`Terminal.cs`)**: new `[Prop] bool AutoFocus = true` plus a fluent `.AutoFocus(bool = true)` extension.
- **React (`Terminal.tsx`)**: `autoFocus` prop (default `true` to match the C# default since defaults aren't serialized); calls `term.focus()` once the terminal is opened and ready, gated by `autoFocus && !isReadOnly` so read-only/closed terminals are unaffected.
- **README**: documented the new prop.

Frontend bundle rebuilds successfully.