### PR TITLE
feat(webmcp): expose view capabilities to browser AI agents via UseWebMcpTool

### DIFF
--- a/src/Ivy.Samples.Shared/Apps/Concepts/WebMcpToolsApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Concepts/WebMcpToolsApp.cs
@@ -1,0 +1,115 @@
+using System.Collections.Immutable;
+using System.ComponentModel;
+
+namespace Ivy.Samples.Shared.Apps.Concepts;
+
+/// <summary>
+/// Exposes this view's capabilities to a browser-resident AI agent through WebMCP.
+///
+/// The view renders the todo list but offers no way to edit it: there is no input, no add button and
+/// no delete action. Every mutation has to arrive through <c>document.modelContext</c>, which makes
+/// the point of WebMCP hard to miss — the handlers run server-side against the very state the UI is
+/// built from, so the list re-renders live as the agent works.
+/// </summary>
+[App(icon: Icons.Bot, searchHints: ["webmcp", "mcp", "agent", "ai", "tools", "modelcontext"])]
+public class WebMcpToolsApp : SampleBase
+{
+    private const string AddTool = "add-todo";
+    private const string AddDescription = "Add a new item to the user's active todo list";
+
+    private const string RemoveTool = "remove-todo";
+    private const string RemoveDescription = "Remove an item from the user's active todo list";
+
+    private const string ListTool = "list-todos";
+    private const string ListDescription = "List the user's current todo items";
+
+    private const string ClearTool = "clear-todos";
+    private const string ClearDescription = "Remove every item from the user's todo list";
+
+    public record AddTodoArgs(
+        [property: Description("The text content of the todo item")] string Text);
+
+    public record RemoveTodoArgs(
+        [property: Description("The exact text of the todo item to remove")] string Text);
+
+    protected override object? BuildSample()
+    {
+        var todos = UseState(ImmutableArray<string>.Empty);
+        var webMcp = UseWebMcpAvailability();
+
+        UseWebMcpTool(AddTool, AddDescription,
+            (AddTodoArgs args) =>
+            {
+                if (string.IsNullOrWhiteSpace(args.Text))
+                {
+                    return WebMcpToolResult.Error("A todo item needs some text.");
+                }
+
+                todos.Set(todos.Value.Add(args.Text));
+                return $"Added todo item: \"{args.Text}\"";
+            });
+
+        UseWebMcpTool(RemoveTool, RemoveDescription,
+            (RemoveTodoArgs args) =>
+            {
+                if (!todos.Value.Contains(args.Text))
+                {
+                    return WebMcpToolResult.Error($"There is no todo item called \"{args.Text}\".");
+                }
+
+                todos.Set(todos.Value.Remove(args.Text));
+                return $"Removed todo item: \"{args.Text}\"";
+            });
+
+        UseWebMcpTool(ListTool, ListDescription,
+            () => todos.Value,
+            new WebMcpToolOptions { ReadOnly = true, UntrustedContent = true });
+
+        UseWebMcpTool(ClearTool, ClearDescription,
+            () =>
+            {
+                var removed = todos.Value.Length;
+                todos.Set(ImmutableArray<string>.Empty);
+                return $"Cleared {removed} todo item(s).";
+            });
+
+        return Layout.Vertical()
+               | Text.H2("Agent-only todo list")
+               | Callout.Info(
+                   "This list has no editing controls on purpose. The only way to change it is for an "
+                   + "AI agent in the browser to call one of the WebMCP tools below.")
+               | AvailabilityCallout(webMcp.Value)
+               | Text.H4("Items")
+               | (todos.Value.IsEmpty
+                   ? Text.Muted("Nothing to do yet. Ask an agent to add something.")
+                   : Layout.Vertical().Gap(2) | todos.Value.Select(Text.Block).ToArray())
+               | Text.H4("Tools exposed to the agent")
+               | (Layout.Vertical().Gap(2)
+                  | ToolRow(AddTool, AddDescription)
+                  | ToolRow(RemoveTool, RemoveDescription)
+                  | ToolRow(ListTool, $"{ListDescription} (read only)")
+                  | ToolRow(ClearTool, ClearDescription));
+    }
+
+    private static object AvailabilityCallout(WebMcpAvailability availability) => availability switch
+    {
+        WebMcpAvailability.Available => Callout.Success(
+            "This browser exposes document.modelContext, so the tools below are live. Drive them "
+            + "from an agent or the Model Context Tool Inspector extension."),
+
+        WebMcpAvailability.Unavailable => Callout.Warning(
+            "This browser does not expose document.modelContext, so nothing below is callable and "
+            + "the list cannot change. WebMCP is still behind a Chrome origin trial: for local "
+            + "development enable chrome://flags/#enable-webmcp-testing and relaunch Chrome (no "
+            + "token needed), or launch Chrome with --enable-features=WebMCPTesting. A deployed "
+            + "origin instead needs a token passed to "
+            + "server.UseWebMcp(o => o.OriginTrialToken = \"...\")."),
+
+        _ => Callout.Info("Checking whether this browser supports WebMCP…")
+    };
+
+    private static object ToolRow(string name, string description) =>
+        Layout.Horizontal().Gap(3)
+        | Text.Monospaced(name)
+        | Text.Muted(description);
+}

--- a/src/Ivy.Samples.Shared/SamplesServer.cs
+++ b/src/Ivy.Samples.Shared/SamplesServer.cs
@@ -15,6 +15,7 @@ public static class SamplesServer
         var server = new Server(args);
         server.UseCulture("en-US");
         server.UseHotReload();
+        server.UseWebMcp();
         server.AddAppsFromAssembly(typeof(SamplesServer).Assembly);
 
         var versionLabel = ServerVersionHelper.GetVersionLabel();

--- a/src/Ivy/Core/Server/AppHub.cs
+++ b/src/Ivy/Core/Server/AppHub.cs
@@ -102,6 +102,9 @@ public class AppHub(
                 Context.ConnectionId));
             appServices.AddSingleton<IClientProvider>(clientProvider);
             appServices.AddSingleton<IUploadService>(new UploadService(Context.ConnectionId, clientProvider));
+            appServices.AddSingleton<IWebMcpToolService>(new WebMcpToolService(
+                clientProvider,
+                enabled: server.ServiceProvider?.GetService<WebMcpOptions>() != null));
 
             var tunneledHttpHandler = new TunneledHttpMessageHandler(clientProvider, Context.ConnectionId);
             appServices.AddSingleton(tunneledHttpHandler);
@@ -1010,6 +1013,80 @@ public class AppHub(
                 var exceptionHandler = appSession.AppServices.GetService<IExceptionHandler>()!;
                 exceptionHandler.HandleException(e);
             }
