### PR TITLE
[00057] Fix Markdown Widget Rendering Prose Dollar Signs as LaTeX Math

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/14_Markdown.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/14_Markdown.md
@@ -93,7 +93,7 @@ public class CodeBlocksMarkdownView : ViewBase
 
 ### Math
 
-Mathematical expressions can be rendered using KaTeX, supporting both inline math with single dollar signs and block math with double dollar signs. This feature is perfect for technical documentation and educational content.
+Mathematical expressions can be rendered using KaTeX. Both inline and block math use double dollar signs (`$$...$$`); a single `$` is always treated as literal text so prose containing dollar signs (shell variables, prices) renders correctly. This feature is perfect for technical documentation and educational content.
 
 ```csharp demo-tabs
 public class MathMarkdownView : ViewBase
@@ -102,7 +102,7 @@ public class MathMarkdownView : ViewBase
     {
         var markdownContent = 
             """
-            Inline: $E = mc^2$
+            Inline: $$E = mc^2$$
             
             $$
             \int_a^b f(x) dx = F(b) - F(a)
@@ -359,7 +359,7 @@ public class ComprehensiveMarkdownView : ViewBase
             }
             ```
             
-            Inline equation: $f(x) = x^2 + 2x + 1$
+            Inline equation: $$f(x) = x^2 + 2x + 1$$
             
             | Language | Type       | Performance |
             |----------|------------|-------------|

--- a/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/MarkdownApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/MarkdownApp.cs
@@ -333,13 +333,13 @@ public class MathTab : ViewBase
                        
                        ## Inline Math
                        
-                       The famous equation: $E = mc^2$
-                       
-                       Another example: The quadratic formula is $x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}$
-                       
-                       Pythagorean theorem: $a^2 + b^2 = c^2$
-                       
-                       Euler's identity: $e^{i\pi} + 1 = 0$
+                       The famous equation: $$E = mc^2$$
+
+                       Another example: The quadratic formula is $$x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}$$
+
+                       Pythagorean theorem: $$a^2 + b^2 = c^2$$
+
+                       Euler's identity: $$e^{i\pi} + 1 = 0$$
                        
                        ## Block Math
                        

--- a/src/Ivy.Test/Views/RichTextMarkdownParserTests.cs
+++ b/src/Ivy.Test/Views/RichTextMarkdownParserTests.cs
@@ -151,6 +151,22 @@ public class RichTextMarkdownParserTests
     }
 
     [Fact]
+    public void Should_Parse_InlineMath()
+    {
+        var runs = ParseAll("Result: $$E = mc^2$$ end\n");
+        var math = runs.First(r => r.Math != null);
+        Assert.Equal("E = mc^2", math.Content);
+    }
+
+    [Fact]
+    public void Should_Treat_SingleDollar_As_Literal()
+    {
+        var runs = ParseAll("bash expands any $ (e.g. $env:PORT, or vars like $IsMacOS) so $ survives\n");
+        Assert.DoesNotContain(runs, r => r.Math != null);
+        Assert.Contains(runs, r => r.Content.Contains("$env:PORT"));
+    }
+
+    [Fact]
     public void Should_Parse_Strikethrough()
     {
         var runs = ParseAll("~~struck~~\n");

--- a/src/Ivy/Views/RichTextMarkdownParser.cs
+++ b/src/Ivy/Views/RichTextMarkdownParser.cs
@@ -333,18 +333,19 @@ public class RichTextMarkdownParser
                 continue;
             }
 
-            // Inline math $...$
-            if (text[i] == '$')
+            // Inline math $$...$$ (a single $ is literal text, matching the Markdown widget's convention)
+            if (i + 1 < text.Length && text[i] == '$' && text[i + 1] == '$')
             {
                 FlushText(runs, sb);
-                i++;
+                i += 2;
                 var mathContent = new StringBuilder();
-                while (i < text.Length && text[i] != '$')
+                while (i < text.Length && !(i + 1 < text.Length && text[i] == '$' && text[i + 1] == '$'))
                 {
                     mathContent.Append(text[i]);
                     i++;
                 }
-                if (i < text.Length) i++; // skip closing $
+                if (i + 1 < text.Length) i += 2; // skip closing $$
+                else i = text.Length; // unterminated: consume to end of line
                 runs.Add(new TextRun(mathContent.ToString()) { Math = "inline" });
                 continue;
             }

--- a/src/frontend/src/components/MarkdownRenderer.test.tsx
+++ b/src/frontend/src/components/MarkdownRenderer.test.tsx
@@ -1,0 +1,17 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, it, expect } from "vitest";
+import MarkdownRenderer from "@/components/MarkdownRenderer";
+
+describe("MarkdownRenderer math handling", () => {
+  it("treats single dollar signs in prose as literal text, not math", () => {
+    const prose = "bash expands any $ (e.g. $env:PORT, or vars like $IsMacOS) so $ survives";
+    const html = renderToStaticMarkup(<MarkdownRenderer content={prose} />);
+    expect(html).not.toContain("katex"); // no math was rendered
+    expect(html).toContain("$env:PORT"); // literal dollars preserved
+  });
+
+  it("still renders $$...$$ as math", () => {
+    const html = renderToStaticMarkup(<MarkdownRenderer content={"$$E = mc^2$$"} />);
+    expect(html).toContain("katex");
+  });
+});

