### PR TITLE
Optimize Widget Serialization Speed with Compiled Lambda Getters

### DIFF
--- a/src/Ivy.Benchmarks/WidgetSerializationBenchmark.cs
+++ b/src/Ivy.Benchmarks/WidgetSerializationBenchmark.cs
@@ -1,0 +1,77 @@
+using BenchmarkDotNet.Attributes;
+using Ivy;
+using Ivy.Core;
+using System.Text.Json.Nodes;
+
+namespace Ivy.Benchmarks;
+
+[MemoryDiagnoser]
+public class WidgetSerializationBenchmark
+{
+    [Params(100, 500)]
+    public int Iterations { get; set; }
+
+    private IWidget[] _widgets = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var widgets = new List<IWidget>();
+        for (int i = 0; i < Iterations; i++)
+        {
+            var buttons = new List<object>();
+            for (int j = 0; j < 10; j++)
+            {
+                buttons.Add(new Button($"Btn {i}-{j}", () => {})
+                    .Width(Size.Units(12))
+                    .Height(Size.Units(6))
+                    .Density(Density.Small));
+            }
+
+            var canvas = new CanvasLayout(buttons.ToArray())
+            {
+                Background = Colors.Slate
+            };
+
+            var card = new Card(canvas)
+            {
+                HoverVariant = HoverEffect.Shadow,
+                Disabled = false
+            };
+
+            // Recursively assign IDs to the widget and all its children
+            AssignIds(card, $"card-{i}");
+
+            widgets.Add(card);
+        }
+
+        _widgets = widgets.ToArray();
+    }
+
+    private void AssignIds(IWidget widget, string id)
+    {
+        widget.Id = id;
+        if (widget.Children != null)
+        {
+            for (int i = 0; i < widget.Children.Length; i++)
+            {
+                if (widget.Children[i] is IWidget child)
+                {
+                    AssignIds(child, $"{id}_{i}");
+                }
+            }
+        }
+    }
+
+    [Benchmark(Baseline = true)]
+    public int SerializeWidgets()
+    {
+        int totalLength = 0;
+        foreach (var widget in _widgets)
+        {
+            var node = WidgetSerializer.Serialize(widget);
+            totalLength += node["id"]?.GetValue<string>().Length ?? 0;
+        }
+        return totalLength;
+    }
+}

--- a/src/Ivy/Core/WidgetSerializer.cs
+++ b/src/Ivy/Core/WidgetSerializer.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Linq.Expressions;
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -96,9 +97,9 @@ public static class WidgetSerializer
 
     private static readonly ConcurrentDictionary<Type, SerializationTypeMetadata> MetadataCache = new();
 
-    private sealed record PropInfo(PropertyInfo Property, PropAttribute Attribute, string CamelCaseName);
+    private sealed record PropInfo(PropertyInfo Property, PropAttribute Attribute, string CamelCaseName, Func<IWidget, object?> Getter);
 
-    private sealed record EventInfo(PropertyInfo Property);
+    private sealed record EventInfo(PropertyInfo Property, Func<IWidget, object?> Getter);
 
     private sealed record SerializationTypeMetadata(
         string TypeName,
@@ -106,6 +107,15 @@ public static class WidgetSerializer
         EventInfo[] EventProperties,
         IWidget? DefaultInstance
     );
