### PR TITLE
Fix process exit hang on redirected stdout/stderr pipe inheritance

### DIFF
--- a/src/Ivy.Test/Helpers/ProcessExtensionsTests.cs
+++ b/src/Ivy.Test/Helpers/ProcessExtensionsTests.cs
@@ -156,4 +156,32 @@ public class ProcessExtensionsTests
         Assert.True(sw.Elapsed < TimeSpan.FromSeconds(10),
             $"Post-kill should complete within 10s (5s kill timeout + margin), took {sw.Elapsed}");
     }
+
+    [Fact]
+    public async Task WaitForExitOrKillAsync_WithRedirectedOutput_ReturnsPromptlyOnProcessExit()
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = OperatingSystem.IsWindows() ? "cmd.exe" : "/bin/sh",
+            Arguments = OperatingSystem.IsWindows() ? "/c echo Hello" : "-c \"echo Hello\"",
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+
+        using var process = Process.Start(psi);
+        Assert.NotNull(process);
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+
+        var sw = Stopwatch.StartNew();
+        var result = await process.WaitForExitOrKillAsync(10000);
+        sw.Stop();
+
+        Assert.True(result);
+        Assert.True(process.HasExited);
+        Assert.Equal(0, process.ExitCode);
+        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(5));
+    }
 }

--- a/src/Ivy/Helpers/ProcessExtensions.cs
+++ b/src/Ivy/Helpers/ProcessExtensions.cs
@@ -29,16 +29,7 @@ public static class ProcessExtensions
     {
         if (process is null) return true;
         using var cts = new CancellationTokenSource(timeoutMs);
-        try
-        {
-            await process.WaitForExitAsync(cts.Token);
-            return true;
-        }
-        catch (OperationCanceledException)
-        {
-            await KillProcessAsync(process);
-            return false;
-        }
+        return await WaitForProcessExitAsync(process, cts.Token);
     }
 
     /// <summary>
@@ -49,15 +40,66 @@ public static class ProcessExtensions
     public static async Task<bool> WaitForExitOrKillAsync(this Process? process, CancellationToken cancellationToken)
     {
         if (process is null) return true;
+        return await WaitForProcessExitAsync(process, cancellationToken);
+    }
+
+    /// <summary>
+    /// Waits for the OS process to terminate without blocking indefinitely on redirected stdout/stderr stream EOF.
+    /// </summary>
+    public static async Task<bool> WaitForProcessExitAsync(this Process? process, CancellationToken cancellationToken)
+    {
+        if (process is null) return true;
+        if (process.HasExited) return true;
+
+        var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        void OnExited(object? sender, EventArgs e) => tcs.TrySetResult(true);
+
         try
         {
-            await process.WaitForExitAsync(cancellationToken);
+            process.EnableRaisingEvents = true;
+            process.Exited += OnExited;
+
+            if (process.HasExited)
+            {
+                tcs.TrySetResult(true);
+            }
+
+            using var reg = cancellationToken.Register(() => tcs.TrySetCanceled(cancellationToken));
+            await tcs.Task;
+
+            // Once the OS process exits, allow up to 1 second for any in-flight stdout/stderr buffers to flush.
+            try
+            {
+                using var drainCts = new CancellationTokenSource(1000);
+                await process.WaitForExitAsync(drainCts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                // Streams did not reach EOF within drain window (likely child process holding pipe open); proceed anyway.
+            }
+            catch (Exception)
+            {
+                // Ignore errors during stream draining
+            }
+
             return true;
         }
         catch (OperationCanceledException)
         {
             await KillProcessAsync(process);
             return false;
+        }
+        finally
+        {
+            try
+            {
+                process.Exited -= OnExited;
+            }
+            catch
+            {
+                // Ignore if process disposed
+            }
         }
     }
 
@@ -107,7 +149,24 @@ public static class ProcessExtensions
         {
             process.Kill(true);
             using var killTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-            await process.WaitForExitAsync(killTimeout.Token);
+
+            if (!process.HasExited)
+            {
+                var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                void OnExited(object? sender, EventArgs e) => tcs.TrySetResult(true);
+                process.EnableRaisingEvents = true;
+                process.Exited += OnExited;
+                try
+                {
+                    if (process.HasExited) tcs.TrySetResult(true);
+                    using var reg = killTimeout.Token.Register(() => tcs.TrySetCanceled(killTimeout.Token));
+                    await tcs.Task;
+                }
+                finally
+                {
+                    try { process.Exited -= OnExited; } catch { }
+                }
+            }
         }
         catch (OperationCanceledException)
         {


### PR DESCRIPTION
## Summary
- Implemented `WaitForProcessExitAsync` in `ProcessExtensions` using `Process.Exited` / `HasExited` with a 1-second drain window for redirected stdout/stderr buffers.
- Prevents `WaitForExitOrKillAsync` from hanging indefinitely when background processes or build daemons inherit redirected stdout/stderr pipe file descriptors.
- Added unit tests in `ProcessExtensionsTests` verifying prompt return upon process exit with redirected streams.