+        });
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Invoked by the browser to say whether it exposes <c>document.modelContext</c>, so a view can
+    /// render a fallback rather than silently registering tools nobody can call.
+    /// </summary>
+    public void WebMcpReport(bool available)
+    {
+        if (!sessionStore.Sessions.TryGetValue(Context.ConnectionId, out var appSession)) return;
+        appSession.AppServices.GetService<IWebMcpToolService>()?.ReportAvailability(available);
+    }
+
+    /// <summary>
+    /// Invoked by the browser when an AI agent calls a tool registered through <c>UseWebMcpTool</c>.
+    /// </summary>
+    /// <remarks>
+    /// Returns as soon as the call is queued rather than awaiting the handler. SignalR's
+    /// <c>MaximumParallelInvocationsPerClient</c> is 1, so awaiting here would stall every other
+    /// invocation on the connection — including UI events — for the duration of the tool call. The
+    /// result comes back out-of-band as a <c>WebMcpToolResult</c> message correlated by
+    /// <paramref name="callId"/>.
+    /// </remarks>
+    public Task WebMcpToolCall(string callId, string toolId, string? argumentsJson)
+    {
+        logger.LogDebug("WebMcpToolCall received: {ToolId} ConnectionId={ConnectionId}", toolId, Context.ConnectionId);
+
+        if (!sessionStore.Sessions.TryGetValue(Context.ConnectionId, out var appSession))
+        {
+            logger.LogDebug("WebMcpToolCall: {ToolId} [AppSession Not Found] ConnectionId={ConnectionId}", toolId, Context.ConnectionId);
+            return Task.CompletedTask;
+        }
+
+        if (appSession.EventQueue == null)
+        {
+            logger.LogWarning("WebMcpToolCall: {ToolId} [EventQueue is null!]", toolId);
+            return Task.CompletedTask;
+        }
+
+        var client = appSession.AppServices.GetService<IClientProvider>();
+        var toolService = appSession.AppServices.GetService<IWebMcpToolService>();
+        if (client == null || toolService == null)
+        {
+            logger.LogWarning("WebMcpToolCall: {ToolId} [WebMCP services unavailable]", toolId);
+            return Task.CompletedTask;
+        }
+
+        // Sharing the UI event queue serializes agent actions with human clicks, so a tool that
+        // mutates state re-renders through the normal widget diff.
+        appSession.EventQueue.Enqueue(async () =>
+        {
+            appSession.LastInteraction = DateTime.UtcNow;
+
+            WebMcpToolResult result;
+            try
+            {
+                result = await toolService.InvokeAsync(toolId, argumentsJson);
+            }
+            catch (Exception e)
+            {
+                appSession.AppServices.GetService<IExceptionHandler>()?.HandleException(e);
+                result = WebMcpToolResult.Error(ExceptionHelper.GetInnerMostException(e).Message);
+            }
+
+            client.Sender.Send("WebMcpToolResult", new Dictionary<string, object?>
+            {
+                ["callId"] = callId,
+                ["isError"] = result.IsError,
+                ["content"] = result.Content
+                    .Select(c => new Dictionary<string, object?> { ["type"] = c.Type, ["text"] = c.Text })
+                    .ToArray()
+            });
         });
 
         return Task.CompletedTask;

--- a/src/Ivy/Core/Server/HtmlPipeline/Filters/WebMcpFilter.cs
+++ b/src/Ivy/Core/Server/HtmlPipeline/Filters/WebMcpFilter.cs
@@ -1,0 +1,32 @@
+using System.Xml.Linq;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Ivy.Core.Server.HtmlPipeline.Filters;
+
+/// <summary>
+/// Emits the markers the browser needs for WebMCP: a flag the frontend reads to decide whether to
+/// touch <c>document.modelContext</c> at all, and the Chrome origin trial token when one is set.
+/// No-ops unless the host called <c>server.UseWebMcp()</c>.
+/// </summary>
+public class WebMcpFilter : IHtmlFilter
+{
+    public void Process(HtmlPipelineContext context, XDocument document)
+    {
+        var options = context.Services.GetService<WebMcpOptions>();
+        if (options == null) return;
+
+        var head = document.Root?.Element("head");
+        if (head == null) return;
+
+        head.Add(new XElement("meta",
+            new XAttribute("name", "ivy-webmcp"),
+            new XAttribute("content", "true")));
+
+        if (!string.IsNullOrWhiteSpace(options.OriginTrialToken))
+        {
+            head.Add(new XElement("meta",
+                new XAttribute("http-equiv", "origin-trial"),
+                new XAttribute("content", options.OriginTrialToken)));
+        }
+    }
+}

--- a/src/Ivy/Core/Server/WebMcpOptions.cs
+++ b/src/Ivy/Core/Server/WebMcpOptions.cs
@@ -1,0 +1,14 @@
+namespace Ivy.Core.Server;
+
+/// <summary>
+/// Configuration for WebMCP support, enabled with <c>server.UseWebMcp()</c>.
+/// </summary>
+public class WebMcpOptions
+{
+    /// <summary>
+    /// Origin trial token for the Chrome WebMCP trial. When set it is emitted as
+    /// <c>&lt;meta http-equiv="origin-trial"&gt;</c>, which is how a production origin opts in.
+    /// Leave null when running on localhost or behind a browser flag.
+    /// </summary>
+    public string? OriginTrialToken { get; set; }
+}

--- a/src/Ivy/Core/ViewBase.WebMcp.cs
+++ b/src/Ivy/Core/ViewBase.WebMcp.cs
@@ -1,0 +1,39 @@
+// ReSharper disable once CheckNamespace
+namespace Ivy;
+
+/// <summary>
+/// WebMCP hooks, mirrored onto <see cref="ViewBase"/> so they can be called bare inside
+/// <c>Build()</c>. The implementations are extension methods on <see cref="IViewContext"/> in
+/// <c>Hooks/UseWebMcpTool.cs</c>; <see cref="ViewBase"/> does not implement that interface, so
+/// without these mirrors a view would have to write <c>this.Context.UseWebMcpTool(...)</c>.
+/// </summary>
+public abstract partial class ViewBase
+{
+    /// <inheritdoc cref="UseWebMcpToolExtensions.UseWebMcpAvailability" />
+    protected IState<WebMcpAvailability> UseWebMcpAvailability() =>
+        this.Context.UseWebMcpAvailability();
+
+    protected void UseWebMcpTool(string name, string description, Action handler, WebMcpToolOptions? options = null) =>
+        this.Context.UseWebMcpTool(name, description, handler, options);
+
+    protected void UseWebMcpTool(string name, string description, Func<object?> handler, WebMcpToolOptions? options = null) =>
+        this.Context.UseWebMcpTool(name, description, handler, options);
+
+    protected void UseWebMcpTool(string name, string description, Func<Task> handler, WebMcpToolOptions? options = null) =>
+        this.Context.UseWebMcpTool(name, description, handler, options);
+
+    protected void UseWebMcpTool(string name, string description, Func<Task<object?>> handler, WebMcpToolOptions? options = null) =>
+        this.Context.UseWebMcpTool(name, description, handler, options);
+
+    protected void UseWebMcpTool<TArgs>(string name, string description, Action<TArgs> handler, WebMcpToolOptions? options = null) =>
+        this.Context.UseWebMcpTool(name, description, handler, options);
+
+    protected void UseWebMcpTool<TArgs>(string name, string description, Func<TArgs, object?> handler, WebMcpToolOptions? options = null) =>
+        this.Context.UseWebMcpTool(name, description, handler, options);
+
+    protected void UseWebMcpTool<TArgs>(string name, string description, Func<TArgs, Task> handler, WebMcpToolOptions? options = null) =>
+        this.Context.UseWebMcpTool(name, description, handler, options);
+
+    protected void UseWebMcpTool<TArgs>(string name, string description, Func<TArgs, Task<object?>> handler, WebMcpToolOptions? options = null) =>
+        this.Context.UseWebMcpTool(name, description, handler, options);
+}

--- a/src/Ivy/Hooks/UseWebMcpTool.cs
+++ b/src/Ivy/Hooks/UseWebMcpTool.cs
@@ -1,0 +1,295 @@
+using System.Reactive.Disposables;
+using System.Text.Json;
+using Ivy.Core.Helpers;
+
+// ReSharper disable once CheckNamespace
+namespace Ivy;
+
+/// <summary>
+/// A single block of content returned from a WebMCP tool. Mirrors the MCP content-block shape
+/// that <c>document.modelContext</c> expects back from <c>execute()</c>.
+/// </summary>
+public record WebMcpContentBlock(string Type, string Text)
+{
+    /// <summary>Creates a plain text content block.</summary>
+    public static WebMcpContentBlock FromText(string text) => new("text", text);
+}
+
+/// <summary>
+/// The result of a WebMCP tool invocation. Handlers may return this directly for full control,
+/// or return any other value and let <see cref="UseWebMcpToolExtensions"/> normalize it.
+/// </summary>
+public record WebMcpToolResult
+{
+    /// <summary>Content blocks handed to the calling agent.</summary>
+    public required IReadOnlyList<WebMcpContentBlock> Content { get; init; }
+
+    /// <summary>When true the agent treats the call as failed rather than successful.</summary>
+    public bool IsError { get; init; }
+
+    /// <summary>A successful result carrying a single text block.</summary>
+    public static WebMcpToolResult Text(string text) => new() { Content = [WebMcpContentBlock.FromText(text)] };
+
+    /// <summary>A successful result carrying no content.</summary>
+    public static WebMcpToolResult Empty() => new() { Content = [] };
+
+    /// <summary>A failed result. The agent sees <c>isError: true</c>.</summary>
+    public static WebMcpToolResult Error(string message) =>
+        new() { Content = [WebMcpContentBlock.FromText(message)], IsError = true };
+}
+
+/// <summary>Optional metadata for a tool registered with <c>UseWebMcpTool</c>.</summary>
+public record WebMcpToolOptions
+{
+    /// <summary>Human readable label an agent may show in its UI.</summary>
+    public string? Title { get; init; }
+
+    /// <summary>Declares that the tool does not modify state (<c>annotations.readOnlyHint</c>).</summary>
+    public bool ReadOnly { get; init; }
+
+    /// <summary>
+    /// Declares that the tool returns content originating outside the application
+    /// (<c>annotations.untrustedContentHint</c>). Set this for anything echoing database rows or
+    /// user-supplied text so the agent treats the result as data rather than instructions.
+    /// </summary>
+    public bool UntrustedContent { get; init; }
+
+    /// <summary>When false the tool is withheld from the browser without removing the hook call.</summary>
+    public bool Enabled { get; init; } = true;
+}
+
+/// <summary>A tool as advertised to the browser.</summary>
+public record WebMcpToolDescriptor
+{
+    /// <summary>Stable per-registration identity. Not visible to the agent.</summary>
+    public required string ToolId { get; init; }
+
+    /// <summary>The tool name the agent sees. Must be unique within the page.</summary>
+    public required string Name { get; init; }
+
+    /// <summary>Natural language description of what the tool does.</summary>
+    public required string Description { get; init; }
+
+    /// <summary>Human readable label an agent may show in its UI.</summary>
+    public string? Title { get; init; }
+
+    /// <summary>JSON Schema for the tool arguments, serialized as JSON. Null when the tool takes none.</summary>
+    public string? InputSchema { get; init; }
+
+    /// <summary><c>annotations.readOnlyHint</c>.</summary>
+    public bool ReadOnly { get; init; }
+
+    /// <summary><c>annotations.untrustedContentHint</c>.</summary>
+    public bool UntrustedContent { get; init; }
+
+    /// <summary>When false the tool is not pushed to the browser.</summary>
+    public bool Enabled { get; init; } = true;
+}
+
+/// <summary>Whether the browser on the other end of this connection can actually run WebMCP tools.</summary>
+public enum WebMcpAvailability
+{
+    /// <summary>The browser has not reported yet. Expect this for the first moments of a connection.</summary>
+    Unknown,
+
+    /// <summary><c>document.modelContext</c> is present; registered tools are live.</summary>
+    Available,
+
+    /// <summary>
+    /// The browser does not expose <c>document.modelContext</c>, so no tool can be called. Either
+    /// WebMCP is disabled on the server or the browser is not enrolled in the origin trial.
+    /// </summary>
+    Unavailable
+}
+
+/// <summary>
+/// Per-connection registry of WebMCP tools. Registrations are pushed to the browser, which mirrors
+/// them onto <c>document.modelContext</c>.
+/// </summary>
+public interface IWebMcpToolService
+{
+    /// <summary>Registers a tool. Dispose the result to unregister it.</summary>
+    IDisposable Register(WebMcpToolDescriptor descriptor, Func<string?, Task<WebMcpToolResult>> handler);
+
+    /// <summary>Replaces the descriptor of an already registered tool, keeping its handler.</summary>
+    void Update(string toolId, WebMcpToolDescriptor descriptor);
+
+    /// <summary>Invokes a registered tool with raw JSON arguments.</summary>
+    Task<WebMcpToolResult> InvokeAsync(string toolId, string? argumentsJson);
+
+    /// <summary>What the browser last reported about its WebMCP support.</summary>
+    WebMcpAvailability Availability { get; }
+
+    /// <summary>Raised when <see cref="Availability"/> changes.</summary>
+    event Action? AvailabilityChanged;
+
+    /// <summary>Called from the hub when the browser reports its WebMCP support.</summary>
+    void ReportAvailability(bool available);
+}
+
+/// <summary>
+/// Exposes an Ivy view's capabilities to browser-resident AI agents through the WebMCP
+/// (<c>document.modelContext</c>) API. Tools live as long as the view that declared them.
+/// </summary>
+public static class UseWebMcpToolExtensions
+{
+    // No arguments.
+
+    /// <summary>Registers a WebMCP tool that takes no arguments and returns nothing.</summary>
+    public static void UseWebMcpTool(this IViewContext context, string name, string description,
+        Action handler, WebMcpToolOptions? options = null) =>
+        UseWebMcpToolCore(context, name, description, null, _ =>
+        {
+            handler();
+            return Task.FromResult<object?>(null);
+        }, options);
+
+    /// <summary>Registers a WebMCP tool that takes no arguments and returns a result.</summary>
+    public static void UseWebMcpTool(this IViewContext context, string name, string description,
+        Func<object?> handler, WebMcpToolOptions? options = null) =>
+        UseWebMcpToolCore(context, name, description, null, _ => Task.FromResult(handler()), options);
+
+    /// <summary>Registers an asynchronous WebMCP tool that takes no arguments and returns nothing.</summary>
+    public static void UseWebMcpTool(this IViewContext context, string name, string description,
+        Func<Task> handler, WebMcpToolOptions? options = null) =>
+        UseWebMcpToolCore(context, name, description, null, async _ =>
+        {
+            await handler();
+            return null;
+        }, options);
+
+    /// <summary>Registers an asynchronous WebMCP tool that takes no arguments and returns a result.</summary>
+    public static void UseWebMcpTool(this IViewContext context, string name, string description,
+        Func<Task<object?>> handler, WebMcpToolOptions? options = null) =>
+        UseWebMcpToolCore(context, name, description, null, _ => handler(), options);
+
+    // With arguments. The JSON Schema advertised to the agent is derived from TArgs.
+
+    /// <summary>Registers a WebMCP tool whose arguments are described by <typeparamref name="TArgs"/>.</summary>
+    public static void UseWebMcpTool<TArgs>(this IViewContext context, string name, string description,
+        Action<TArgs> handler, WebMcpToolOptions? options = null) =>
+        UseWebMcpToolCore(context, name, description, typeof(TArgs), json =>
+        {
+            handler(DeserializeArguments<TArgs>(json));
+            return Task.FromResult<object?>(null);
+        }, options);
+
+    /// <summary>Registers a WebMCP tool whose arguments are described by <typeparamref name="TArgs"/>.</summary>
+    public static void UseWebMcpTool<TArgs>(this IViewContext context, string name, string description,
+        Func<TArgs, object?> handler, WebMcpToolOptions? options = null) =>
+        UseWebMcpToolCore(context, name, description, typeof(TArgs),
+            json => Task.FromResult(handler(DeserializeArguments<TArgs>(json))), options);
+
+    /// <summary>Registers an asynchronous WebMCP tool whose arguments are described by <typeparamref name="TArgs"/>.</summary>
+    public static void UseWebMcpTool<TArgs>(this IViewContext context, string name, string description,
+        Func<TArgs, Task> handler, WebMcpToolOptions? options = null) =>
+        UseWebMcpToolCore(context, name, description, typeof(TArgs), async json =>
+        {
+            await handler(DeserializeArguments<TArgs>(json));
+            return null;
+        }, options);
+
+    /// <summary>Registers an asynchronous WebMCP tool whose arguments are described by <typeparamref name="TArgs"/>.</summary>
+    public static void UseWebMcpTool<TArgs>(this IViewContext context, string name, string description,
+        Func<TArgs, Task<object?>> handler, WebMcpToolOptions? options = null) =>
+        UseWebMcpToolCore(context, name, description, typeof(TArgs),
+            json => handler(DeserializeArguments<TArgs>(json)), options);
+
+    /// <summary>
+    /// Reports whether the browser can actually run WebMCP tools, so a view can offer a fallback
+    /// instead of silently doing nothing. Starts at <see cref="WebMcpAvailability.Unknown"/> and
+    /// rebuilds the view once the browser reports in.
+    /// </summary>
+    public static IState<WebMcpAvailability> UseWebMcpAvailability(this IViewContext context)
+    {
+        var service = context.UseService<IWebMcpToolService>();
+        var state = context.UseState(() => service.Availability);
+
+        context.UseEffect(() =>
+        {
+            void OnChanged() => state.Set(service.Availability);
+
+            service.AvailabilityChanged += OnChanged;
+            // The report can land between this build and the effect running.
+            OnChanged();
+
+            return Disposable.Create(() => service.AvailabilityChanged -= OnChanged);
+        }, [EffectTrigger.OnMount()]);
+
+        return state;
+    }
+
+    private static void UseWebMcpToolCore(IViewContext context, string name, string description,
+        Type? argumentsType, Func<string?, Task<object?>> invoke, WebMcpToolOptions? options)
+    {
+        options ??= new WebMcpToolOptions();
+
+        var service = context.UseService<IWebMcpToolService>();
+        var toolId = context.UseRef(() => Guid.NewGuid().ToString("N"));
+
+        // The effect below is registered once and pins the delegate it captured on the first build.
+        // Routing through a ref that is refreshed every build keeps the handler — and the view state
+        // it closes over — current. See ViewContext.UseEffectHook.
+        var invokeRef = context.UseRef(invoke);
+        invokeRef.Value = invoke;
+
+        var descriptor = new WebMcpToolDescriptor
+        {
+            ToolId = toolId.Value,
+            Name = name,
+            Description = description,
+            Title = options.Title,
+            InputSchema = argumentsType == null ? null : WebMcpSchemaGenerator.GetSchemaJson(argumentsType),
+            ReadOnly = options.ReadOnly,
+            UntrustedContent = options.UntrustedContent,
+            Enabled = options.Enabled
+        };
+        var descriptorRef = context.UseRef(descriptor);
+        descriptorRef.Value = descriptor;
+
+        // A state whose value is the descriptor itself doubles as the change trigger for the update
+        // effect below. buildOnChange is false so refreshing it cannot loop the build.
+        var descriptorState = context.UseState(descriptor, buildOnChange: false);
+        descriptorState.Set(descriptor);
+
+        // Registration happens exactly once. EffectQueue only drains returned disposables at unmount,
+        // so a re-running effect would leak registrations rather than replace them.
+        context.UseEffect(
+            () => service.Register(descriptorRef.Value, json => NormalizeAsync(invokeRef.Value, json)),
+            [EffectTrigger.OnMount()]);
+
+        // Descriptor changes are applied in place, which needs no cleanup.
+        context.UseEffect(() => service.Update(toolId.Value, descriptorRef.Value), descriptorState);
+    }
+
+    /// <summary>
+    /// Maps a handler's return value onto the shape <c>execute()</c> must resolve with, matching the
+    /// normalization in GoogleChromeLabs/use-webmcp-tool.
+    /// </summary>
+    private static async Task<WebMcpToolResult> NormalizeAsync(Func<string?, Task<object?>> invoke, string? argumentsJson)
+    {
+        try
+        {
+            var result = await invoke(argumentsJson);
+            return result switch
+            {
+                null => WebMcpToolResult.Empty(),
+                WebMcpToolResult toolResult => toolResult,
+                string text => WebMcpToolResult.Text(text),
+                Exception exception => WebMcpToolResult.Error(ExceptionHelper.GetInnerMostException(exception).Message),
+                _ => WebMcpToolResult.Text(JsonSerializer.Serialize(result, JsonHelper.CamelCaseOptions))
+            };
+        }
+        catch (Exception exception)
+        {
+            // A failure must never read as success to the agent.
+            return WebMcpToolResult.Error(ExceptionHelper.GetInnerMostException(exception).Message);
+        }
+    }
+
+    private static TArgs DeserializeArguments<TArgs>(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return default!;
+        return JsonSerializer.Deserialize<TArgs>(json, JsonHelper.CamelCaseOptions)!;
+    }
+}

--- a/src/Ivy/Server.cs
+++ b/src/Ivy/Server.cs
@@ -108,6 +108,7 @@ public class Server
     private PluginReferencesWatcher? _pluginReferencesWatcher;
     private Func<Server, WebApplicationBuilder, PluginContextBase>? _pluginContextFactory;
     private ManifestOptions? _manifestOptions;
+    private WebMcpOptions? _webMcpOptions;
     private ServerArgs _args;
     private bool _presetsLoaded;
 
@@ -528,6 +529,18 @@ public class Server
         _manifestOptions = new ManifestOptions();
         configure?.Invoke(_manifestOptions);
         Services.AddSingleton(_manifestOptions);
+        return this;
+    }
+
+    /// <summary>
+    /// Enables WebMCP, letting views expose tools to browser-resident AI agents with
+    /// <c>UseWebMcpTool</c>. Without this call the hook is inert and nothing is sent to the browser.
+    /// </summary>
+    public Server UseWebMcp(Action<WebMcpOptions>? configure = null)
+    {
+        _webMcpOptions = new WebMcpOptions();
+        configure?.Invoke(_webMcpOptions);
+        Services.AddSingleton(_webMcpOptions);
         return this;
     }
 
