### PR TITLE
Add optional Tools slot to Field widget

### DIFF
--- a/src/Ivy/Widgets/Inputs/Field.cs
+++ b/src/Ivy/Widgets/Inputs/Field.cs
@@ -7,6 +7,7 @@ public enum LabelPosition
     Left
 }
 
+[Slot("Tools")]
 public record Field : WidgetBase<Field>
 {
     public Field(IAnyInput input, string? label = null, string? description = null, bool required = false, string? help = null, Density density = Ivy.Density.Medium) : base([input])
@@ -63,6 +64,13 @@ public static class FieldExtensions
     public static Field Required(this Field field) => field with { Required = true };
 
     public static Field LabelPosition(this Field field, LabelPosition position) => field with { LabelPosition = position };
+
+    /// <summary>
+    /// Adds an optional widget rendered in the field's tools slot. In <see cref="Ivy.LabelPosition.Top"/>
+    /// the tools are placed at the right of the label row; in <see cref="Ivy.LabelPosition.Left"/> they
+    /// are placed below the label.
+    /// </summary>
+    public static Field Tools(this Field field, object tools) => field with { Children = field.WithSlot("Tools", tools) };
 
     public static Field WithField(this IAnyInput input) => new Field(input);
 

--- a/src/frontend/src/widgets/inputs/FieldWidget.tsx
+++ b/src/frontend/src/widgets/inputs/FieldWidget.tsx
@@ -15,6 +15,9 @@ interface FieldWidgetProps {
   width?: string;
   height?: string;
   labelPosition?: "Top" | "Left" | 0 | 1;
+  slots?: {
+    Tools?: React.ReactNode[];
+  };
 }
 
 export const FieldWidget: React.FC<FieldWidgetProps> = ({
@@ -27,6 +30,7 @@ export const FieldWidget: React.FC<FieldWidgetProps> = ({
   width,
   height,
   labelPosition,
+  slots,
 }) => {
   const childrenRef = React.useRef<HTMLDivElement>(null);
   const [inputId, setInputId] = React.useState<string | undefined>(undefined);
@@ -63,39 +67,49 @@ export const FieldWidget: React.FC<FieldWidgetProps> = ({
 
   const isLeft = labelPosition === "Left" || labelPosition === 1;
 
+  const tools = slots?.Tools;
+  const hasTools = Array.isArray(tools) ? tools.length > 0 : Boolean(tools);
+
+  const labelContent = label && (
+    <>
+      <label
+        htmlFor={inputId}
+        className={`${labelSizeClass} font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70`}
+      >
+        {label} {required && <span className="font-mono text-primary">*</span>}
+      </label>
+      {help && (
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                aria-label="Help"
+                className="inline-flex items-center justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
+              >
+                <Icon
+                  name="Info"
+                  size="14"
+                  className="text-muted-foreground hover:text-foreground transition-colors"
+                />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent className="bg-popover text-popover-foreground shadow-md">
+              {help}
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      )}
+    </>
+  );
+
   if (isLeft) {
     return (
       <div className={`flex flex-col sm:flex-row ${gapClass} ${flexClass} min-w-0`} style={styles}>
-        {label && (
-          <div className="flex items-center gap-1.5 min-w-[120px] w-1/4 sm:w-1/3 pt-2 sm:pt-0 sm:mt-2.5 self-start">
-            <label
-              htmlFor={inputId}
-              className={`${labelSizeClass} font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70`}
-            >
-              {label} {required && <span className="font-mono text-primary">*</span>}
-            </label>
-            {help && (
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      type="button"
-                      aria-label="Help"
-                      className="inline-flex items-center justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
-                    >
-                      <Icon
-                        name="Info"
-                        size="14"
-                        className="text-muted-foreground hover:text-foreground transition-colors"
-                      />
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent className="bg-popover text-popover-foreground shadow-md">
-                    {help}
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            )}
+        {(label || hasTools) && (
+          <div className="flex flex-col gap-2 min-w-[120px] w-1/4 sm:w-1/3 pt-2 sm:pt-0 sm:mt-2.5 self-start">
+            {label && <div className="flex items-center gap-1.5">{labelContent}</div>}
+            {hasTools && <div className="flex flex-col gap-1">{tools}</div>}
           </div>
         )}
         <div ref={childrenRef} className="flex-1 flex flex-col gap-2 min-w-0">
@@ -110,35 +124,19 @@ export const FieldWidget: React.FC<FieldWidgetProps> = ({
 
   return (
     <div className={`flex flex-col ${gapClass} ${flexClass} min-w-0`} style={styles}>
-      {label && (
-        <div className="flex items-center gap-1.5">
-          <label
-            htmlFor={inputId}
-            className={`${labelSizeClass} font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70`}
-          >
-            {label} {required && <span className="font-mono text-primary">*</span>}
-          </label>
-          {help && (
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    aria-label="Help"
-                    className="inline-flex items-center justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
-                  >
-                    <Icon
-                      name="Info"
-                      size="14"
-                      className="text-muted-foreground hover:text-foreground transition-colors"
-                    />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent className="bg-popover text-popover-foreground shadow-md">
-                  {help}
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
+      {(label || hasTools) && (
+        // The label row height is driven purely by the label so a field with tools has the
+        // exact same padding as one without (tools are absolutely positioned, centered on the
+        // label line, and right-aligned). items-end keeps the label bottom-aligned, and the
+        // min-height only kicks in when there is no label so a tools-only row stays visible.
+        <div
+          className={`relative flex items-end gap-1.5 ${!label && hasTools ? "min-h-[1.25rem]" : ""}`}
+        >
+          {labelContent}
+          {hasTools && (
+            <div className="absolute right-0 top-1/2 -translate-y-1/2 flex items-center gap-1">
+              {tools}
+            </div>
           )}
         </div>
       )}


### PR DESCRIPTION
Adds an optional `Tools` slot to the `Field` widget so an arbitrary widget can be rendered alongside the label.

- **Backend** (`Field.cs`): new `[Slot("Tools")]` and additive `.Tools(...)` extension method (binary-safe for plugins).
- **Frontend** (`FieldWidget.tsx`):
  - `LabelPosition.Top`: tools render right-aligned on the label row, absolutely positioned so the label→input padding is identical with or without tools; label is bottom-aligned.
  - `LabelPosition.Left`: tools render below the label.

Verified live that a field with tools and one without have pixel-identical label padding (14px row, 10px gap to input).