### PR TITLE
Fix localhost connection error in webview on macOS/Linux

### DIFF
--- a/src/Ivy.Desktop/DesktopWindow.cs
+++ b/src/Ivy.Desktop/DesktopWindow.cs
@@ -258,7 +258,7 @@ public class DesktopWindow(Server server)
         var ivyTlsEnv = Environment.GetEnvironmentVariable("IVY_TLS");
         var useTls = !string.IsNullOrEmpty(ivyTlsEnv)
             ? ivyTlsEnv.ToLowerInvariant() is "1" or "true" or "yes" or "on"
-            : true; // Default to true if not overridden
+            : OperatingSystem.IsWindows(); // Default to true on Windows, false on other platforms
         var url = $"{(useTls ? "https" : "http")}://localhost:{port}";
 
         // Show splash while the server starts

--- a/src/Ivy/Server.cs
+++ b/src/Ivy/Server.cs
@@ -684,7 +684,7 @@ public class Server
             var ivyTlsEnv = Environment.GetEnvironmentVariable("IVY_TLS");
             var useTls = !string.IsNullOrEmpty(ivyTlsEnv)
                 ? ivyTlsEnv?.ToLowerInvariant() is "1" or "true" or "yes" or "on"
-                : !isContainer && !hasPortEnv && !_args.IsCliCommand; // default: TLS for local dev only
+                : !isContainer && !hasPortEnv && !_args.IsCliCommand && OperatingSystem.IsWindows(); // default: TLS for local dev only on Windows
             var scheme = useTls ? "https" : "http";
             builder.WebHost.UseUrls($"{scheme}://{host}:{_args.Port}");
         }


### PR DESCRIPTION
Default useTls to false on macOS/Linux in DesktopWindow and Server to avoid connection errors on platforms where WKWebView/WebKitGTK cannot bypass self-signed certificate validation errors.