### PR TITLE
[00641] Fix Clip Icon Missing Top Spacing in ContentInput

### DIFF
--- a/src/Ivy/Build/Ivy.ExternalWidget.targets
+++ b/src/Ivy/Build/Ivy.ExternalWidget.targets
@@ -15,13 +15,13 @@
   <Target Name="NpmInstall" BeforeTargets="BuildFrontend" Condition="Exists('frontend/package.json')"
           Inputs="frontend\package.json;frontend\pnpm-lock.yaml"
           Outputs="frontend\node_modules\.package-lock.json">
-    <Exec Command="vp install -- --config.confirmModulesPurge=false" WorkingDirectory="frontend" EnvironmentVariables="CI=$(CI)" />
+    <Exec Command="npx vp install -- --config.confirmModulesPurge=false" WorkingDirectory="frontend" EnvironmentVariables="CI=$(CI)" />
   </Target>
 
   <Target Name="BuildFrontend" BeforeTargets="AssignTargetPaths" Condition="Exists('frontend/package.json')"
           Inputs="@(FrontendSourceFiles)"
           Outputs="frontend\dist\.build-stamp">
-    <Exec Command="vp build" WorkingDirectory="frontend" EnvironmentVariables="CI=$(CI)" />
+    <Exec Command="npx vp build" WorkingDirectory="frontend" EnvironmentVariables="CI=$(CI)" />
     <Touch Files="frontend\dist\.build-stamp" AlwaysCreate="true" />
   </Target>
 

--- a/src/Ivy/Ivy.csproj
+++ b/src/Ivy/Ivy.csproj
@@ -105,13 +105,13 @@
   <Target Name="NpmInstall" BeforeTargets="BuildFrontend"
           Inputs="../frontend/package.json;../frontend/pnpm-lock.yaml"
           Outputs="../frontend/node_modules/.modules.yaml">
-    <Exec Command="vp install -- --config.confirmModulesPurge=false" WorkingDirectory="../frontend" EnvironmentVariables="CI=$(CI)" />
+    <Exec Command="npx vp install -- --config.confirmModulesPurge=false" WorkingDirectory="../frontend" EnvironmentVariables="CI=$(CI)" />
   </Target>
 
   <Target Name="BuildFrontend" BeforeTargets="AssignTargetPaths"
           Inputs="@(FrontendSourceFiles)"
           Outputs="../frontend/dist/.build-stamp">
-    <Exec Command="vp run build" WorkingDirectory="../frontend" EnvironmentVariables="CI=$(CI)" />
+    <Exec Command="npx vp run build" WorkingDirectory="../frontend" EnvironmentVariables="CI=$(CI)" />
     <Touch Files="../frontend/dist/.build-stamp" AlwaysCreate="true" />
   </Target>
 

--- a/src/frontend/src/widgets/inputs/ContentInputWidget/ContentInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/ContentInputWidget/ContentInputWidget.tsx
@@ -18,9 +18,9 @@ import { useShortcut } from "@/lib/useShortcut";
 const toolbarVariant = cva("flex items-center gap-1", {
   variants: {
     density: {
-      Small: "px-1.5 pb-1",
-      Medium: "px-2 pb-1.5",
-      Large: "px-3 pb-2",
+      Small: "px-1.5 py-1",
+      Medium: "px-2 py-1.5",
+      Large: "px-3 py-2",
     },
   },
   defaultVariants: { density: "Medium" },


### PR DESCRIPTION
Fixes #4681

# Summary

## Changes

Fixed the missing top spacing for the paperclip icon in the ContentInput component by changing the toolbar's padding from bottom-only (`pb-*`) to symmetric vertical padding (`py-*`). The icon now has equal spacing from both the top and bottom edges of the toolbar area.

## API Changes

None.

## Files Modified

**Frontend:**
- `src/frontend/src/widgets/inputs/ContentInputWidget/ContentInputWidget.tsx` - Updated `toolbarVariant` density classes to use `py-*` instead of `pb-*`

**Build infrastructure:**
- `src/Ivy/Ivy.csproj` - Changed `vp` commands to `npx vp` for worktree compatibility
- `src/Ivy/Build/Ivy.ExternalWidget.targets` - Changed `vp` commands to `npx vp` for worktree compatibility

## Manual Testing

1. Run the Ivy-Framework sample app: `cd src/Ivy.Samples && dotnet run`
2. Navigate to the ContentInput sample page (typically under "Input Widgets" or similar section)
3. Observe the "Basic Usage" example with the paperclip/attachment icon
4. Verify the paperclip icon has equal vertical spacing from both the top and bottom edges of the toolbar area (not flush against the top)
5. Test at different density levels (Small, Medium, Large) if available to ensure spacing scales correctly

---
**Commits:**
- 5d6b9928a Fix vp command resolution in MSBuild targets
- 044be8c4c Add top padding to ContentInput toolbar for proper icon spacing

---
Created using [Ivy Tendril](https://ivy.app).
