### PR TITLE
fix: revert npx vp back to bare vp in MSBuild targets

### DIFF
--- a/src/Ivy/Build/Ivy.ExternalWidget.targets
+++ b/src/Ivy/Build/Ivy.ExternalWidget.targets
@@ -15,13 +15,13 @@
   <Target Name="NpmInstall" BeforeTargets="BuildFrontend" Condition="Exists('frontend/package.json')"
           Inputs="frontend\package.json;frontend\pnpm-lock.yaml"
           Outputs="frontend\node_modules\.package-lock.json">
-    <Exec Command="npx vp install -- --config.confirmModulesPurge=false" WorkingDirectory="frontend" EnvironmentVariables="CI=$(CI)" />
+    <Exec Command="vp install -- --config.confirmModulesPurge=false" WorkingDirectory="frontend" EnvironmentVariables="CI=$(CI)" />
   </Target>
 
   <Target Name="BuildFrontend" BeforeTargets="AssignTargetPaths" Condition="Exists('frontend/package.json')"
           Inputs="@(FrontendSourceFiles)"
           Outputs="frontend\dist\.build-stamp">
-    <Exec Command="npx vp build" WorkingDirectory="frontend" EnvironmentVariables="CI=$(CI)" />
+    <Exec Command="vp build" WorkingDirectory="frontend" EnvironmentVariables="CI=$(CI)" />
     <Touch Files="frontend\dist\.build-stamp" AlwaysCreate="true" />
   </Target>
 

--- a/src/Ivy/Ivy.csproj
+++ b/src/Ivy/Ivy.csproj
@@ -105,13 +105,13 @@
   <Target Name="NpmInstall" BeforeTargets="BuildFrontend"
           Inputs="../frontend/package.json;../frontend/pnpm-lock.yaml"
           Outputs="../frontend/node_modules/.modules.yaml">
-    <Exec Command="npx vp install -- --config.confirmModulesPurge=false" WorkingDirectory="../frontend" EnvironmentVariables="CI=$(CI)" />
+    <Exec Command="vp install -- --config.confirmModulesPurge=false" WorkingDirectory="../frontend" EnvironmentVariables="CI=$(CI)" />
   </Target>
 
   <Target Name="BuildFrontend" BeforeTargets="AssignTargetPaths"
           Inputs="@(FrontendSourceFiles)"
           Outputs="../frontend/dist/.build-stamp">
-    <Exec Command="npx vp run build" WorkingDirectory="../frontend" EnvironmentVariables="CI=$(CI)" />
+    <Exec Command="vp run build" WorkingDirectory="../frontend" EnvironmentVariables="CI=$(CI)" />
     <Touch Files="../frontend/dist/.build-stamp" AlwaysCreate="true" />
   </Target>
 


### PR DESCRIPTION
## Summary
Reverts 5d6b9928a ("Fix vp command resolution in MSBuild targets"), which changed the MSBuild `Exec` commands in `src/Ivy/Ivy.csproj` and `src/Ivy/Build/Ivy.ExternalWidget.targets` from bare `vp` to `npx vp`.

That change broke the backend-checks job on every PR (e.g. #4713, #4714) with:

```
EXEC : error : `npx vp` is not the correct way to use the Vite+ CLI
```

## Why
The Vite+ CLI (`vp`) is a standalone binary — installed in CI by `voidzero-dev/setup-vp@v1` and put on PATH — not a local node_modules tool. `npx vp` resolves the unrelated placeholder `vp` package on npm, which rejects the invocation with the error above. All other workflows (frontend checks, unit tests) already invoke bare `vp`.

## Verification
- `dotnet build src/Ivy/Ivy.csproj` succeeds locally: `vp install` and `vp run build` both run through MSBuild with 0 warnings/errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)