### PR TITLE
Remove Version from PluginManifest

### DIFF
--- a/src/Ivy.Plugin.Abstractions/CompatibilitySuppressions.xml
+++ b/src/Ivy.Plugin.Abstractions/CompatibilitySuppressions.xml
@@ -66,6 +66,13 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Ivy.Plugins.PluginManifest.get_Version</Target>
+    <Left>lib/net10.0/Ivy.Plugin.Abstractions.dll</Left>
+    <Right>lib/net10.0/Ivy.Plugin.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Ivy.Plugins.PluginManifest.set_ConfigSectionName(System.String)</Target>
     <Left>lib/net10.0/Ivy.Plugin.Abstractions.dll</Left>
     <Right>lib/net10.0/Ivy.Plugin.Abstractions.dll</Right>
@@ -81,6 +88,13 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Ivy.Plugins.PluginManifest.set_Name(System.String)</Target>
+    <Left>lib/net10.0/Ivy.Plugin.Abstractions.dll</Left>
+    <Right>lib/net10.0/Ivy.Plugin.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Ivy.Plugins.PluginManifest.set_Version(System.Version)</Target>
     <Left>lib/net10.0/Ivy.Plugin.Abstractions.dll</Left>
     <Right>lib/net10.0/Ivy.Plugin.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>

--- a/src/Ivy.Plugin.Abstractions/PluginManifest.cs
+++ b/src/Ivy.Plugin.Abstractions/PluginManifest.cs
@@ -11,7 +11,6 @@ public record PluginManifest
 {
     public required string Id { get; init; }
     public required string Title { get; init; }
-    public required Version Version { get; init; }
     public Version? MinimumHostVersion { get; init; }
     public PluginIcon? Icon { get; init; }
 }

--- a/src/Ivy.Test/PluginConfigurationValidationTests.cs
+++ b/src/Ivy.Test/PluginConfigurationValidationTests.cs
@@ -256,7 +256,6 @@ public class PluginConfigurationValidationTests
         {
             Id = "Ivy.Plugin.Fake",
             Title = "Fake",
-            Version = new Version(1, 0, 0),
         };
 
         public PluginConfigurationSchema? ConfigurationSchema { get; }

--- a/src/Ivy.Test/PluginLoaderTests.cs
+++ b/src/Ivy.Test/PluginLoaderTests.cs
@@ -504,7 +504,6 @@ public class PluginLoaderTests
         {
             Id = Id,
             Title = "Test Plugin",
-            Version = new Version(1, 0)
         };
 
         public Ivy.Plugins.PluginConfigurationSchema? ConfigurationSchema => null;
@@ -645,7 +644,6 @@ public class PluginLoaderTests
         {
             Id = "Ivy.Plugin.TypedTest",
             Title = "Typed Test",
-            Version = new Version(1, 0)
         };
 
         public Ivy.Plugins.PluginConfigurationSchema? ConfigurationSchema => null;

--- a/src/Ivy/Core/Plugins/PluginLoader.cs
+++ b/src/Ivy/Core/Plugins/PluginLoader.cs
@@ -109,7 +109,7 @@ public class PluginLoader : IPluginManager
 
         foreach (var plugin in _plugins)
         {
-            _logger.LogInformation("Loaded plugin: {Id} v{Version}", plugin.Instance.Manifest.Id, plugin.Instance.Manifest.Version);
+            _logger.LogInformation("Loaded plugin: {Id}", plugin.Instance.Manifest.Id);
             ExternalWidgetRegistry.Instance.RegisterAssembly(plugin.Assembly);
         }
     }
@@ -474,7 +474,7 @@ public class PluginLoader : IPluginManager
                     _plugins.Add(plugin);
                     _failedPlugins.Remove(pluginPath);
 
-                    _logger.LogInformation("Loaded plugin (unconfigured): {Id} v{Version}", manifest.Id, manifest.Version);
+                    _logger.LogInformation("Loaded plugin (unconfigured): {Id}", manifest.Id);
                     loadedPluginId = manifest.Id;
 
                     goto done;
@@ -515,7 +515,7 @@ public class PluginLoader : IPluginManager
             _failedPlugins.Remove(pluginPath);
 
             ExternalWidgetRegistry.Instance.RegisterAssembly(plugin.Assembly);
-            _logger.LogInformation("Loaded plugin: {Id} v{Version}", manifest.Id, manifest.Version);
+            _logger.LogInformation("Loaded plugin: {Id}", manifest.Id);
 
             loadedPluginId = manifest.Id;
         }