+
+    private static Func<IWidget, object?> CreateGetter(Type type, PropertyInfo property)
+    {
+        var param = Expression.Parameter(typeof(IWidget), "w");
+        var cast = Expression.Convert(param, type);
+        var prop = Expression.Property(cast, property);
+        var convertProp = Expression.Convert(prop, typeof(object));
+        return Expression.Lambda<Func<IWidget, object?>>(convertProp, param).Compile();
+    }
 
     private static SerializationTypeMetadata GetMetadata(Type type)
     {
@@ -116,12 +126,12 @@ public static class WidgetSerializer
             var propProperties = allProperties
                 .Select(p => (Property: p, Attribute: p.GetCustomAttribute<PropAttribute>()))
                 .Where(x => x.Attribute != null)
-                .Select(x => new PropInfo(x.Property, x.Attribute!, Utils.PascalCaseToCamelCase(x.Property.Name)))
+                .Select(x => new PropInfo(x.Property, x.Attribute!, Utils.PascalCaseToCamelCase(x.Property.Name), CreateGetter(t, x.Property)))
                 .ToArray();
 
             var eventProperties = allProperties
                 .Where(p => p.GetCustomAttribute<EventAttribute>() != null)
-                .Select(p => new EventInfo(p))
+                .Select(p => new EventInfo(p, CreateGetter(t, p)))
                 .ToArray();
 
             IWidget? defaultInstance = null;
@@ -185,12 +195,12 @@ public static class WidgetSerializer
         var props = new JsonObject();
         foreach (var propInfo in metadata.PropProperties)
         {
-            var value = GetPropertyValue(widget, propInfo.Property, propInfo.Attribute);
+            var value = GetPropertyValue(widget, propInfo);
 
             // Skip properties that match their default values (unless AlwaysSerialize is set)
             if (!propInfo.Attribute.AlwaysSerialize && metadata.DefaultInstance != null)
             {
-                var defaultValue = GetPropertyValue(metadata.DefaultInstance, propInfo.Property, propInfo.Attribute);
+                var defaultValue = GetPropertyValue(metadata.DefaultInstance, propInfo);
                 if (ValuesAreEqual(value, defaultValue))
                     continue;
             }
@@ -208,7 +218,7 @@ public static class WidgetSerializer
             var eventsArray = new JsonArray();
             foreach (var eventInfo in metadata.EventProperties)
             {
-                if (eventInfo.Property.GetValue(widget) != null)
+                if (eventInfo.Getter(widget) != null)
                     eventsArray.Add(JsonValue.Create(eventInfo.Property.Name));
             }
             json["events"] = eventsArray;
@@ -242,10 +252,12 @@ public static class WidgetSerializer
         return json;
     }
 
-    private static object? GetPropertyValue(IWidget widget, PropertyInfo property, PropAttribute attribute)
+    private static object? GetPropertyValue(IWidget widget, PropInfo propInfo)
     {
+        var attribute = propInfo.Attribute;
         if (attribute.IsAttached)
         {
+            var property = propInfo.Property;
             if (!property.PropertyType.IsArray)
                 throw new InvalidOperationException("Attached properties must be arrays.");
 
@@ -264,6 +276,6 @@ public static class WidgetSerializer
             return attachedValues;
         }
 
-        return property.GetValue(widget);
+        return propInfo.Getter(widget);
     }
 }


### PR DESCRIPTION
This PR optimizes Ivy's widget serialization performance by replacing dynamic reflection (`PropertyInfo.GetValue`) with compiled lambda expression delegates (`Func<IWidget, object?>`) that are compiled and cached at type metadata initialization.

We also added a new benchmark `WidgetSerializationBenchmark.cs` that measures raw widget serialization (card containing canvas layout with 10 buttons) to isolate the improvement.

### Benchmark Results (ShortRun on Arm64 Apple M4 Max)

#### Raw Widget Serialization Benchmark (`WidgetSerializationBenchmark`)
- 100 iterations (~1,200 widgets): 1.458ms -> 1.117ms (**~23.4% speedup**)
- 500 iterations (~6,000 widgets): 7.267ms -> 5.587ms (**~23.1% speedup**)

#### End-to-End State Refresh Benchmark (`MemoizationBenchmark`)
- UpdateUnmemoized: 79.30ms -> 76.91ms (**~3.0% speedup** overall tree refresh)
- UpdateMemoized: 55.48ms -> 51.31ms (**~7.5% speedup** overall tree refresh)

All 1,467 unit tests passed.