### PR TITLE
perf(diff-view): optimize large diff scrolling with content-visibility virtualization

### DIFF
--- a/src/widgets/Ivy.Widgets.DiffView/frontend/src/DiffView.tsx
+++ b/src/widgets/Ivy.Widgets.DiffView/frontend/src/DiffView.tsx
@@ -213,7 +213,7 @@ export const DiffView: React.FC<DiffViewProps> = ({
 
         return (
           // scrollMarginTop keeps the jump-to-file target clear of the sticky dropdown.
-          <div key={fileIndex} id={elementId} style={{ scrollMarginTop: showFileDropdown ? "2rem" : 0 }}>
+          <div key={fileIndex} id={elementId} className="ivy-diff-file" style={{ scrollMarginTop: showFileDropdown ? "2rem" : 0 }}>
             {hasHeader && (
               <div
                 className={`relative flex items-center gap-2 px-3 py-1.5 text-[11px] bg-[var(--muted)] text-[var(--muted-foreground)] border-b border-[var(--border)] sticky top-0 z-10 rounded-t-md before:absolute before:-top-px before:inset-x-0 before:h-2 before:bg-[var(--muted)] before:rounded-t-md${collapsible ? " cursor-pointer select-none" : ""}`}

--- a/src/widgets/Ivy.Widgets.DiffView/frontend/src/custom-diff.css
+++ b/src/widgets/Ivy.Widgets.DiffView/frontend/src/custom-diff.css
@@ -101,3 +101,14 @@
   background-color: var(--accent);
   color: var(--accent-foreground);
 }
+
+/* Virtualization / rendering performance for large diffs */
+.ivy-diff-file {
+  content-visibility: auto;
+  contain-intrinsic-size: 1px 400px;
+}
+
+.diff-hunk {
+  content-visibility: auto;
+  contain-intrinsic-size: 1px 150px;
+}


### PR DESCRIPTION
Addresses Ivy-Interactive/Ivy-Tendril#2138

### Summary of Changes
- Applied `content-visibility: auto` and `contain-intrinsic-size` to file wrappers (`.ivy-diff-file`) and diff hunks (`.diff-hunk`).
- Skips rendering and layout calculations for off-screen hunks/lines during scrolling, resolving lag when scrolling 1000+ line diffs.