### PR TITLE
[00074] Open Review Actions in a PTY Terminal Tab

### DIFF
--- a/src/Ivy.Hooks.Pty/UsePty.cs
+++ b/src/Ivy.Hooks.Pty/UsePty.cs
@@ -14,13 +14,19 @@ public record PtyOptions
     public Action<string>? OnOutput { get; init; }
 }
 
+// GetProcessId reads the spawned process's current OS process id, or null before the process
+// has started (or after it has exited/been disposed). A live accessor rather than a plain field:
+// the value is only known once the async spawn in UsePtyExtensions.UsePty completes, which may
+// be after the render that returned this handle, so callers must read it at the point of use
+// (e.g. inside their own effect cleanup) rather than capture it.
 public record PtyHandle(
     IWriteStream<byte[]> Stream,
     Action<string> HandleInput,
     Action<int, int> HandleResize,
     Action Kill,
     bool Closed,
-    int? ExitCode
+    int? ExitCode,
+    Func<int?>? GetProcessId = null
 );
 
 public static class UsePtyExtensions
@@ -92,7 +98,7 @@ public static class UsePtyExtensions
             KillPty(pty.Value);
         }
 
-        return new PtyHandle(stream, HandleInput, HandleResize, Kill, closed.Value, exitCode.Value);
+        return new PtyHandle(stream, HandleInput, HandleResize, Kill, closed.Value, exitCode.Value, () => pty.Value?.Pid);
     }
 
     // CommandLineToArgvW-compatible argument quoting (the same algorithm as .NET's


### PR DESCRIPTION
# Summary

Companion PR to [Plan 00074](https://github.com/Ivy-Interactive/Ivy-Tendril/pull/2011)
(Ivy-Tendril): adds `ReviewActionApp`, which hosts a Tendril review action's PowerShell process
in a PTY terminal tab and must reliably kill the whole process tree (including grandchildren
like `dotnet run`) when the tab closes. Empirical testing showed the PTY's own job-object
teardown alone was not sufficient in all cases, so `PtyHandle` needs to expose the spawned
process's OS pid to let the caller back it up with an explicit process-tree kill.

## API Changes

- Changed (additive): `Ivy.Hooks.Pty.PtyHandle` gained a new trailing field
  `Func<int?>? GetProcessId = null` - a live accessor to the spawned process's OS pid. Existing
  positional/named construction of `PtyHandle` is unaffected since the field is optional and
  appended at the end of the record.

## Files Modified

- `src/Ivy.Hooks.Pty/UsePty.cs` - `PtyHandle.GetProcessId`

## Manual Testing

Covered end-to-end by the Ivy-Tendril companion PR: open a review action whose command spawns a
grandchild process, close its tab, and confirm both the shell and the grandchild process
disappear within a few seconds.

---
## Commits

- 303be4cab Plan 00074: Surface process id on PtyHandle for explicit tree kill

---
Created using [Ivy Tendril](https://ivy.app).
