### PR TITLE
fix: make dropdown menus scroll when taller than viewport

### DIFF
--- a/src/frontend/src/components/ui/dropdown-menu.tsx
+++ b/src/frontend/src/components/ui/dropdown-menu.tsx
@@ -63,7 +63,7 @@ const DropdownMenuSubContent = React.forwardRef<
     ref={ref}
     collisionPadding={8}
     className={cn(
-      "z-50 min-w-[8rem] max-w-[calc(100vw-16px)] overflow-hidden rounded-box border bg-popover p-1 text-popover-foreground shadow-lg flex flex-col gap-0.5 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      "z-50 min-w-[8rem] max-w-[calc(100vw-16px)] max-h-[var(--radix-dropdown-menu-content-available-height)] overflow-y-auto rounded-box border bg-popover p-1 text-popover-foreground shadow-lg flex flex-col gap-0.5 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
       className,
     )}
     {...props}
@@ -80,7 +80,7 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       collisionPadding={8}
       className={cn(
-        "z-50 min-w-[8rem] max-w-[calc(100vw-16px)] overflow-hidden rounded-box border bg-popover p-1 text-popover-foreground shadow-md flex flex-col gap-0.5",
+        "z-50 min-w-[8rem] max-w-[calc(100vw-16px)] max-h-[var(--radix-dropdown-menu-content-available-height)] overflow-y-auto rounded-box border bg-popover p-1 text-popover-foreground shadow-md flex flex-col gap-0.5",
         "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className,
       )}

--- a/src/frontend/src/widgets/dropDownMenu/DropDownMenuWidget.tsx
+++ b/src/frontend/src/widgets/dropDownMenu/DropDownMenuWidget.tsx
@@ -1,6 +1,5 @@
 import { useEventHandler } from "@/components/event-handler";
 import React, { useRef, useState } from "react";
