### PR TITLE
[00076] Fix Copy Button Not Square

### DIFF
--- a/src/frontend/src/components/CopyToClipboardButton.tsx
+++ b/src/frontend/src/components/CopyToClipboardButton.tsx
@@ -4,7 +4,7 @@ import { cn } from "@/lib/utils";
 import { copyToClipboard } from "@/lib/clipboard";
 import { Densities } from "@/types/density";
 import { cva } from "class-variance-authority";
-import { controlHeight } from "@/components/ui/density-scale";
+import { controlHeight, controlSize } from "@/components/ui/density-scale";
 
 const copyIconVariant = cva("", {
   variants: {
@@ -20,13 +20,13 @@ const copyIconVariant = cva("", {
 });
 
 const copyButtonSizeVariant = cva(
-  "p-2 rounded bg-transparent hover:bg-accent focus:outline-none cursor-pointer flex items-center",
+  "rounded bg-transparent hover:bg-accent focus:outline-none cursor-pointer flex items-center justify-center",
   {
     variants: {
       density: {
-        Small: controlHeight.Small,
-        Medium: controlHeight.Medium,
-        Large: controlHeight.Large,
+        Small: controlSize.Small,
+        Medium: controlSize.Medium,
+        Large: controlSize.Large,
       },
     },
     defaultVariants: {

--- a/src/frontend/src/components/CopyToClipboardButton.tsx
+++ b/src/frontend/src/components/CopyToClipboardButton.tsx
@@ -4,7 +4,7 @@ import { cn } from "@/lib/utils";
 import { copyToClipboard } from "@/lib/clipboard";
 import { Densities } from "@/types/density";
 import { cva } from "class-variance-authority";
-import { controlHeight, controlSize } from "@/components/ui/density-scale";
+import { controlSize } from "@/components/ui/density-scale";
 
 const copyIconVariant = cva("", {
   variants: {


### PR DESCRIPTION
Fixes #4658

# Summary

## Changes

Fixed the copy-to-clipboard button in icon-only mode to render as a square. Changed `CopyToClipboardButton` from using `controlHeight` (height-only via `h-*` classes) to `controlSize` (square dimensions via `size-*` classes), removed padding that conflicted with fixed sizing, and added `justify-center` for proper icon centering.

## API Changes

None.

## Files Modified

**Frontend components:**
- `src/frontend/src/components/CopyToClipboardButton.tsx` — Updated button size variant to use `controlSize` instead of `controlHeight`

## Manual Testing

1. Run the Ivy Framework desktop app
2. Navigate to the Test Agent view
3. Locate the Raw Output section with the copy-to-clipboard button
4. Observe that the copy button now renders as a proper square (equal width and height)
5. Test the button at different density settings (Small, Medium, Large) to verify square dimensions are maintained across all sizes

---

**Commits:**
- d71f4dc3e Remove unused controlHeight import
- 68f214d50 Fix copy button to render as square using controlSize

---
Created using [Ivy Tendril](https://ivy.app).