@@ -1364,6 +1377,7 @@ public static class WebApplicationExtensions
                 .Use<ThemeFilter>()
                 .Use<ManifestFilter>()
                 .Use<OpenGraphFilter>()
+                .Use<WebMcpFilter>()
                 .Use<BasePathFilter>();
 
             foreach (var filter in server.GetCustomFilters())

--- a/src/Ivy/Services/WebMcpSchemaGenerator.cs
+++ b/src/Ivy/Services/WebMcpSchemaGenerator.cs
@@ -1,0 +1,81 @@
+using System.Collections.Concurrent;
+using System.ComponentModel;
+using System.Reflection;
+using System.Text.Json.Nodes;
+using System.Text.Json.Schema;
+using Ivy.Core.Helpers;
+
+// ReSharper disable once CheckNamespace
+namespace Ivy;
+
+/// <summary>
+/// Derives the JSON Schema advertised to browser agents from a tool's argument type.
+/// </summary>
+internal static class WebMcpSchemaGenerator
+{
+    private static readonly ConcurrentDictionary<Type, string> Cache = new();
+
+    /// <summary>
+    /// Returns the JSON Schema for <paramref name="argumentsType"/> as a JSON string. Schemas are
+    /// generated with camelCase property names so they match both what the agent sends and how the
+    /// arguments are deserialized back into the tool's argument type.
+    /// </summary>
+    public static string GetSchemaJson(Type argumentsType) =>
+        Cache.GetOrAdd(argumentsType, static type =>
+        {
+            var exporterOptions = new JsonSchemaExporterOptions
+            {
+                TransformSchemaNode = static (context, schema) =>
+                {
+                    if (schema is not JsonObject node) return schema;
+
+                    var isRoot = context.PropertyInfo == null;
+
+                    // JsonSchemaExporter does not read [Description] on its own, but those
+                    // descriptions are what tell the agent what each argument means.
+                    var description = isRoot
+                        ? GetDescription(context.TypeInfo.Type)
+                        : GetDescription(context.PropertyInfo!.AttributeProvider);
+
+                    if (description != null && !node.ContainsKey("description"))
+                    {
+                        node["description"] = description;
+                    }
+
+                    // The exporter marks a reference type as nullable, which at the root would
+                    // advertise `"type": ["object", "null"]`. Agents expect a plain object there.
+                    if (isRoot) StripNullFromType(node);
+
+                    return node;
+                }
+            };
+
+            return JsonSchemaExporter
+                .GetJsonSchemaAsNode(JsonHelper.CamelCaseOptions, type, exporterOptions)
+                .ToJsonString();
+        });
+
+    private static void StripNullFromType(JsonObject node)
+    {
+        if (node["type"] is not JsonArray types) return;
+
+        var named = types
+            .OfType<JsonValue>()
+            .Select(v => v.GetValue<string>())
+            .Where(t => t != "null")
+            .ToArray();
+
+        if (named.Length == 1)
+        {
+            node["type"] = named[0];
+        }
+    }
+
+    private static string? GetDescription(ICustomAttributeProvider? provider) =>
+        provider?.GetCustomAttributes(typeof(DescriptionAttribute), inherit: true)
+            .OfType<DescriptionAttribute>()
+            .FirstOrDefault()?.Description;
+
+    private static string? GetDescription(Type type) =>
+        type.GetCustomAttribute<DescriptionAttribute>()?.Description;
+}

