### PR TITLE
chore: bump Ivy.DesignSystem to 1.1.32

### DIFF
--- a/src/Ivy/Ivy.csproj
+++ b/src/Ivy/Ivy.csproj
@@ -78,7 +78,7 @@
     <PackageReference Include="System.IO.Hashing" Version="10.0.9" />
     <PackageReference Include="Ivy.SystemTextJson.JsonDiffPatch" Version="2.0.4" />
     <PackageReference Include="Ivy.NativeJsonDiff" Version="2.0.0" />
-    <PackageReference Include="Ivy.DesignSystem" Version="1.1.31" />
+    <PackageReference Include="Ivy.DesignSystem" Version="1.1.32" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ivy/packages.lock.json
+++ b/src/Ivy/packages.lock.json
@@ -58,9 +58,9 @@
       },
       "Ivy.DesignSystem": {
         "type": "Direct",
-        "requested": "[1.1.31, )",
-        "resolved": "1.1.31",
-        "contentHash": "aXfUn+P1qe441TeZ6ZdYYPAXWFCAH8q6uVlU3dfMFlELqX1e7TMCgDkgFSnw72fapRsbRobi7gOJTFVPcz93Aw=="
+        "requested": "[1.1.32, )",
+        "resolved": "1.1.32",
+        "contentHash": "AKd+RScCGwIuflYMNYB5EkHb7z4e/xzigfwKC7wsnhXuutL7z2l8anfP7NUArBSQaFIThqg2FLGG5OjaiUWRAQ=="
       },
       "Ivy.NativeJsonDiff": {
         "type": "Direct",


### PR DESCRIPTION
Bumps the `Ivy.DesignSystem` NuGet package from **1.1.31 → 1.1.32**.

## Changes
- `src/Ivy/Ivy.csproj` — `PackageReference` version bump
- `src/Ivy/packages.lock.json` — refreshed via `dotnet restore` (resolved version + content hash)

No build verification performed, as requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)