### PR TITLE
fix(backend): safely URL-encode SignalR connection parameters in use-backend

### DIFF
--- a/src/Ivy.Integration.Tests/AppHubIntegrationTests.cs
+++ b/src/Ivy.Integration.Tests/AppHubIntegrationTests.cs
@@ -121,4 +121,32 @@ public class AppHubIntegrationTests : IAsyncLifetime
         // Verify session store has exactly the second connection
         Assert.True(_server.SessionStore.Sessions.ContainsKey(connection2.ConnectionId!));
     }
+
+    [Fact]
+    public async Task HubConnection_WithSpecialCharactersInAppArgs_CanConnect()
+    {
+        var jsonArgs = "{\"Prompt\":\"User wants to discuss plan in review mode.\",\"Title\":\"#22\"}";
+        var encodedArgs = System.Web.HttpUtility.UrlEncode(jsonArgs);
+        var url = $"{_server.BaseUrl}/ivy/messages?appId=test-app&appArgs={encodedArgs}&machineId=test-machine&shell=false";
+
+        await using var connection = new HubConnectionBuilder()
+            .WithUrl(url)
+            .Build();
+
+        var refreshTcs = new TaskCompletionSource<object?>();
+        connection.On<object?>("Refresh", payload =>
+        {
+            refreshTcs.TrySetResult(payload);
+        });
+
+        await connection.StartAsync();
+        Assert.Equal(HubConnectionState.Connected, connection.State);
+
+        var payload = await refreshTcs.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.NotNull(payload);
+
+        var json = payload.ToString()!;
+        Assert.Contains("widgets", json);
+    }
 }
+

--- a/src/frontend/src/hooks/use-backend.tsx
+++ b/src/frontend/src/hooks/use-backend.tsx
@@ -4,7 +4,7 @@ import { MessagePackHubProtocol } from "@microsoft/signalr-protocol-msgpack";
 import { WidgetEventHandlerType, WidgetNode } from "@/types/widgets";
 import { useToast } from "@/hooks/use-toast";
 import { showError } from "@/hooks/use-error-sheet";
-import { getIvyHost, getIvyBasePath, getMachineId } from "@/lib/utils";
+import { getIvyHost, getIvyBasePath, getMachineId, buildSignalRUrl } from "@/lib/utils";
 import { validateRedirectUrl, validateLinkUrl, extractAnchorId } from "@/lib/url";
 import { logger } from "@/lib/logger";
 import { copyToClipboard } from "@/lib/clipboard";
@@ -759,10 +759,14 @@ export const useBackend = (
     const connectedAccountLogin = pageParams.get("connectedAccountLogin");
 
     // Build SignalR connection URL
-    let signalRUrl = `${getIvyHost()}/ivy/messages?appId=${latestAppIdRef.current ?? ""}&appArgs=${stableAppArgs ?? ""}&machineId=${machineId}&parentId=${parentId ?? ""}&shell=${latestAppShellRef.current}`;
-    if (oauthLogin) {
-      signalRUrl += `&oauthLogin=${oauthLogin}`;
-    }
+    const signalRUrl = buildSignalRUrl(getIvyHost(), {
+      appId: latestAppIdRef.current,
+      appArgs: stableAppArgs,
+      machineId,
+      parentId,
+      shell: latestAppShellRef.current,
+      oauthLogin,
+    });
     // Clean up auth-related query parameters from the URL
     if (oauthLogin || connectedAccountLogin) {
       pageParams.delete("oauthLogin");

--- a/src/frontend/src/lib/utils.test.ts
+++ b/src/frontend/src/lib/utils.test.ts
@@ -733,3 +733,81 @@ describe("getShellParam", () => {
     expect(utils.getShellParam()).toBe(false);
   });
 });
