### PR TITLE
[00676] Use the Command Glyph for Mac Modifier Labels in Tooltips

### DIFF
--- a/src/frontend/src/lib/shortcut.test.ts
+++ b/src/frontend/src/lib/shortcut.test.ts
@@ -53,8 +53,8 @@ describe("formatShortcutForDisplay", () => {
 });
 
 describe("modifierKeyLabel", () => {
-  it("returns 'Cmd' on Mac", () => {
-    expect(modifierKeyLabel(true)).toBe("Cmd");
+  it("returns '⌘' on Mac", () => {
+    expect(modifierKeyLabel(true)).toBe("⌘");
   });
 
   it("returns 'Ctrl' on non-Mac platforms", () => {

--- a/src/frontend/src/lib/shortcut.ts
+++ b/src/frontend/src/lib/shortcut.ts
@@ -5,11 +5,11 @@ export const isMac =
   typeof navigator !== "undefined" && /Mac|iPod|iPhone|iPad/.test(navigator.userAgent);
 
 /**
- * Plain-text label for the Ctrl/Cmd modifier in prose (tooltips, hints). On Mac the
- * binding fires on Command — see parseShortcut(), which maps ctrl → meta — so the label
- * must say "Cmd" there. Key caps use the ⌘ glyph instead; see Kbd.tsx.
+ * Label for the Ctrl/Cmd modifier in prose (tooltips, hints). On Mac the binding fires on
+ * Command — see parseShortcut(), which maps ctrl → meta — and Mac labels use the ⌘ glyph
+ * throughout the frontend (Kbd.tsx, formatShortcutForDisplay), so this returns ⌘ there.
  */
-export const modifierKeyLabel = (mac: boolean = isMac): string => (mac ? "Cmd" : "Ctrl");
+export const modifierKeyLabel = (mac: boolean = isMac): string => (mac ? "⌘" : "Ctrl");
 
 export interface ParsedShortcut {
   ctrl: boolean;

--- a/src/frontend/src/widgets/dataTables/hooks/useCellHoverTooltip.test.ts
+++ b/src/frontend/src/widgets/dataTables/hooks/useCellHoverTooltip.test.ts
@@ -51,6 +51,11 @@ describe("useCellHoverTooltip", () => {
     expect(hookSource).toContain("const columnWidth = args.bounds.width");
     expect(hookSource).not.toContain("getVisibleColumnWidthAt");
   });
+
+  it("should take the modifier label from lib/shortcut instead of sniffing navigator", () => {
+    expect(hookSource).toContain("modifierKeyLabel");
+    expect(hookSource).not.toContain("navigator.platform");
+  });
 });
 
 describe("getCellTooltipPlacementStyle", () => {

--- a/src/frontend/src/widgets/dataTables/hooks/useCellHoverTooltip.ts
+++ b/src/frontend/src/widgets/dataTables/hooks/useCellHoverTooltip.ts
@@ -6,6 +6,7 @@ import { getCellFont } from "../utils/canvasText";
 import { getTruncatedCellTooltip } from "../utils/cellTooltip";
 import { DENSITY_CONFIG } from "../dataTableEditor/constants";
 import { DataColumn } from "../types/types";
+import { modifierKeyLabel } from "@/lib/shortcut";
 
 interface UseCellHoverTooltipProps {
   columns: DataColumn[];
@@ -35,6 +36,9 @@ const defaultTooltipLayout: CellTooltipLayout = {
   cellGap: 8,
   viewportInset: 8,
 };
+
+/** Modifier+click opens a link cell; see useCellInteractions. */
+const LINK_HINT = `${modifierKeyLabel()}+click to open link`;
 
 /** Positions tooltip above or below the cell based on available viewport space. */
 export function getCellTooltipPlacementStyle(
@@ -142,15 +146,12 @@ export const useCellHoverTooltip = ({
         return;
       }
 
-      const isMac = typeof navigator !== "undefined" && /Mac|iPhone|iPad/.test(navigator.platform);
-      const linkHint = isMac ? "\u2318+click to open link" : "Ctrl+click to open link";
-
       setTooltip({
         x: args.bounds.x + args.bounds.width / 2,
         y: args.bounds.y,
         cellHeight: args.bounds.height,
-        content: truncatedText ?? (isLinkCell ? linkHint : ""),
-        hint: truncatedText && isLinkCell ? linkHint : undefined,
+        content: truncatedText ?? (isLinkCell ? LINK_HINT : ""),
+        hint: truncatedText && isLinkCell ? LINK_HINT : undefined,
       });
     },
     [


### PR DESCRIPTION
Follow-up to [Plan 00661](https://github.com/Ivy-Interactive/Ivy-Framework/pull/4757): change `modifierKeyLabel()` to return the ⌘ glyph on Mac instead of the word "Cmd", matching the established house style throughout the frontend.

## Problem

Plan 00661 added `modifierKeyLabel()` returning `"Cmd"` on Mac because issue #1978 literally asked for "Cmd+B". But every other Mac-modifier label in the frontend uses the ⌘ glyph:
- `Kbd.tsx` — `ctrl`/`cmd`/`meta` → `⌘`
- `formatShortcutForDisplay` — `⌘`
- `useCellHoverTooltip.ts:146` — `"⌘+click to open link"` in plain tooltip prose

The last one is the decisive precedent: it proves ⌘ is the house style in tooltip *prose*, not just key caps. So `modifierKeyLabel` is the one place spelling it out, and the sidebar tooltip reads `Toggle sidebar (Cmd+B)` where the data-grid tooltip beside it reads `⌘+click`.

Second issue: `useCellHoverTooltip.ts` rolls its own platform check instead of importing `isMac`, using the deprecated `navigator.platform` and omitting `iPod`.

## Solution

Three files:
1. **shortcut.ts** — `modifierKeyLabel` returns `"⌘"` on Mac
2. **SidebarLayoutWidget.tsx** — no change; interpolation picks up the glyph for free
3. **useCellHoverTooltip.ts** — consolidate to module-level `LINK_HINT` importing `modifierKeyLabel`, removing the duplicate platform check

Net effect: `Toggle sidebar (⌘+B)` on Mac, `Toggle sidebar (Ctrl+B)` elsewhere, and one source of truth for "is this a Mac".

---

**Commits:**
- `107e81bd6` Use ⌘ glyph for Mac modifier labels in tooltips (plan 00676)

---
Created using [Ivy Tendril](https://ivy.app).
