### PR TITLE
[00052] Fix Hover Styles for Content Tabs Variant

### DIFF
--- a/src/frontend/src/widgets/layouts/tabs/TabsLayoutWidget.test.tsx
+++ b/src/frontend/src/widgets/layouts/tabs/TabsLayoutWidget.test.tsx
@@ -33,12 +33,14 @@ describe("TabsLayoutWidget - Content variant", () => {
   it("renders tab buttons with subtle hover styles and not hover:bg-secondary", () => {
     mount(
       <TabsLayoutWidget id="test-tabs" variant="Content" selectedIndex={0} events={["OnSelect"]}>
-        <TabWidget id="tab-1" title="Tab 1">
-          <div>Content 1</div>
-        </TabWidget>
-        <TabWidget id="tab-2" title="Tab 2">
-          <div>Content 2</div>
-        </TabWidget>
+        {[
+          <TabWidget key="tab-1" id="tab-1" title="Tab 1">
+            {[<div key="1">Content 1</div>]}
+          </TabWidget>,
+          <TabWidget key="tab-2" id="tab-2" title="Tab 2">
+            {[<div key="2">Content 2</div>]}
+          </TabWidget>,
+        ]}
       </TabsLayoutWidget>,
     );
 
@@ -56,9 +58,11 @@ describe("TabsLayoutWidget - Content variant", () => {
   it("does not render dead static hover highlight element", () => {
     mount(
       <TabsLayoutWidget id="test-tabs" variant="Content" selectedIndex={0} events={[]}>
-        <TabWidget id="tab-1" title="Tab 1">
-          <div>Content 1</div>
-        </TabWidget>
+        {[
+          <TabWidget key="tab-1" id="tab-1" title="Tab 1">
+            {[<div key="1">Content 1</div>]}
+          </TabWidget>,
+        ]}
       </TabsLayoutWidget>,
     );
 

--- a/src/frontend/src/widgets/layouts/tabs/TabsLayoutWidget.test.tsx
+++ b/src/frontend/src/widgets/layouts/tabs/TabsLayoutWidget.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { TabsLayoutWidget } from "./TabsLayoutWidget";
+import { TabWidget } from "./TabWidget";
+import { EventHandlerProvider } from "@/components/event-handler";
+
+let container: HTMLDivElement;
+let root: Root;
+const eventHandler = vi.fn();
+
+function mount(element: React.ReactElement) {
+  act(() => {
+    root.render(<EventHandlerProvider eventHandler={eventHandler}>{element}</EventHandlerProvider>);
+  });
+}
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  eventHandler.mockClear();
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+describe("TabsLayoutWidget - Content variant", () => {
+  it("renders tab buttons with subtle hover styles and not hover:bg-secondary", () => {
+    mount(
+      <TabsLayoutWidget id="test-tabs" variant="Content" selectedIndex={0} events={["OnSelect"]}>
+        <TabWidget id="tab-1" title="Tab 1">
+          <div>Content 1</div>
+        </TabWidget>
+        <TabWidget id="tab-2" title="Tab 2">
+          <div>Content 2</div>
+        </TabWidget>
+      </TabsLayoutWidget>,
+    );
+
+    const tabButtons = container.querySelectorAll("button[role='tab']");
+    expect(tabButtons.length).toBe(2);
+
+    tabButtons.forEach((tabButton) => {
+      const className = tabButton.getAttribute("class") || "";
+      expect(className).not.toContain("hover:bg-secondary");
+      expect(className).toContain("hover:text-foreground");
+      expect(className).toContain("hover:bg-muted/50");
+    });
+  });
+
+  it("does not render dead static hover highlight element", () => {
+    mount(
+      <TabsLayoutWidget id="test-tabs" variant="Content" selectedIndex={0} events={[]}>
+        <TabWidget id="tab-1" title="Tab 1">
+          <div>Content 1</div>
+        </TabWidget>
+      </TabsLayoutWidget>,
+    );
+
+    const highlight = container.querySelector(".bg-accent\\/20");
+    expect(highlight).toBeNull();
+  });
+});

--- a/src/frontend/src/widgets/layouts/tabs/components/Variants.tsx
+++ b/src/frontend/src/widgets/layouts/tabs/components/Variants.tsx
@@ -106,14 +106,6 @@ export const ContentVariant: React.FC<ContentVariantProps> = ({
           className={"relative flex gap-x-[6px] gap-y-[20px] items-center"}
           role="tablist"
         >
-          {/* Hover Highlight */}
-          <div
-            className="absolute h-[26px] transition-all duration-300 ease-out bg-accent/20 rounded-[6px] flex items-center"
-            style={{
-              opacity: activeIndex !== null ? 1 : 0,
-              pointerEvents: "none",
-            }}
-          />
           <div
             className={cn(
               "absolute bottom-[-6px] h-[2px] bg-foreground",
@@ -143,7 +135,7 @@ export const ContentVariant: React.FC<ContentVariantProps> = ({
                 aria-selected={index === activeIndex}
                 tabIndex={0}
                 className={cn(
-                  "px-3 py-1.5 cursor-pointer transition-colors duration-300 h-[26px] rounded-selector hover:bg-secondary",
+                  "px-3 py-1.5 cursor-pointer transition-colors duration-300 h-[26px] rounded-selector hover:text-foreground hover:bg-muted/50",
                   index === activeIndex ? "text-foreground" : "text-muted-foreground",
                 )}
                 onClick={() => {
@@ -174,7 +166,7 @@ export const ContentVariant: React.FC<ContentVariantProps> = ({
           {addButtonText && (
             <button
               onClick={() => safeEvent("OnAddButtonClick", [0])}
-              className="px-3 py-1.5 cursor-pointer transition-colors duration-300 text-muted-foreground hover:text-foreground hover:muted-foreground rounded-[6px] flex items-center justify-center aspect-square border-none ml-2"
+              className="px-3 py-1.5 cursor-pointer transition-colors duration-300 text-muted-foreground hover:text-foreground hover:bg-muted/50 rounded-[6px] flex items-center justify-center aspect-square border-none ml-2"
             >
               <div className="text-sm font-medium leading-4 whitespace-nowrap flex items-center justify-center">
                 {addButtonText}


### PR DESCRIPTION
# Summary

## Changes

Updated the hover styles for the `Content` variant of `TabsLayoutWidget` to use subtle foreground and muted background styling (`hover:text-foreground hover:bg-muted/50`) rather than `hover:bg-secondary`. Also removed the unused static hover highlight element.

## API Changes

None.

## Files Modified

- `src/frontend/src/widgets/layouts/tabs/components/Variants.tsx`: Replaced saturated `hover:bg-secondary` styles with `hover:text-foreground hover:bg-muted/50` on tab buttons and add button, and removed dead hover highlight `div`.
- `src/frontend/src/widgets/layouts/tabs/TabsLayoutWidget.test.tsx`: Added unit tests verifying `ContentVariant` hover styles and absence of dead highlight DOM elements.

## Manual Testing

1. Launch the Ivy Samples application (`dotnet run --project src/Ivy.Samples/Ivy.Samples.csproj --browse`).
2. In the navigation sidebar, search for and open "Tabs layout" (`TabsApp`).
3. Hover over the tabs in the "Content variant (default)" and "Content variant" sections across different themes (e.g. Default, Forest, Cyberpunk).
4. Verify that hovering over inactive tabs subtly highlights the tab with `hover:bg-muted/50` and brightens text to foreground color without painting bright secondary brand colors over the tab.

---
## Commits

- 3cc9ad4bb Fix TabsLayoutWidget test children typing (00052)
- a6a3c647f Fix hover styles for Content tabs variant (00052)

---
Created using [Ivy Tendril](https://ivy.app).