--- a/src/frontend/src/components/MarkdownRenderer.tsx
+++ b/src/frontend/src/components/MarkdownRenderer.tsx
@@ -269,7 +269,7 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
   const typography = useTypography();
   const contentFeatures = useMemo(
     () => ({
-      hasMath: hasContentFeature(content, /(\$|\\\(|\\\[|\\begin\{)/),
+      hasMath: hasContentFeature(content, /(\$\$|\\\(|\\\[|\\begin\{)/),
       hasCodeBlocks: hasContentFeature(content, /```/),
       hasMermaid: hasContentFeature(content, /```mermaid/),
       hasGraphviz: hasContentFeature(content, /```(graphviz|dot)/),
@@ -279,7 +279,11 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
 
   const plugins = useMemo(() => {
     const remarkPlugins = [remarkGfm, remarkGemoji, remarkCustomEmojiPlugin];
-    if (contentFeatures.hasMath) remarkPlugins.push(remarkMath as typeof remarkGfm);
+    if (contentFeatures.hasMath)
+      remarkPlugins.push([
+        remarkMath,
+        { singleDollarTextMath: false },
+      ] as unknown as typeof remarkGfm);
 
     const rehypePlugins = [rehypeRaw, rehypeSlug];
     if (contentFeatures.hasMath) rehypePlugins.push(rehypeKatex as unknown as typeof rehypeRaw);


### PR DESCRIPTION
# Summary

## Changes

Fixed the Ivy `Markdown` widget so a single `$` in prose (shell variables like `$env:PORT`, prices, etc.) is always literal text; math now requires `$$...$$` for both inline and block expressions. Updated docs and the Markdown sample app's math examples to the new `$$` convention, and added a standalone runnable example demonstrating the fix.

## API Changes

None. This is a rendering behavior change, not a public API change — however it is a **breaking change in Markdown content semantics**: any existing Markdown content that relied on single-`$`-delimited inline math (`$E = mc^2$`) will now render the dollar signs as literal text instead of KaTeX. Authors must switch to `$$...$$`.

## Files Modified

- `src/frontend/src/components/MarkdownRenderer.tsx` — disabled `remark-math`'s `singleDollarTextMath`, tightened the `hasMath` detection regex to require `$$`
- `src/frontend/src/components/MarkdownRenderer.test.tsx` (new) — verifies prose dollars stay literal and `$$...$$` still renders as KaTeX
- `src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/14_Markdown.md` — updated math examples and prose to the `$$` convention
- `src/Ivy.Samples.Shared/Apps/Widgets/Primitives/MarkdownApp.cs` — updated the `MathTab`'s inline math examples to `$$` (found via repo-wide grep, not originally cited by the plan)
- `src/experiments/LatexMarkdownFix/` (new, Ivy-Tendril repo) — standalone Ivy app demonstrating before/after behavior, modeled on `FieldToolsDemo`

## Manual Testing

1. Run `dotnet run` from `src/experiments/LatexMarkdownFix` (in the Ivy-Tendril repo).
2. Open the app in a browser and select the "Latex Markdown Fix" tab.
3. Observe: the first block ("bash expands any $ (e.g. $env:PORT, or vars like $IsMacOS) so $ survives") renders as plain readable text — no collapsed spaces or serif italic math formatting.
4. Observe: the second block (`$$E = mc^2$$`) still renders as KaTeX math.
5. Alternatively, in the Ivy-Framework repo's `src/frontend`, run `pnpm vp exec vitest run src/components/MarkdownRenderer.test.tsx` to confirm both automated assertions pass.

## Fix: RichTextMarkdownParser had the same single-dollar-as-math bug

Per reviewer feedback (accepted recommendation), `src/Ivy/Views/RichTextMarkdownParser.cs` — a separate C# streaming markdown parser used for the RichText/streaming-LLM-output widget (not the Markdown widget) — had the identical bug: any single `$` opened inline math and greedily paired with the next `$` on the line. Applied the same convention: a lone `$` is now literal text; inline math requires `$$...$$`. The pre-existing multi-line display-math block detection (a line starting with `$$` opening a block terminated by a line that is exactly `$$`) was left unchanged, since it's a distinct code path from the inline pairing bug that was reported.

### Files Modified

- `src/Ivy/Views/RichTextMarkdownParser.cs` — `ParseInline`'s math branch now matches `$$...$$` instead of pairing single `$`; an unpaired single `$` falls through to the existing literal-text handling.
- `src/Ivy.Test/Views/RichTextMarkdownParserTests.cs` — added `Should_Parse_InlineMath` (`$$...$$` still renders as math) and `Should_Treat_SingleDollar_As_Literal` (prose with multiple `$` stays literal, no `Math` run produced).

**Note:** This is a non-user-facing internal parser fix (no widget/API change), so the manual testing section above does not need updating.

---
## Commits in this repo (Ivy-Framework)
- d28b8232d Fix RichTextMarkdownParser to treat single $ as literal, $$ as math
- 4305d062d Add MarkdownRenderer test for prose dollar signs vs LaTeX math
- 109eb5f71 Fix Markdown widget rendering prose dollar signs as LaTeX math

---
Created using [Ivy Tendril](https://ivy.app).
