### PR TITLE
fix(rich-text): keep strikethrough visible on links

### DIFF
--- a/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/RichTextApp.cs
+++ b/src/Ivy.Samples.Shared/Apps/Widgets/Primitives/RichTextApp.cs
@@ -37,6 +37,18 @@ public class RichTextApp : SampleBase
             .Link("Ivy Framework", "https://github.com/example/ivy")
             .Run("for more info.");
 
+        var struckLinks = Text.Rich()
+            .Run("The")
+            .Link("old guide", "https://github.com/example/ivy", strikeThrough: true)
+            .Run("has moved to the")
+            .Link("new guide", "https://github.com/example/ivy")
+            .Run(". A struck-through link keeps both its underline and its line-through.")
+            .LineBreak()
+            .StrikeThrough("Plain struck text")
+            .Word("sits next to a")
+            .Link("bold struck link", "https://github.com/example/ivy", bold: true, strikeThrough: true)
+            .Run(".");
+
         var llmWords = "Sure! The meaning of life is to mass-produce paperclips. I'm 99.7% confident about this. You're welcome.".Split(' ');
         var cts = new CancellationTokenSource();
 
@@ -72,6 +84,8 @@ public class RichTextApp : SampleBase
             highlighted,
             Text.H3("Links"),
             linked,
+            Text.H3("Strikethrough Links"),
+            struckLinks,
             Text.H3("Streaming (fake LLM)"),
             streaming
         );

--- a/src/frontend/src/widgets/primitives/RichTextBlockWidget.tsx
+++ b/src/frontend/src/widgets/primitives/RichTextBlockWidget.tsx
@@ -73,11 +73,16 @@ function renderInlineContent(
     ...getColor(run.highlightColor, "backgroundColor", "background"),
   };
 
