### PR TITLE
[00661] Show Cmd+B in Sidebar Toggle Tooltip on Mac

### DIFF
--- a/src/frontend/src/lib/shortcut.test.ts
+++ b/src/frontend/src/lib/shortcut.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { formatShortcutForDisplay } from "./shortcut";
+import { formatShortcutForDisplay, modifierKeyLabel } from "./shortcut";
 
 describe("formatShortcutForDisplay", () => {
   it("renders Backspace as ⌫", () => {
@@ -49,5 +49,15 @@ describe("formatShortcutForDisplay", () => {
     expect(formatShortcutForDisplay("ArrowDown")).toContain("↓");
     expect(formatShortcutForDisplay("ArrowLeft")).toContain("←");
     expect(formatShortcutForDisplay("ArrowRight")).toContain("→");
+  });
+});
+
+describe("modifierKeyLabel", () => {
+  it("returns 'Cmd' on Mac", () => {
+    expect(modifierKeyLabel(true)).toBe("Cmd");
+  });
+
+  it("returns 'Ctrl' on non-Mac platforms", () => {
+    expect(modifierKeyLabel(false)).toBe("Ctrl");
   });
 });

--- a/src/frontend/src/lib/shortcut.ts
+++ b/src/frontend/src/lib/shortcut.ts
@@ -4,6 +4,13 @@ import React from "react";
 export const isMac =
   typeof navigator !== "undefined" && /Mac|iPod|iPhone|iPad/.test(navigator.userAgent);
 
+/**
+ * Plain-text label for the Ctrl/Cmd modifier in prose (tooltips, hints). On Mac the
+ * binding fires on Command — see parseShortcut(), which maps ctrl → meta — so the label
+ * must say "Cmd" there. Key caps use the ⌘ glyph instead; see Kbd.tsx.
+ */
+export const modifierKeyLabel = (mac: boolean = isMac): string => (mac ? "Cmd" : "Ctrl");
+
 export interface ParsedShortcut {
   ctrl: boolean;
   shift: boolean;

--- a/src/frontend/src/widgets/layouts/sidebar/SidebarLayoutWidget.tsx
+++ b/src/frontend/src/widgets/layouts/sidebar/SidebarLayoutWidget.tsx
@@ -8,6 +8,7 @@ import { ChevronRight, PanelLeftClose, PanelLeftOpen } from "lucide-react";
 import { MenuItem, WidgetEventHandlerType } from "@/types/widgets";
 import { useFocusable } from "@/hooks/use-focus-management";
 import { useShortcut } from "@/lib/useShortcut";
+import { modifierKeyLabel } from "@/lib/shortcut";
 import { sidebarMenuRef } from "./sidebar-refs";
 import { useEventHandler } from "@/components/event-handler";
 import { cn, getAppId } from "@/lib/utils";
@@ -20,6 +21,7 @@ import { SidebarLayoutContext, useSidebarLayout } from "./sidebar-layout-context
 // so icons keep their x-position while the sidebar width animates.
 const SIDEBAR_RAIL_WIDTH_PX = 54;
 const SIDEBAR_OPEN_STORAGE_KEY = "ivy-sidebar-open";
+const TOGGLE_SHORTCUT_LABEL = `${modifierKeyLabel()}+B`;
 
 interface SidebarLayoutWidgetProps {
   slots?: {
@@ -108,7 +110,7 @@ const SidebarToggleButton: React.FC<{ isSidebarOpen: boolean; onToggle: () => vo
           )}
         </button>
       </TooltipTrigger>
-      <TooltipContent side="right">Toggle sidebar (Ctrl+B)</TooltipContent>
+      <TooltipContent side="right">Toggle sidebar ({TOGGLE_SHORTCUT_LABEL})</TooltipContent>
     </Tooltip>
   </TooltipProvider>
 );
@@ -463,7 +465,9 @@ export const SidebarLayoutWidget: React.FC<SidebarLayoutWidgetProps> = ({
                     )}
                   </button>
                 </TooltipTrigger>
-                <TooltipContent side="right">Toggle sidebar (Ctrl+B)</TooltipContent>
+                <TooltipContent side="right">
+                  Toggle sidebar ({TOGGLE_SHORTCUT_LABEL})
+                </TooltipContent>
               </Tooltip>
             </TooltipProvider>
           )}


### PR DESCRIPTION
## Problem

[Issue #1978](https://github.com/Ivy-Interactive/Ivy-Tendril/issues/1978): the sidebar toggle tooltip always reads "Toggle sidebar (Ctrl+B)", including on macOS, where the shortcut users actually press is ⌘B. Expected: "Toggle sidebar (Cmd+B)" on Mac.

The bug is display-only. The binding is already correct — `useShortcut("sidebar-layout-toggle", "CTRL+B", ...)` goes through `parseShortcut()` which maps `ctrl` → `meta` when `isMac`, so the shortcut fires on ⌘B on Mac today. Only the tooltip label needs fixing.

## Solution

**1. Add a plain-text modifier label helper to `src/frontend/src/lib/shortcut.ts`**

Added `modifierKeyLabel()` function that returns `"Cmd"` on Mac and `"Ctrl"` elsewhere. The existing display helpers (`formatShortcutForDisplay`, `Kbd`) return React nodes and are wrong for plain tooltip text.

**2. Use it in `SidebarLayoutWidget.tsx`**

Replaced both hardcoded `"Toggle sidebar (Ctrl+B)"` strings with dynamic labels using `modifierKeyLabel()`.

**3. Added unit tests**

Added tests to `shortcut.test.ts` verifying `modifierKeyLabel(true)` returns `"Cmd"` and `modifierKeyLabel(false)` returns `"Ctrl"`.

---

**Commits:**
- bfa0e3dbf Show Cmd+B in sidebar toggle tooltip on Mac (plan 00661)

---
Created using [Ivy Tendril](https://ivy.app).