--- a/src/Ivy/Services/WebMcpToolService.cs
+++ b/src/Ivy/Services/WebMcpToolService.cs
@@ -1,0 +1,95 @@
+using System.Collections.Concurrent;
+using System.Reactive.Disposables;
+
+// ReSharper disable once CheckNamespace
+namespace Ivy;
+
+/// <summary>
+/// Holds the WebMCP tools declared by the views of a single SignalR connection and mirrors them to
+/// the browser, which in turn registers them on <c>document.modelContext</c>.
+/// </summary>
+/// <param name="client">Sender for the owning connection.</param>
+/// <param name="enabled">False when the host never called <c>server.UseWebMcp()</c>.</param>
+public class WebMcpToolService(IClientProvider client, bool enabled) : IWebMcpToolService
+{
+    private sealed record Registration(WebMcpToolDescriptor Descriptor, Func<string?, Task<WebMcpToolResult>> Handler);
+
+    private readonly ConcurrentDictionary<string, Registration> _tools = new();
+
+    /// <inheritdoc />
+    public WebMcpAvailability Availability { get; private set; } = WebMcpAvailability.Unknown;
+
+    /// <inheritdoc />
+    public event Action? AvailabilityChanged;
+
+    /// <inheritdoc />
+    public void ReportAvailability(bool available)
+    {
+        var reported = available ? WebMcpAvailability.Available : WebMcpAvailability.Unavailable;
+        if (Availability == reported) return;
+
+        Availability = reported;
+        AvailabilityChanged?.Invoke();
+    }
+
+    /// <inheritdoc />
+    public IDisposable Register(WebMcpToolDescriptor descriptor, Func<string?, Task<WebMcpToolResult>> handler)
+    {
+        _tools[descriptor.ToolId] = new Registration(descriptor, handler);
+        PushToolList();
+
+        return Disposable.Create(() =>
+        {
+            if (_tools.TryRemove(descriptor.ToolId, out _))
+            {
+                PushToolList();
+            }
+        });
+    }
+
+    /// <inheritdoc />
+    public void Update(string toolId, WebMcpToolDescriptor descriptor)
+    {
+        if (!_tools.TryGetValue(toolId, out var existing)) return;
+        _tools[toolId] = existing with { Descriptor = descriptor };
+        PushToolList();
+    }
+
+    /// <inheritdoc />
+    public Task<WebMcpToolResult> InvokeAsync(string toolId, string? argumentsJson)
+    {
+        if (!_tools.TryGetValue(toolId, out var registration))
+        {
+            return Task.FromResult(WebMcpToolResult.Error("This tool is no longer available."));
+        }
+
+        return registration.Handler(argumentsJson);
+    }
+
+    /// <summary>
+    /// Sends the full current tool set. Deltas would buy nothing here: the browser side replaces its
+    /// registrations wholesale, so the last message always wins.
+    /// </summary>
+    private void PushToolList()
+    {
+        if (!enabled) return;
+
+        var payload = _tools.Values
+            .Select(r => r.Descriptor)
+            .Where(d => d.Enabled)
+            .OrderBy(d => d.Name, StringComparer.Ordinal)
+            .Select(d => new Dictionary<string, object?>
+            {
+                ["toolId"] = d.ToolId,
+                ["name"] = d.Name,
+                ["title"] = d.Title,
+                ["description"] = d.Description,
+                ["inputSchema"] = d.InputSchema,
+                ["readOnly"] = d.ReadOnly,
+                ["untrustedContent"] = d.UntrustedContent
+            })
+            .ToArray();
+
+        client.Sender.Send("WebMcpTools", payload);
+    }
+}

