### PR TITLE
Position toast notifications at bottom-right corner

### DIFF
--- a/src/frontend/src/components/ui/toast.tsx
+++ b/src/frontend/src/components/ui/toast.tsx
@@ -14,7 +14,7 @@ const ToastViewport = React.forwardRef<
   <ToastPrimitives.Viewport
     ref={ref}
     className={cn(
-      "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse gap-1 p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
+      "fixed bottom-0 right-0 z-[100] flex max-h-screen w-full flex-col-reverse gap-1 p-4 sm:max-w-[420px]",
       className,
     )}
     {...props}


### PR DESCRIPTION
## Summary
- Updated `ToastViewport` in `toast.tsx` to position toasts at `fixed bottom-0 right-0` instead of `fixed top-0`
- Ensures toasts stack and appear at the bottom-right corner.