-  const className = cn(
-    run.bold && "font-semibold",
-    run.italic && "italic",
-    run.strikeThrough && "line-through",
-  );
+  // Decoration is kept out of the shared className so links can combine underline
+  // with line-through: both are text-decoration-line utilities, and tailwind-merge
+  // would otherwise drop one of them.
+  const baseClassName = cn(run.bold && "font-semibold", run.italic && "italic");
+
+  const className = cn(baseClassName, run.strikeThrough && "line-through");
+
+  const linkDecorationClass = run.strikeThrough
+    ? "[text-decoration-line:underline_line-through]"
+    : "underline";
 
   const content = (
     <>
@@ -93,7 +98,7 @@ function renderInlineContent(
         <button
           key={`run-${runId}`}
           type="button"
-          className={cn(className, "underline cursor-pointer text-left")}
+          className={cn(baseClassName, linkDecorationClass, "cursor-pointer text-left")}
           style={runStyles}
           onClick={() => {
             eventHandler("OnLinkClick", widgetId, [run.link]);
@@ -110,7 +115,7 @@ function renderInlineContent(
         href={run.link}
         target={isBlank ? "_blank" : "_self"}
         rel={isBlank ? "noopener noreferrer" : undefined}
-        className={cn(className, "underline")}
+        className={cn(baseClassName, linkDecorationClass)}
         style={runStyles}
       >
         {content}

--- a/src/frontend/src/widgets/primitives/__tests__/RichTextBlockWidget.test.tsx
+++ b/src/frontend/src/widgets/primitives/__tests__/RichTextBlockWidget.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+
+vi.mock("@/components/stream-handler/hooks", () => ({
+  useStream: () => undefined,
+}));
+
+const sentEvents: Array<{ name: string; id: string; args: unknown[] }> = [];
+vi.mock("@/components/event-handler/hooks", () => ({
+  useEventHandler: () => (name: string, id: string, args: unknown[]) =>
+    sentEvents.push({ name, id, args }),
+}));
+
+import { RichTextBlockWidget } from "../RichTextBlockWidget";
+
+describe("RichTextBlockWidget link decoration", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    sentEvents.length = 0;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  const render = (runs: unknown[], events: string[] = []) =>
+    act(() => {
+      root.render(<RichTextBlockWidget id="rt" runs={runs as never} events={events} />);
+    });
+
+  const decoration = (el: Element | null) =>
+    (el?.className ?? "")
+      .split(/\s+/)
+      .filter((c) => c === "underline" || c === "line-through" || c.startsWith("[text-decoration"));
+
+  it("renders a plain link as underlined only", () => {
+    render([{ content: "docs", link: "https://example.com" }]);
+    const anchor = container.querySelector("a");
+    expect(anchor).not.toBeNull();
+    expect(decoration(anchor)).toEqual(["underline"]);
+  });
+
+  it("keeps both underline and line-through on a struck-through link", () => {
+    render([{ content: "docs", link: "https://example.com", strikeThrough: true }]);
+    const anchor = container.querySelector("a");
+    expect(anchor).not.toBeNull();
+    expect(decoration(anchor)).toEqual(["[text-decoration-line:underline_line-through]"]);
+    expect(anchor?.className).not.toContain("line-through ");
+  });
+
+  it("keeps both decorations on a struck-through OnLinkClick link", () => {
+    render(
+      [{ content: "docs", link: "https://example.com", strikeThrough: true }],
+      ["OnLinkClick"],
+    );
+    const button = container.querySelector("button");
+    expect(button).not.toBeNull();
+    expect(decoration(button)).toEqual(["[text-decoration-line:underline_line-through]"]);
+    expect(button?.className).toContain("cursor-pointer");
+  });
+
+  it("preserves bold and italic alongside the link decoration", () => {
+    render([
+      {
+        content: "docs",
+        link: "https://example.com",
+        strikeThrough: true,
+        bold: true,
+        italic: true,
+      },
+    ]);
+    const anchor = container.querySelector("a");
+    expect(anchor?.className).toContain("font-semibold");
+    expect(anchor?.className).toContain("italic");
+    expect(decoration(anchor)).toEqual(["[text-decoration-line:underline_line-through]"]);
+  });
+
+  it("still uses line-through for non-link runs", () => {
+    render([{ content: "gone", strikeThrough: true }]);
+    const span = container.querySelector("span.line-through");
+    expect(span).not.toBeNull();
+    expect(container.querySelector("a")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

`RichTextBuilder.Link` accepts `strikeThrough`, and `TextRun.StrikeThrough` reached the frontend, but the decoration was silently dropped when rendering a link run — a struck-through link rendered underlined only.

Both link branches in `RichTextBlockWidget` composed their classes as `cn(className, "underline")`, where `className` already carried `"line-through"`. `cn` is `twMerge(clsx(...))`, and tailwind-merge puts `underline` and `line-through` in the same `text-decoration-line` group, so the later class won:

```
twMerge('font-semibold italic line-through', 'underline')
  -> 'font-semibold italic underline'
```

## Fix

Decoration is kept out of the shared `className`. Non-link runs still use `line-through`; link runs get a single combined utility, `[text-decoration-line:underline_line-through]`, so tailwind-merge has nothing to collapse. Applies to both the `<a>` and the `OnLinkClick` `<button>` path.

## Verification

- New `RichTextBlockWidget.test.tsx` — 5 tests: plain link stays underline-only, struck link keeps both decorations on both link paths, bold/italic survive alongside, non-link runs still use `line-through`.
- Ran the suite against the **pre-fix** source: the 3 strikethrough-link tests fail (`["underline"]` received), the 2 controls pass. So the tests genuinely pin the behavior rather than just describing it.
- Verified in the running samples app — computed `text-decoration-line`:

| Link | Computed |
|---|---|
| struck link | `underline line-through` |
| plain link | `underline` |
| bold + struck link | `underline line-through` |

- `tsc -b` clean; full frontend suite 1304 passed. The 5 failures in `src/widgets/charts/sharedUtils.test.ts` are pre-existing on `development` (confirmed by stashing this change and re-running).

## Also

Adds a **Strikethrough Links** section to the RichText sample app covering struck link, plain link, struck non-link text, and bold+struck link.

## Not addressed

`Button`/`LinkBuilder` links lose their strikethrough **on hover** — the `link` variant's `hover:underline` overrides the base `line-through`. Base state renders correctly. Left alone as out of scope.