-import { X } from "lucide-react";
 
 import {
   DropdownMenu,
@@ -18,8 +17,8 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { MenuItem } from "@/types/widgets";
 import Icon from "@/components/Icon";
-import { camelCase, cn } from "@/lib/utils";
-import { getColor, getWidth } from "@/lib/styles";
+import { camelCase } from "@/lib/utils";
+import { getColor } from "@/lib/styles";
 import { ShortcutKeys } from "@/components/Kbd";
 import { Densities } from "@/types/density";
 
@@ -33,7 +32,6 @@ interface DropDownMenuWidgetProps {
   alignOffset?: number;
   stayOpen?: boolean;
   density?: Densities;
-  width?: string;
   events?: string[];
   slots?: {
     Trigger?: React.ReactNode[];
@@ -93,12 +91,7 @@ const DropDownMenuItemGroup = ({
         >
           {item.icon && <Icon name={item.icon} size={iconSize} style={colorStyle} />}
           {item.label}
-          {item.checked &&
-            (stayOpen ? (
-              <X className="ml-auto size-4 shrink-0 text-muted-foreground" />
-            ) : (
-              <span className="ml-auto">✓</span>
-            ))}
+          {item.checked && <span className="ml-auto">✓</span>}
           {item.shortcut && (
             <DropdownMenuShortcut>
               <ShortcutKeys shortcut={item.shortcut} />
@@ -189,7 +182,6 @@ export const DropDownMenuWidget: React.FC<DropDownMenuWidgetProps> = ({
   alignOffset = 0,
   stayOpen = false,
   density = Densities.Medium,
-  width,
   events = EMPTY_EVENTS,
 }) => {
   const eventHandler = useEventHandler();
@@ -199,7 +191,6 @@ export const DropDownMenuWidget: React.FC<DropDownMenuWidgetProps> = ({
   const iconSize = density === Densities.Small ? 12 : density === Densities.Large ? 16 : 14;
   const contentMarginClass =
     density === Densities.Small ? "m-1" : density === Densities.Large ? "m-3" : "m-2";
-  const widthStyles = getWidth(width);
 
   if (!slots?.Trigger) {
     return <div className="text-red-500">Error: DropDownMenu requires Trigger slot.</div>;
@@ -223,29 +214,25 @@ export const DropDownMenuWidget: React.FC<DropDownMenuWidgetProps> = ({
   };
 
   return (
-    <div style={widthStyles} className={cn(width && "min-w-0")}>
-      <DropdownMenu open={open} onOpenChange={handleOpenChange}>
-        <DropdownMenuTrigger ref={triggerRef} asChild>
-          <div style={{ maxWidth: "100%", minWidth: 0, width: width ? "100%" : undefined }}>
-            {slots.Trigger}
-          </div>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent
-          onClick={(e) => e.stopPropagation()}
-          align={camelCase(align) as "center" | "end" | "start" | undefined}
-          side={camelCase(side) as "top" | "right" | "bottom" | "left" | undefined}
-          className={contentMarginClass}
-          alignOffset={alignOffset}
-        >
-          {slots.Header && <DropdownMenuLabel>{slots.Header}</DropdownMenuLabel>}
-          <DropDownMenuItemGroup
-            items={items}
-            onItemClick={onItemClick}
-            iconSize={iconSize}
-            stayOpen={stayOpen}
-          />
-        </DropdownMenuContent>
-      </DropdownMenu>
-    </div>
+    <DropdownMenu open={open} onOpenChange={handleOpenChange}>
+      <DropdownMenuTrigger ref={triggerRef} asChild>
+        <div style={{ maxWidth: "100%", minWidth: 0 }}>{slots.Trigger}</div>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        onClick={(e) => e.stopPropagation()}
+        align={camelCase(align) as "center" | "end" | "start" | undefined}
+        side={camelCase(side) as "top" | "right" | "bottom" | "left" | undefined}
+        className={contentMarginClass}
+        alignOffset={alignOffset}
+      >
+        {slots.Header && <DropdownMenuLabel>{slots.Header}</DropdownMenuLabel>}
+        <DropDownMenuItemGroup
+          items={items}
+          onItemClick={onItemClick}
+          iconSize={iconSize}
+          stayOpen={stayOpen}
+        />
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 };

--- a/src/frontend/src/widgets/dropDownMenu/DropDownMenuWidget.tsx
+++ b/src/frontend/src/widgets/dropDownMenu/DropDownMenuWidget.tsx
@@ -1,5 +1,6 @@
 import { useEventHandler } from "@/components/event-handler";
 import React, { useRef, useState } from "react";
+import { X } from "lucide-react";
 
 import {
   DropdownMenu,
@@ -17,8 +18,8 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { MenuItem } from "@/types/widgets";
 import Icon from "@/components/Icon";
-import { camelCase } from "@/lib/utils";
-import { getColor } from "@/lib/styles";
+import { camelCase, cn } from "@/lib/utils";
+import { getColor, getWidth } from "@/lib/styles";
 import { ShortcutKeys } from "@/components/Kbd";
 import { Densities } from "@/types/density";
 
@@ -32,6 +33,7 @@ interface DropDownMenuWidgetProps {
   alignOffset?: number;
   stayOpen?: boolean;
   density?: Densities;
+  width?: string;
   events?: string[];
   slots?: {
     Trigger?: React.ReactNode[];
@@ -91,7 +93,12 @@ const DropDownMenuItemGroup = ({
         >
           {item.icon && <Icon name={item.icon} size={iconSize} style={colorStyle} />}
           {item.label}
-          {item.checked && <span className="ml-auto">✓</span>}
+          {item.checked &&
+            (stayOpen ? (
+              <X className="ml-auto size-4 shrink-0 text-muted-foreground" />
+            ) : (
+              <span className="ml-auto">✓</span>
+            ))}
           {item.shortcut && (
             <DropdownMenuShortcut>
               <ShortcutKeys shortcut={item.shortcut} />
@@ -182,6 +189,7 @@ export const DropDownMenuWidget: React.FC<DropDownMenuWidgetProps> = ({
   alignOffset = 0,
   stayOpen = false,
   density = Densities.Medium,
+  width,
   events = EMPTY_EVENTS,
 }) => {
   const eventHandler = useEventHandler();
@@ -191,6 +199,7 @@ export const DropDownMenuWidget: React.FC<DropDownMenuWidgetProps> = ({
   const iconSize = density === Densities.Small ? 12 : density === Densities.Large ? 16 : 14;
   const contentMarginClass =
     density === Densities.Small ? "m-1" : density === Densities.Large ? "m-3" : "m-2";
+  const widthStyles = getWidth(width);
 
   if (!slots?.Trigger) {
     return <div className="text-red-500">Error: DropDownMenu requires Trigger slot.</div>;
@@ -214,25 +223,29 @@ export const DropDownMenuWidget: React.FC<DropDownMenuWidgetProps> = ({
   };
 
   return (
-    <DropdownMenu open={open} onOpenChange={handleOpenChange}>
-      <DropdownMenuTrigger ref={triggerRef} asChild>
-        <div style={{ maxWidth: "100%", minWidth: 0 }}>{slots.Trigger}</div>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent
-        onClick={(e) => e.stopPropagation()}
-        align={camelCase(align) as "center" | "end" | "start" | undefined}
-        side={camelCase(side) as "top" | "right" | "bottom" | "left" | undefined}
-        className={contentMarginClass}
-        alignOffset={alignOffset}
-      >
-        {slots.Header && <DropdownMenuLabel>{slots.Header}</DropdownMenuLabel>}
-        <DropDownMenuItemGroup
-          items={items}
-          onItemClick={onItemClick}
-          iconSize={iconSize}
-          stayOpen={stayOpen}
-        />
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <div style={widthStyles} className={cn(width && "min-w-0")}>
+      <DropdownMenu open={open} onOpenChange={handleOpenChange}>
+        <DropdownMenuTrigger ref={triggerRef} asChild>
+          <div style={{ maxWidth: "100%", minWidth: 0, width: width ? "100%" : undefined }}>
+            {slots.Trigger}
+          </div>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          onClick={(e) => e.stopPropagation()}
+          align={camelCase(align) as "center" | "end" | "start" | undefined}
+          side={camelCase(side) as "top" | "right" | "bottom" | "left" | undefined}
+          className={contentMarginClass}
+          alignOffset={alignOffset}
+        >
+          {slots.Header && <DropdownMenuLabel>{slots.Header}</DropdownMenuLabel>}
+          <DropDownMenuItemGroup
+            items={items}
+            onItemClick={onItemClick}
+            iconSize={iconSize}
+            stayOpen={stayOpen}
+          />
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
   );
 };


### PR DESCRIPTION
## Summary
- Cap `DropdownMenuContent` / `SubContent` to Radix available height (`--radix-dropdown-menu-content-available-height`) and use `overflow-y-auto` instead of `overflow-hidden`.
- Fixes long menus (e.g. the project selector in Tendril's New Plan dialog) clipping off-screen items with no way to scroll.

## Test plan
- [ ] Open a dropdown with more items than fit the viewport; confirm the list scrolls and all items are reachable
- [ ] Confirm short dropdowns are unchanged
- [ ] Spot-check nested submenu content still opens and scrolls when tall


Made with [Cursor](https://cursor.com)