### PR TITLE
[00627] Remove Background Color From Activity Heatmap

### DIFF
--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/ActivityHeatmap.tsx
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/ActivityHeatmap.tsx
@@ -234,11 +234,11 @@ export function ActivityHeatmap({
 
   return (
     <div className="ivy-activity-heatmap-container">
-      <div className="overflow-x-auto h-100 bg-card ivy-activity-heatmap-scroll"
+      <div className="overflow-x-auto h-100 ivy-activity-heatmap-scroll"
         ref={scrollXContainer}>
         <div className={`inline-flex flex-col gap-[${cellGapSize}px] font-sans h-100`}>
           {showMonthLabels && (
-            <div className="sticky top-0 flex gap-1 pb-2 text-[#57606a] w-full bg-card">
+            <div className="sticky top-0 flex gap-1 pb-2 text-[#57606a] w-full">
               {showDayLabels && <div style={{ width: `${labelWidth}px` }} />}
               {columns.map((_, ci) => (
                 <div
@@ -257,7 +257,7 @@ export function ActivityHeatmap({
             style={{ gap: `${cellGapSize}px` }}
           >
             {showDayLabels && (
-              <div className="flex flex-col justify-end sticky left-0 top-0 bottom-0 bg-card">
+              <div className="flex flex-col justify-end sticky left-0 top-0 bottom-0">
                 <div
                   className="grid text-secondary-foreground opacity-50 *:pr-2 *:text-right"
                   style={{

--- a/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/style.css
+++ b/src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/style.css
@@ -6,7 +6,6 @@
     overflow-y: auto;
     position: relative;
     display: flex;
-    background-color: var(--card);
 }
 
 .ivy-activity-heatmap-scroll {


### PR DESCRIPTION
Fixes #4680

# Summary

## Changes

Removed all background color declarations from the activity heatmap widget components to create a cleaner, more transparent appearance that blends with its parent container.

## API Changes

None.

## Files Modified

- **src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/style.css** — Removed `background-color: var(--card)` from `.ivy-activity-heatmap-container`
- **src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/ActivityHeatmap.tsx** — Removed `bg-card` classes from scroll wrapper, month labels row, and day labels column

## Manual Testing

1. Launch the Ivy Framework application with the activity heatmap widget
2. Navigate to a view displaying the activity heatmap
3. Observe that the heatmap now has a transparent background instead of a card-style background
4. Verify that the heatmap grid, month labels, and day labels are still visible and properly positioned
5. Check that the heatmap blends naturally with its parent container's background

---
## Commits

- 070d4e413 — Remove background color from activity heatmap component

---
Created using [Ivy Tendril](https://ivy.app).