### PR TITLE
Fix sidebar news card blocking menu items after dismissal

### DIFF
--- a/src/frontend/src/widgets/internal/SidebarNewsWidget.tsx
+++ b/src/frontend/src/widgets/internal/SidebarNewsWidget.tsx
@@ -64,7 +64,7 @@ function News({ articles }: { articles: NewsArticle[] }) {
     dismissedNews === null ? [] : articles.filter(({ id }) => !dismissedNews.includes(id));
   const cardCount = cards.length;
 
-  const [prevCardCount, setPrevCardCount] = React.useState(cardCount);
+  const [prevCardCount, setPrevCardCount] = React.useState<number | null>(null);
   if (cardCount !== prevCardCount) {
     setPrevCardCount(cardCount);
     if (cardCount > 0) {


### PR DESCRIPTION
## Summary
- The sidebar "news" promo card (e.g. "Star Tendril on GitHub") never fully collapsed after being dismissed for single-article feeds. Its invisible sizer div kept reserving full card height, pushing/blocking menu items rendered below it (e.g. Settings) into a dead click zone.
- Root cause: a regression from commit `29da6c00a2` — `prevCardCount` was initialized to the current `cardCount`, so the mount-time transition was never observed, and `showCompleted` never flipped to `true` when the last card was dismissed, so the widget's unmount condition never fired.
- Fix: initialize `prevCardCount` to `null` instead of `cardCount`, restoring the original "always true while any card is showing" semantics.

## Test plan
- [x] Rebuilt frontend (`npm run build`) and Ivy.Tendril (`dotnet build -p:IvySource=true`) against this change
- [x] Verified locally: dismissing the sidebar news card now shows "You're all caught up!" and the sidebar footer fully collapses after ~2.7s, with the Settings menu item clickable in its correct position