### PR TITLE
[00064] Allow List Item Titles to Wrap Fully Instead of Truncating with an Ellipsis

### DIFF
--- a/src/frontend/src/widgets/primitives/TextBlockWidget.tsx
+++ b/src/frontend/src/widgets/primitives/TextBlockWidget.tsx
@@ -239,7 +239,7 @@ export const TextBlockWidget: React.FC<TextBlockWidgetProps> = ({
       style={styles}
       className={cn(
         strikeThrough && "line-through",
-        noWrap ? "whitespace-nowrap" : "whitespace-normal",
+        noWrap ? "whitespace-nowrap" : variant === "Literal" && "whitespace-normal",
         bold && "font-semibold",
         variant === "Literal" && !bold && "font-normal",
         italic && "italic",

--- a/src/frontend/src/widgets/primitives/TextBlockWidget.tsx
+++ b/src/frontend/src/widgets/primitives/TextBlockWidget.tsx
@@ -239,8 +239,9 @@ export const TextBlockWidget: React.FC<TextBlockWidgetProps> = ({
       style={styles}
       className={cn(
         strikeThrough && "line-through",
-        noWrap && "whitespace-nowrap",
+        noWrap ? "whitespace-nowrap" : "whitespace-normal",
         bold && "font-semibold",
+        variant === "Literal" && !bold && "font-normal",
         italic && "italic",
         muted && "text-muted-foreground",
         density && scaleClasses[density],


### PR DESCRIPTION
# Summary

Fix for [Ivy-Interactive/Ivy-Tendril#1627](https://github.com/Ivy-Interactive/Ivy-Tendril/pull/1627) (plan 00064): the reviewer's follow-up screenshot showed sidebar list item titles still stuck on one line and rendered bold. Root cause: `Text.Literal(title)` renders a bare `<span>` with no whitespace/font-weight class of its own when not explicitly set, so it was inheriting `whitespace-nowrap` and `font-medium` from an ancestor styled element (Ivy Framework's shared button base classes) via ordinary CSS inheritance.

Fixed in `TextBlockWidget.tsx` by giving the `"Literal"` variant an explicit `whitespace-normal`/`font-normal` default so it no longer depends on its container. A first attempt applied the whitespace default to every variant, which broke `TableCellWidget`'s default ellipsis-truncation behavior (Block-variant cells rely on inheriting an ambient `nowrap`); a follow-up commit scoped the fix to the `"Literal"` variant only, restoring table truncation while keeping the title fix.

## Files Modified

- `src/frontend/src/widgets/primitives/TextBlockWidget.tsx`

---
Commits:
- aa6251e29 Make TextBlock Literal spans wrap and render normal weight
- a4ed50742 Scope TextBlock whitespace-normal default to Literal variant only

---
Created using [Ivy Tendril](https://ivy.app).
