### PR TITLE
fix(desktop): implement native macOS clipboard copy fallback using pbcopy

### DIFF
--- a/src/Ivy/Client/ClientExtensions.cs
+++ b/src/Ivy/Client/ClientExtensions.cs
@@ -80,6 +80,33 @@ public static class ClientExtensions
 
     public static void CopyToClipboard(this IClientProvider client, string content)
     {
+        if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.OSX))
+        {
+            try
+            {
+                using var process = new System.Diagnostics.Process
+                {
+                    StartInfo = new System.Diagnostics.ProcessStartInfo
+                    {
+                        FileName = "pbcopy",
+                        UseShellExecute = false,
+                        RedirectStandardInput = true,
+                        CreateNoWindow = true
+                    }
+                };
+                process.Start();
+                using (var writer = process.StandardInput)
+                {
+                    writer.Write(content);
+                }
+                process.WaitForExit();
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"[CopyToClipboard] Failed to copy natively using pbcopy: {ex.Message}");
+            }
+        }
+
         client.Sender.Send("CopyToClipboard", content);
     }
 


### PR DESCRIPTION
This PR fixes the copy-to-clipboard functionality on macOS Desktop by executing a native `pbcopy` command from the C# backend. This bypasses the strict WebKit/Safari clipboard API requirements which block clipboard writes when executed outside of an active JS user gesture (such as in an asynchronous SignalR callback).

Closes:
- Ivy-Interactive/Ivy-Tendril#1421
- Ivy-Interactive/Ivy-Tendril#1417
- Ivy-Interactive/Ivy-Tendril#1416