### PR TITLE
Support arbitrary URL query parameters as appArgs in frontend getAppArgs

### DIFF
--- a/src/frontend/src/lib/utils.test.ts
+++ b/src/frontend/src/lib/utils.test.ts
@@ -811,3 +811,76 @@ describe("buildSignalRUrl", () => {
     expect(parsed.searchParams.has("oauthLogin")).toBe(false);
   });
 });
+
+describe("getAppArgs", () => {
+  const originalLocation = window.location;
+
+  afterEach(() => {
+    Object.defineProperty(window, "location", {
+      value: originalLocation,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it("returns explicit appArgs parameter if present", () => {
+    Object.defineProperty(window, "location", {
+      value: {
+        ...window.location,
+        search: "?appArgs=%7B%22foo%22%3A%22bar%22%7D",
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    expect(utils.getAppArgs()).toBe('{"foo":"bar"}');
+  });
+
+  it("converts arbitrary query parameters to JSON when explicit appArgs is not provided", () => {
+    Object.defineProperty(window, "location", {
+      value: {
+        ...window.location,
+        search: "?planId=00001-OptimizeDiffViewer&share=1",
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    const result = utils.getAppArgs();
+    expect(result).not.toBeNull();
+    const parsed = JSON.parse(result!);
+    expect(parsed.planId).toBe("00001-OptimizeDiffViewer");
+    expect(parsed.share).toBe("1");
+  });
+
+  it("ignores reserved query parameters when constructing JSON args", () => {
+    Object.defineProperty(window, "location", {
+      value: {
+        ...window.location,
+        search: "?appId=drafts&shell=true&planId=00001-OptimizeDiffViewer",
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    const result = utils.getAppArgs();
+    expect(result).not.toBeNull();
+    const parsed = JSON.parse(result!);
+    expect(parsed.planId).toBe("00001-OptimizeDiffViewer");
+    expect(parsed.appId).toBeUndefined();
+    expect(parsed.shell).toBeUndefined();
+  });
+
+  it("returns null when no non-reserved query parameters exist", () => {
+    Object.defineProperty(window, "location", {
+      value: {
+        ...window.location,
+        search: "?appId=drafts&shell=true",
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    expect(utils.getAppArgs()).toBeNull();
+  });
+});

--- a/src/frontend/src/lib/utils.ts
+++ b/src/frontend/src/lib/utils.ts
@@ -62,7 +62,24 @@ export function getAppId(): string | null {
 
 export function getAppArgs(): string | null {
   const urlParams = new URLSearchParams(window.location.search);
-  return urlParams.get("appArgs");
+  const explicitAppArgs = urlParams.get("appArgs");
+  if (explicitAppArgs) {
+    return explicitAppArgs;
+  }
+
+  // If no explicit appArgs parameter, collect all remaining query params (except framework-reserved ones)
+  const reservedParams = new Set(["appId", "parentId", "shell", "chrome", "oauthLogin"]);
+  const argsObj: Record<string, string> = {};
+  let hasArgs = false;
+
+  for (const [key, value] of urlParams.entries()) {
+    if (!reservedParams.has(key)) {
+      argsObj[key] = value;
+      hasArgs = true;
+    }
+  }
+
+  return hasArgs ? JSON.stringify(argsObj) : null;
 }
 
 export function getParentId(): string | null {


### PR DESCRIPTION
### Summary
When users visit URLs containing individual query parameters like `/drafts?planId=00001-...&share=1`, `getAppArgs()` in the frontend previously returned `null` because it only looked for `?appArgs=...`. As a result, the SignalR connection was initiated without the query parameters, preventing `AppContext.GetArgs<T>()` and `UseArgs<T>()` from reading `planId`.

### Changes
- Updated `getAppArgs()` in `utils.ts` to collect all non-reserved query parameters into a JSON string if `appArgs` is not explicitly provided.
- Added comprehensive unit tests in `utils.test.ts` for explicit and implicit query parameter extraction.
- Rebuilt frontend assets.
