### PR TITLE
fix(process): decouple WaitForExitOrKillAsync from pipe EOF when child processes inherit redirected streams

### DIFF
--- a/src/Ivy.Test/Helpers/ProcessExtensionsTests.cs
+++ b/src/Ivy.Test/Helpers/ProcessExtensionsTests.cs
@@ -156,4 +156,38 @@ public class ProcessExtensionsTests
         Assert.True(sw.Elapsed < TimeSpan.FromSeconds(10),
             $"Post-kill should complete within 10s (5s kill timeout + margin), took {sw.Elapsed}");
     }
+
+    [Fact]
+    public async Task WaitForExitOrKillAsync_WhenChildHoldsRedirectedPipes_ReturnsPromptlyAfterParentExits()
+    {
+        if (OperatingSystem.IsWindows())
+            return; // POSIX shell background fork test
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "/bin/sh",
+            Arguments = "-c \"sleep 10 >&1 & exit 0\"",
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+
+        using var process = new Process { StartInfo = psi };
+        process.OutputDataReceived += (_, _) => { };
+        process.ErrorDataReceived += (_, _) => { };
+        process.Start();
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+
+        var sw = Stopwatch.StartNew();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var result = await process.WaitForExitOrKillAsync(cts.Token);
+        sw.Stop();
+
+        Assert.True(result);
+        Assert.True(process.HasExited);
+        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(3),
+            $"Should exit promptly without waiting for background child to close pipe, took {sw.Elapsed.TotalSeconds}s");
+    }
 }

--- a/src/Ivy/Helpers/ProcessExtensions.cs
+++ b/src/Ivy/Helpers/ProcessExtensions.cs
@@ -29,16 +29,7 @@ public static class ProcessExtensions
     {
         if (process is null) return true;
         using var cts = new CancellationTokenSource(timeoutMs);
-        try
-        {
-            await process.WaitForExitAsync(cts.Token);
-            return true;
-        }
-        catch (OperationCanceledException)
-        {
-            await KillProcessAsync(process);
-            return false;
-        }
+        return await WaitForExitOrKillAsync(process, cts.Token).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -51,13 +42,65 @@ public static class ProcessExtensions
         if (process is null) return true;
         try
         {
-            await process.WaitForExitAsync(cancellationToken);
+            await WaitForProcessExitAsync(process, cancellationToken).ConfigureAwait(false);
             return true;
         }
         catch (OperationCanceledException)
         {
-            await KillProcessAsync(process);
+            await KillProcessAsync(process).ConfigureAwait(false);
             return false;
+        }
+    }
+
+    private static async Task WaitForProcessExitAsync(Process process, CancellationToken cancellationToken)
+    {
+        try
+        {
+            if (process.HasExited)
+                return;
+        }
+        catch (InvalidOperationException)
+        {
+            return;
+        }
+
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        void OnExited(object? sender, EventArgs e) => tcs.TrySetResult();
+
+        try
+        {
+            process.EnableRaisingEvents = true;
+            process.Exited += OnExited;
+
+            if (process.HasExited)
+            {
+                tcs.TrySetResult();
+            }
+
+            await using (cancellationToken.Register(() => tcs.TrySetCanceled(cancellationToken)))
+            {
+                await tcs.Task.ConfigureAwait(false);
+            }
+
+            // Give a short bounded drain period for any in-flight redirected output events
+            // without hanging indefinitely if background child processes inherited the pipe handles.
+            await Task.Delay(250, CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (InvalidOperationException)
+        {
+            // Process already exited or disposed
+        }
+        finally
+        {
+            try
+            {
+                process.Exited -= OnExited;
+            }
+            catch
+            {
+                // Process already disposed
+            }
         }
     }
 


### PR DESCRIPTION
### Summary
Fixes process monitoring hang when child worker daemons inherit and keep open redirected stdout/stderr pipes.

- `WaitForExitOrKillAsync` now uses `WaitForProcessExitAsync` observing `process.Exited` with a bounded drain grace period rather than blocking indefinitely for `EOF` on inherited stream handles.
- Adds unit test `WaitForExitOrKillAsync_WhenChildHoldsRedirectedPipes_ReturnsPromptlyAfterParentExits` verifying prompt return.