### PR TITLE
[00655] Fix Full-Height DataTable Not Filling Available Space

### DIFF
--- a/src/frontend/src/widgets/dataTables/DataTableWidget.test.ts
+++ b/src/frontend/src/widgets/dataTables/DataTableWidget.test.ts
@@ -9,6 +9,14 @@ import * as path from "path";
 describe("DataTableWidget - container style for height modes", () => {
   const source = fs.readFileSync(path.resolve(__dirname, "./DataTableWidget.tsx"), "utf-8");
 
+  // Isolate the `if (height === "Full") { ... }` branch so assertions about the
+  // Full-height container don't accidentally match the explicit-height `else` branch.
+  const fullBranch = (() => {
+    const start = source.indexOf('if (height === "Full")');
+    const elseIndex = source.indexOf("} else {", start);
+    return start >= 0 && elseIndex > start ? source.slice(start, elseIndex) : "";
+  })();
+
   it('should set display flex on outer container when height is "Full"', () => {
     expect(source).toContain('containerStyle.display = "flex"');
     expect(source).toContain('containerStyle.flexDirection = "column"');
@@ -28,8 +36,15 @@ describe("DataTableWidget - container style for height modes", () => {
     expect(source).toContain("containerStyle.minHeight = minHeight");
   });
 
-  it("should set maxHeight to 100% so tables shrink with the viewport", () => {
-    expect(source).toContain('containerStyle.maxHeight = "100%"');
+  it('should not clamp the "Full" height branch with a percentage maxHeight', () => {
+    // Regression guard for issue #1695 / PR #4485: a percentage max-height
+    // collapses the table to its min-height inside the scrolling app host.
+    // flexGrow fills the flex parent, so the Full branch must not set maxHeight.
+    expect(fullBranch).not.toBe("");
+    expect(fullBranch).not.toContain('containerStyle.maxHeight = "100%"');
+    // The fill behaviour and responsive lower bound must remain in place.
+    expect(fullBranch).toContain("containerStyle.flexGrow = 1");
+    expect(fullBranch).toContain("containerStyle.minHeight = minHeight");
   });
 
   it("should apply getHeight for explicit pixel heights", () => {

--- a/src/frontend/src/widgets/dataTables/DataTableWidget.tsx
+++ b/src/frontend/src/widgets/dataTables/DataTableWidget.tsx
@@ -110,7 +110,8 @@ export const DataTable: React.FC<DataTableWidgetProps> = ({
     containerStyle.flexGrow = 1;
     containerStyle.flexShrink = 1;
     containerStyle.minHeight = minHeight;
-    containerStyle.maxHeight = "100%";
+    // no maxHeight — flexGrow fills the flex parent; a percentage max-height
+    // collapses the table inside the scrolling app host (issue #1695 / PR #4485).
   } else {
     containerStyle.display = "flex";
     containerStyle.flexDirection = "column";


### PR DESCRIPTION
# Summary

## Changes

Removed the `maxHeight: "100%"` clamp from the DataTable widget's `height === "Full"`
branch (introduced by PR #4485). Inside a scrolling parent the percentage max-height
resolved against an ambiguous ancestor height and collapsed the table to its density-aware
minimum, leaving a whitespace band below the rows (issue #1695). `flexGrow: 1` already fills
the flex parent, and `flexShrink: 1` + `minHeight` preserve the responsive lower bound #4485
intended, so full-height tables now fill their container again while still shrinking-then-scrolling
on short viewports.

## API Changes

None. Frontend-only styling change; no public C# API, TypeScript prop, or config surface changed.

## Files Modified

- **Widget fix**
  - `src/frontend/src/widgets/dataTables/DataTableWidget.tsx` — dropped `containerStyle.maxHeight = "100%"` from the `Full` branch (replaced with an explanatory comment).
- **Test**
  - `src/frontend/src/widgets/dataTables/DataTableWidget.test.ts` — replaced the test that asserted the clamp was present with a regression guard that isolates the `Full` branch and asserts `maxHeight = "100%"` is absent while `flexGrow`/`minHeight` remain.

## Manual Testing

1. Run the Ivy-Tendril app (it source-references this framework) and open `http://localhost:5010/jobs`.
2. Observe the Jobs table: it should fill the full available height of its container with **no** large empty whitespace band below the rows.
3. Resize the browser window to a short height: the table should shrink to a few readable rows and then the **page** should scroll — it should not collapse to zero or overflow.
4. Check another full-height table page (e.g. Pull Requests / Dashboard) to confirm the same fill behaviour.
5. If any page uses a fixed-height table (`.Height(Size.Px(...))`), confirm it is unaffected (the `else` branch was not touched).

---

## Commits

- 40e08f256 Fix full-height DataTable collapsing inside scrolling parent (plan 00655)

---
Created using [Ivy Tendril](https://ivy.app).