### PR TITLE
Collapse main app sidebar to icon rail with in-sidebar toggle

### DIFF
--- a/src/Ivy/Widgets/Layouts/SidebarLayout.cs
+++ b/src/Ivy/Widgets/Layouts/SidebarLayout.cs
@@ -17,7 +17,12 @@ public record SidebarLayout : WidgetBase<SidebarLayout>
 {
     public static Size DefaultWidth => Size.Rem(16);
 
-    public SidebarLayout(object mainContent, object sidebarContent, object? sidebarHeader = null, object? sidebarFooter = null, Size? width = null, object? sidebarHeaderCollapsed = null, object? sidebarFooterCollapsed = null)
+    public SidebarLayout(object mainContent, object sidebarContent, object? sidebarHeader = null, object? sidebarFooter = null, Size? width = null)
+    : this(mainContent, sidebarContent, sidebarHeader, sidebarFooter, width, null, null)
+    {
+    }
+
+    public SidebarLayout(object mainContent, object sidebarContent, object? sidebarHeader, object? sidebarFooter, Size? width, object? sidebarHeaderCollapsed, object? sidebarFooterCollapsed)
     : base(BuildSlots(mainContent, sidebarContent, sidebarHeader, sidebarFooter, sidebarHeaderCollapsed, sidebarFooterCollapsed))
     {
         Width = (width ?? DefaultWidth).ToResponsive();

--- a/src/Ivy/Widgets/Layouts/SidebarLayout.cs
+++ b/src/Ivy/Widgets/Layouts/SidebarLayout.cs
@@ -11,22 +11,26 @@ namespace Ivy;
 [Slot("SidebarContent")]
 [Slot("SidebarHeader")]
 [Slot("SidebarFooter")]
+[Slot("SidebarHeaderCollapsed")]
+[Slot("SidebarFooterCollapsed")]
 public record SidebarLayout : WidgetBase<SidebarLayout>
 {
     public static Size DefaultWidth => Size.Rem(16);
 
-    public SidebarLayout(object mainContent, object sidebarContent, object? sidebarHeader = null, object? sidebarFooter = null, Size? width = null)
-    : base(BuildSlots(mainContent, sidebarContent, sidebarHeader, sidebarFooter))
+    public SidebarLayout(object mainContent, object sidebarContent, object? sidebarHeader = null, object? sidebarFooter = null, Size? width = null, object? sidebarHeaderCollapsed = null, object? sidebarFooterCollapsed = null)
+    : base(BuildSlots(mainContent, sidebarContent, sidebarHeader, sidebarFooter, sidebarHeaderCollapsed, sidebarFooterCollapsed))
     {
         Width = (width ?? DefaultWidth).ToResponsive();
     }
 
-    private static Slot[] BuildSlots(object mainContent, object sidebarContent, object? sidebarHeader, object? sidebarFooter) =>
+    private static Slot[] BuildSlots(object mainContent, object sidebarContent, object? sidebarHeader, object? sidebarFooter, object? sidebarHeaderCollapsed, object? sidebarFooterCollapsed) =>
     [
         new Slot("MainContent", mainContent),
         new Slot("SidebarContent", sidebarContent),
         sidebarHeader != null ? new Slot("SidebarHeader", sidebarHeader) : new Slot("SidebarHeader"),
-        sidebarFooter != null ? new Slot("SidebarFooter", sidebarFooter) : new Slot("SidebarFooter")
+        sidebarFooter != null ? new Slot("SidebarFooter", sidebarFooter) : new Slot("SidebarFooter"),
+        sidebarHeaderCollapsed != null ? new Slot("SidebarHeaderCollapsed", sidebarHeaderCollapsed) : new Slot("SidebarHeaderCollapsed"),
+        sidebarFooterCollapsed != null ? new Slot("SidebarFooterCollapsed", sidebarFooterCollapsed) : new Slot("SidebarFooterCollapsed")
     ];
 
     internal SidebarLayout() { }

--- a/src/frontend/src/widgets/layouts/sidebar/SidebarLayoutWidget.tsx
+++ b/src/frontend/src/widgets/layouts/sidebar/SidebarLayoutWidget.tsx
@@ -88,6 +88,30 @@ const hasContent = (slot?: React.ReactNode[]): boolean => {
   });
 };
 
+const SidebarToggleButton: React.FC<{ isSidebarOpen: boolean; onToggle: () => void }> = ({
+  isSidebarOpen,
+  onToggle,
+}) => (
+  <TooltipProvider delayDuration={300}>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          onClick={onToggle}
+          className="p-2 rounded-selector text-muted-foreground hover:bg-accent hover:text-accent-foreground cursor-pointer"
+          aria-label={isSidebarOpen ? "Close sidebar" : "Open sidebar"}
+        >
+          {isSidebarOpen ? (
+            <PanelLeftClose className="size-4" />
+          ) : (
+            <PanelLeftOpen className="size-4" />
+          )}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="right">Toggle sidebar (Ctrl+B)</TooltipContent>
+    </Tooltip>
+  </TooltipProvider>
+);
+
 export const SidebarLayoutWidget: React.FC<SidebarLayoutWidgetProps> = ({
   slots,
   showToggleButton = true,
@@ -295,44 +319,32 @@ export const SidebarLayoutWidget: React.FC<SidebarLayoutWidgetProps> = ({
             width: isCollapsedToRail ? `${SIDEBAR_RAIL_WIDTH_PX}px` : effectiveSidebarWidth,
           }}
         >
-          {showToggleButton && isIconRail && (
-            <div
-              className={cn(
-                "flex shrink-0 px-2 pt-2",
-                isCollapsedToRail ? "justify-center" : "justify-end",
-              )}
-            >
-              <TooltipProvider delayDuration={300}>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      onClick={handleManualToggle}
-                      className="p-2 rounded-selector text-muted-foreground hover:bg-accent hover:text-accent-foreground cursor-pointer"
-                      aria-label={isSidebarOpen ? "Close sidebar" : "Open sidebar"}
-                    >
-                      {isSidebarOpen ? (
-                        <PanelLeftClose className="size-4" />
-                      ) : (
-                        <PanelLeftOpen className="size-4" />
-                      )}
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent side="right">Toggle sidebar (Ctrl+B)</TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
+          {/* In the rail the toggle is its own centered row at the top; when expanded it sits in
+              the top-right corner, aligned with the top of the header title instead of pushing it
+              down. The header slot lives in a separate DOM subtree, so we overlay rather than nest. */}
+          {showToggleButton && isIconRail && isCollapsedToRail && (
+            <div className="flex justify-center shrink-0 px-2 pt-2">
+              <SidebarToggleButton isSidebarOpen={isSidebarOpen} onToggle={handleManualToggle} />
             </div>
           )}
-          {isCollapsedToRail
-            ? hasContent(slots?.SidebarHeaderCollapsed) && (
-                <div className="flex flex-col items-center shrink-0 px-2 pb-2 gap-y-2 h-fit animate-in fade-in duration-300">
-                  {slots?.SidebarHeaderCollapsed}
-                </div>
-              )
-            : hasContent(slots?.SidebarHeader) && (
-                <div className="flex flex-col shrink-0 px-2 pb-2 gap-y-4 h-fit">
-                  {slots?.SidebarHeader}
-                </div>
-              )}
+          <div className="relative shrink-0">
+            {showToggleButton && isIconRail && !isCollapsedToRail && (
+              <div className="absolute top-2 right-2 z-10">
+                <SidebarToggleButton isSidebarOpen={isSidebarOpen} onToggle={handleManualToggle} />
+              </div>
+            )}
+            {isCollapsedToRail
+              ? hasContent(slots?.SidebarHeaderCollapsed) && (
+                  <div className="flex flex-col items-center px-2 pb-2 gap-y-2 h-fit animate-in fade-in duration-300">
+                    {slots?.SidebarHeaderCollapsed}
+                  </div>
+                )
+              : hasContent(slots?.SidebarHeader) && (
+                  <div className="flex flex-col px-2 pb-2 gap-y-4 h-fit">
+                    {slots?.SidebarHeader}
+                  </div>
+                )}
+          </div>
           {slots?.SidebarContent &&
             (sidebarContentScroll === "None" ? (
               <div className="flex-1 min-h-0 min-w-0 overflow-hidden">{slots.SidebarContent}</div>

--- a/src/frontend/src/widgets/layouts/sidebar/SidebarLayoutWidget.tsx
+++ b/src/frontend/src/widgets/layouts/sidebar/SidebarLayoutWidget.tsx
@@ -788,7 +788,7 @@ const renderMenuItems = (
             <h4
               className={cn(
                 "sticky top-0 z-10 bg-card text-small-label text-muted-foreground mb-0 overflow-hidden whitespace-nowrap transition-all duration-300",
-                collapsed ? "h-0 p-0 opacity-0" : "h-8 p-2 opacity-100",
+                collapsed ? "h-0 w-0 p-0 opacity-0" : "h-8 p-2 opacity-100",
               )}
             >
               {item.label}

--- a/src/frontend/src/widgets/layouts/sidebar/SidebarLayoutWidget.tsx
+++ b/src/frontend/src/widgets/layouts/sidebar/SidebarLayoutWidget.tsx
@@ -14,12 +14,19 @@ import { cn, getAppId } from "@/lib/utils";
 import { getWidth } from "@/lib/styles";
 import { Separator } from "@/components/ui/separator";
 import { SidebarMenuBadge } from "@/components/ui/sidebar";
+import { SidebarLayoutContext, useSidebarLayout } from "./sidebar-layout-context";
+
+// 8px rail padding + 8px item padding + 16px icon + 8px + 8px, so menu icons keep
+// their x-position while the sidebar width animates.
+const SIDEBAR_RAIL_WIDTH_PX = 48;
 
 interface SidebarLayoutWidgetProps {
   slots?: {
     SidebarHeader?: React.ReactNode[];
     SidebarContent?: React.ReactNode[];
     SidebarFooter?: React.ReactNode[];
+    SidebarHeaderCollapsed?: React.ReactNode[];
+    SidebarFooterCollapsed?: React.ReactNode[];
     MainContent: React.ReactNode[];
   };
   showToggleButton?: boolean;
@@ -200,11 +207,24 @@ export const SidebarLayoutWidget: React.FC<SidebarLayoutWidgetProps> = ({
         ? `${currentWidth}px`
         : sidebarWidth;
 
+  // On desktop, the main app sidebar collapses to an icon rail instead of sliding offscreen.
+  const isIconRail = mainAppSidebar && !isMobileViewport;
+  const isCollapsedToRail = isIconRail && !isSidebarOpen;
+
   // Handle manual toggle
   const handleManualToggle = useCallback(() => {
     dispatchSidebar((prev) => ({ isSidebarOpen: !prev.isSidebarOpen }));
     dispatchSidebar({ isManuallyToggled: true });
   }, [dispatchSidebar]);
+
+  const sidebarContextValue = useMemo(
+    () => ({
+      collapsed: isCollapsedToRail,
+      expand: () => dispatchSidebar({ isSidebarOpen: true, isManuallyToggled: true }),
+      toggle: handleManualToggle,
+    }),
+    [isCollapsedToRail, handleManualToggle, dispatchSidebar],
+  );
 
   // Register keyboard shortcut for toggling sidebar (Ctrl+B)
   useShortcut("sidebar-layout-toggle", "CTRL+B", handleManualToggle, {
@@ -252,112 +272,161 @@ export const SidebarLayoutWidget: React.FC<SidebarLayoutWidgetProps> = ({
   }, [mainAppSidebar, isMobileViewport, dispatchSidebar]);
 
   return (
-    <div
-      ref={containerRef}
-      className="grid h-full w-full remove-parent-padding"
-      style={{
-        gridTemplateColumns: isSidebarOpen ? `${effectiveSidebarWidth} 1fr` : "0 1fr",
-        transition: isResizing ? "none" : "grid-template-columns 300ms ease-in-out",
-      }}
-    >
-      {/* Custom Sidebar with Slide Animation */}
+    <SidebarLayoutContext.Provider value={sidebarContextValue}>
       <div
-        ref={sidebarRef}
-        className={`flex h-full flex-col bg-card text-foreground border-r border-border relative overflow-hidden ${
-          isResizing ? "" : "transition-transform duration-300 ease-in-out"
-        } ${isSidebarOpen ? "translate-x-0" : "-translate-x-full"}`}
-        style={{ width: effectiveSidebarWidth }}
+        ref={containerRef}
+        className="grid h-full w-full remove-parent-padding"
+        style={{
+          gridTemplateColumns: isSidebarOpen
+            ? `${effectiveSidebarWidth} 1fr`
+            : isIconRail
+              ? `${SIDEBAR_RAIL_WIDTH_PX}px 1fr`
+              : "0 1fr",
+          transition: isResizing ? "none" : "grid-template-columns 300ms ease-in-out",
+        }}
       >
-        {hasContent(slots?.SidebarHeader) && (
-          <div className="flex flex-col shrink-0 p-2 gap-y-4 h-fit">{slots?.SidebarHeader}</div>
-        )}
-        {slots?.SidebarContent &&
-          (sidebarContentScroll === "None" ? (
-            <div className="flex-1 min-h-0 min-w-0 overflow-hidden">{slots.SidebarContent}</div>
-          ) : (
-            <div className="flex-1 min-h-0 min-w-0 overflow-hidden">
-              <ScrollArea className="h-full w-full">
-                <div className="p-2 gap-y-2">{slots.SidebarContent}</div>
-              </ScrollArea>
-            </div>
-          ))}
-        {hasContent(slots?.SidebarFooter) && (
-          <div className="flex flex-col shrink-0">
-            <div className="flex flex-col p-2 gap-4 min-h-0">{slots?.SidebarFooter}</div>
-          </div>
-        )}
-        {/* Resize Handle */}
-        {resizable && isSidebarOpen && (
-          <div
-            className={cn("absolute top-0 right-0 w-1 h-full cursor-ew-resize group")}
-            onMouseDown={handleResizeStart}
-            onTouchStart={handleResizeStart}
-            role="separator"
-            aria-orientation="vertical"
-            aria-label="Resize sidebar"
-            tabIndex={0}
-            onKeyDown={(e) => {
-              if (e.key === "ArrowLeft") {
-                dispatchSidebar((prev) => ({
-                  currentWidth: Math.max(minWidthPx, prev.currentWidth - 10),
-                }));
-              } else if (e.key === "ArrowRight") {
-                dispatchSidebar((prev) => ({
-                  currentWidth: Math.min(maxWidthPx, prev.currentWidth + 10),
-                }));
-              }
-            }}
-          >
+        {/* Custom Sidebar with Slide Animation */}
+        <div
+          ref={sidebarRef}
+          className={`flex h-full flex-col bg-card text-foreground border-r border-border relative overflow-hidden ${
+            isResizing ? "" : "transition-[width,transform] duration-300 ease-in-out"
+          } ${isSidebarOpen || isCollapsedToRail ? "translate-x-0" : "-translate-x-full"}`}
+          style={{
+            width: isCollapsedToRail ? `${SIDEBAR_RAIL_WIDTH_PX}px` : effectiveSidebarWidth,
+          }}
+        >
+          {isCollapsedToRail
+            ? hasContent(slots?.SidebarHeaderCollapsed) && (
+                <div className="flex flex-col items-center shrink-0 p-2 gap-y-2 h-fit animate-in fade-in duration-300">
+                  {slots?.SidebarHeaderCollapsed}
+                </div>
+              )
+            : hasContent(slots?.SidebarHeader) && (
+                <div className="flex flex-col shrink-0 p-2 gap-y-4 h-fit">
+                  {slots?.SidebarHeader}
+                </div>
+              )}
+          {slots?.SidebarContent &&
+            (sidebarContentScroll === "None" ? (
+              <div className="flex-1 min-h-0 min-w-0 overflow-hidden">{slots.SidebarContent}</div>
+            ) : (
+              <div className="flex-1 min-h-0 min-w-0 overflow-hidden">
+                <ScrollArea className="h-full w-full">
+                  <div className="p-2 gap-y-2">{slots.SidebarContent}</div>
+                </ScrollArea>
+              </div>
+            ))}
+          {isCollapsedToRail
+            ? hasContent(slots?.SidebarFooterCollapsed) && (
+                <div className="flex flex-col items-center shrink-0 p-2 gap-y-2 animate-in fade-in duration-300">
+                  {slots?.SidebarFooterCollapsed}
+                </div>
+              )
+            : hasContent(slots?.SidebarFooter) && (
+                <div className="flex flex-col shrink-0">
+                  <div className="flex flex-col p-2 gap-4 min-h-0">{slots?.SidebarFooter}</div>
+                </div>
+              )}
+          {showToggleButton && isIconRail && (
             <div
               className={cn(
-                "absolute top-1/2 -translate-y-1/2 right-0 w-1 h-8 rounded-full bg-border",
-                "opacity-0 group-hover:opacity-100 transition-opacity",
-                isResizing && "opacity-100",
+                "flex shrink-0 p-2",
+                isCollapsedToRail ? "justify-center" : "justify-end",
               )}
-            />
-          </div>
-        )}
-      </div>
+            >
+              <TooltipProvider delayDuration={300}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      onClick={handleManualToggle}
+                      className="p-2 rounded-selector text-muted-foreground hover:bg-accent hover:text-accent-foreground cursor-pointer"
+                      aria-label={isSidebarOpen ? "Close sidebar" : "Open sidebar"}
+                    >
+                      {isSidebarOpen ? (
+                        <PanelLeftClose className="size-4" />
+                      ) : (
+                        <PanelLeftOpen className="size-4" />
+                      )}
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="right">Toggle sidebar (Ctrl+B)</TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            </div>
+          )}
+          {/* Resize Handle */}
+          {resizable && isSidebarOpen && (
+            <div
+              className={cn("absolute top-0 right-0 w-1 h-full cursor-ew-resize group")}
+              onMouseDown={handleResizeStart}
+              onTouchStart={handleResizeStart}
+              role="separator"
+              aria-orientation="vertical"
+              aria-label="Resize sidebar"
+              tabIndex={0}
+              onKeyDown={(e) => {
+                if (e.key === "ArrowLeft") {
+                  dispatchSidebar((prev) => ({
+                    currentWidth: Math.max(minWidthPx, prev.currentWidth - 10),
+                  }));
+                } else if (e.key === "ArrowRight") {
+                  dispatchSidebar((prev) => ({
+                    currentWidth: Math.min(maxWidthPx, prev.currentWidth + 10),
+                  }));
+                }
+              }}
+            >
+              <div
+                className={cn(
+                  "absolute top-1/2 -translate-y-1/2 right-0 w-1 h-8 rounded-full bg-border",
+                  "opacity-0 group-hover:opacity-100 transition-opacity",
+                  isResizing && "opacity-100",
+                )}
+              />
+            </div>
+          )}
+        </div>
 
-      {/* min-w-0 keeps the 1fr grid track from overflowing the viewport on narrow screens. */}
-      <div
-        className={cn(
-          `relative h-full overflow-auto min-w-0`,
-          !mainAppSidebar ? `p-${mainContentPadding ?? 2}` : "",
-        )}
-      >
-        {showToggleButton && mainAppSidebar && (
-          <TooltipProvider delayDuration={300}>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  onClick={handleManualToggle}
-                  className="absolute top-0 left-1 z-50 p-2 rounded-selector bg-background hover:bg-muted hover:text-accent-foreground cursor-pointer"
-                  style={{ marginTop: "3px" }}
-                  aria-label={isSidebarOpen ? "Close sidebar" : "Open sidebar"}
-                >
-                  {isSidebarOpen ? (
-                    <PanelLeftClose className="size-4" />
-                  ) : (
-                    <PanelLeftOpen className="size-4" />
-                  )}
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="right">Toggle sidebar (Ctrl+B)</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-        )}
-        {/* On mobile, the content sliver beside the open drawer closes it instead of being interactive. */}
-        {mainAppSidebar && isMobileViewport && isSidebarOpen && (
-          <div
-            className="absolute inset-0 z-40 cursor-pointer"
-            onClick={() => dispatchSidebar({ isSidebarOpen: false })}
-            aria-label="Close sidebar"
-          />
-        )}
-        {slots?.MainContent}
+        {/* min-w-0 keeps the 1fr grid track from overflowing the viewport on narrow screens. */}
+        <div
+          className={cn(
+            `relative h-full overflow-auto min-w-0`,
+            !mainAppSidebar ? `p-${mainContentPadding ?? 2}` : "",
+          )}
+        >
+          {showToggleButton && mainAppSidebar && isMobileViewport && (
+            <TooltipProvider delayDuration={300}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    onClick={handleManualToggle}
+                    className="absolute top-0 left-1 z-50 p-2 rounded-selector bg-background hover:bg-muted hover:text-accent-foreground cursor-pointer"
+                    style={{ marginTop: "3px" }}
+                    aria-label={isSidebarOpen ? "Close sidebar" : "Open sidebar"}
+                  >
+                    {isSidebarOpen ? (
+                      <PanelLeftClose className="size-4" />
+                    ) : (
+                      <PanelLeftOpen className="size-4" />
+                    )}
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="right">Toggle sidebar (Ctrl+B)</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          )}
+          {/* On mobile, the content sliver beside the open drawer closes it instead of being interactive. */}
+          {mainAppSidebar && isMobileViewport && isSidebarOpen && (
+            <div
+              className="absolute inset-0 z-40 cursor-pointer"
+              onClick={() => dispatchSidebar({ isSidebarOpen: false })}
+              aria-label="Close sidebar"
+            />
+          )}
+          {slots?.MainContent}
+        </div>
       </div>
-    </div>
+    </SidebarLayoutContext.Provider>
   );
 };
 
@@ -395,6 +464,35 @@ const getFlatItemsInSearchRenderOrder = (items: MenuItem[]): MenuItem[] => {
 // Animation duration for collapsible sections (in milliseconds)
 const COLLAPSIBLE_ANIMATION_DURATION = 300;
 
+const CollapsedRailTooltip: React.FC<{
+  label: string;
+  collapsed: boolean;
+  children: React.ReactElement;
+}> = ({ label, collapsed, children }) =>
+  collapsed ? (
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger asChild>{children}</TooltipTrigger>
+        <TooltipContent side="right">{label}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  ) : (
+    children
+  );
+
+const menuLabelClasses = (collapsed: boolean) =>
+  cn("text-sm whitespace-nowrap transition-opacity duration-200", collapsed && "opacity-0");
+
+// Icon-less items would render as blank rows in the rail, so fall back to the label's initial.
+const MenuItemIcon: React.FC<{ item: MenuItem; collapsed: boolean }> = ({ item, collapsed }) =>
+  !item.icon && collapsed ? (
+    <span className="size-4 shrink-0 flex items-center justify-center text-xs font-medium">
+      {(item.label ?? "").charAt(0).toUpperCase()}
+    </span>
+  ) : (
+    <Icon name={item.icon} size={16} className="shrink-0" />
+  );
+
 const CollapsibleMenuItem: React.FC<{
   item: MenuItem;
   events: string[];
@@ -422,6 +520,7 @@ const CollapsibleMenuItem: React.FC<{
   const prevShouldBeOpenRef = useRef(shouldBeOpen);
   const [isPenHovered, setIsPenHovered] = useState(false);
   const itemRef = useRef<HTMLLIElement>(null);
+  const { collapsed, expand } = useSidebarLayout();
 
   // Sync local state with derived state
   if (shouldBeOpen !== prevShouldBeOpenRef.current) {
@@ -450,18 +549,41 @@ const CollapsibleMenuItem: React.FC<{
   const isActive = item.tag === activeTag;
 
   if (item.children && item.children.length > 0) {
+    const triggerClasses = cn(
+      "group flex w-full items-center gap-2 rounded-selector p-2 text-large-label cursor-pointer h-8 text-left overflow-hidden",
+      isActive
+        ? "bg-secondary text-accent-foreground"
+        : "hover:bg-accent hover:text-accent-foreground",
+      isPenHovered && "bg-accent text-accent-foreground",
+    );
+
+    // In the collapsed rail, a section icon expands the sidebar with the section opened
+    // instead of toggling a hidden submenu.
+    if (collapsed) {
+      return (
+        <li className="relative" ref={itemRef} data-menu-item={item.tag || item.label}>
+          <CollapsedRailTooltip label={item.label} collapsed>
+            <button
+              className={triggerClasses}
+              onClick={() => {
+                expand();
+                handleOpenChange(true);
+              }}
+            >
+              <MenuItemIcon item={item} collapsed={collapsed} />
+              <span className={menuLabelClasses(collapsed)}>{item.label}</span>
+            </button>
+          </CollapsedRailTooltip>
+        </li>
+      );
+    }
+
     return (
       <Collapsible open={isOpen} onOpenChange={handleOpenChange}>
         <li className="relative" ref={itemRef} data-menu-item={item.tag || item.label}>
           <CollapsibleTrigger asChild>
             <button
-              className={cn(
-                "group flex w-full items-center gap-2 rounded-selector p-2 text-large-label cursor-pointer h-8 text-left",
-                isActive
-                  ? "bg-secondary text-accent-foreground"
-                  : "hover:bg-accent hover:text-accent-foreground",
-                isPenHovered && "bg-accent text-accent-foreground",
-              )}
+              className={triggerClasses}
               onClick={() => {
                 // For items with children, toggle the collapsible state
                 // Only try to navigate if the item has a tag
@@ -481,9 +603,9 @@ const CollapsibleMenuItem: React.FC<{
                 }
               }}
             >
-              <Icon name={item.icon} size={16} />
-              <span className="text-sm">{item.label}</span>
-              <ChevronRight className="ml-auto size-4 transition-transform group-data-[state=open]:rotate-90" />
+              <MenuItemIcon item={item} collapsed={collapsed} />
+              <span className={menuLabelClasses(collapsed)}>{item.label}</span>
+              <ChevronRight className="ml-auto size-4 shrink-0 transition-transform group-data-[state=open]:rotate-90" />
             </button>
           </CollapsibleTrigger>
           <CollapsibleContent>
@@ -499,6 +621,7 @@ const CollapsibleMenuItem: React.FC<{
                   expandedSections,
                   onExpandChange,
                   pathKey,
+                  collapsed,
                 )}
             </ul>
           </CollapsibleContent>
@@ -513,31 +636,39 @@ const CollapsibleMenuItem: React.FC<{
         data-menu-item={item.tag || item.label}
         className="relative"
       >
-        <button
-          className={cn(
-            "flex w-full items-center gap-2 rounded-selector p-2 text-large-label cursor-pointer h-8 text-left",
-            isActive
-              ? "bg-secondary text-accent-foreground"
-              : "hover:bg-accent hover:text-accent-foreground",
-            isPenHovered && "bg-accent text-accent-foreground",
-          )}
-          onClick={() => onItemClick(item)}
-          onMouseDown={(e) => onCtrlRightMouseClick(e, item)}
-          onPointerEnter={(e) => {
-            if (e.pointerType === "pen") {
-              setIsPenHovered(true);
-            }
-          }}
-          onPointerLeave={(e) => {
-            if (e.pointerType === "pen") {
-              setIsPenHovered(false);
-            }
-          }}
-        >
-          <Icon name={item.icon} size={16} />
-          <span className="text-sm">{item.label}</span>
-          {item.badge && <SidebarMenuBadge>{item.badge}</SidebarMenuBadge>}
-        </button>
+        <CollapsedRailTooltip label={item.label} collapsed={collapsed}>
+          <button
+            className={cn(
+              "flex w-full items-center gap-2 rounded-selector p-2 text-large-label cursor-pointer h-8 text-left overflow-hidden",
+              isActive
+                ? "bg-secondary text-accent-foreground"
+                : "hover:bg-accent hover:text-accent-foreground",
+              isPenHovered && "bg-accent text-accent-foreground",
+            )}
+            onClick={() => onItemClick(item)}
+            onMouseDown={(e) => onCtrlRightMouseClick(e, item)}
+            onPointerEnter={(e) => {
+              if (e.pointerType === "pen") {
+                setIsPenHovered(true);
+              }
+            }}
+            onPointerLeave={(e) => {
+              if (e.pointerType === "pen") {
+                setIsPenHovered(false);
+              }
+            }}
+          >
+            <MenuItemIcon item={item} collapsed={collapsed} />
+            <span className={menuLabelClasses(collapsed)}>{item.label}</span>
+            {item.badge && (
+              <SidebarMenuBadge
+                className={cn("transition-opacity duration-200", collapsed && "opacity-0")}
+              >
+                {item.badge}
+              </SidebarMenuBadge>
+            )}
+          </button>
+        </CollapsedRailTooltip>
       </li>
     );
   }
@@ -552,34 +683,43 @@ const MenuItemButton: React.FC<{
   onMouseDown: (e: React.MouseEvent) => void;
 }> = ({ item, isActive, level, onClick, onMouseDown }) => {
   const [isPenHovered, setIsPenHovered] = useState(false);
+  const { collapsed } = useSidebarLayout();
 
   return (
-    <button
-      className={cn(
-        "flex w-full items-center gap-2 rounded-selector p-2 cursor-pointer h-8 text-left",
-        level === 1 ? "text-body" : "text-body",
-        isActive
-          ? "bg-secondary text-accent-foreground"
-          : "hover:bg-accent hover:text-accent-foreground",
-        isPenHovered && "bg-accent text-accent-foreground",
-      )}
-      onClick={onClick}
-      onMouseDown={onMouseDown}
-      onPointerEnter={(e) => {
-        if (e.pointerType === "pen") {
-          setIsPenHovered(true);
-        }
-      }}
-      onPointerLeave={(e) => {
-        if (e.pointerType === "pen") {
-          setIsPenHovered(false);
-        }
-      }}
-    >
-      <Icon name={item.icon} size={16} />
-      <span className="text-sm">{item.label}</span>
-      {item.badge && <SidebarMenuBadge>{item.badge}</SidebarMenuBadge>}
-    </button>
+    <CollapsedRailTooltip label={item.label} collapsed={collapsed}>
+      <button
+        className={cn(
+          "flex w-full items-center gap-2 rounded-selector p-2 cursor-pointer h-8 text-left overflow-hidden",
+          level === 1 ? "text-body" : "text-body",
+          isActive
+            ? "bg-secondary text-accent-foreground"
+            : "hover:bg-accent hover:text-accent-foreground",
+          isPenHovered && "bg-accent text-accent-foreground",
+        )}
+        onClick={onClick}
+        onMouseDown={onMouseDown}
+        onPointerEnter={(e) => {
+          if (e.pointerType === "pen") {
+            setIsPenHovered(true);
+          }
+        }}
+        onPointerLeave={(e) => {
+          if (e.pointerType === "pen") {
+            setIsPenHovered(false);
+          }
+        }}
+      >
+        <MenuItemIcon item={item} collapsed={collapsed} />
+        <span className={menuLabelClasses(collapsed)}>{item.label}</span>
+        {item.badge && (
+          <SidebarMenuBadge
+            className={cn("transition-opacity duration-200", collapsed && "opacity-0")}
+          >
+            {item.badge}
+          </SidebarMenuBadge>
+        )}
+      </button>
+    </CollapsedRailTooltip>
   );
 };
 
@@ -593,6 +733,7 @@ const renderMenuItems = (
   expandedSections: Set<string> = new Set(),
   onExpandChange: (pathKey: string, expanded: boolean) => void = () => {},
   parentPathKey: string = "",
+  collapsed: boolean = false,
 ) => {
   const onItemClick = (item: MenuItem) => {
     if (!item.tag) return;
@@ -612,8 +753,19 @@ const renderMenuItems = (
     if ("children" in item) {
       if (level === 0) {
         return (
-          <div key={itemPathKey} className="flex flex-col gap-y-1 mt-6 first:mt-0">
-            <h4 className="sticky top-0 z-10 bg-card p-2 text-small-label text-muted-foreground mb-0">
+          <div
+            key={itemPathKey}
+            className={cn(
+              "flex flex-col gap-y-1 first:mt-0 transition-all duration-300",
+              collapsed ? "mt-2" : "mt-6",
+            )}
+          >
+            <h4
+              className={cn(
+                "sticky top-0 z-10 bg-card text-small-label text-muted-foreground mb-0 overflow-hidden whitespace-nowrap transition-all duration-300",
+                collapsed ? "h-0 p-0 opacity-0" : "h-8 p-2 opacity-100",
+              )}
+            >
               {item.label}
             </h4>
             <ul className="flex flex-col gap-y-0.5">
@@ -628,6 +780,7 @@ const renderMenuItems = (
                   expandedSections,
                   onExpandChange,
                   itemPathKey,
+                  collapsed,
                 )}
             </ul>
           </div>
@@ -691,6 +844,7 @@ export const SidebarMenuWidget: React.FC<SidebarMenuWidgetProps> = ({
   searchActive = false,
 }) => {
   const eventHandler = useEventHandler();
+  const { collapsed } = useSidebarLayout();
   const [selectedIndex, setSelectedIndex] = useState(0);
   const prevSearchActiveRef = React.useRef(searchActive);
 
@@ -979,7 +1133,7 @@ export const SidebarMenuWidget: React.FC<SidebarMenuWidgetProps> = ({
       style={{ outline: "none" }}
       data-sidebar-menu-widget
     >
-      {searchActive ? (
+      {searchActive && !collapsed ? (
         flatItems.length > 0 ? (
           renderMenuItemsWithHighlight(items)
         ) : (
@@ -997,6 +1151,8 @@ export const SidebarMenuWidget: React.FC<SidebarMenuWidgetProps> = ({
           activeTag,
           expandedSections,
           handleExpandChange,
+          "",
+          collapsed,
         )
       )}
     </div>

--- a/src/frontend/src/widgets/layouts/sidebar/SidebarLayoutWidget.tsx
+++ b/src/frontend/src/widgets/layouts/sidebar/SidebarLayoutWidget.tsx
@@ -295,42 +295,10 @@ export const SidebarLayoutWidget: React.FC<SidebarLayoutWidgetProps> = ({
             width: isCollapsedToRail ? `${SIDEBAR_RAIL_WIDTH_PX}px` : effectiveSidebarWidth,
           }}
         >
-          {isCollapsedToRail
-            ? hasContent(slots?.SidebarHeaderCollapsed) && (
-                <div className="flex flex-col items-center shrink-0 p-2 gap-y-2 h-fit animate-in fade-in duration-300">
-                  {slots?.SidebarHeaderCollapsed}
-                </div>
-              )
-            : hasContent(slots?.SidebarHeader) && (
-                <div className="flex flex-col shrink-0 p-2 gap-y-4 h-fit">
-                  {slots?.SidebarHeader}
-                </div>
-              )}
-          {slots?.SidebarContent &&
-            (sidebarContentScroll === "None" ? (
-              <div className="flex-1 min-h-0 min-w-0 overflow-hidden">{slots.SidebarContent}</div>
-            ) : (
-              <div className="flex-1 min-h-0 min-w-0 overflow-hidden">
-                <ScrollArea className="h-full w-full">
-                  <div className="p-2 gap-y-2">{slots.SidebarContent}</div>
-                </ScrollArea>
-              </div>
-            ))}
-          {isCollapsedToRail
-            ? hasContent(slots?.SidebarFooterCollapsed) && (
-                <div className="flex flex-col items-center shrink-0 p-2 gap-y-2 animate-in fade-in duration-300">
-                  {slots?.SidebarFooterCollapsed}
-                </div>
-              )
-            : hasContent(slots?.SidebarFooter) && (
-                <div className="flex flex-col shrink-0">
-                  <div className="flex flex-col p-2 gap-4 min-h-0">{slots?.SidebarFooter}</div>
-                </div>
-              )}
           {showToggleButton && isIconRail && (
             <div
               className={cn(
-                "flex shrink-0 p-2",
+                "flex shrink-0 px-2 pt-2",
                 isCollapsedToRail ? "justify-center" : "justify-end",
               )}
             >
@@ -354,6 +322,38 @@ export const SidebarLayoutWidget: React.FC<SidebarLayoutWidgetProps> = ({
               </TooltipProvider>
             </div>
           )}
+          {isCollapsedToRail
+            ? hasContent(slots?.SidebarHeaderCollapsed) && (
+                <div className="flex flex-col items-center shrink-0 px-2 pb-2 gap-y-2 h-fit animate-in fade-in duration-300">
+                  {slots?.SidebarHeaderCollapsed}
+                </div>
+              )
+            : hasContent(slots?.SidebarHeader) && (
+                <div className="flex flex-col shrink-0 px-2 pb-2 gap-y-4 h-fit">
+                  {slots?.SidebarHeader}
+                </div>
+              )}
+          {slots?.SidebarContent &&
+            (sidebarContentScroll === "None" ? (
+              <div className="flex-1 min-h-0 min-w-0 overflow-hidden">{slots.SidebarContent}</div>
+            ) : (
+              <div className="flex-1 min-h-0 min-w-0 overflow-hidden">
+                <ScrollArea className="h-full w-full">
+                  <div className="p-2 w-full">{slots.SidebarContent}</div>
+                </ScrollArea>
+              </div>
+            ))}
+          {isCollapsedToRail
+            ? hasContent(slots?.SidebarFooterCollapsed) && (
+                <div className="flex flex-col items-center shrink-0 p-2 gap-y-2 animate-in fade-in duration-300">
+                  {slots?.SidebarFooterCollapsed}
+                </div>
+              )
+            : hasContent(slots?.SidebarFooter) && (
+                <div className="flex flex-col shrink-0">
+                  <div className="flex flex-col p-2 gap-4 min-h-0">{slots?.SidebarFooter}</div>
+                </div>
+              )}
           {/* Resize Handle */}
           {resizable && isSidebarOpen && (
             <div
@@ -480,8 +480,18 @@ const CollapsedRailTooltip: React.FC<{
     children
   );
 
+// Collapse the label to zero width in the rail (not just opacity) so the button shrinks to icon
+// width; otherwise the still-laid-out labels keep every button label-wide and centering scatters.
 const menuLabelClasses = (collapsed: boolean) =>
-  cn("text-sm whitespace-nowrap transition-opacity duration-200", collapsed && "opacity-0");
+  cn(
+    "text-sm whitespace-nowrap overflow-hidden transition-[max-width,opacity] duration-200",
+    collapsed ? "max-w-0 opacity-0" : "max-w-[12rem] opacity-100",
+  );
+
+// In the rail, center the icon (matching the centered header/footer/toggle icons) and drop the
+// horizontal padding and label gap so it lines up with them instead of sitting a hair to the right.
+const menuButtonRailClasses = (collapsed: boolean) =>
+  collapsed ? "justify-center gap-0 px-0" : "";
 
 // Icon-less items would render as blank rows in the rail, so fall back to the label's initial.
 const MenuItemIcon: React.FC<{ item: MenuItem; collapsed: boolean }> = ({ item, collapsed }) =>
@@ -555,6 +565,7 @@ const CollapsibleMenuItem: React.FC<{
         ? "bg-secondary text-accent-foreground"
         : "hover:bg-accent hover:text-accent-foreground",
       isPenHovered && "bg-accent text-accent-foreground",
+      menuButtonRailClasses(collapsed),
     );
 
     // In the collapsed rail, a section icon expands the sidebar with the section opened
@@ -644,6 +655,7 @@ const CollapsibleMenuItem: React.FC<{
                 ? "bg-secondary text-accent-foreground"
                 : "hover:bg-accent hover:text-accent-foreground",
               isPenHovered && "bg-accent text-accent-foreground",
+              menuButtonRailClasses(collapsed),
             )}
             onClick={() => onItemClick(item)}
             onMouseDown={(e) => onCtrlRightMouseClick(e, item)}
@@ -695,6 +707,7 @@ const MenuItemButton: React.FC<{
             ? "bg-secondary text-accent-foreground"
             : "hover:bg-accent hover:text-accent-foreground",
           isPenHovered && "bg-accent text-accent-foreground",
+          menuButtonRailClasses(collapsed),
         )}
         onClick={onClick}
         onMouseDown={onMouseDown}

--- a/src/frontend/src/widgets/layouts/sidebar/SidebarLayoutWidget.tsx
+++ b/src/frontend/src/widgets/layouts/sidebar/SidebarLayoutWidget.tsx
@@ -16,9 +16,9 @@ import { Separator } from "@/components/ui/separator";
 import { SidebarMenuBadge } from "@/components/ui/sidebar";
 import { SidebarLayoutContext, useSidebarLayout } from "./sidebar-layout-context";
 
-// 8px rail padding + 8px item padding + 16px icon + 8px + 8px, so menu icons keep
-// their x-position while the sidebar width animates.
-const SIDEBAR_RAIL_WIDTH_PX = 48;
+// Wide enough for a menu item's full icon box (container padding + button padding + 16px icon)
+// so icons keep their x-position while the sidebar width animates.
+const SIDEBAR_RAIL_WIDTH_PX = 54;
 
 interface SidebarLayoutWidgetProps {
   slots?: {
@@ -323,7 +323,7 @@ export const SidebarLayoutWidget: React.FC<SidebarLayoutWidgetProps> = ({
               the top-right corner, aligned with the top of the header title instead of pushing it
               down. The header slot lives in a separate DOM subtree, so we overlay rather than nest. */}
           {showToggleButton && isIconRail && isCollapsedToRail && (
-            <div className="flex justify-center shrink-0 px-2 pt-2">
+            <div className="flex justify-center shrink-0 px-2 pt-2 pb-2">
               <SidebarToggleButton isSidebarOpen={isSidebarOpen} onToggle={handleManualToggle} />
             </div>
           )}

--- a/src/frontend/src/widgets/layouts/sidebar/index.ts
+++ b/src/frontend/src/widgets/layouts/sidebar/index.ts
@@ -1,2 +1,3 @@
 export { SidebarLayoutWidget, SidebarMenuWidget } from "./SidebarLayoutWidget";
 export { sidebarMenuRef } from "./sidebar-refs";
+export { SidebarLayoutContext, useSidebarLayout } from "./sidebar-layout-context";

--- a/src/frontend/src/widgets/layouts/sidebar/sidebar-layout-context.ts
+++ b/src/frontend/src/widgets/layouts/sidebar/sidebar-layout-context.ts
@@ -1,0 +1,15 @@
+import { createContext, useContext } from "react";
+
+export interface SidebarLayoutContextValue {
+  collapsed: boolean;
+  expand: () => void;
+  toggle: () => void;
+}
+
+export const SidebarLayoutContext = createContext<SidebarLayoutContextValue>({
+  collapsed: false,
+  expand: () => {},
+  toggle: () => {},
+});
+
+export const useSidebarLayout = () => useContext(SidebarLayoutContext);

--- a/src/frontend/src/widgets/layouts/tabs/components/Variants.tsx
+++ b/src/frontend/src/widgets/layouts/tabs/components/Variants.tsx
@@ -267,7 +267,7 @@ export const TabsVariant: React.FC<TabsVariantProps> = ({
     >
       <div className="flex-shrink-0" style={getWidth(width)}>
         <div
-          className="relative min-h-10 flex items-end pl-10 md:pl-2 pr-6 before:absolute before:inset-x-0 before:bottom-0 before:h-px before:bg-border before:z-0 overflow-hidden"
+          className="relative min-h-10 flex items-end pl-10 md:pl-0 pr-6 before:absolute before:inset-x-0 before:bottom-0 before:h-px before:bg-border before:z-0 overflow-hidden"
           ref={containerRef}
         >
           <DndContext

--- a/src/frontend/src/widgets/layouts/tabs/components/Variants.tsx
+++ b/src/frontend/src/widgets/layouts/tabs/components/Variants.tsx
@@ -267,7 +267,7 @@ export const TabsVariant: React.FC<TabsVariantProps> = ({
     >
       <div className="flex-shrink-0" style={getWidth(width)}>
         <div
-          className="relative min-h-10 flex items-end pl-10 pr-6 before:absolute before:inset-x-0 before:bottom-0 before:h-px before:bg-border before:z-0 overflow-hidden"
+          className="relative min-h-10 flex items-end pl-10 md:pl-2 pr-6 before:absolute before:inset-x-0 before:bottom-0 before:h-px before:bg-border before:z-0 overflow-hidden"
           ref={containerRef}
         >
           <DndContext


### PR DESCRIPTION

<img width="1512" height="982" alt="Screenshot 2026-07-17 at 14 44 59" src="https://github.com/user-attachments/assets/fa706990-240a-4db9-87ab-3fc180283278" />

## Summary
Redesigns the main app sidebar collapse behavior (part of the Tendril chrome redesign; companion PR in Ivy-Tendril):

- **Icon rail on desktop**: collapsing the main app sidebar now shrinks it to a 48px icon rail instead of sliding it fully offscreen. Menu items render icon-only with right-side tooltips (icon-less items fall back to the label's initial), group headers fade/collapse, badges fade, and clicking a collapsed section expands the sidebar with that section open. Icons keep their x-position through the 300ms width transition, so the collapse is seamless.
- **Toggle inside the sidebar**: the sidebar toggle moved from floating over the main content into the bottom of the sidebar (desktop). The floating toggle remains only for the mobile drawer, whose behavior is unchanged. The tab bar row no longer reserves space for the floating button on desktop (`pl-10` → `md:pl-2`).
- **New collapsed slots**: `SidebarLayout` gains optional `SidebarHeaderCollapsed` / `SidebarFooterCollapsed` slots (C# + frontend) so shells can provide rail-sized header/footer content (e.g. an icon-only primary action). Without them, header/footer hide while collapsed.
- **Context for sidebar widgets**: new `SidebarLayoutContext` (`useSidebarLayout()`) exposes `{collapsed, expand, toggle}`; `SidebarMenuWidget` uses it for rail rendering. Search-result rendering is suppressed while collapsed (results would otherwise render clipped inside the 48px rail).

## Notes for reviewers
- `DefaultSidebarAppShell` consumers get the rail by default with hidden header/search/footer while collapsed; menu icons (or letter fallbacks) plus the in-rail toggle keep it functional. Wiring collapsed slots into `DefaultSidebarAppShell` could be a follow-up.
- Standalone `TabsLayout` widgets using the `Tabs` variant lose 32px of left padding on desktop (`pl-10` existed to clear the floating toggle).
- Non-main-app sidebars (`MainAppSidebar` unset) are unchanged.

## Testing
- Frontend: `tsc` + vite build clean, 1289 vitest tests pass, lint clean.
- C#: `Ivy.Test` 1365 tests pass.
- Manual browser verification of the Samples app (tabs + rail + toggle) and Ivy Tendril (rail, tooltips, navigation, New Plan dialog from rail, settings dropdown from rail, mobile drawer) on desktop and mobile viewports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
