### PR TITLE
chore: bump Rustino.NET to 0.3.9

### DIFF
--- a/src/Ivy.Desktop/Ivy.Desktop.csproj
+++ b/src/Ivy.Desktop/Ivy.Desktop.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Rustino.NET" Version="0.3.8" />
+    <PackageReference Include="Rustino.NET" Version="0.3.9" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Picks up the fix for the macOS "Where is use_default?" dialog on first desktop notification (Ivy-Interactive/Rustino#20, fixes Ivy-Interactive/Ivy-Tendril#1682 downstream).

🤖 Generated with [Claude Code](https://claude.com/claude-code)