@@ -675,7 +675,7 @@ public class PluginLoader : IPluginManager
                     _plugins.Add(newPlugin);
                     _failedPlugins.Remove(directory);
 
-                    _logger.LogInformation("Reloaded plugin (unconfigured): {Id} v{Version}", manifest.Id, manifest.Version);
+                    _logger.LogInformation("Reloaded plugin (unconfigured): {Id}", manifest.Id);
                 }
             }
 
@@ -716,7 +716,7 @@ public class PluginLoader : IPluginManager
                     _failedPlugins.Remove(directory);
 
                     ExternalWidgetRegistry.Instance.RegisterAssembly(newPlugin.Assembly);
-                    _logger.LogInformation("Reloaded plugin: {Id} v{Version}", manifest.Id, manifest.Version);
+                    _logger.LogInformation("Reloaded plugin: {Id}", manifest.Id);
                 }
             }
         }

--- a/src/Ivy/Core/Plugins/PluginLoader.cs
+++ b/src/Ivy/Core/Plugins/PluginLoader.cs
@@ -236,7 +236,21 @@ public class PluginLoader : IPluginManager
         }
 
         var (pluginType, pluginAssembly) = found[0];
-        var instance = (IIvyPlugin)ActivatorUtilities.CreateInstance(serviceProvider, pluginType);
+        IIvyPlugin instance;
+        try
+        {
+            instance = (IIvyPlugin)ActivatorUtilities.CreateInstance(serviceProvider, pluginType);
+        }
+        catch (Exception ex) when (ex is MissingMethodException or TypeLoadException or TypeInitializationException or MissingFieldException)
+        {
+            _logger.LogError(ex,
+                "Plugin type {Type} in '{Directory}' is incompatible with the current host. " +
+                "It may have been built against a different version of the plugin abstractions.",
+                pluginType.FullName, directory);
+            failureReason = $"Incompatible plugin type {pluginType.Name}: {ex.Message}";
+            DeleteShadowDirectory(shadowDir);
+            return null;
+        }
         return (instance, pluginAssembly, loadContext, directory, shadowDir);
     }
 
@@ -273,7 +287,7 @@ public class PluginLoader : IPluginManager
                     }
                     catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
                     {
-                        _logger.LogError(ex, "Error loading deferred plugin from {Directory}", directory);
+                        RecordFailure(directory, ex);
                     }
                 }
                 _logger.LogInformation("Background plugin loading complete. {Count} plugin(s) loaded.", Plugins.Count);
@@ -1207,6 +1221,14 @@ public class PluginLoader : IPluginManager
             RecordFailure(directory, ex);
         }
         catch (ReflectionTypeLoadException ex)
+        {
+            RecordFailure(directory, ex);
+        }
+        catch (MissingMethodException ex)
+        {
+            RecordFailure(directory, ex);
+        }
+        catch (TypeLoadException ex)
         {
             RecordFailure(directory, ex);
         }

--- a/src/plugins/plugins/Ivy.Plugin.Example.AppProvider/ExampleAppProviderPlugin.cs
+++ b/src/plugins/plugins/Ivy.Plugin.Example.AppProvider/ExampleAppProviderPlugin.cs
@@ -17,7 +17,6 @@ public class ExampleAppProviderPlugin : IIvyPlugin<IIvyExtendedPluginContext>
     {
         Id = "Ivy.Plugin.Example.AppProvider",
         Title = "Example App Provider",
-        Version = new Version(1, 0, 0),
     };
 
     public PluginConfigurationSchema? ConfigurationSchema { get; } = new SchemaBuilder()

--- a/src/plugins/plugins/Ivy.Plugin.HelloWorld/HelloWorldPlugin.cs
+++ b/src/plugins/plugins/Ivy.Plugin.HelloWorld/HelloWorldPlugin.cs
@@ -10,7 +10,6 @@ public class HelloWorldPlugin : IIvyPlugin<IIvyPluginContext>
     {
         Id = "Ivy.Plugin.HelloWorld",
         Title = "Hello World Plugin",
-        Version = new Version(1, 0, 0),
     };
 
     public PluginConfigurationSchema? ConfigurationSchema { get; } = new SchemaBuilder()


### PR DESCRIPTION
Plugin version is now determined from the NuGet package (.nuspec) or project file at runtime, not from a compile-time constant in the manifest. This eliminates the potential mismatch where authors bump the NuGet package version but forget to update PluginManifest.Version.