+
+describe("buildSignalRUrl", () => {
+  const baseHost = "http://localhost:5010";
+
+  it("builds a basic SignalR URL with all required options", () => {
+    const url = utils.buildSignalRUrl(baseHost, {
+      appId: "my-app",
+      machineId: "machine-123",
+      shell: true,
+    });
+
+    const parsed = new URL(url);
+    expect(parsed.origin).toBe("http://localhost:5010");
+    expect(parsed.pathname).toBe("/ivy/messages");
+    expect(parsed.searchParams.get("appId")).toBe("my-app");
+    expect(parsed.searchParams.get("machineId")).toBe("machine-123");
+    expect(parsed.searchParams.get("shell")).toBe("true");
+    expect(parsed.searchParams.get("appArgs")).toBeNull();
+    expect(parsed.searchParams.get("parentId")).toBeNull();
+    expect(parsed.searchParams.get("oauthLogin")).toBeNull();
+  });
+
+  it("safely encodes appArgs containing special characters like # and &", () => {
+    const jsonArgs = JSON.stringify({
+      Prompt: "User wants to discuss the plan /path/to/00022-my-plan currently in Review mode.",
+      Title: "#22",
+    });
+
+    const url = utils.buildSignalRUrl(baseHost, {
+      appId: "agent",
+      appArgs: jsonArgs,
+      machineId: "machine-123",
+      parentId: "parent-456",
+      shell: false,
+      oauthLogin: "github",
+    });
+
+    // Verify raw URL does not contain an unencoded '#' that would start a fragment
+    expect(url.includes("#22")).toBe(false);
+    expect(url.includes("%2322")).toBe(true);
+
+    // Verify that parsing the URL as standard HTTP URL decodes all parameters cleanly
+    const parsed = new URL(url);
+    expect(parsed.hash).toBe("");
+    expect(parsed.searchParams.get("appId")).toBe("agent");
+    expect(parsed.searchParams.get("appArgs")).toBe(jsonArgs);
+    expect(parsed.searchParams.get("machineId")).toBe("machine-123");
+    expect(parsed.searchParams.get("parentId")).toBe("parent-456");
+    expect(parsed.searchParams.get("shell")).toBe("false");
+    expect(parsed.searchParams.get("oauthLogin")).toBe("github");
+
+    // Verify parsed appArgs JSON is intact
+    const parsedArgs = JSON.parse(parsed.searchParams.get("appArgs")!);
+    expect(parsedArgs.Title).toBe("#22");
+    expect(parsedArgs.Prompt).toBe(
+      "User wants to discuss the plan /path/to/00022-my-plan currently in Review mode.",
+    );
+  });
+
+  it("handles null/undefined optional parameters without adding empty query params", () => {
+    const url = utils.buildSignalRUrl(baseHost, {
+      appId: null,
+      appArgs: null,
+      machineId: "machine-123",
+      parentId: null,
+      shell: true,
+      oauthLogin: null,
+    });
+
+    const parsed = new URL(url);
+    expect(parsed.searchParams.get("machineId")).toBe("machine-123");
+    expect(parsed.searchParams.get("shell")).toBe("true");
+    expect(parsed.searchParams.has("appId")).toBe(false);
+    expect(parsed.searchParams.has("appArgs")).toBe(false);
+    expect(parsed.searchParams.has("parentId")).toBe(false);
+    expect(parsed.searchParams.has("oauthLogin")).toBe(false);
+  });
+});

--- a/src/frontend/src/lib/utils.ts
+++ b/src/frontend/src/lib/utils.ts
@@ -279,3 +279,32 @@ export function isLocalFilesEnabled(): boolean {
   const meta = document.querySelector('meta[name="ivy-dangerously-allow-local-files"]');
   return meta?.getAttribute("content") === "true";
 }
+
+export interface SignalRUrlOptions {
+  appId?: string | null;
+  appArgs?: string | null;
+  machineId: string;
+  parentId?: string | null;
+  shell: boolean;
+  oauthLogin?: string | null;
+}
+
+export function buildSignalRUrl(baseHost: string, options: SignalRUrlOptions): string {
+  const params = new URLSearchParams();
+  if (options.appId) {
+    params.set("appId", options.appId);
+  }
+  if (options.appArgs) {
+    params.set("appArgs", options.appArgs);
+  }
+  params.set("machineId", options.machineId);
+  if (options.parentId) {
+    params.set("parentId", options.parentId);
+  }
+  params.set("shell", String(options.shell));
+  if (options.oauthLogin) {
+    params.set("oauthLogin", options.oauthLogin);
+  }
+
+  return `${baseHost}/ivy/messages?${params.toString()}`;
+}


### PR DESCRIPTION
### Summary
Properly percent-encode SignalR query parameters (including `appArgs`, `appId`, `machineId`, `parentId`, `shell`, and `oauthLogin`) using `URLSearchParams` via `buildSignalRUrl`.

### Root Cause
Previously, `signalRUrl` was constructed via template string interpolation. When `appArgs` contained `#` (e.g. `{"Title":"#22", ...}`), the `#` was treated as a URL fragment delimiter, causing `machineId` and all subsequent parameters to be omitted from the HTTP query string sent to the backend. This broke SignalR connection initialization for Tendril's 'Discuss with agent' tabs.

### Verification
- Added frontend unit tests for `buildSignalRUrl` in `utils.test.ts` (all 1300 frontend tests pass)
- Added backend integration test in `AppHubIntegrationTests.cs` (all 16 tests pass)
- All 1370 `Ivy.Test` and 2190 `Ivy.Tendril.Test` tests pass