### PR TITLE
[00033] Fix Checkbox Label Click Hitbox

### DIFF
--- a/src/frontend/src/widgets/inputs/BoolInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/BoolInputWidget.tsx
@@ -86,25 +86,27 @@ const InputLabel: React.FC<{
   label?: string;
   description?: string;
   density?: Densities;
-  onClick?: () => void;
   disabled?: boolean;
-}> = React.memo(({ id, label, description, density = Densities.Medium, onClick, disabled }) => {
+}> = React.memo(({ id, label, description, density = Densities.Medium, disabled }) => {
   if (!label && !description) return null;
   const d = normalizeInputDensity(density);
 
-  const cursorClass = onClick ? (disabled ? "cursor-not-allowed" : "cursor-pointer") : undefined;
-
+  // Native htmlFor association toggles the control — do not re-add a JS click handler here.
   return (
-    <div onClick={onClick} className={cn("min-w-0 flex-1", cursorClass)}>
+    <Label
+      htmlFor={id}
+      className={cn(
+        "min-w-0 flex-1 self-stretch flex flex-col justify-center",
+        disabled ? "cursor-not-allowed" : "cursor-pointer",
+      )}
+    >
       {label && (
-        <Label htmlFor={id} className={cn("block truncate", labelSizeVariant({ density: d }))}>
-          {label}
-        </Label>
+        <span className={cn("block truncate", labelSizeVariant({ density: d }))}>{label}</span>
       )}
       {description && (
-        <p className={cn("block", descriptionSizeVariant({ density: d }))}>{description}</p>
+        <span className={cn("block", descriptionSizeVariant({ density: d }))}>{description}</span>
       )}
-    </div>
+    </Label>
   );
 });
 
@@ -148,19 +150,6 @@ const VariantComponents = {
       "data-testid": dataTestId,
     }: CheckboxVariantProps) => {
       const d = normalizeInputDensity(density);
-      // Toggle cycle for label clicks: null → true → false → null (if nullable)
-      const handleLabelClick = () => {
-        if (disabled || loading) return;
-        if (nullable) {
-          const isTrue = value === true || (value as any) === 1;
-          const isNull = value === null || value === undefined;
-          if (isNull) onCheckedChange(true);
-          else if (isTrue) onCheckedChange(false);
-          else onCheckedChange(null);
-        } else {
-          onCheckedChange(!value);
-        }
-      };
 
       const checkboxElement = (
         <div className="relative flex shrink-0">
@@ -201,7 +190,6 @@ const VariantComponents = {
             label={label}
             description={description}
             density={density}
-            onClick={handleLabelClick}
             disabled={disabled || loading}
           />
         </div>
@@ -226,10 +214,6 @@ const VariantComponents = {
       "data-testid": dataTestId,
     }: SwitchVariantProps) => {
       const d = normalizeInputDensity(density);
-      const handleLabelClick = () => {
-        if (disabled || loading) return;
-        onCheckedChange(!value);
-      };
 
       const switchElement = (
         <div className="relative flex shrink-0">
@@ -270,7 +254,6 @@ const VariantComponents = {
             label={label}
             description={description}
             density={density}
-            onClick={handleLabelClick}
             disabled={disabled || loading}
           />
         </div>
@@ -295,10 +278,6 @@ const VariantComponents = {
       "data-testid": dataTestId,
     }: ToggleVariantProps) => {
       const d = normalizeInputDensity(density);
-      const handleLabelClick = () => {
-        if (disabled || loading) return;
-        onPressedChange(!value);
-      };
 
       const toggleElement = (
         <div className="relative flex shrink-0">
@@ -341,7 +320,6 @@ const VariantComponents = {
             label={label}
             description={description}
             density={density}
-            onClick={handleLabelClick}
             disabled={disabled || loading}
           />
         </div>


### PR DESCRIPTION
## Changes

Fixed an unreliable click hitbox on checkbox/switch/toggle labels caused by a double-toggle race: the label's native `htmlFor` association and a redundant custom `onClick` handler both fired on the same click, canceling out or double-toggling depending on timing. `InputLabel` now renders a single native `<Label htmlFor={id}>` that fills the entire label row (text, blank space, and description), with the redundant `handleLabelClick` handlers removed from all three variants (Checkbox, Switch, Toggle).

## API Changes

None. This is an internal frontend component refactor with no changes to public widget props, C# APIs, or backend behavior.

## Files Modified

- `src/frontend/src/widgets/inputs/BoolInputWidget.tsx` — rewrote `InputLabel` to a single native `<Label>` wrapper (spans instead of nested `<Label>`+`<p>`), removed `onClick` prop and the three `handleLabelClick` definitions in the `Checkbox`, `Switch`, and `Toggle` variant components.

## Manual Testing

1. Run the Samples app and open the Bool Input sample (`Widgets > Inputs > BoolInput`).
2. For a labeled checkbox, click:
   - directly on the label text,
   - the empty space to the right of the text within the label row,
   - the description line (if present).
   Each click should toggle the value exactly once (watch the `OnChange` event / displayed value — it should not double-toggle or fail to respond).
3. Repeat the same three clicks for a Switch and a Toggle variant.
4. For a nullable checkbox, click the label repeatedly and confirm it cycles null → true → false → null.
5. For a disabled checkbox/switch/toggle, click its label and confirm nothing happens (cursor shows `not-allowed`).

---
### Commits
- e2b0df00b Fix checkbox/switch/toggle label click hitbox (Plan 00033)

---
Created using [Ivy Tendril](https://ivy.app).
