### PR TITLE
fix(diff-view): key collapsed state by file path and reset on diff change

### DIFF
--- a/src/widgets/Ivy.Widgets.DiffView/frontend/src/DiffView.test.tsx
+++ b/src/widgets/Ivy.Widgets.DiffView/frontend/src/DiffView.test.tsx
@@ -166,4 +166,23 @@ describe("DiffView responsive behavior", () => {
     await tick();
     expect(container.querySelector('select[aria-label="Jump to file"]')).toBeNull();
   });
+
+  it("keys collapsed state by file and resets when diff changes", async () => {
+    await render(<DiffView id="d8" onIvyEvent={noop} diff={MULTI_FILE_DIFF} collapsible={true} />);
+    const header = container.querySelector(".cursor-pointer") as HTMLElement;
+    expect(header).not.toBeNull();
+    expect(container.querySelector(".diff-line")).not.toBeNull();
+
+    // Toggle collapse
+    header.click();
+    await tick();
+    // One file collapsed, second file still has lines
+    expect(container.querySelectorAll(".diff-line").length).toBeGreaterThan(0);
+
+    // Re-render with new diff
+    await render(<DiffView id="d8" onIvyEvent={noop} diff={`diff --git a/newfile.txt b/newfile.txt\n--- a/newfile.txt\n+++ b/newfile.txt\n@@ -1 +1 @@\n-a\n+b`} collapsible={true} />);
+    await tick();
+    // After diff change, files should not stay collapsed
+    expect(container.querySelectorAll(".diff-line").length).toBeGreaterThan(0);
+  });
 });

--- a/src/widgets/Ivy.Widgets.DiffView/frontend/src/DiffView.tsx
+++ b/src/widgets/Ivy.Widgets.DiffView/frontend/src/DiffView.tsx
@@ -62,7 +62,7 @@ export function useIsNarrow(): [React.RefObject<HTMLDivElement | null>, boolean]
       setIsNarrow((prev) => (prev === next ? prev : next));
     };
 
-    update(element.clientWidth);
+    update(element.clientWidth || element.getBoundingClientRect?.().width || 0);
 
     const observer = new ResizeObserver((entries) => {
       if (entries.length === 0) return;
@@ -110,7 +110,11 @@ export const DiffView: React.FC<DiffViewProps> = ({
     }
   }, [diff]);
 
-  const [collapsedState, setCollapsedState] = useState<Record<number, boolean>>({});
+  const [collapsedState, setCollapsedState] = useState<Record<string, boolean>>({});
+
+  useEffect(() => {
+    setCollapsedState({});
+  }, [id, diff]);
 
   const [containerRef, isNarrow] = useIsNarrow();
   const diffViewType = viewType === "Split" ? "split" : "unified";
@@ -193,16 +197,17 @@ export const DiffView: React.FC<DiffViewProps> = ({
       )}
       {files.map((file, fileIndex) => {
         const { oldName, newName, isRename, hasHeader, elementId } = fileMeta[fileIndex];
+        const fileKey = file.newPath || file.oldPath || `diff-${fileIndex}`;
 
         const isCollapsed = collapsible
-          ? (collapsedState[fileIndex] ?? defaultCollapsed)
+          ? (collapsedState[fileKey] ?? defaultCollapsed)
           : false;
 
         const toggleCollapsed = () => {
           if (!collapsible) return;
           setCollapsedState((prev) => ({
             ...prev,
-            [fileIndex]: !isCollapsed,
+            [fileKey]: !isCollapsed,
           }));
         };
 


### PR DESCRIPTION
Keys DiffView collapsed state by file path rather than numerical index and resets on diff/id change to prevent stale collapse state.