### PR TITLE
[00031] Fix Copy Paste in Xterm Widget

### DIFF
--- a/src/widgets/Ivy.Widgets.Xterm/frontend/src/Terminal.tsx
+++ b/src/widgets/Ivy.Widgets.Xterm/frontend/src/Terminal.tsx
@@ -343,8 +343,10 @@ export const Terminal: React.FC<TerminalProps> = ({
       term.loadAddon(clipboardAddon);
     }
 
-    // Manual paste handler for Shadow DOM compatibility
-    const handlePaste = (e: ClipboardEvent) => {
+    // Paste handler for browser paste events (right-click paste, etc.) on
+    // xterm's internal textarea. Defined here (outer scope) so the cleanup
+    // closure below can remove the exact same listener reference.
+    const handleTextareaPaste = (e: ClipboardEvent) => {
       if (!allowClipboardRef.current || term.options.disableStdin) return;
       e.preventDefault();
       const text = e.clipboardData?.getData("text");
@@ -352,25 +354,6 @@ export const Terminal: React.FC<TerminalProps> = ({
         term.paste(text);
       }
     };
-
-    // Keyboard-based paste handler (Ctrl+V / Cmd+V) using Clipboard API
-    const handleKeyDown = async (e: KeyboardEvent) => {
-      if (!allowClipboardRef.current || term.options.disableStdin) return;
-      if ((e.ctrlKey || e.metaKey) && e.key === "v") {
-        e.preventDefault();
-        try {
-          const text = await navigator.clipboard.readText();
-          if (text) {
-            term.paste(text);
-          }
-        } catch {
-          // Clipboard API not available or permission denied, fall back to paste event
-        }
-      }
-    };
-
-    container.addEventListener("paste", handlePaste);
-    container.addEventListener("keydown", handleKeyDown);
 
     let disposed = false;
 
@@ -400,6 +383,33 @@ export const Terminal: React.FC<TerminalProps> = ({
       if (disposed) return;
 
       term.open(container);
+
+      // Intercept Ctrl+V / Cmd+V before xterm consumes the key event. xterm.js
+      // captures keyboard input on its own internal hidden <textarea>, so
+      // container-level keydown listeners never fire — attachCustomKeyEventHandler
+      // runs before xterm processes the key, which is the standard approach for
+      // clipboard handling inside a Shadow DOM.
+      term.attachCustomKeyEventHandler((e: KeyboardEvent) => {
+        if (!allowClipboardRef.current || term.options.disableStdin) return true;
+        if (e.type === "keydown" && (e.ctrlKey || e.metaKey) && e.key === "v") {
+          e.preventDefault();
+          navigator.clipboard
+            .readText()
+            .then((text) => {
+              if (text) term.paste(text);
+            })
+            .catch(() => {
+              // Clipboard API unavailable — browser paste event will handle it
+            });
+          return false; // Prevent xterm from processing this key
+        }
+        // Allow Ctrl+C to copy selected text (xterm handles this natively with ClipboardAddon)
+        return true;
+      });
+
+      if (term.textarea) {
+        term.textarea.addEventListener("paste", handleTextareaPaste);
+      }
 
       // Canvas renderer draws box-drawing and block-element glyphs procedurally
       // (customGlyphs, on by default), so the Claude logo and other block art
@@ -477,8 +487,9 @@ export const Terminal: React.FC<TerminalProps> = ({
       disposed = true;
       terminalReadyRef.current = false;
       window.removeEventListener("resize", handleWindowResize);
-      container.removeEventListener("paste", handlePaste);
-      container.removeEventListener("keydown", handleKeyDown);
+      if (term.textarea) {
+        term.textarea.removeEventListener("paste", handleTextareaPaste);
+      }
       resizeObserver.disconnect();
 
       // Remove tooltip


### PR DESCRIPTION
# Summary

## Changes

Fixed copy/paste in the Xterm terminal widget. Ctrl+V paste previously never worked because xterm.js
captures keyboard input on its own internal hidden `<textarea>` inside the Shadow DOM, so the
container-level `keydown`/`paste` listeners never fired. Replaced them with xterm's
`attachCustomKeyEventHandler` API (which intercepts key events before xterm processes them) plus a
`paste` listener attached directly to xterm's own textarea for right-click paste.

## API Changes

None. This is a frontend-only fix inside `src/widgets/Ivy.Widgets.Xterm/frontend/src/Terminal.tsx` —
no C# widget API, props, or events changed.

## Files Modified

- `src/widgets/Ivy.Widgets.Xterm/frontend/src/Terminal.tsx` — replaced container-level clipboard event
  listeners with `term.attachCustomKeyEventHandler` (Ctrl+V/Cmd+V) and a textarea-level `paste` listener
  (right-click paste), keeping the existing `ClipboardAddon` for OSC 52 copy support.

## Manual Testing

1. Run a sample app that hosts the Xterm widget (e.g. `Ivy.Widgets.Xterm/.samples`) with an input-enabled
   terminal (`OnInput` event registered, not read-only).
2. Click into the terminal to focus it, copy some text to the system clipboard from anywhere, then press
   Ctrl+V (or Cmd+V on macOS). The copied text should be pasted into the terminal — previously nothing
   happened.
3. Right-click inside the terminal and choose "Paste" from the browser's context menu (if available) —
   text should also paste correctly.
4. Select text in the terminal and press Ctrl+C — copy should continue to work as before (unaffected by
   this change, handled natively by `ClipboardAddon`).
5. Confirm no console errors appear and the terminal still resizes/renders correctly, since the
   `attachCustomKeyEventHandler` runs on every key event across the whole terminal, not just paste.

---
Commits:
- 192137ffb Fix copy/paste in Xterm widget via attachCustomKeyEventHandler

---
Created using [Ivy Tendril](https://ivy.app).
