### PR TITLE
feat(button): add StrikeThrough prop for struck-out, muted buttons and links

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/01_Button.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/03_Common/01_Button.md
@@ -94,6 +94,18 @@ Buttons with URLs support [right-click actions](../../01_Onboarding/02_Concepts/
             .Url("https://github.com/Ivy-Interactive/Ivy-Framework")
 ```
 
+## Strike Through
+
+Use `.StrikeThrough()` to draw a line through the button's text and dim it to muted gray. This is useful for links that point at something retired, expired or already handled.
+
+```csharp demo-tabs
+    Layout.Horizontal()
+        | new Button("Expired Link").Link()
+            .Url("https://github.com/Ivy-Interactive/Ivy-Framework")
+            .StrikeThrough()
+        | new Button("Cancelled").Secondary().StrikeThrough()
+```
+
 
 <WidgetDocs Type="Ivy.Button" ExtensionTypes="Ivy.ButtonExtensions" SourceUrl="https://github.com/Ivy-Interactive/Ivy-Framework/blob/main/src/Ivy/Widgets/Button.cs"/>
 

--- a/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/ButtonApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/ButtonApp.cs
@@ -31,6 +31,7 @@ public class ButtonApp() : SampleBase
     protected override object? BuildSample()
     {
         var label = UseState("Click a button");
+        var strikeThrough = UseState(true);
 
         var eventHandler = (Event<Button> e) =>
         {
@@ -120,6 +121,17 @@ public class ButtonApp() : SampleBase
                        .Icon(Icons.ExternalLink, Align.Right)
                    | new Button("Link Style", variant: ButtonVariant.Link)
                        .Url("https://github.com/Ivy-Interactive/Ivy-Framework")
+               )
+
+               | Text.H2("Strike Through")
+               | strikeThrough.ToBoolInput().Label("Strike through").Variant(BoolInputVariant.Switch)
+               | (Layout.Horizontal().Gap(8)
+                   | new Button("Primary", eventHandler).StrikeThrough(strikeThrough.Value)
+                   | new Button("Secondary", eventHandler, variant: ButtonVariant.Secondary).StrikeThrough(strikeThrough.Value)
+                   | new Button("Inline", eventHandler, variant: ButtonVariant.Inline).StrikeThrough(strikeThrough.Value)
+                   | new Button("Link", variant: ButtonVariant.Link)
+                       .Url("https://github.com/Ivy-Interactive/Ivy-Framework")
+                       .StrikeThrough(strikeThrough.Value)
                )
 
                | Text.H2("AI Button")

--- a/src/Ivy/Widgets/Button.cs
+++ b/src/Ivy/Widgets/Button.cs
@@ -76,6 +76,8 @@ public record Button : WidgetBase<Button>
 
     [Prop] public Colors? Foreground { get; set; }
 
+    [Prop] public bool StrikeThrough { get; set; }
+
     [Prop] public string? Url { get; set; }
 
     [Prop] public LinkTarget Target { get; set; } = LinkTarget.Self;
@@ -169,6 +171,8 @@ public static class ButtonExtensions
     public static Button Variant(this Button button, ButtonVariant variant) => button with { Variant = variant };
 
     public static Button Foreground(this Button button, Colors color) => button with { Foreground = color };
+
+    public static Button StrikeThrough(this Button button, bool strikeThrough = true) => button with { StrikeThrough = strikeThrough };
 
     public static Button Tooltip(this Button button, string tooltip) => button with { Tooltip = tooltip };
 

--- a/src/frontend/src/widgets/button/ButtonWidget.tsx
+++ b/src/frontend/src/widgets/button/ButtonWidget.tsx
@@ -42,6 +42,7 @@ interface ButtonWidgetProps {
   disabled: boolean;
   tooltip?: string;
   foreground?: string;
+  strikeThrough?: boolean;
   loading?: boolean;
   url?: string;
   target?: "Blank" | "Self";
@@ -100,6 +101,7 @@ export const ButtonWidget: React.FC<ButtonWidgetProps> = ({
   disabled = false,
   tooltip,
   foreground,
+  strikeThrough = false,
   url,
   target = "Self",
   loading = false,
@@ -343,6 +345,7 @@ export const ButtonWidget: React.FC<ButtonWidgetProps> = ({
           disabled={disabled}
           className={cn(
             "relative z-10 flex items-center gap-1",
+            strikeThrough && "line-through text-muted-foreground",
             getContainerHeight().button,
             borderRadiusClasses.button,
             buttonSize !== "icon" && !hasExplicitWidth && "w-min",
@@ -403,6 +406,7 @@ export const ButtonWidget: React.FC<ButtonWidgetProps> = ({
             ? "p-2 h-auto items-start justify-start text-left"
             : "p-2 h-auto items-start justify-start text-left inline-block"),
         (variant === "Link" || variant === "Inline") && "min-w-0 max-w-full overflow-hidden",
+        strikeThrough && "line-through text-muted-foreground",
       )}
       tooltipText={
         tooltip || ((variant === "Link" || variant === "Inline") && title ? title : undefined)


### PR DESCRIPTION
Adds a `StrikeThrough` prop to `Button` that draws a line through the button's text and dims it to the theme's muted gray. Handy for links pointing at something retired, expired, or already handled.

```csharp
new Button("Expired Link").Link()
    .Url("https://github.com/Ivy-Interactive/Ivy-Framework")
    .StrikeThrough()
```

### Changes

| File | What |
|---|---|
| `src/Ivy/Widgets/Button.cs` | New `[Prop] bool StrikeThrough` + `.StrikeThrough(bool = true)` extension |
| `src/frontend/src/widgets/button/ButtonWidget.tsx` | Applies `line-through text-muted-foreground`, in both the standard and `Ai` render paths |
| `src/Ivy.Samples.Shared/.../ButtonApp.cs` | New "Strike Through" section with a switch toggling it live |
| `Docs/02_Widgets/03_Common/01_Button.md` | "Strike Through" section with a `demo-tabs` example |

### Notes

- **Naming:** `StrikeThrough`, matching the existing `TextBlock.StrikeThrough` / `RichTextBlock.StrikeThrough` / `Text.P(...).StrikeThrough()` API.
- **Color:** `text-muted-foreground` is the same muted-gray token `TextBlockWidget` uses, so it adapts to light/dark. An explicit `.Foreground(...)` still wins, since that is applied as an inline style.
- **Plugin compatibility:** additive only — a new prop with a default and a new extension method, per `src/CLAUDE.md`.
- The `<WidgetDocs>` prop table picks up the new prop on regeneration.

### Verification

- `dotnet build` of `Ivy` and `Ivy.Samples.Shared`: 0 warnings, 0 errors
- `tsc --noEmit`: clean
- `vp fmt --check` on the changed widget: clean
- 34 frontend button tests pass
- Ran the sample app and toggled the switch — buttons strike through and dim as expected
