### PR TITLE
[00631] Fix Loading Screen Overflow Causing Unwanted Scrollbar

### DIFF
--- a/src/frontend/src/components/LoadingScreen.tsx
+++ b/src/frontend/src/components/LoadingScreen.tsx
@@ -13,7 +13,7 @@ export const LoadingScreen = () => {
   }, []);
 
   return (
-    <div className="flex items-center justify-center h-screen overflow-hidden">
+    <div className="flex items-center justify-center h-full overflow-hidden">
       {showAnimation && <Loading />}
     </div>
   );


### PR DESCRIPTION
Fixes https://github.com/Ivy-Interactive/Ivy-Tendril/issues/1487

## Problem

The initial loading screen (spinner icon + "Loading..." text) overflows at the bottom of the viewport and triggers an unwanted scrollbar.

**Root cause:** `LoadingScreen.tsx` uses `h-screen` (100vh) for its container height. However, this component is rendered inside `wrapAppContent()` which wraps all app content in a div with class `w-full h-full p-4 overflow-y-auto`. The `p-4` adds 1rem (16px) padding on all sides. Since the outer `#root` element is already `100vh`, the loading screen's `h-screen` (100vh) plus the 32px of vertical padding exceeds the available space, causing overflow.

## Solution

Changed `h-screen` to `h-full` in `LoadingScreen.tsx` so the loading screen respects its parent container's height instead of using the viewport height directly.

---

**Commits:**
- 52d63671d Fix LoadingScreen overflow by using h-full instead of h-screen

---
Created using [Ivy Tendril](https://ivy.app).