### PR TITLE
Fix reentrancy crash in Disposables.Dispose during app teardown

### DIFF
--- a/src/Ivy/Core/Helpers/Disposables.cs
+++ b/src/Ivy/Core/Helpers/Disposables.cs
@@ -26,10 +26,14 @@ public class Disposables(params IEnumerable<IDisposable> disposables) : IDisposa
 
     public void Dispose()
     {
-        foreach (var disposable in _disposables)
+        // Snapshot the list first: a disposable's Dispose() may re-enter and
+        // modify _disposables (e.g. via Add or a nested Dispose), which would
+        // otherwise invalidate the enumerator.
+        var snapshot = _disposables.ToArray();
+        _disposables.Clear();
+        foreach (var disposable in snapshot)
         {
             disposable.Dispose();
         }
-        _disposables.Clear();
     }
 }


### PR DESCRIPTION
## Problem

Stopping the server printed a stack trace while disposing app state:

```
Error disposing app state for ...
System.InvalidOperationException: Collection was modified; enumeration operation may not execute.
   at Ivy.Core.Helpers.Disposables.Dispose() ... Disposables.cs:line 29
```

Root cause: `Disposables.Dispose()` enumerated the live `_disposables` list while calling each `Dispose()`. During recursive widget-tree teardown, one disposable's `Dispose()` re-entered and modified the same collection (via `Add` or a nested dispose), invalidating the enumerator.

## Fix

Snapshot the list into an array and clear it before iterating, so any re-entrant `Add`/`Dispose` touches the now-empty live list without breaking iteration. Clearing up front also guards against double-dispose on re-entry.

Purely internal change — no public API surface affected.