### PR TITLE
[00076] Fix UTF-8 Corruption and Add Output Capture to Ivy.Hooks.Pty

### DIFF
--- a/src/Ivy-Framework.slnx
+++ b/src/Ivy-Framework.slnx
@@ -39,6 +39,8 @@
   <Project Path="Ivy.Docs.Shared/Ivy.Docs.Shared.csproj" />
   <Project Path="Ivy.Docs.Test/Ivy.Docs.Test.csproj" />
   <Project Path="Ivy.Docs/Ivy.Docs.csproj" />
+  <Project Path="Ivy.Hooks.Pty/Ivy.Hooks.Pty.csproj" />
+  <Project Path="Ivy.Hooks.Pty.Test/Ivy.Hooks.Pty.Test.csproj" />
   <Project Path="Ivy.Samples.Shared/Ivy.Samples.Shared.csproj" />
   <Project Path="Ivy.Samples/Ivy.Samples.csproj" />
   <Project Path="Ivy.Test/Ivy.Test.csproj" />

--- a/src/Ivy.Hooks.Pty.Test/AnsiEscapeTests.cs
+++ b/src/Ivy.Hooks.Pty.Test/AnsiEscapeTests.cs
@@ -1,0 +1,93 @@
+namespace Ivy.Hooks.Pty.Test;
+
+public class AnsiEscapeTests
+{
+    [Fact]
+    public void Strip_CsiColorCodes()
+    {
+        var result = AnsiEscape.Strip("\x1b[31mred\x1b[0m");
+
+        Assert.Equal("red", result);
+    }
+
+    [Fact]
+    public void Strip_OscSequences_BelTerminated()
+    {
+        var result = AnsiEscape.Strip("\x1b]0;title\x07text");
+
+        Assert.Equal("text", result);
+    }
+
+    [Fact]
+    public void Strip_OscSequences_StTerminated()
+    {
+        var result = AnsiEscape.Strip("\x1b]0;title\x1b\\text");
+
+        Assert.Equal("text", result);
+    }
+
+    [Fact]
+    public void Strip_OscSequences_UnterminatedAtEndOfString()
+    {
+        var result = AnsiEscape.Strip("before\x1b]0;untermina");
+
+        Assert.Equal("before", result);
+    }
+
+    [Fact]
+    public void Strip_OtherEscapeSequences_TwoCharSequenceRemoved()
+    {
+        // ESI (ESC M) is a plain two-byte escape sequence with no CSI/OSC introducer.
+        var result = AnsiEscape.Strip("a\x1bMb");
+
+        Assert.Equal("ab", result);
+    }
+
+    [Fact]
+    public void Strip_PreservesNewlinesTabsAndCarriageReturns()
+    {
+        const string input = "a\r\nb\tc";
+
+        var result = AnsiEscape.Strip(input);
+
+        Assert.Equal(input, result);
+    }
+
+    [Fact]
+    public void Strip_RemovesRemainingControlChars()
+    {
+        // \x is a variable-width hex escape in C# and greedily consumes any hex-digit letters
+        // (a-f/A-F) that immediately follow it, so e.g. "\x07b" would parse as the single
+        // codepoint 0x07b rather than BEL followed by 'b'. \u (always exactly 4 hex digits) is
+        // used here instead of \x to keep each control char and the following letter distinct.
+        var result = AnsiEscape.Strip("a\u0007b\u0008c\u007fd");
+
+        Assert.Equal("abcd", result);
+    }
+
+    [Fact]
+    public void Strip_PlainText_Unchanged()
+    {
+        const string input = "just plain text, nothing special here.";
+
+        Assert.Equal(input, AnsiEscape.Strip(input));
+    }
+
+    [Fact]
+    public void Strip_EmptyAndNullInput_ReturnsEmpty()
+    {
+        Assert.Equal(string.Empty, AnsiEscape.Strip(""));
+        Assert.Equal(string.Empty, AnsiEscape.Strip(null));
+    }
+
+    [Fact]
+    public void Strip_RealisticRedrawSequence_LeavesVisibleTextOnly()
+    {
+        // Cursor positioning + SGR (color) heavy sequence, similar to what a TUI redraw emits.
+        var input = "\x1b[2J\x1b[H\x1b[1;32mStatus: \x1b[0mOK\x1b[10;1H\x1b[?25l";
+
+        var result = AnsiEscape.Strip(input);
+
+        Assert.Equal("Status: OK", result);
+    }
+}

