### PR TITLE
[00604] Add Bottom Default Padding to Sheets

### DIFF
--- a/src/frontend/src/widgets/sheet/SheetWidget.tsx
+++ b/src/frontend/src/widgets/sheet/SheetWidget.tsx
@@ -284,7 +284,7 @@ export const SheetWidget: React.FC<SheetWidgetProps> = ({
           </SheetDescription>
         </SheetHeader>
         <div className="flex-1 mt-4 overflow-y-auto min-h-0">
-          <div className="h-full min-h-0 pb-4 pt-1 pl-4 pr-4">{slots.Content}</div>
+          <div className="min-h-full pb-6 pt-1 pl-4 pr-4">{slots.Content}</div>
         </div>
       </SheetContent>
     </Sheet>


### PR DESCRIPTION
Fixes Ivy-Interactive/Ivy-Tendril#1415

# Summary

## Changes

Modified SheetWidget.tsx to add visible bottom padding to sheet content when scrolled. Changed the inner content div from `h-full` to `min-h-full` to allow the container to grow beyond the scroll area, and increased bottom padding from `pb-4` to `pb-6` for better spacing.

## API Changes

None.

## Files Modified

- **src/frontend/src/widgets/sheet/SheetWidget.tsx** — Updated content wrapper className (line 287)

## Manual Testing

1. Launch Tendril app
2. Open any sheet with scrollable content (e.g., a plan sheet from the Jobs view, or a verification report sheet)
3. Scroll to the bottom of the sheet content
4. Verify there is visible breathing room (1.5rem padding) below the last content element
5. Check that sheets with short content (no scrolling) still display correctly with proper bottom spacing

---

**Commits:**
- 3219478a5 Add bottom padding to sheet content

---

Created using [Ivy Tendril](https://ivy.app).