### PR TITLE
[00093] Disable Backspace Browser Back Navigation in Desktop Apps

### DIFF
--- a/src/frontend/src/lib/__tests__/shortcutRegistry.test.ts
+++ b/src/frontend/src/lib/__tests__/shortcutRegistry.test.ts
@@ -197,8 +197,8 @@ describe("shortcutRegistry", () => {
     document.body.removeChild(input);
   });
 
-  it("should not install global listener when registry is empty", () => {
-    expect(_isListenerInstalled()).toBe(false);
+  it("should install global listener at module load even when registry is empty", () => {
+    expect(_isListenerInstalled()).toBe(true);
     expect(_getRegistrySize()).toBe(0);
   });
 
@@ -359,6 +359,67 @@ describe("getRegisteredShortcuts", () => {
     const inactive = shortcuts.find((s) => s.id === "btn-inactive");
     expect(active?.isActive).toBe(true);
     expect(inactive?.isActive).toBe(false);
+  });
+});
+
+describe("backspace navigation prevention", () => {
+  beforeEach(() => {
+    _resetForTesting();
+  });
+
+  it("prevents browser back-navigation on Backspace outside text inputs", () => {
+    const event = new KeyboardEvent("keydown", {
+      key: "Backspace",
+      code: "Backspace",
+      bubbles: true,
+      cancelable: true,
+    });
+    const preventDefaultSpy = vi.spyOn(event, "preventDefault");
+    window.dispatchEvent(event);
+
+    expect(preventDefaultSpy).toHaveBeenCalled();
+  });
+
+  it("allows Backspace in input fields", () => {
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+
+    const event = new KeyboardEvent("keydown", {
+      key: "Backspace",
+      code: "Backspace",
+      bubbles: true,
+      cancelable: true,
+    });
+    const preventDefaultSpy = vi.spyOn(event, "preventDefault");
+    input.dispatchEvent(event);
+
+    expect(preventDefaultSpy).not.toHaveBeenCalled();
+    document.body.removeChild(input);
+  });
+
+  it("registered Backspace shortcuts still fire", () => {
+    const handler = vi.fn();
+    registerShortcut(
+      makeRegistration({
+        id: "btn-backspace",
+        shortcut: makeShortcut("Backspace"),
+        handler,
+        skipInInputs: true,
+      }),
+    );
+
+    const event = new KeyboardEvent("keydown", {
+      key: "Backspace",
+      code: "Backspace",
+      bubbles: true,
+      cancelable: true,
+    });
+    const preventDefaultSpy = vi.spyOn(event, "preventDefault");
+    window.dispatchEvent(event);
+
+    expect(preventDefaultSpy).toHaveBeenCalled();
+    expect(handler).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/frontend/src/lib/shortcutRegistry.ts
+++ b/src/frontend/src/lib/shortcutRegistry.ts
@@ -62,6 +62,11 @@ function handleKeyDown(event: KeyboardEvent) {
   const isInputField =
     target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable;
 
+  // Prevent browser back-navigation on Backspace outside text inputs
+  if (event.key === "Backspace" && !isInputField) {
+    event.preventDefault();
+  }
+
   for (const registration of registry.values()) {
     const { shortcut, handler, isActive, skipInInputs, id } = registration;
 
@@ -174,3 +179,6 @@ export function _getRegistrySize(): number {
 export function _isListenerInstalled(): boolean {
   return listenerInstalled;
 }
+
+// Install the listener at module load to ensure Backspace prevention is always active
+installListener();

--- a/src/frontend/src/lib/shortcutRegistry.ts
+++ b/src/frontend/src/lib/shortcutRegistry.ts
@@ -168,6 +168,8 @@ export function _resetForTesting(): void {
     sweepTimerId = null;
   }
   removeListener();
+  // Reinstall listener to match module-load state (for backspace prevention)
+  installListener();
 }
 
 /** For testing only — returns the current registry size */


### PR DESCRIPTION
# Summary

## Changes

Added global keydown handler to prevent browser back-navigation when Backspace is pressed outside text input fields. The handler installs at module load and prevents the legacy browser behavior where Backspace = "go back in history," which is inappropriate in single-page desktop applications and causes loss of application state.

## API Changes

None. This is an internal change to keyboard event handling within the shortcut registry system.

## Files Modified

**Frontend:**
- `src/frontend/src/lib/shortcutRegistry.ts` — Added backspace prevention logic in `handleKeyDown()`, called `installListener()` at module load, and updated `_resetForTesting()` to reinstall listener
- `src/frontend/src/lib/__tests__/shortcutRegistry.test.ts` — Added 3 new tests for backspace prevention behavior and updated existing listener test

## Manual Testing

1. **Launch any Ivy desktop app** (e.g., Tendril, Ivy Samples)
2. **Navigate to any view** with interactive elements (buttons, tables, lists)
3. **Click on a non-input element** (button, table row, or empty space) to ensure focus is NOT in a text field
4. **Press Backspace** — Observe that the app does NOT navigate away or lose state
5. **Click into a text input or textarea** field
6. **Press Backspace** — Observe that characters are deleted normally (typing works as expected)
7. **Register a Backspace shortcut** (e.g., Tendril's Delete/Decline buttons use `.ShortcutKey("Backspace")`)
8. **Press Backspace while the shortcut is active** — Observe that the shortcut fires AND the browser doesn't navigate back

---

## Commits

- c0361445f Fix test environment for backspace prevention
- 4ac17deed Prevent backspace from triggering browser back navigation

---
Created using [Ivy Tendril](https://ivy.app).
