### PR TITLE
security: upgrade Microsoft.OpenApi to 3.9.0

### DIFF
--- a/src/Ivy/Ivy.csproj
+++ b/src/Ivy/Ivy.csproj
@@ -77,7 +77,7 @@
     <PackageReference Include="Ivy.SystemTextJson.JsonDiffPatch" Version="2.0.4" />
     <PackageReference Include="Ivy.NativeJsonDiff" Version="2.0.0" />
     <PackageReference Include="Ivy.DesignSystem" Version="1.1.32" />
-    <PackageReference Include="Microsoft.OpenApi" Version="3.5.4" />
+    <PackageReference Include="Microsoft.OpenApi" Version="3.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ivy/packages.lock.json
+++ b/src/Ivy/packages.lock.json
@@ -164,9 +164,9 @@
       },
       "Microsoft.OpenApi": {
         "type": "Direct",
-        "requested": "[3.5.4, )",
-        "resolved": "3.5.4",
-        "contentHash": "Dhiio8mc5aLT8ujQfSP6iBdy4UDdkf3iGl1S7W2XtiAfsPZghkHydnAqivtdPvMB3JcgKVzwkLrq2BW5Lb5uxg=="
+        "requested": "[3.9.0, )",
+        "resolved": "3.9.0",
+        "contentHash": "2sDK6AFY1L/Xg8JvwlaDoPwzGqCftjUgHG2NhCy8gNV/1v4eXziYoH39e/pwC7oTBJInuYUUJqfkRpIMPQ/Fyw=="
       },
       "Newtonsoft.Json": {
         "type": "Direct",


### PR DESCRIPTION
Resolves the Microsoft.OpenApi circular schema reference vulnerability (CVE-2026-49451 / Dependabot alert #241).