--- a/src/Ivy.Hooks.Pty.Test/Ivy.Hooks.Pty.Test.csproj
+++ b/src/Ivy.Hooks.Pty.Test/Ivy.Hooks.Pty.Test.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Ivy.Hooks.Pty\Ivy.Hooks.Pty.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Ivy.Hooks.Pty.Test/PtyOutputDecoderTests.cs
+++ b/src/Ivy.Hooks.Pty.Test/PtyOutputDecoderTests.cs
@@ -1,0 +1,172 @@
+using System.Text;
+
+namespace Ivy.Hooks.Pty.Test;
+
+public class PtyOutputDecoderTests
+{
+    private const string MixedText = "héllo ✅ 🎉 ┌─┐";
+
+    public static IEnumerable<object[]> SplitIndexes()
+    {
+        var byteCount = Encoding.UTF8.GetByteCount(MixedText);
+        for (var i = 0; i <= byteCount; i++)
+        {
+            yield return [i];
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(SplitIndexes))]
+    public void Decode_MultiByteSplitAcrossChunks_RoundTrips(int splitIndex)
+    {
+        var bytes = Encoding.UTF8.GetBytes(MixedText);
+        var decoder = new PtyOutputDecoder(captureOutput: false, maxCaptureLength: 1_000_000);
+
+        var first = decoder.Decode(bytes[..splitIndex], splitIndex);
+        var second = decoder.Decode(bytes[splitIndex..], bytes.Length - splitIndex);
+
+        var result = first + second;
+        Assert.Equal(MixedText, result);
+        Assert.DoesNotContain('�', result);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    public void Decode_FourByteEmoji_SplitAtEveryBoundary(int splitIndex)
+    {
+        const string emoji = "🎉"; // 4 UTF-8 bytes
+        var bytes = Encoding.UTF8.GetBytes(emoji);
+        Assert.Equal(4, bytes.Length);
+
+        var decoder = new PtyOutputDecoder(captureOutput: false, maxCaptureLength: 1_000_000);
+        var first = decoder.Decode(bytes[..splitIndex], splitIndex);
+        var second = decoder.Decode(bytes[splitIndex..], bytes.Length - splitIndex);
+
+        Assert.Equal(emoji, first + second);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    public void Decode_BoxDrawingGlyphs_SplitAcrossChunks(int splitIndex)
+    {
+        const string boxDrawing = "┌─┐"; // each glyph is a 3-byte UTF-8 sequence
+        var bytes = Encoding.UTF8.GetBytes(boxDrawing);
+
+        var decoder = new PtyOutputDecoder(captureOutput: false, maxCaptureLength: 1_000_000);
+        var first = decoder.Decode(bytes[..splitIndex], splitIndex);
+        var second = decoder.Decode(bytes[splitIndex..], bytes.Length - splitIndex);
+
+        Assert.Equal(boxDrawing, first + second);
+    }
+
+    [Fact]
+    public void Utf8GetString_OnSplitInput_ProducesReplacementChars()
+    {
+        // Regression guard documenting the old stateless behavior this plan replaces:
+        // Encoding.UTF8.GetString, called independently per chunk, corrupts a multi-byte
+        // sequence split across the chunk boundary.
+        const string emoji = "🎉";
+        var bytes = Encoding.UTF8.GetBytes(emoji);
+
+        var firstChunk = Encoding.UTF8.GetString(bytes, 0, 2);
+        var secondChunk = Encoding.UTF8.GetString(bytes, 2, 2);
+
+        Assert.Contains('�', firstChunk + secondChunk);
+        Assert.NotEqual(emoji, firstChunk + secondChunk);
+    }
+
+    [Fact]
+    public void Decode_WithoutCapture_TextIsEmpty()
+    {
+        var decoder = new PtyOutputDecoder(captureOutput: false, maxCaptureLength: 1_000_000);
+        var bytes = Encoding.UTF8.GetBytes("hello");
+
+        var chunk = decoder.Decode(bytes, bytes.Length);
+
+        Assert.Equal("hello", chunk);
+        Assert.Equal("", decoder.Text);
+    }
+
+    [Fact]
+    public void Capture_AccumulatesAcrossChunks()
+    {
+        var decoder = new PtyOutputDecoder(captureOutput: true, maxCaptureLength: 1_000_000);
+
+        foreach (var chunk in new[] { "hello ", "world", "!" })
+        {
+            var bytes = Encoding.UTF8.GetBytes(chunk);
+            decoder.Decode(bytes, bytes.Length);
+        }
+
+        Assert.Equal("hello world!", decoder.Text);
+    }
+
+    [Fact]
+    public void Capture_NeverExceedsMaxLength()
+    {
+        const int max = 100;
+        var decoder = new PtyOutputDecoder(captureOutput: true, maxCaptureLength: max);
+
+        for (var i = 0; i < 20; i++)
+        {
+            var chunk = Encoding.UTF8.GetBytes(new string('x', 50));
+            decoder.Decode(chunk, chunk.Length);
+            Assert.True(decoder.Text.Length <= max);
+        }
+    }
+
+    [Fact]
+    public void Capture_KeepsNewestOutput_DropsOldest()
+    {
+        const int max = 50;
+        var decoder = new PtyOutputDecoder(captureOutput: true, maxCaptureLength: max);
+
+        var firstMarker = Encoding.UTF8.GetBytes("FIRST-MARKER-");
+        decoder.Decode(firstMarker, firstMarker.Length);
+
+        for (var i = 0; i < 10; i++)
+        {
+            var filler = Encoding.UTF8.GetBytes(new string('x', 20));
+            decoder.Decode(filler, filler.Length);
+        }
+
+        var lastMarker = Encoding.UTF8.GetBytes("LAST-MARKER");
+        decoder.Decode(lastMarker, lastMarker.Length);
+
+        Assert.EndsWith("LAST-MARKER", decoder.Text);
+        Assert.DoesNotContain("FIRST-MARKER", decoder.Text);
+    }
+
+    [Fact]
+    public void Capture_SingleChunkLargerThanCap_IsTruncatedToCap()
+    {
+        const int max = 100;
+        var decoder = new PtyOutputDecoder(captureOutput: true, maxCaptureLength: max);
+
+        var huge = Encoding.UTF8.GetBytes(new string('y', 1000));
+        decoder.Decode(huge, huge.Length);
+
+        Assert.True(decoder.Text.Length <= max);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(-1000)]
+    public void Capture_NonPositiveMaxLength_IsClampedAndDoesNotThrow(int maxCaptureLength)
+    {
+        var decoder = new PtyOutputDecoder(captureOutput: true, maxCaptureLength: maxCaptureLength);
+
+        var exception = Record.Exception(() =>
+        {
+            var bytes = Encoding.UTF8.GetBytes("hello world");
+            decoder.Decode(bytes, bytes.Length);
+        });
+
+        Assert.Null(exception);
+        Assert.Equal(1, decoder.Text.Length);
+    }
+}

--- a/src/Ivy.Hooks.Pty/AnsiEscape.cs
+++ b/src/Ivy.Hooks.Pty/AnsiEscape.cs
@@ -1,0 +1,49 @@
+using System.Text.RegularExpressions;
+
+namespace Ivy.Hooks.Pty;
+
+/// <summary>
+/// Strips ANSI escape sequences and other terminal control codes from raw PTY output, so text
+/// captured via <see cref="PtyOptions.OnOutput"/> or <see cref="PtyHandle.Output"/> can be read,
+/// logged, or matched against as plain text.
+/// </summary>
+/// <remarks>
+/// A C# port of the frontend's stripper in
+/// <c>src/widgets/Ivy.Widgets.Xterm/frontend/src/Terminal.tsx</c> (the <c>markStreamDataIfVisible</c>
+/// regex chain). Applied in the same order: OSC first, since OSC bodies can themselves contain
+/// <c>[</c>, which would otherwise confuse the CSI pattern.
+/// </remarks>
+public static class AnsiEscape
+{
+    // OSC (Operating System Command), e.g. window title: ESC ] ... (BEL | ESC \) terminated.
+    // Falls back to end-of-string so an OSC sequence truncated mid-chunk doesn't swallow
+    // everything that follows it in a later Decode call.
+    private static readonly Regex Osc = new(@"\x1b\][\s\S]*?(\x07|\x1b\\|$)", RegexOptions.Compiled);
+
+    // CSI (Control Sequence Introducer), e.g. colors, cursor movement: ESC [ params intermediates final.
+    private static readonly Regex Csi = new(@"\x1b\[[0-9;?]*[ -/]*[@-~]", RegexOptions.Compiled);
+
+    // Any other two-character ESC sequence (e.g. character-set selection).
+    private static readonly Regex Esc = new(@"\x1b[\s\S]", RegexOptions.Compiled);
+
+    // Remaining control characters, deliberately keeping \t (0x09), \n (0x0A) and \r (0x0D) so the
+    // result stays readable multi-line text. The frontend version strips those too, because it only
+    // needs to answer "is anything visible here" for its loading-overlay heuristic.
+    private static readonly Regex Control = new(@"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Removes ANSI/VT escape sequences and non-whitespace control characters from <paramref name="text"/>.
+    /// Newlines, carriage returns and tabs are preserved. Returns <see cref="string.Empty"/> for
+    /// <c>null</c> or empty input.
+    /// </summary>
+    public static string Strip(string? text)
+    {
+        if (string.IsNullOrEmpty(text)) return string.Empty;
+
+        var result = Osc.Replace(text, "");
+        result = Csi.Replace(result, "");
+        result = Esc.Replace(result, "");
+        result = Control.Replace(result, "");
+        return result;
+    }
+}

--- a/src/Ivy.Hooks.Pty/Ivy.Hooks.Pty.csproj
+++ b/src/Ivy.Hooks.Pty/Ivy.Hooks.Pty.csproj
@@ -38,4 +38,8 @@
     <PackageReference Include="Porta.Pty" Version="1.0.6" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Ivy.Hooks.Pty.Test" />
+  </ItemGroup>
+
 </Project>

--- a/src/Ivy.Hooks.Pty/PtyOutputDecoder.cs
+++ b/src/Ivy.Hooks.Pty/PtyOutputDecoder.cs
@@ -1,0 +1,56 @@
+using System.Text;
+
+namespace Ivy.Hooks.Pty;
+
+// Owns the stateful UTF-8 decoder used to turn raw PTY read chunks into text, plus the optional
+// capped transcript backing PtyHandle.Output. A single instance lives for the lifetime of one
+// UsePty hook invocation (held in a UseRef so it survives PtyHandle being rebuilt every render).
+internal sealed class PtyOutputDecoder(bool captureOutput, int maxCaptureLength)
+{
+    // Stateful decoder: a multi-byte UTF-8 sequence that straddles two 4KB reads is only decoded
+    // correctly if the trailing partial bytes of one Decode call are remembered for the next one.
+    // Encoding.UTF8.GetString (stateless) would instead emit a U+FFFD replacement character here.
+    private readonly Decoder _decoder = Encoding.UTF8.GetDecoder();
+    private readonly StringBuilder? _transcript = captureOutput ? new StringBuilder() : null;
+    private readonly int _maxCaptureLength = Math.Max(1, maxCaptureLength);
+    private readonly object _gate = new();
+    private char[] _chars = [];
+
+    // Called only from the single PTY reader task, so the decoder itself needs no lock.
+    public string Decode(byte[] buffer, int count)
+    {
+        var max = Encoding.UTF8.GetMaxCharCount(count);
+        if (_chars.Length < max) _chars = new char[max];
+        var written = _decoder.GetChars(buffer, 0, count, _chars, 0);
+        var text = new string(_chars, 0, written);
+        if (text.Length > 0) Append(text);
+        return text;
+    }
+
+    // Read from the render path (or a UseInterval poll) while Decode runs on the reader task.
+    public string Text
+    {
+        get
+        {
+            lock (_gate) return _transcript?.ToString() ?? string.Empty;
+        }
+    }
+
+    private void Append(string text)
+    {
+        if (_transcript == null) return;
+
+        lock (_gate)
+        {
+            _transcript.Append(text);
+            if (_transcript.Length > _maxCaptureLength)
+            {
+                // Drop an extra 1/8 of the cap so trimming is amortized instead of running a
+                // full memmove on every 4 KB chunk once the cap is reached. Keeps the newest
+                // output (a tail is what you want from a long-running interactive CLI).
+                var excess = _transcript.Length - _maxCaptureLength + _maxCaptureLength / 8;
+                _transcript.Remove(0, Math.Min(excess, _transcript.Length));
+            }
+        }
+    }
+}

--- a/src/Ivy.Hooks.Pty/README.md
+++ b/src/Ivy.Hooks.Pty/README.md
@@ -1,0 +1,65 @@
+# Ivy.Hooks.Pty
+
+Server-side PTY (pseudo-terminal) hosting for Ivy apps, built on [Porta.Pty](https://www.nuget.org/packages/Porta.Pty). Spawns a real process (a shell, `claude`, `codex`, ...) attached to a pseudo-terminal and streams its raw output to a `Ivy.Widgets.Xterm.Terminal` widget, or lets server code observe/capture that output directly.
+
+## Three concepts, three directions
+
+The `Terminal` widget and `UsePty` hook are routinely confused with each other because there are three distinct data paths:
+
+| Concept                | Direction         | Carries                                                                 |
+|-------------------------|--------------------|--------------------------------------------------------------------------|
+| `Terminal.OnInput`      | browser → server   | keystrokes the user types (xterm `onData`), forwarded to PTY stdin       |
+| `Terminal.Stream`       | server → browser   | raw PTY output bytes, one way, base64-encoded over SignalR                |
+| `PtyOptions.OnOutput`   | server → server    | the only server-side tap on what the hosted process printed              |
+
+`OnInput` never sees program output, and `Stream` is write-only towards the browser — so `PtyOptions.OnOutput` (and the related `PtyOptions.CaptureOutput` / `PtyHandle.Output`, below) is the only way for your own C# code to observe a hosted process.
+
+## `UsePty`
+
+```csharp
+var pty = context.UsePty(
+    OperatingSystem.IsWindows() ? ["cmd"] : ["bash"],
+    workingDirectory,
+    new PtyOptions { /* ... */ }
+);
+
+return new Terminal()
+    .Stream(pty.Stream)
+    .OnInput(pty.HandleInput)
+    .OnResize(pty.HandleResize)
+    .Closed(pty.Closed);
+```
+
+`UsePty` is itself a hook (backed by `UseState`/`UseEffect`/`UseRef`), so it must be called unconditionally and, per analyser rule `IVYHOOK005`, as the **first statement** in `Build()`. If its arguments need non-trivial computation, compute them in static helper methods and call those inline as arguments — do not compute them in statements preceding the call (see `ChatView.BuildClaudeCommandLine` in `Ivy.IvyML.Studio` for the pattern).
+
+### `PtyOptions`
+
+| Property           | Default       | Meaning                                                                                   |
+|---------------------|---------------|---------------------------------------------------------------------------------------------|
+| `WorkingDirectory`  | `null`        | Process working directory (overridable by `UsePty`'s own `workingDirectory` parameter).      |
+| `Environment`       | `null`        | Extra environment variables merged over the parent process's environment. An empty/null value removes the key. |
+| `Cols` / `Rows`     | `120` / `30`  | Initial PTY size.                                                                            |
+| `OnOutput`          | `null`        | Invoked with decoded text as output arrives (see below).                                     |
+| `CaptureOutput`     | `false`       | Opt-in: accumulate output into `PtyHandle.Output` (see below).                               |
+| `MaxCaptureLength`  | `1_000_000`   | Character cap for the accumulated transcript. Only relevant when `CaptureOutput` is set.     |
+
+### `PtyHandle`
+
+`Stream`, `HandleInput`, `HandleResize`, `Kill`, `Closed`, `ExitCode` wire directly into a `Terminal` widget, as shown above. Two additional members exist purely for server-side observation:
+
+- **`OnOutput`** is invoked on the PTY reader thread (not the render thread) every time a chunk of output is read, with the chunk's text decoded across chunk boundaries — a multi-byte UTF-8 sequence split across two reads decodes correctly instead of producing `�` replacement characters. The text still contains raw ANSI escape sequences; pipe it through `AnsiEscape.Strip` for readable text.
+- **`Output`** (`PtyHandle.Output`) is the accumulated transcript when `PtyOptions.CaptureOutput` is set (empty string otherwise). It shares the same decode stream as `OnOutput`, is capped at `MaxCaptureLength` characters (keeping the *newest* output, dropping the oldest), and materializes a new string on each access — read it when you need it (e.g. on a poll interval or user action), not on every render.
+
+`PtyHandle` is rebuilt on every render, but the underlying process, decoder, and transcript buffer live in hook state (a `UseRef`) and persist across renders exactly like `pty.Stream` already does.
+
+## `AnsiEscape`
+
+```csharp
+var readable = AnsiEscape.Strip(pty.Output);
+```
+
+Strips ANSI/VT escape sequences (OSC, CSI, and other `ESC`-prefixed sequences) and non-whitespace control characters, while preserving newlines, carriage returns, and tabs so the result stays readable multi-line text. A C# port of the frontend's stripper in `Terminal.tsx`.
+
+## Example: capturing output alongside a live terminal
+
+See `src/widgets/Ivy.Widgets.Xterm/.samples/Apps/OutputCaptureApp.cs` for a full sample that shows a live `Terminal` next to a read-only pane rendering `AnsiEscape.Strip(pty.Output)`, refreshed on a `UseInterval` poll.

--- a/src/Ivy.Hooks.Pty/UsePty.cs
+++ b/src/Ivy.Hooks.Pty/UsePty.cs
@@ -12,6 +12,16 @@ public record PtyOptions
     public int Cols { get; init; } = 120;
     public int Rows { get; init; } = 30;
     public Action<string>? OnOutput { get; init; }
+
+    // Opt-in accumulated transcript, exposed via PtyHandle.Output. Off by default: most callers
+    // only need the live OnOutput callback or the raw byte Stream, and an unbounded StringBuilder
+    // per PTY session is wasted memory otherwise.
+    public bool CaptureOutput { get; init; }
+
+    // Character cap for the accumulated transcript (only relevant when CaptureOutput is true).
+    // Once exceeded, the oldest text is dropped so PtyHandle.Output always holds a bounded tail
+    // of the most recent output instead of growing unbounded for a long-running interactive CLI.
+    public int MaxCaptureLength { get; init; } = 1_000_000;
 }
 
 // GetProcessId reads the spawned process's current OS process id, or null before the process
@@ -27,7 +37,22 @@ public record PtyHandle(
     bool Closed,
     int? ExitCode,
     Func<int?>? GetProcessId = null
-);
+)
+{
+    // Live accessor into the hook-state-held PtyOutputDecoder, not a captured value: the decoder
+    // outlives any single PtyHandle instance (which is rebuilt every render), and Output must
+    // reflect output that has arrived since this PtyHandle was constructed.
+    internal Func<string>? OutputProvider { get; init; }
+
+    /// <summary>
+    /// The accumulated output text captured since the PTY started, when <see cref="PtyOptions.CaptureOutput"/>
+    /// is set (empty string otherwise). Decoded across chunk boundaries and capped at
+    /// <see cref="PtyOptions.MaxCaptureLength"/> characters, keeping the newest output. Contains raw
+    /// ANSI escape sequences — pipe through <see cref="AnsiEscape.Strip"/> for readable text. Materializes
+    /// a new string on each access, so read it when needed rather than on every render.
+    /// </summary>
+    public string Output => OutputProvider?.Invoke() ?? string.Empty;
+}
 
 public static class UsePtyExtensions
 {
@@ -47,12 +72,17 @@ public static class UsePtyExtensions
         var pty = context.UseRef<IPtyConnection?>(() => null);
         var cts = context.UseRef<CancellationTokenSource?>(() => null);
 
+        // Lives in hook state (not the PtyHandle record) so the decoder — and any transcript it is
+        // accumulating — survives PtyHandle being rebuilt on every render.
+        var decoder = context.UseRef<PtyOutputDecoder>(
+            () => new PtyOutputDecoder(options.CaptureOutput, options.MaxCaptureLength));
+
         context.UseEffect(() =>
         {
             cts.Value = new CancellationTokenSource();
             var token = cts.Value.Token;
 
-            _ = StartPtyAsync(commandLine, cwd, options, stream, pty, closed, exitCode, token);
+            _ = StartPtyAsync(commandLine, cwd, options, stream, pty, closed, exitCode, decoder.Value, token);
 
             return Disposable.Create(() =>
             {
@@ -98,7 +128,10 @@ public static class UsePtyExtensions
             KillPty(pty.Value);
         }
 
-        return new PtyHandle(stream, HandleInput, HandleResize, Kill, closed.Value, exitCode.Value, () => pty.Value?.Pid);
+        return new PtyHandle(stream, HandleInput, HandleResize, Kill, closed.Value, exitCode.Value, () => pty.Value?.Pid)
+        {
+            OutputProvider = () => decoder.Value.Text
+        };
     }
 
     // CommandLineToArgvW-compatible argument quoting (the same algorithm as .NET's
@@ -159,6 +192,7 @@ public static class UsePtyExtensions
         IState<IPtyConnection?> ptyRef,
         IState<bool> closed,
         IState<int?> exitCode,
+        PtyOutputDecoder decoder,
         CancellationToken cancellationToken)
     {
         if (commandLine.Length == 0) return;
@@ -226,6 +260,10 @@ public static class UsePtyExtensions
                 closed.Set(true);
             };
 
+            // Constant for the connection's lifetime, so the decoder never sees a gap in its byte
+            // stream (skipping Decode on some chunks would desync its stateful UTF-8 decoder).
+            var wantsText = options.OnOutput != null || options.CaptureOutput;
+
             _ = Task.Run(async () =>
             {
                 var buffer = new byte[4096];
@@ -239,9 +277,14 @@ public static class UsePtyExtensions
                         Buffer.BlockCopy(buffer, 0, data, 0, bytesRead);
                         stream.Write(data);
 
-                        // OnOutput callback gets the decoded text for parsing
-                        var text = Encoding.UTF8.GetString(buffer, 0, bytesRead);
-                        options.OnOutput?.Invoke(text);
+                        if (wantsText)
+                        {
+                            // Decoded across read boundaries by the stateful decoder (see
+                            // PtyOutputDecoder) so multi-byte UTF-8 sequences split across two
+                            // 4KB reads don't decode to U+FFFD replacement characters.
+                            var text = decoder.Decode(buffer, bytesRead);
+                            if (text.Length > 0) options.OnOutput?.Invoke(text);
+                        }
                     }
                 }
                 catch (OperationCanceledException) { }
@@ -260,8 +303,14 @@ public static class UsePtyExtensions
         }
         catch (Exception ex)
         {
-            var errorMsg = Encoding.UTF8.GetBytes($"\r\n[Error starting PTY: {ex.Message}]\r\n");
+            var errorText = $"\r\n[Error starting PTY: {ex.Message}]\r\n";
+            var errorMsg = Encoding.UTF8.GetBytes(errorText);
             stream.Write(errorMsg);
+
+            // Feed the error text through the decoder (but not OnOutput, preserving today's
+            // callback contract) so PtyHandle.Output explains a failed spawn too.
+            decoder.Decode(errorMsg, errorMsg.Length);
+
             closed.Set(true);
         }
     }

--- a/src/widgets/Ivy.Widgets.Xterm/.samples/Apps/OutputCaptureApp.cs
+++ b/src/widgets/Ivy.Widgets.Xterm/.samples/Apps/OutputCaptureApp.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Ivy;
 using Ivy.Hooks.Pty;
 using Ivy.Widgets.Xterm;
@@ -7,9 +8,17 @@ namespace XtermSamples.Apps;
 
 // Demonstrates PtyOptions.CaptureOutput / PtyHandle.Output (chunk-boundary-safe UTF-8 decoding)
 // and AnsiEscape.Strip, side by side with the live Terminal that already exercises pty.Stream.
+//
+// The motivating real-world use case for CaptureOutput is server-side detection of URLs a hosted
+// process prints to its console (e.g. "Ivy is running on https://localhost:5011"), so a caller
+// can surface that link without the user having to click it inside the terminal itself (that
+// client-side case is already covered by Terminal.OnLinkClick / WebLinksAddon). This sample
+// regex-matches URLs out of the captured, ANSI-stripped transcript to prove that path works.
 [App(title: "Output Capture", icon: Icons.ScrollText, group: ["Terminal"], allowDuplicateTabs: true)]
 class OutputCaptureApp : ViewBase
 {
+    private static readonly Regex UrlPattern = new(@"https?://[^\s""'<>]+", RegexOptions.Compiled);
+
     public override object Build()
     {
         // IVYHOOK005: UsePty must be the first statement in Build(). A deliberately small
@@ -29,8 +38,16 @@ class OutputCaptureApp : ViewBase
             () => transcript.Set(AnsiEscape.Strip(pty.Output)),
             TimeSpan.FromMilliseconds(500));
 
+        // Recomputed fresh every render from the already-stripped transcript state, so no extra
+        // hook/state is needed just to keep this in sync with `transcript`.
+        var detectedUrls = UrlPattern.Matches(transcript.Value)
+            .Select(m => m.Value.TrimEnd('.', ',', ')', ']', ':'))
+            .Distinct()
+            .ToArray();
+
         return Layout.Vertical().Gap(2).Width(Size.Full()).Height(Size.Full())
             | Text.Muted("Type `echo héllo ✅ 🎉 ┌─┐` — the captured transcript on the right decodes correctly across chunk boundaries and strips ANSI.")
+            | Text.Muted("Type `echo Server running on https://localhost:5011` — the URL is detected below, proving console-printed URLs can be picked up server-side from PtyHandle.Output.")
             | (Layout.Horizontal().Gap(4).Width(Size.Full()).Height(Size.Full())
                 | new Terminal()
                     .Stream(pty.Stream)
@@ -43,6 +60,10 @@ class OutputCaptureApp : ViewBase
                 | new CodeBlock(transcript.Value, Languages.Text)
                     .ShowCopyButton(true)
                     .Width(Size.Half())
-                    .Height(Size.Full()));
+                    .Height(Size.Full()))
+            | Text.Muted("Detected URLs (regex-matched from the captured, ANSI-stripped transcript):")
+            | (detectedUrls.Length == 0
+                ? Text.Muted("None yet.")
+                : Layout.Wrap(detectedUrls.Select(url => (object)new Button(url).Url(url).Link().OpenInNewTab())));
     }
 }

--- a/src/widgets/Ivy.Widgets.Xterm/.samples/Apps/OutputCaptureApp.cs
+++ b/src/widgets/Ivy.Widgets.Xterm/.samples/Apps/OutputCaptureApp.cs
@@ -1,0 +1,48 @@
+using Ivy;
+using Ivy.Hooks.Pty;
+using Ivy.Widgets.Xterm;
+using Terminal = Ivy.Widgets.Xterm.Terminal;
+
+namespace XtermSamples.Apps;
+
+// Demonstrates PtyOptions.CaptureOutput / PtyHandle.Output (chunk-boundary-safe UTF-8 decoding)
+// and AnsiEscape.Strip, side by side with the live Terminal that already exercises pty.Stream.
+[App(title: "Output Capture", icon: Icons.ScrollText, group: ["Terminal"], allowDuplicateTabs: true)]
+class OutputCaptureApp : ViewBase
+{
+    public override object Build()
+    {
+        // IVYHOOK005: UsePty must be the first statement in Build(). A deliberately small
+        // MaxCaptureLength makes the "keeps newest, drops oldest" trimming behavior visible
+        // during a normal demo session instead of requiring megabytes of output.
+        var pty = Context.UsePty(
+            OperatingSystem.IsWindows() ? ["cmd"] : ["bash"],
+            options: new PtyOptions { CaptureOutput = true, MaxCaptureLength = 4000 }
+        );
+
+        var transcript = UseState("");
+
+        // PtyHandle is rebuilt every render, but the underlying process and decoder persist
+        // across renders exactly as pty.Stream already does, so re-reading pty.Output on each
+        // tick is safe and cheap.
+        Context.UseInterval(
+            () => transcript.Set(AnsiEscape.Strip(pty.Output)),
+            TimeSpan.FromMilliseconds(500));
+
+        return Layout.Vertical().Gap(2).Width(Size.Full()).Height(Size.Full())
+            | Text.Muted("Type `echo héllo ✅ 🎉 ┌─┐` — the captured transcript on the right decodes correctly across chunk boundaries and strips ANSI.")
+            | (Layout.Horizontal().Gap(4).Width(Size.Full()).Height(Size.Full())
+                | new Terminal()
+                    .Stream(pty.Stream)
+                    .OnInput(pty.HandleInput)
+                    .OnResize(pty.HandleResize)
+                    .Closed(pty.Closed)
+                    .AllowClipboard()
+                    .Width(Size.Half())
+                    .Height(Size.Full())
+                | new CodeBlock(transcript.Value, Languages.Text)
+                    .ShowCopyButton(true)
+                    .Width(Size.Half())
+                    .Height(Size.Full()));
+    }
+}

--- a/src/widgets/Ivy.Widgets.Xterm/README.md
+++ b/src/widgets/Ivy.Widgets.Xterm/README.md
@@ -2,6 +2,11 @@
 
 A terminal emulator widget for Ivy Framework powered by [xterm.js](https://xtermjs.org/).
 
+> **Naming note:** `Ivy.Widgets.Xterm.Terminal` (this widget) is a different type from `Ivy.Terminal`,
+> a static display primitive documented in [14_Terminal.md](../../Ivy.Docs.Shared/Docs/02_Widgets/03_Common/14_Terminal.md).
+> The samples in this package alias the import to avoid the clash:
+> `using Terminal = Ivy.Widgets.Xterm.Terminal;`
+
 ## Installation
 
 ```bash
@@ -12,7 +17,8 @@ dotnet add package Ivy.Widgets.Xterm
 
 ### Terminal
 
-A fully-featured terminal emulator component.
+A fully-featured terminal emulator component that renders a raw byte stream (typically from a
+server-side PTY, see [Terminal + PTY](#terminal--pty) below).
 
 **External React Libraries Used:**
 - [@xterm/xterm](https://www.npmjs.com/package/@xterm/xterm) - Terminal emulator
@@ -22,31 +28,26 @@ A fully-featured terminal emulator component.
 #### Basic Usage
 
 ```csharp
-using Ivy.Widgets.Xterm;
+using Terminal = Ivy.Widgets.Xterm.Terminal;
 
 // Simple terminal with default settings
 new Terminal()
-
-// Terminal with dark theme and custom font
-new Terminal()
-    .DarkTheme()
-    .FontSize(16)
-    .CursorBlink(true)
 
 // Terminal with initial content
 new Terminal()
     .InitialContent("Welcome!\r\n$ ")
 
 // Terminal with a loading overlay shown until the attached
-// process writes its first output to the stream
+// process writes its first (visible) output to the stream
 new Terminal()
     .Stream(pty.Stream)
     .Loading("Starting Claude Code...")
 
 // Terminal with event handlers
 new Terminal()
-    .HandleData(data => Console.WriteLine($"User typed: {data}"))
-    .HandleResize((cols, rows) => Console.WriteLine($"Resized: {cols}x{rows}"))
+    .OnInput(data => Console.WriteLine($"User typed: {data}"))
+    .OnResize((cols, rows) => Console.WriteLine($"Resized: {cols}x{rows}"))
+    .OnLinkClick(url => Console.WriteLine($"Link clicked: {url}"))
 ```
 
 #### Props
@@ -55,54 +56,51 @@ new Terminal()
 |------|------|---------|-------------|
 | `Cols` | `int?` | `null` | Fixed column count (auto-fit if not set) |
 | `Rows` | `int?` | `null` | Fixed row count (auto-fit if not set) |
-| `FontSize` | `int` | `14` | Font size in pixels |
-| `FontFamily` | `string` | `"Menlo, Monaco, 'Courier New', monospace"` | Font family |
-| `LineHeight` | `double` | `1.0` | Line height multiplier |
 | `CursorBlink` | `bool` | `true` | Enable cursor blinking |
 | `CursorStyle` | `CursorStyle` | `Block` | Cursor style (`Block`, `Underline`, `Bar`) |
 | `Scrollback` | `int` | `1000` | Lines to keep in scrollback buffer |
-| `Theme` | `TerminalTheme?` | Dark theme | Terminal color theme |
 | `InitialContent` | `string?` | `null` | Initial content to display |
+| `Closed` | `bool` | `false` | Marks the terminal as closed (e.g. the attached process exited); typically bound to `pty.Closed` |
+| `AllowClipboard` | `bool` | `true` | Allow clipboard copy/paste inside the terminal |
 | `AutoFocus` | `bool` | `true` | Automatically focus the terminal on mount so it receives keyboard input |
-| `Loading` | `bool` | `false` | Show a loading overlay (spinner + text) until the first stream data arrives |
+| `Loading` | `bool` | `false` | Show a loading overlay (spinner + text) until the first visible stream data arrives |
 | `LoadingText` | `string?` | `"Loading..."` | Text shown in the loading overlay |
+| `Background` | `Colors?` | `null` | Terminal background color |
+| `Foreground` | `Colors?` | `null` | Terminal foreground (text) color |
+| `Stream` | `IWriteStream<byte[]>?` | `null` | Raw output byte stream rendered by the terminal, typically `pty.Stream` |
 
 #### Events
 
 | Event | Args | Description |
 |-------|------|-------------|
-| `OnData` | `string` | Fired when user types in the terminal |
-| `OnResize` | `int cols, int rows` | Fired when terminal dimensions change |
-| `OnTitleChange` | `string` | Fired when terminal title changes (via OSC sequences) |
+| `OnInput` | `string` | Fired when the user types in the terminal (raw keystroke data from xterm's `onData`) |
+| `OnResize` | `TerminalSize` (`Cols`, `Rows`), with `Action<int, int>` and `Action<TerminalSize>` overloads | Fired when terminal dimensions change |
+| `OnLinkClick` | `string` | Fired when the user clicks a detected URL in the terminal output |
 
-#### Themes
+## Terminal + PTY
 
-Built-in themes are available:
+`Terminal` only renders bytes and forwards keystrokes — it does not spawn or manage a process.
+Pair it with `Ivy.Hooks.Pty`'s `UsePty` hook to host a real process:
 
 ```csharp
-// Dark theme (VS Code-like)
-new Terminal().DarkTheme()
+using Ivy.Hooks.Pty;
+using Terminal = Ivy.Widgets.Xterm.Terminal;
 
-// Light theme
-new Terminal().LightTheme()
+// IVYHOOK005: UsePty must be the first statement in Build().
+var pty = Context.UsePty(OperatingSystem.IsWindows() ? ["cmd"] : ["bash"], workingDirectory);
 
-// Custom theme
-new Terminal().Theme(new TerminalTheme
-{
-    Background = "#000000",
-    Foreground = "#00ff00",
-    Cursor = "#00ff00",
-    // ... other colors
-})
+return new Terminal()
+    .Stream(pty.Stream)
+    .OnInput(pty.HandleInput)
+    .OnResize(pty.HandleResize)
+    .Closed(pty.Closed)
+    .AllowClipboard();
 ```
 
-#### TerminalTheme Properties
-
-All color properties accept CSS color strings (hex, rgb, rgba):
-
-- `Background`, `Foreground`, `Cursor`, `CursorAccent`, `Selection`
-- `Black`, `Red`, `Green`, `Yellow`, `Blue`, `Magenta`, `Cyan`, `White`
-- `BrightBlack`, `BrightRed`, `BrightGreen`, `BrightYellow`, `BrightBlue`, `BrightMagenta`, `BrightCyan`, `BrightWhite`
+See [ClaudeCodeApp.cs](.samples/Apps/ClaudeCodeApp.cs) for a complete example, and the
+[`Ivy.Hooks.Pty` README](../../Ivy.Hooks.Pty/README.md) for how `Terminal.OnInput`, `Terminal.Stream`
+and `PtyOptions.OnOutput`/`PtyOptions.CaptureOutput` relate to each other — they are three distinct,
+one-directional data paths and are routinely confused.
 
 ## Development
 
@@ -139,6 +137,7 @@ The sample server uses an app shell with multiple demo apps (in `.samples/Apps/`
 - **Shell** — an interactive system shell (`cmd` on Windows, `bash` otherwise)
 - **Hello Console** — runs the Spectre.Console demo app from `.console/HelloApp`
 - **Claude Code** — runs the `claude` CLI in the terminal (requires Claude Code to be installed and on `PATH`)
+- **Output Capture** — a shell paired with a read-only pane showing `PtyHandle.Output` (via `PtyOptions.CaptureOutput`), demonstrating chunk-boundary-safe UTF-8 decoding and `AnsiEscape.Strip`
 
 ## Creating New Widgets
 


### PR DESCRIPTION
# Summary

## Changes

Fixed a UTF-8 chunk-boundary decoding bug in `Ivy.Hooks.Pty`'s PTY reader loop (multi-byte
characters split across a 4KB read previously decoded to `�` replacement characters) by hoisting a
single stateful `Encoding.UTF8.GetDecoder()` into a new internal `PtyOutputDecoder`. Added an
opt-in, size-capped output transcript (`PtyOptions.CaptureOutput` / `MaxCaptureLength` /
`PtyHandle.Output`) sharing the same decode stream as the existing `OnOutput` callback, plus a new
public `AnsiEscape.Strip` helper (a C# port of the frontend's ANSI-stripping regexes) for reading
captured output as plain text. Documented the previously-undocumented three-way
`OnInput`/`Stream`/`OnOutput` data-path split and rewrote the stale Xterm widget README.

## API Changes

- **`Ivy.Hooks.Pty.PtyOptions`** — new properties: `bool CaptureOutput` (default `false`), `int MaxCaptureLength` (default `1_000_000`).
- **`Ivy.Hooks.Pty.PtyHandle`** — new property: `string Output` (empty string unless `CaptureOutput` is set; capped, keeps newest output). No change to the record's positional constructor parameters, so all existing `new PtyHandle(...)` call sites are unaffected.
- **`Ivy.Hooks.Pty.AnsiEscape`** (new public static class) — `static string Strip(string? text)`.
- **`Ivy.Hooks.Pty.PtyOutputDecoder`** (new, `internal`) — not part of the public API surface.

## Files Modified

**Core fix**
- `src/Ivy.Hooks.Pty/PtyOutputDecoder.cs` (new) — stateful UTF-8 decoder + capped transcript.
- `src/Ivy.Hooks.Pty/AnsiEscape.cs` (new) — ANSI/control-char stripper.
- `src/Ivy.Hooks.Pty/UsePty.cs` — wires the decoder into the reader loop and spawn-failure path; adds `PtyOptions`/`PtyHandle` members.

**Tests**
- `src/Ivy.Hooks.Pty.Test/` (new project) — `PtyOutputDecoderTests.cs`, `AnsiEscapeTests.cs`, registered in `Ivy-Framework.slnx` alongside `Ivy.Hooks.Pty` (neither was previously part of the solution's CI build/test path).
- `src/Ivy.Hooks.Pty/Ivy.Hooks.Pty.csproj` — `InternalsVisibleTo` for the new test project.

**Documentation**
- `src/Ivy.Hooks.Pty/README.md` (new).
- `src/widgets/Ivy.Widgets.Xterm/README.md` — rewritten against the actual `Terminal.cs` props/events.

**Sample**
- `src/widgets/Ivy.Widgets.Xterm/.samples/Apps/OutputCaptureApp.cs` (new) — live `Terminal` next to a `PtyHandle.Output` transcript pane, refreshed via `UseInterval`; also detects `https?://` URLs in the captured, ANSI-stripped transcript and lists them as clickable link buttons.

## Manual Testing

1. Run the Xterm samples app: `cd src/widgets/Ivy.Widgets.Xterm/.samples && dotnet run` (add `--find-available-port` if the default port is busy).
2. Open the "Output Capture" app (Terminal group) in the browser.
3. In the left terminal pane, type `echo héllo ✅ 🎉 ┌─┐` and press Enter.
4. Observe the right-hand read-only pane: it should show the same accented/emoji/box-drawing characters with no `�` replacement characters, and no visible ANSI escape codes.
5. Keep producing output (e.g. repeat the echo, or run `dir`/`ls`) until more than 4000 characters have been printed; confirm the right pane's earliest lines are dropped while the newest output remains, and its length never grows unbounded.
6. Type a command that prints a URL (e.g. `echo Server running on https://localhost:5011`) and confirm it appears as a clickable link in the "Detected URLs" section below the panes.

This was also independently verified by the `IvyFrameworkVerification` delegated check, which built
a standalone Playwright-driven sample exercising the same scenarios plus `PtyOptions.OnOutput` and
`AnsiEscape.Strip` in isolation.

---
## Commits

- `f49eea237` sample(hooks-pty): detect URLs in captured PTY output
- `e33578c52` sample(hooks-pty): add Output Capture demo app
- `a51f3246d` docs(hooks-pty): add Ivy.Hooks.Pty README, rewrite stale Xterm README
- `faf7d463f` test(hooks-pty): add Ivy.Hooks.Pty.Test project
- `630fc483f` fix(hooks-pty): fix UTF-8 chunk-boundary corruption, add output capture

---
Created using [Ivy Tendril](https://ivy.app).
