### PR TITLE
Use checkbox for boolean plugin config fields

### DIFF
--- a/src/Ivy/Apps/PluginConfigurationView.cs
+++ b/src/Ivy/Apps/PluginConfigurationView.cs
@@ -47,7 +47,9 @@ public class PluginConfigurationView(string pluginId, PluginConfigurationSchema 
     {
         return field.Type switch
         {
-            ConfigFieldType.Boolean => state.ToSelectInput(["true", "false"], placeholder: "Select..."),
+            ConfigFieldType.Boolean => new BoolInput(
+                value: string.Equals(state.Value, "true", StringComparison.OrdinalIgnoreCase),
+                onChange: e => { state.Set(e.Value ? "true" : "false"); }),
             ConfigFieldType.Secret => state.ToTextInput(placeholder: field.Description ?? field.Key, variant: TextInputVariant.Password),
             _ => state.ToTextInput(placeholder: field.Description ?? field.Key),
         };

--- a/src/frontend/src/widgets/inputs/BoolInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/BoolInputWidget.tsx
@@ -102,9 +102,7 @@ const InputLabel: React.FC<{
         </Label>
       )}
       {description && (
-        <p className={cn("block truncate", descriptionSizeVariant({ density: d }))}>
-          {description}
-        </p>
+        <p className={cn("block", descriptionSizeVariant({ density: d }))}>{description}</p>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- Replace the awkward true/false dropdown with a proper checkbox for boolean fields in the plugin configuration UI
- Remove `truncate` CSS class from BoolInput description text so longer descriptions wrap instead of being cut off with ellipsis