### PR TITLE
Make AppRepository thread-safe to prevent duplicate apps in the sidebar

### DIFF
--- a/src/Ivy.Test/AppRepositoryConcurrencyTests.cs
+++ b/src/Ivy.Test/AppRepositoryConcurrencyTests.cs
@@ -65,7 +65,9 @@ public class AppRepositoryConcurrencyTests(ITestOutputHelper output)
                     problem = $"{who}: {duplicates.Length} duplicated label(s) out of {labels.Count} leaves, e.g. {string.Join(", ", duplicates.Take(3))}";
                 }
             }
-            catch (Exception ex)
+            // Deliberately broad: a torn rebuild can surface as any of several exception types, and an
+            // unhandled exception on a worker thread kills the test host instead of failing the test.
+            catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
             {
                 problem = $"{who}: threw {ex.GetType().Name}: {ex.Message}";
             }
@@ -89,7 +91,7 @@ public class AppRepositoryConcurrencyTests(ITestOutputHelper output)
                 {
                     repository.Reload(reservedPaths);
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
                 {
                     lock (problemLock)
                     {
@@ -123,8 +125,8 @@ public class AppRepositoryConcurrencyTests(ITestOutputHelper output)
         // registers a plugin's factory and reloads. The plugin's apps must survive, even though the
         // in-flight reload snapshotted its factories before that registration and finishes last.
         var repository = new AppRepository();
-        var startupReloadEnteredFactory = new ManualResetEventSlim(false);
-        var releaseStartupReload = new ManualResetEventSlim(false);
+        using var startupReloadEnteredFactory = new ManualResetEventSlim(false);
+        using var releaseStartupReload = new ManualResetEventSlim(false);
 
         var isFirstCall = true;
         repository.AddFactory(() =>

--- a/src/Ivy.Test/AppRepositoryConcurrencyTests.cs
+++ b/src/Ivy.Test/AppRepositoryConcurrencyTests.cs
@@ -1,0 +1,186 @@
+using Ivy.Core.Apps;
+using Xunit.Abstractions;
+
+namespace Ivy.Test;
+
+/// <summary>
+/// Reload runs concurrently in practice: plugin load/unload, hot reload and the deferred plugin loader
+/// all call it from threadpool threads while the main thread is still building the app. These tests pin
+/// the invariants that concurrency previously broke.
+/// </summary>
+public class AppRepositoryConcurrencyTests(ITestOutputHelper output)
+{
+    private static AppDescriptor[] MakeApps(string prefix, int count) =>
+        Enumerable.Range(0, count).Select(i => new AppDescriptor
+        {
+            Id = $"{prefix}-app-{i}",
+            Title = $"{prefix} App {i}",
+            // Mix of root-level apps and grouped apps so the group-lookup path is covered too.
+            Group = i % 3 == 0 ? [] : [$"Group{i % 3}"],
+            IsVisible = true,
+        }).ToArray();
+
+    private static List<string> LeafLabels(MenuItem[] items)
+    {
+        var labels = new List<string>();
+
+        void Walk(MenuItem item)
+        {
+            if (item.Children is { Length: > 0 })
+            {
+                foreach (var child in item.Children) Walk(child);
+            }
+            else
+            {
+                labels.Add(item.Label ?? "<null>");
+            }
+        }
+
+        foreach (var item in items) Walk(item);
+        return labels;
+    }
+
+    [Fact]
+    public void ConcurrentReloads_DoNotDuplicateMenuItems()
+    {
+        // Two reloads that overlapped used to build into one shared root, so both loops appended their
+        // full app set to the same tree and every app showed up twice in the sidebar.
+        var repository = new AppRepository();
+        repository.AddFactory(() => MakeApps("core", 20));
+        repository.AddFactory(() => MakeApps("plugin", 20));
+
+        var reservedPaths = new HashSet<string>();
+        var problems = new List<string>();
+        var problemLock = new object();
+
+        void Check(string who)
+        {
+            string? problem = null;
+            try
+            {
+                var labels = LeafLabels(repository.GetMenuItems());
+                var duplicates = labels.GroupBy(x => x).Where(g => g.Count() > 1).Select(g => $"{g.Key} x{g.Count()}").ToArray();
+                if (duplicates.Length > 0)
+                {
+                    problem = $"{who}: {duplicates.Length} duplicated label(s) out of {labels.Count} leaves, e.g. {string.Join(", ", duplicates.Take(3))}";
+                }
+            }
+            catch (Exception ex)
+            {
+                problem = $"{who}: threw {ex.GetType().Name}: {ex.Message}";
+            }
+
+            if (problem == null) return;
+            lock (problemLock)
+            {
+                if (problems.Count < 10) problems.Add(problem);
+            }
+        }
+
+        const int iterations = 300;
+        using var start = new Barrier(3);
+
+        Thread Reloader(string name) => new(() =>
+        {
+            start.SignalAndWait();
+            for (var i = 0; i < iterations; i++)
+            {
+                try
+                {
+                    repository.Reload(reservedPaths);
+                }
+                catch (Exception ex)
+                {
+                    lock (problemLock)
+                    {
+                        if (problems.Count < 10) problems.Add($"{name} threw {ex.GetType().Name}: {ex.Message}");
+                    }
+                }
+
+                Check(name);
+            }
+        });
+
+        var reloaderA = Reloader("reloadA");
+        var reloaderB = Reloader("reloadB");
+        var reader = new Thread(() =>
+        {
+            start.SignalAndWait();
+            for (var i = 0; i < iterations * 20; i++) Check("reader");
+        });
+
+        foreach (var thread in new[] { reloaderA, reloaderB, reader }) thread.Start();
+        foreach (var thread in new[] { reloaderA, reloaderB, reader }) thread.Join();
+
+        foreach (var problem in problems) output.WriteLine(problem);
+        Assert.Empty(problems);
+    }
+
+    [Fact]
+    public void Reload_DoesNotPublishStaleTree_WhenAnotherReloadStartsLater()
+    {
+        // Models startup: the main thread is midway through Reload when the deferred plugin loader
+        // registers a plugin's factory and reloads. The plugin's apps must survive, even though the
+        // in-flight reload snapshotted its factories before that registration and finishes last.
+        var repository = new AppRepository();
+        var startupReloadEnteredFactory = new ManualResetEventSlim(false);
+        var releaseStartupReload = new ManualResetEventSlim(false);
+
+        var isFirstCall = true;
+        repository.AddFactory(() =>
+        {
+            // Only the startup reload's invocation blocks; later reloads run straight through.
+            if (isFirstCall)
+            {
+                isFirstCall = false;
+                startupReloadEnteredFactory.Set();
+                Assert.True(releaseStartupReload.Wait(TimeSpan.FromSeconds(10)));
+            }
+
+            return MakeApps("core", 3);
+        });
+
+        var startupReload = new Thread(() => repository.Reload(new HashSet<string>()));
+        startupReload.Start();
+        Assert.True(startupReloadEnteredFactory.Wait(TimeSpan.FromSeconds(10)));
+
+        // Plugin loads on another thread: registers its factory, then reloads.
+        repository.AddFactory(() => MakeApps("plugin", 3));
+        var pluginReload = new Thread(() => repository.Reload(new HashSet<string>()));
+        pluginReload.Start();
+
+        releaseStartupReload.Set();
+        Assert.True(startupReload.Join(TimeSpan.FromSeconds(10)));
+        Assert.True(pluginReload.Join(TimeSpan.FromSeconds(10)));
+
+        var appIds = repository.All().Select(a => a.Id).ToArray();
+        output.WriteLine("Final app ids: " + string.Join(", ", appIds));
+
+        Assert.Contains("plugin-app-0", appIds);
+        Assert.Contains("core-app-0", appIds);
+        Assert.Contains("plugin App 0", LeafLabels(repository.GetMenuItems()));
+    }
+
+    [Fact]
+    public void DuplicateAppId_AcrossFactories_YieldsOneMenuItem_AndLastRegistrationWins()
+    {
+        // Two factories claiming the same id must not each get a menu item. The dictionary has always
+        // been last-wins, and callers depend on that to override built-in apps, so the tree follows it.
+        var repository = new AppRepository();
+        repository.AddFactory(() => [
+            new AppDescriptor { Id = "shared", Title = "First", Group = [], IsVisible = true }
+        ]);
+        repository.AddFactory(() => [
+            new AppDescriptor { Id = "shared", Title = "Second", Group = [], IsVisible = true }
+        ]);
+
+        repository.Reload(new HashSet<string>());
+
+        var labels = LeafLabels(repository.GetMenuItems());
+        output.WriteLine("Labels: " + string.Join(", ", labels));
+
+        Assert.Single(labels);
+        Assert.Equal("Second", labels[0]);
+        Assert.Equal("Second", repository.GetApp("shared")?.Title);
+    }
+}

--- a/src/Ivy/Core/Apps/AppRepository.cs
+++ b/src/Ivy/Core/Apps/AppRepository.cs
@@ -56,6 +56,7 @@ public class AppRepository : IAppRepository
     private readonly Subject<Unit> _reloaded = new();
     private readonly Subject<IReadOnlySet<string>> _appsRefreshRequested = new();
     private readonly List<Func<AppDescriptor[]>> _factories = [];
+    private readonly object _lock = new();
 
     public IObservable<Unit> Reloaded => _reloaded;
     public IObservable<IReadOnlySet<string>> AppsRefreshRequested => _appsRefreshRequested;
@@ -66,35 +67,69 @@ public class AppRepository : IAppRepository
             _appsRefreshRequested.OnNext(appIds);
     }
 
-    private IAppRepositoryNode? Root { get; set; }
+    /// <summary>
+    /// An immutable view of the app tree. Never mutated once published: <see cref="Reload"/> builds a
+    /// replacement and swaps it in, so readers always observe a fully built repository instead of one
+    /// that is midway through a rebuild.
+    /// </summary>
+    private sealed class Snapshot
+    {
+        public required AppRepositoryGroup Root { get; init; }
 
-    private Dictionary<string, AppDescriptor> Apps { get; } = new();
+        public required IReadOnlyDictionary<string, AppDescriptor> Apps { get; init; }
+    }
 
-    public IReadOnlySet<string> InvalidAppIds => _invalidAppIds;
+    private Snapshot _snapshot = new()
+    {
+        Root = new AppRepositoryGroup("Root"),
+        Apps = new Dictionary<string, AppDescriptor>(),
+    };
+
+    // Deliberately spans reloads and is reset explicitly via ClearInvalidAppIds, so it cannot live in
+    // the snapshot. Guarded by _lock instead.
+    public IReadOnlySet<string> InvalidAppIds
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _invalidAppIds.ToHashSet(StringComparer.OrdinalIgnoreCase);
+            }
+        }
+    }
 
     private HashSet<string> _invalidAppIds { get; } = new(StringComparer.OrdinalIgnoreCase);
 
     public void Reload(IReadOnlySet<string> reservedPaths)
     {
-        Root = new AppRepositoryGroup("Root");
-        Apps.Clear();
+        Func<AppDescriptor[]>[] factoriesSnapshot;
+        lock (_lock)
+        {
+            factoriesSnapshot = _factories.ToArray();
+        }
+
+        var root = new AppRepositoryGroup("Root");
+        var apps = new Dictionary<string, AppDescriptor>();
 
         //add apps to tree
         var indexFixups = new List<(IAppRepositoryGroup, AppDescriptor)>();
-        foreach (var appDescriptor in _factories.SelectMany(factory => factory()))
+        foreach (var appDescriptor in factoriesSnapshot.SelectMany(factory => factory()))
         {
             if (!ValidateAppId(appDescriptor.Id, reservedPaths))
             {
-                _invalidAppIds.Add(appDescriptor.Id);
+                lock (_lock)
+                {
+                    _invalidAppIds.Add(appDescriptor.Id);
+                }
                 // Do not add invalid apps to repository
                 continue;
             }
 
-            Apps[appDescriptor.Id] = appDescriptor;
+            apps[appDescriptor.Id] = appDescriptor;
 
             if (appDescriptor.IsVisible || appDescriptor.IsIndex)
             {
-                var current = Root;
+                IAppRepositoryNode current = root;
                 foreach (var part in appDescriptor.Group)
                 {
                     if (current is not IAppRepositoryGroup group)
@@ -139,39 +174,40 @@ public class AppRepository : IAppRepository
         }
 
         //traverse the tree and on each leaf (nodes that are not groups) set link next and previous
-        if (Root is AppRepositoryGroup rootGroup)
+        // Get all leaf nodes in a flat list, maintaining their order
+        var leafNodes = GetAllLeafNodes(root);
+
+        // Set next and previous links for each leaf node
+        for (int i = 0; i < leafNodes.Count; i++)
         {
-            // Get all leaf nodes in a flat list, maintaining their order
-            var leafNodes = GetAllLeafNodes(rootGroup);
-
-            // Set next and previous links for each leaf node
-            for (int i = 0; i < leafNodes.Count; i++)
+            // Set previous link (except for first node)
+            if (i > 0)
             {
-                // Set previous link (except for first node)
-                if (i > 0)
-                {
-                    var previousNode = leafNodes[i - 1];
-                    var previousLink = new InternalLink(previousNode.Title, previousNode is AppDescriptor app ? app.Id : throw new InvalidOperationException("Previous node is not an app."));
-                    leafNodes[i].Previous = previousLink;
-                }
-                else
-                {
-                    leafNodes[i].Previous = null;
-                }
+                var previousNode = leafNodes[i - 1];
+                var previousLink = new InternalLink(previousNode.Title, previousNode is AppDescriptor app ? app.Id : throw new InvalidOperationException("Previous node is not an app."));
+                leafNodes[i].Previous = previousLink;
+            }
+            else
+            {
+                leafNodes[i].Previous = null;
+            }
 
-                // Set next link (except for last node)
-                if (i < leafNodes.Count - 1)
-                {
-                    var nextNode = leafNodes[i + 1];
-                    var nextLink = new InternalLink(nextNode.Title, nextNode is AppDescriptor app ? app.Id : throw new InvalidOperationException("Next node is not an app."));
-                    leafNodes[i].Next = nextLink;
-                }
-                else
-                {
-                    leafNodes[i].Next = null;
-                }
+            // Set next link (except for last node)
+            if (i < leafNodes.Count - 1)
+            {
+                var nextNode = leafNodes[i + 1];
+                var nextLink = new InternalLink(nextNode.Title, nextNode is AppDescriptor app ? app.Id : throw new InvalidOperationException("Next node is not an app."));
+                leafNodes[i].Next = nextLink;
+            }
+            else
+            {
+                leafNodes[i].Next = null;
             }
         }
+
+        // Publish the new state in a single reference assignment. Readers hold either the old snapshot
+        // or the new one, never a partially populated tree.
+        Volatile.Write(ref _snapshot, new Snapshot { Root = root, Apps = apps });
 
         _reloaded.OnNext(default);
     }
@@ -199,55 +235,64 @@ public class AppRepository : IAppRepository
 
     public void AddFactory(Func<AppDescriptor[]> factory)
     {
-        _factories.Add(factory);
+        lock (_lock)
+        {
+            _factories.Add(factory);
+        }
     }
 
     public bool RemoveFactory(Func<AppDescriptor[]> factory)
     {
-        return _factories.Remove(factory);
+        lock (_lock)
+        {
+            return _factories.Remove(factory);
+        }
     }
 
     public AppDescriptor GetAppOrDefault(string? id)
     {
+        var apps = Volatile.Read(ref _snapshot).Apps;
+
         var app = id != null
-            ? Apps.GetValueOrDefault(id)
+            ? apps.GetValueOrDefault(id)
             : null;
 
         return app
-            ?? Apps.Values.FirstOrDefault(x => !AppIds.ShouldNotBeAutoDefaultApps.Contains(x.Id))
-            ?? Apps.GetValueOrDefault(AppIds.ErrorNotFound)
+            ?? apps.Values.FirstOrDefault(x => !AppIds.ShouldNotBeAutoDefaultApps.Contains(x.Id))
+            ?? apps.GetValueOrDefault(AppIds.ErrorNotFound)
             ?? throw new InvalidOperationException("No serviceable apps are registered on this server.");
     }
 
     public AppDescriptor? GetApp(string id)
     {
-        return Apps.Values.FirstOrDefault(e => e.Id == id);
+        return Volatile.Read(ref _snapshot).Apps.Values.FirstOrDefault(e => e.Id == id);
     }
 
     public AppDescriptor? GetApp(Type type)
     {
-        return Apps.Values.FirstOrDefault(e => e.Type == type);
+        return Volatile.Read(ref _snapshot).Apps.Values.FirstOrDefault(e => e.Type == type);
     }
 
     public MenuItem[] GetMenuItems()
     {
-        if (Root is AppRepositoryGroup group)
-        {
-            return group.Children.OrderBy(e => e.Order).ThenBy(e => e.Title).Select(e => e.GetMenuItem()).ToArray();
-        }
-        return [];
+        var root = Volatile.Read(ref _snapshot).Root;
+        return root.Children.OrderBy(e => e.Order).ThenBy(e => e.Title).Select(e => e.GetMenuItem()).ToArray();
     }
 
     public IEnumerable<AppDescriptor> All()
     {
-        return Apps.Values;
+        return Volatile.Read(ref _snapshot).Apps.Values.ToArray();
     }
 
     private bool ValidateAppId(string appId, IReadOnlySet<string> reservedPaths)
     {
-        if (_invalidAppIds.Contains(appId))
+        lock (_lock)
         {
-            return false;
+            // Already reported on an earlier reload; don't log the same error again.
+            if (_invalidAppIds.Contains(appId))
+            {
+                return false;
+            }
         }
 
         switch (AppRoutingHelpers.ValidateAppId(appId, reservedPaths))
@@ -279,6 +324,9 @@ public class AppRepository : IAppRepository
 
     public void ClearInvalidAppIds()
     {
-        _invalidAppIds.Clear();
+        lock (_lock)
+        {
+            _invalidAppIds.Clear();
+        }
     }
 }

--- a/src/Ivy/Core/Apps/AppRepository.cs
+++ b/src/Ivy/Core/Apps/AppRepository.cs
@@ -58,6 +58,10 @@ public class AppRepository : IAppRepository
     private readonly List<Func<AppDescriptor[]>> _factories = [];
     private readonly object _lock = new();
 
+    // Serializes Reload. Held across the whole rebuild, unlike _lock, which only guards the two
+    // fields that cannot live in a snapshot.
+    private readonly object _reloadLock = new();
+
     public IObservable<Unit> Reloaded => _reloaded;
     public IObservable<IReadOnlySet<string>> AppsRefreshRequested => _appsRefreshRequested;
 
@@ -68,10 +72,19 @@ public class AppRepository : IAppRepository
     }
 
     /// <summary>
-    /// An immutable view of the app tree. Never mutated once published: <see cref="Reload"/> builds a
-    /// replacement and swaps it in, so readers always observe a fully built repository instead of one
-    /// that is midway through a rebuild.
+    /// A view of the app tree. <see cref="Reload"/> builds a replacement and swaps it in, so readers
+    /// always observe a fully built repository instead of one that is midway through a rebuild.
     /// </summary>
+    /// <remarks>
+    /// Only the container is immutable: the group tree and the app dictionary are never touched again
+    /// once published. The <see cref="AppDescriptor"/> instances inside them are not. Factories
+    /// registered through <c>Server.AddApp(AppDescriptor)</c> or <c>IIvyPluginContext.AddApp</c> close
+    /// over a single descriptor and return that same instance from every reload, and the leaf-link pass
+    /// in <see cref="Reload"/> writes <see cref="AppDescriptor.Next"/> and
+    /// <see cref="AppDescriptor.Previous"/> on whatever instances the factories hand back. A later
+    /// reload can therefore change those two properties on descriptors that this snapshot — and any
+    /// live session holding an injected descriptor — still references.
+    /// </remarks>
     private sealed class Snapshot
     {
         public required AppRepositoryGroup Root { get; init; }
@@ -102,17 +115,35 @@ public class AppRepository : IAppRepository
 
     public void Reload(IReadOnlySet<string> reservedPaths)
     {
+        // Serialized end to end so that a reload which starts later also publishes later. Publishing in
+        // completion order instead would let a slow reload overwrite the result of one that started
+        // after it, republishing a tree that predates the factories the later reload picked up. At
+        // startup that silently drops the apps of every plugin the deferred loader brought in.
+        lock (_reloadLock)
+        {
+            ReloadCore(reservedPaths);
+        }
+
+        // Fired outside _reloadLock. The notification carries no payload and subscribers respond by
+        // re-reading the current snapshot, so a redundant or late notification is harmless — whereas
+        // holding the lock across subscriber callbacks would stall every other reload behind arbitrary
+        // view code.
+        _reloaded.OnNext(default);
+    }
+
+    private void ReloadCore(IReadOnlySet<string> reservedPaths)
+    {
         Func<AppDescriptor[]>[] factoriesSnapshot;
         lock (_lock)
         {
             factoriesSnapshot = _factories.ToArray();
         }
 
-        var root = new AppRepositoryGroup("Root");
+        //collect apps first, so each id resolves to exactly one descriptor before the tree is built.
+        //the last registration of an id wins, which is what lets a caller override a built-in app by
+        //registering their own (UseErrorNotFound over the default error app, for example).
         var apps = new Dictionary<string, AppDescriptor>();
-
-        //add apps to tree
-        var indexFixups = new List<(IAppRepositoryGroup, AppDescriptor)>();
+        var appIdsInRegistrationOrder = new List<string>();
         foreach (var appDescriptor in factoriesSnapshot.SelectMany(factory => factory()))
         {
             if (!ValidateAppId(appDescriptor.Id, reservedPaths))
@@ -125,7 +156,21 @@ public class AppRepository : IAppRepository
                 continue;
             }
 
+            if (!apps.ContainsKey(appDescriptor.Id))
+            {
+                appIdsInRegistrationOrder.Add(appDescriptor.Id);
+            }
+
             apps[appDescriptor.Id] = appDescriptor;
+        }
+
+        //add apps to tree — one node per id, so two factories yielding the same id cannot produce two
+        //menu items for it
+        var root = new AppRepositoryGroup("Root");
+        var indexFixups = new List<(IAppRepositoryGroup, AppDescriptor)>();
+        foreach (var appId in appIdsInRegistrationOrder)
+        {
+            var appDescriptor = apps[appId];
 
             if (appDescriptor.IsVisible || appDescriptor.IsIndex)
             {
@@ -208,8 +253,6 @@ public class AppRepository : IAppRepository
         // Publish the new state in a single reference assignment. Readers hold either the old snapshot
         // or the new one, never a partially populated tree.
         Volatile.Write(ref _snapshot, new Snapshot { Root = root, Apps = apps });
-
-        _reloaded.OnNext(default);
     }
 
     private List<IAppRepositoryNode> GetAllLeafNodes(IAppRepositoryGroup group)


### PR DESCRIPTION
Tendril loads plugins on a background task at startup, so two Reloads ran concurrently; both re-read the shared Root and filled one tree, duplicating nearly every menu item. Reload now builds an immutable snapshot published with one Volatile.Write, and is serialized so a slow reload can't republish a stale tree over a later one's result.

The tree is now built from the resolved app dictionary, so each id gets one node. No public signatures changed.