--- a/src/frontend/src/hooks/use-backend.tsx
+++ b/src/frontend/src/hooks/use-backend.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useRef, useId } from "react";
 import * as signalR from "@microsoft/signalr";
 import { MessagePackHubProtocol } from "@microsoft/signalr-protocol-msgpack";
 import { WidgetEventHandlerType, WidgetNode } from "@/types/widgets";
@@ -12,6 +12,14 @@ import { applyPatch, Operation } from "fast-json-patch";
 import { ToastAction } from "@/components/ui/toast";
 import { setThemeGlobal } from "@/components/theme-provider";
 import { setExternalWidgetRegistry, ExternalWidgetInfo } from "@/widgets/externalWidgetLoader";
+import {
+  syncTools,
+  resolveToolCall,
+  releaseScope,
+  registerAvailabilityReporter,
+  type WebMcpToolMessage,
+  type WebMcpToolResultMessage,
+} from "@/lib/webmcp";
 
 type UpdateMessage = Array<{
   iteration: number;
@@ -371,6 +379,10 @@ export const useBackend = (
   const connectionId = connection?.connectionId;
   const currentConnectionRef = useRef<signalR.HubConnection | null>(null);
   const lastIterationRef = useRef<number>(-1);
+  // Scope for WebMCP tool registrations. Deliberately not connection.connectionId: that changes on
+  // automatic reconnect, which would orphan the previous registrations in the document-global
+  // registry. This id is stable for the life of the hook instance, which is what ownership means here.
+  const webMcpScope = useId();
 
   // Use a ref that gets updated with the latest connection so we always have it in the callback
   const latestConnectionRef = useRef(connection);
@@ -970,6 +982,32 @@ export const useBackend = (
               handleHttpRequest(message);
             });
 
+            // SignalR withholds client invocations until OnConnectedAsync completes, so the session
+            // exists by the time this lands.
+            registerAvailabilityReporter(webMcpScope, (available) => {
+              connection.invoke("WebMcpReport", available).catch((err) => {
+                logger.error("[WebMcp] Availability report failed:", err);
+              });
+            });
+
+            connection.on("WebMcpTools", (tools: WebMcpToolMessage[]) => {
+              logger.debug(`[${connection.connectionId}] WebMcpTools`, {
+                count: tools?.length ?? 0,
+              });
+              syncTools(webMcpScope, tools ?? [], (callId, toolId, argumentsJson) => {
+                connection.invoke("WebMcpToolCall", callId, toolId, argumentsJson).catch((err) => {
+                  logger.error("[WebMcp] Tool call invoke failed:", { toolId, error: err });
+                });
+              });
+            });
+
+            connection.on("WebMcpToolResult", (message: WebMcpToolResultMessage) => {
+              logger.debug(`[${connection.connectionId}] WebMcpToolResult`, {
+                callId: message?.callId,
+              });
+              resolveToolCall(webMcpScope, message);
+            });
+
             connection.on("StreamData", (message: StreamDataMessage) => {
               const handler = streamRegistryRef.current.get(message.streamId);
               if (handler) {
@@ -1024,6 +1062,8 @@ export const useBackend = (
           initialRetryTimerRef.current = null;
         }
 
+        releaseScope(webMcpScope);
+
         connection.off("Refresh");
         connection.off("Update");
         connection.off("Toast");
@@ -1033,6 +1073,8 @@ export const useBackend = (
         connection.off("ReloadPage");
         connection.off("HttpRequest");
         connection.off("StreamData");
+        connection.off("WebMcpTools");
+        connection.off("WebMcpToolResult");
         connection.off("SetAuthCookies");
         connection.off("SetRootAppId");
         connection.off("SetTheme");
@@ -1065,6 +1107,7 @@ export const useBackend = (
     handleError,
     stableAppId,
     parentId,
+    webMcpScope,
   ]);
 
   useEffect(() => {

--- a/src/frontend/src/lib/webmcp.ts
+++ b/src/frontend/src/lib/webmcp.ts
@@ -1,0 +1,402 @@
+import { logger } from "./logger";
+
+/**
+ * Document-global bridge between Ivy's server-driven tool declarations and the experimental WebMCP
+ * browser API (`document.modelContext`).
+ *
+ * Apps are not iframed — AppHostWidget mounts a second `useBackend`, so the AppShell and the hosted
+ * app share one document and one `document.modelContext`. Registrations are therefore grouped by
+ * scope, one per `useBackend` instance, and tool names are claimed document-wide.
+ *
+ * A scope is deliberately not a SignalR connection id: that changes on automatic reconnect, which
+ * would strand the previous registrations here with no one left to release them.
+ */
+
+/** A tool as pushed from the server in a `WebMcpTools` message. */
+export interface WebMcpToolMessage {
+  toolId: string;
+  name: string;
+  title?: string | null;
+  description: string;
+  /** JSON Schema, serialized as a JSON string. */
+  inputSchema?: string | null;
+  readOnly: boolean;
+  untrustedContent: boolean;
+}
+
+/** The server's answer to a tool call, in a `WebMcpToolResult` message. */
+export interface WebMcpToolResultMessage {
+  callId: string;
+  isError: boolean;
+  content: { type: string; text: string }[];
+}
+
+/** Sends a tool call to the server. Implemented by `useBackend` over `connection.invoke`. */
+export type WebMcpCallSender = (callId: string, toolId: string, argumentsJson: string) => void;
+
+/** Tells the server whether this browser can run WebMCP tools. */
+export type WebMcpAvailabilityReporter = (available: boolean) => void;
+
+interface PendingCall {
+  resolve: (result: WebMcpExecuteResult) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+interface RegisteredTool {
+  /** Aborting this unregisters the tool. */
+  controller: AbortController;
+  /** Descriptor fingerprint, so an unchanged tool is never needlessly re-registered. */
+  signature: string;
+}
+
+interface ScopeEntry {
+  registered: Map<string, RegisteredTool>;
+  pending: Map<string, PendingCall>;
+  /** Last tool set the server asked for, replayed if the browser API shows up late. */
+  desired?: { tools: WebMcpToolMessage[]; send: WebMcpCallSender };
+  /**
+   * Serializes syncs. `registerTool` is async, and the server sends one message per tool as views
+   * mount, so overlapping syncs would collide on duplicate names and lose tools.
+   */
+  syncChain: Promise<void>;
+}
+
+/** A tool handler that never returns would leave the agent hanging; bound it instead. */
+const CALL_TIMEOUT_MS = 60_000;
+
+/**
+ * A polyfill or extension can define `document.modelContext` after our first tools message lands.
+ * Re-check on this bounded schedule rather than dropping the tools for the life of the page.
+ */
+const RETRY_DELAYS_MS = [250, 1000, 3000];
+
+const scopes = new Map<string, ScopeEntry>();
+/** Tool name to the scope that currently owns it. Names must be unique per document. */
+const nameOwners = new Map<string, string>();
+const availabilityReporters = new Map<string, WebMcpAvailabilityReporter>();
+
+let callCounter = 0;
+let retryAttempt = 0;
+let retryTimer: ReturnType<typeof setTimeout> | null = null;
+let unavailableReported = false;
+let lastAvailability: boolean | null = null;
+
+function getModelContext(): WebMcpModelContext | undefined {
+  // `navigator.modelContext` was the original spelling and is deprecated as of Chrome 150.
+  return document.modelContext ?? navigator.modelContext;
+}
+
+/** Why WebMCP is not usable right now, or null when it is. */
+function getUnavailableReason(): string | null {
+  const meta = document.querySelector('meta[name="ivy-webmcp"]');
+  if (meta?.getAttribute("content") !== "true") {
+    return "WebMCP is not enabled on the server. Call server.UseWebMcp() in Program.cs.";
+  }
+  if (typeof getModelContext()?.registerTool !== "function") {
+    return (
+      "This browser does not expose document.modelContext. WebMCP is behind a Chrome origin " +
+      "trial. For local development enable chrome://flags/#enable-webmcp-testing and relaunch " +
+      "Chrome (no token needed), or launch Chrome with --enable-features=WebMCPTesting. For a " +
+      'deployed origin, pass an origin trial token to server.UseWebMcp(o => o.OriginTrialToken = "...").'
+    );
+  }
+  return null;
+}
+
+/** True when the host enabled WebMCP and the browser actually implements it. */
+export function isWebMcpAvailable(): boolean {
+  return getUnavailableReason() === null;
+}
+
+/**
+ * Registers a scope's channel for telling the server about WebMCP support, and reports the current
+ * state immediately. The report is repeated if support appears later during the retry window.
+ */
+export function registerAvailabilityReporter(
+  scopeId: string,
+  report: WebMcpAvailabilityReporter,
+): void {
+  availabilityReporters.set(scopeId, report);
+  const available = isWebMcpAvailable();
+  lastAvailability = available;
+  report(available);
+}
+
+/** Pushes a changed availability verdict to every scope. */
+function notifyAvailability(): void {
+  const available = isWebMcpAvailable();
+  if (available === lastAvailability) return;
+
+  lastAvailability = available;
+  for (const report of availabilityReporters.values()) {
+    report(available);
+  }
+}
+
+function getEntry(scopeId: string): ScopeEntry {
+  let entry = scopes.get(scopeId);
+  if (!entry) {
+    entry = { registered: new Map(), pending: new Map(), syncChain: Promise.resolve() };
+    scopes.set(scopeId, entry);
+  }
+  return entry;
+}
+
+function unregisterTool(scopeId: string, entry: ScopeEntry, name: string): void {
+  entry.registered.get(name)?.controller.abort();
+  entry.registered.delete(name);
+  if (nameOwners.get(name) === scopeId) {
+    nameOwners.delete(name);
+  }
+}
+
+/** Aborts every registration a scope owns. Leaves the entry itself in place. */
+function unregisterAllTools(scopeId: string, entry: ScopeEntry): void {
+  for (const [name, tool] of entry.registered) {
+    tool.controller.abort();
+    if (nameOwners.get(name) === scopeId) {
+      nameOwners.delete(name);
+    }
+  }
+  entry.registered.clear();
+}
+
+/** Fingerprint of everything that would require re-registering a tool. */
+function toolSignature(tool: WebMcpToolMessage): string {
+  return JSON.stringify([
+    tool.toolId,
+    tool.name,
+    tool.title ?? null,
+    tool.description,
+    tool.inputSchema ?? null,
+    tool.readOnly,
+    tool.untrustedContent,
+  ]);
+}
+
+/** Resolves every in-flight call as an error so no agent is left waiting. */
+function failPendingCalls(entry: ScopeEntry, reason: string): void {
+  for (const pending of entry.pending.values()) {
+    clearTimeout(pending.timer);
+    pending.resolve(errorResult(reason));
+  }
+  entry.pending.clear();
+}
+
+function parseInputSchema(tool: WebMcpToolMessage): object | undefined {
+  if (!tool.inputSchema) return undefined;
+  try {
+    return JSON.parse(tool.inputSchema) as object;
+  } catch (error) {
+    logger.error("Failed to parse WebMCP input schema", { tool: tool.name, error });
+    return undefined;
+  }
+}
+
+/**
+ * Brings a scope's registrations in line with `tools`. The server sends its full current set, and
+ * one message per tool as views mount, so this diffs rather than rebuilding: unchanged tools are
+ * left alone and only real additions and removals touch the browser.
+ */
+export function syncTools(
+  scopeId: string,
+  tools: WebMcpToolMessage[],
+  send: WebMcpCallSender,
+): void {
+  const entry = getEntry(scopeId);
+  entry.desired = { tools, send };
+  applyDesiredTools(scopeId, entry);
+}
+
+/** Schedules a bounded re-check for a WebMCP implementation that appears after page load. */
+function scheduleRetry(): void {
+  if (retryTimer !== null || retryAttempt >= RETRY_DELAYS_MS.length) return;
+
+  const delay = RETRY_DELAYS_MS[retryAttempt++];
+  retryTimer = setTimeout(() => {
+    retryTimer = null;
+    notifyAvailability();
+    for (const [scopeId, entry] of scopes) {
+      if (entry.desired) applyDesiredTools(scopeId, entry);
+    }
+  }, delay);
+}
+
+function applyDesiredTools(scopeId: string, entry: ScopeEntry): void {
+  // Queue behind any sync already in flight. registerTool is async, so overlapping syncs would
+  // race each other onto the same tool names.
+  entry.syncChain = entry.syncChain
+    .then(() => syncScope(scopeId, entry))
+    .catch((error) => logger.error("WebMCP sync failed", { scopeId, error }));
+}
+
+async function syncScope(scopeId: string, entry: ScopeEntry): Promise<void> {
+  const desired = entry.desired;
+  if (!desired) return;
+
+  notifyAvailability();
+
+  const unavailable = getUnavailableReason();
+  if (unavailable !== null) {
+    // Silence here is what makes "my tools never showed up" impossible to diagnose.
+    if (!unavailableReported) {
+      unavailableReported = true;
+      logger.warn(`WebMCP tools were not registered. ${unavailable}`, {
+        toolCount: desired.tools.length,
+      });
+    }
+    scheduleRetry();
+    return;
+  }
+
+  const modelContext = getModelContext();
+  if (!modelContext) return;
+
+  const { tools, send } = desired;
+  const wanted = new Map(tools.map((tool) => [tool.name, tool]));
+
+  // Drop anything gone or changed. Collect first: deleting mid-iteration is a footgun.
+  const stale: string[] = [];
+  for (const [name, current] of entry.registered) {
+    const tool = wanted.get(name);
+    if (!tool || toolSignature(tool) !== current.signature) stale.push(name);
+  }
+  for (const name of stale) {
+    unregisterTool(scopeId, entry, name);
+  }
+
+  for (const tool of tools) {
+    if (entry.registered.has(tool.name)) continue;
+
+    const previousOwner = nameOwners.get(tool.name);
+    if (previousOwner !== undefined && previousOwner !== scopeId) {
+      // Two scopes in one document claimed the same name. Last registration wins.
+      if (process.env.NODE_ENV === "development") {
+        logger.warn("Duplicate WebMCP tool name across scopes; last registration wins", {
+          tool: tool.name,
+          previousOwner,
+          scopeId,
+        });
+      }
+      const owner = scopes.get(previousOwner);
+      if (owner) unregisterTool(previousOwner, owner, tool.name);
+    }
+
+    const controller = new AbortController();
+    const inputSchema = parseInputSchema(tool);
+
+    try {
+      // Awaited so the map only ever claims tools the browser actually accepted.
+      await modelContext.registerTool(
+        {
+          name: tool.name,
+          description: tool.description,
+          ...(tool.title ? { title: tool.title } : {}),
+          ...(inputSchema ? { inputSchema } : {}),
+          annotations: {
+            readOnlyHint: tool.readOnly,
+            untrustedContentHint: tool.untrustedContent,
+          },
+          execute: (input) => invokeTool(scopeId, tool.toolId, input, send),
+        },
+        { signal: controller.signal },
+      );
+
+      entry.registered.set(tool.name, { controller, signature: toolSignature(tool) });
+      nameOwners.set(tool.name, scopeId);
+    } catch (error) {
+      // Registration can fail on permissions policy or a name the browser rejects. Leave the name
+      // unclaimed rather than unregistering it — another scope may legitimately own it.
+      logger.error("Failed to register WebMCP tool", { tool: tool.name, error });
+    }
+  }
+}
+
+function invokeTool(
+  scopeId: string,
+  toolId: string,
+  input: Record<string, unknown>,
+  send: WebMcpCallSender,
+): Promise<WebMcpExecuteResult> {
+  const entry = getEntry(scopeId);
+  const callId = `${++callCounter}`;
+
+  return new Promise<WebMcpExecuteResult>((resolve) => {
+    const timer = setTimeout(() => {
+      entry.pending.delete(callId);
+      resolve(errorResult("The tool did not respond in time."));
+    }, CALL_TIMEOUT_MS);
+
+    entry.pending.set(callId, { resolve, timer });
+
+    try {
+      send(callId, toolId, JSON.stringify(input ?? {}));
+    } catch (error) {
+      clearTimeout(timer);
+      entry.pending.delete(callId);
+      logger.error("Failed to send WebMCP tool call", { toolId, error });
+      resolve(errorResult("The tool could not be reached."));
+    }
+  });
+}
+
+/** Completes the pending call a `WebMcpToolResult` message refers to. */
+export function resolveToolCall(scopeId: string, message: WebMcpToolResultMessage): void {
+  const entry = scopes.get(scopeId);
+  const pending = entry?.pending.get(message.callId);
+  if (!entry || !pending) return;
+
+  clearTimeout(pending.timer);
+  entry.pending.delete(message.callId);
+  pending.resolve({
+    content: (message.content ?? []).map((block) => ({
+      type: "text",
+      text: block.text,
+    })),
+    isError: message.isError,
+  });
+}
+
+/**
+ * Drops everything a scope owns. Pending calls resolve as errors rather than hanging, which is what
+ * losing the app mid-call must look like to the agent.
+ */
+export function releaseScope(scopeId: string): void {
+  const entry = scopes.get(scopeId);
+  if (!entry) return;
+
+  unregisterAllTools(scopeId, entry);
+  failPendingCalls(entry, "The connection to the application was lost.");
+  scopes.delete(scopeId);
+  availabilityReporters.delete(scopeId);
+}
+
+function errorResult(text: string): WebMcpExecuteResult {
+  return { content: [{ type: "text", text }], isError: true };
+}
+
+/** For testing only. Clears all registrations and pending calls. */
+export function _resetForTesting(): void {
+  for (const [scopeId, entry] of scopes) {
+    unregisterAllTools(scopeId, entry);
+    failPendingCalls(entry, "Reset.");
+  }
+  scopes.clear();
+  nameOwners.clear();
+  availabilityReporters.clear();
+  callCounter = 0;
+  retryAttempt = 0;
+  unavailableReported = false;
+  lastAvailability = null;
+  if (retryTimer !== null) {
+    clearTimeout(retryTimer);
+    retryTimer = null;
+  }
+}
+
+/** For testing only. Number of tools currently registered across all scopes. */
+export function _getRegistrySize(): number {
+  let total = 0;
+  for (const entry of scopes.values()) total += entry.registered.size;
+  return total;
+}

--- a/src/frontend/src/types/webmcp.d.ts
+++ b/src/frontend/src/types/webmcp.d.ts
@@ -1,0 +1,50 @@
+/**
+ * Ambient declarations for the experimental WebMCP browser API.
+ *
+ * Spec: https://webmachinelearning.github.io/webmcp/ (W3C Web Machine Learning CG, not on the
+ * standards track). Shipping in a Chrome origin trial. `navigator.modelContext` was the original
+ * spelling and is deprecated as of Chrome 150 in favour of `document.modelContext`; both are
+ * declared here so feature detection can cover either.
+ */
+
+interface WebMcpToolAnnotations {
+  readOnlyHint?: boolean;
+  untrustedContentHint?: boolean;
+}
+
+interface WebMcpContentBlock {
+  type: "text";
+  text: string;
+}
+
+interface WebMcpExecuteResult {
+  content: WebMcpContentBlock[];
+  isError?: boolean;
+}
+
+interface WebMcpToolDescriptor {
+  name: string;
+  description: string;
+  title?: string;
+  inputSchema?: object;
+  annotations?: WebMcpToolAnnotations;
+  execute: (input: Record<string, unknown>) => Promise<WebMcpExecuteResult>;
+}
+
+interface WebMcpRegisterToolOptions {
+  signal?: AbortSignal;
+  exposedTo?: string[];
+}
+
+interface WebMcpModelContext extends EventTarget {
+  registerTool(tool: WebMcpToolDescriptor, options?: WebMcpRegisterToolOptions): Promise<void>;
+  getTools(options?: { fromOrigins?: string[] }): Promise<unknown[]>;
+}
+
+interface Document {
+  modelContext?: WebMcpModelContext;
+}
+
+interface Navigator {
+  modelContext?: WebMcpModelContext;
+}


### PR DESCRIPTION
## What

Adds [WebMCP](https://webmachinelearning.github.io/webmcp/) support to Ivy. WebMCP is a W3C Web Machine Learning CG spec (Google + Microsoft, currently in a Chrome origin trial) that lets a page declare functions as **tools** a browser-resident AI agent can discover and invoke — instead of the agent screenshotting the DOM and guessing where to click.

Ivy is an unusually good fit: because apps are pure C# with server-held state, a tool handler runs against the *same* state the human is looking at, and the widget diff that follows re-renders the UI live as the agent works. Authors write one hook call and never touch JavaScript.

```csharp
[App(icon: Icons.Bot)]
public class TodoApp : ViewBase
{
    public override object? Build()
    {
        var todos = UseState(ImmutableArray<string>.Empty);

        UseWebMcpTool("add-todo", "Add a new item to the user's active todo list",
            (AddTodoArgs args) => { todos.Set(todos.Value.Add(args.Text)); return $"Added \"{args.Text}\""; });

        UseWebMcpTool("list-todos", "List the user's current todo items",
            () => todos.Value,
            new WebMcpToolOptions { ReadOnly = true, UntrustedContent = true });

        return /* … */;
    }
}

public record AddTodoArgs(
    [property: Description("The text content of the todo item")] string Text);
```

Enable it in `Program.cs`. Without this the hook is inert and nothing reaches the browser:

```csharp
server.UseWebMcp();                                        // local dev
server.UseWebMcp(o => o.OriginTrialToken = "…");           // deployed origin
```

## API surface

| Member | Purpose |
|---|---|
| `UseWebMcpTool(...)` | Declares a tool for the lifetime of the view. 8 overloads: sync/async × with/without a typed args record × void/returning. |
| `UseWebMcpAvailability()` | `IState<WebMcpAvailability>` — `Unknown` → `Available`/`Unavailable`, so a view can offer a fallback instead of silently registering tools nobody can call. |
| `WebMcpToolOptions` | `Title`, `ReadOnly`, `UntrustedContent`, `Enabled`. |
| `WebMcpToolResult` | `Text` / `Error` / `Empty` for full control over the result. |
| `server.UseWebMcp(...)` | Opt-in, plus optional origin-trial token injection. |

Return values normalize exactly the way [`GoogleChromeLabs/use-webmcp-tool`](https://github.com/GoogleChromeLabs/use-webmcp-tool) does — `string` → text block, `null` → empty content, other objects → JSON, thrown or returned exceptions → `isError: true`. Input schemas come from `JsonSchemaExporter` (built into net10, no new package), with `[Description]` flowing through to per-argument docs.

## How it works

```
Build() ──UseWebMcpTool──▶ IWebMcpToolService (per connection)
                                  │ Send("WebMcpTools", […])
                                  ▼
                          lib/webmcp.ts ──registerTool──▶ document.modelContext
                                  ▲                              │ execute(input)
          Send("WebMcpToolResult", {callId, content, isError})   ▼
        AppHub.WebMcpToolCall(callId, toolId, argsJson) ◀──invoke── pending-call map
                    └─▶ AppSession.EventQueue.Enqueue(…)   (serialized with UI events)
```

Tool calls run on the session's existing `EventDispatchQueue`, the same queue UI events use, so agent actions serialize with human clicks and re-render through the normal widget diff.

## Design notes worth reviewing

Four constraints shaped this more than anything else:

- **The hub method doesn't await the handler.** `MaximumParallelInvocationsPerClient` is left at its default of 1 (`Server.cs`), so awaiting a slow tool would stall every other invocation on that connection — including `Event`. Raising the limit isn't an option either: parallel invocations would let two `Event` calls enqueue out of order. So the result comes back out-of-band keyed on a `callId`, mirroring the existing HTTP tunnel pattern inverted.

- **Registration is one mount effect plus a latest-ref.** `EffectQueue` only drains returned disposables at unmount, so a re-running effect would leak registrations rather than replace them; and `ViewContext.UseEffectHook` pins the first build's closure, which would otherwise capture stale state.

- **The browser registry is keyed by a per-`useBackend` scope, not the SignalR connection id.** That id changes on automatic reconnect, which would strand registrations with no owner left to release them. Apps aren't iframed — `AppHostWidget` mounts a second `useBackend` — so the AppShell and the hosted app share one `document.modelContext` and tool names are claimed document-wide.

- **Syncs are serialized and diffed.** `registerTool` is async and the server sends one message per tool as views mount. An abort-all-then-re-register-all approach raced against itself, collided on duplicate names, and silently dropped tools — reproducibly 2 of 4. Each scope now queues syncs behind one another and diffs by descriptor signature, leaving unchanged tools untouched.

## Verification

Driven end-to-end against the **real** Chrome WebMCP API (Chrome 151, `--enable-features=WebMCPTesting`), not a stub:

| call | result |
|---|---|
| `getTools()` | all 4 tools, correct schemas incl. `[Description]` text and annotations |
| `add-todo` | correct text **and** the item appears in the rendered UI with no reload |
| `list-todos` | `["native call"]` |
| `remove-todo` (bad arg) | `isError: true` |
| `clear-todos` | `Cleared 1 todo item(s)`, list emptied |
| availability | callout flips to the `Available` branch |

Also verified: closing the app's shell tab unregisters all tools; with no WebMCP present the page renders and behaves exactly as before (feature detection), and Ivy logs one actionable console warning naming the exact remedy rather than failing silently.

Solution builds clean (0 warnings), frontend typecheck/lint/format pass, `dotnet format --verify-no-changes` passes. Frontend test suite unchanged at 1284 passing — the 5 failures in `charts/sharedUtils.test.ts` are pre-existing locale-dependent assertions unrelated to this change.

## Not included

- Tests. Deliberately scoped out: `Ivy.Test` for schema generation and the service, vitest for the browser registry (`_resetForTesting` hooks are already in place), and a Playwright e2e injecting a fake `document.modelContext` via `addInitScript`.
- A docs page under `Ivy.Docs.Shared/Docs/03_Hooks/02_Core/`.
- AppShell-derived tools (`list-apps`, `navigate-to-app`) — the highest-leverage follow-up, since it would make every existing Ivy app agent-navigable with zero author effort.
- Cross-origin `exposedTo` / `fromOrigins`.

## Security posture

A tool executes server-side with the user's full auth session — the same authority as a button click. Only what `UseWebMcpTool` declares is ever exposed, `exposedTo` is never set (same-origin only), and `UntrustedContent` marks tools returning database rows so the agent treats them as data rather than instructions.

## Risk

The spec is young — `navigator.modelContext` → `document.modelContext` already happened once mid-origin-trial. All browser-API contact is confined to `src/frontend/src/lib/webmcp.ts`, so the next rename touches one file.
