### PR TITLE
[00057] Fix Sheet Close Button Hover Font Color

### DIFF
--- a/src/frontend/src/components/ui/close-button.test.tsx
+++ b/src/frontend/src/components/ui/close-button.test.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { Dialog, DialogContent, DialogHeader } from "./dialog";
+import { Sheet, SheetContent } from "./sheet";
+import { NumberRangeInputWidget } from "@/widgets/inputs/NumberRangeInputWidget";
+import { EventHandlerProvider } from "@/components/event-handler";
+
+let container: HTMLDivElement;
+let root: Root;
+
+function mount(element: React.ReactElement) {
+  act(() => {
+    root.render(<EventHandlerProvider eventHandler={() => {}}>{element}</EventHandlerProvider>);
+  });
+}
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+describe("Close and Clear Button Hover Styles", () => {
+  describe("DialogHeader close button", () => {
+    it("renders close button with standardized hover colors and inheriting icon", () => {
+      mount(
+        <Dialog open={true}>
+          <DialogContent>
+            <DialogHeader>
+              <span>Title</span>
+            </DialogHeader>
+          </DialogContent>
+        </Dialog>,
+      );
+
+      const closeButton = Array.from(document.body.querySelectorAll("button")).find(
+        (b) => b.querySelector(".sr-only")?.textContent === "Close",
+      );
+      expect(closeButton).toBeDefined();
+
+      const btnClasses = closeButton?.className ?? "";
+      expect(btnClasses).toContain("text-muted-foreground");
+      expect(btnClasses).toContain("hover:bg-accent");
+      expect(btnClasses).toContain("hover:text-accent-foreground");
+      expect(btnClasses).toContain("transition-colors");
+      expect(btnClasses).toContain("rounded-selector");
+
+      const icon = closeButton?.querySelector("svg");
+      expect(icon).not.toBeNull();
+      const iconClasses = icon?.getAttribute("class") ?? "";
+      expect(iconClasses).toContain("size-4");
+      expect(iconClasses).not.toContain("text-muted-foreground");
+      expect(iconClasses).not.toContain("hover:text-foreground");
+    });
+  });
+
+  describe("SheetContent close button", () => {
+    it("renders close button with standardized hover colors and inheriting icon", () => {
+      mount(
+        <Sheet open={true}>
+          <SheetContent>
+            <div>Content</div>
+          </SheetContent>
+        </Sheet>,
+      );
+
+      const closeButton = Array.from(document.body.querySelectorAll("button")).find(
+        (b) => b.querySelector(".sr-only")?.textContent === "Close",
+      );
+      expect(closeButton).toBeDefined();
+
+      const btnClasses = closeButton?.className ?? "";
+      expect(btnClasses).toContain("text-muted-foreground");
+      expect(btnClasses).toContain("hover:bg-accent");
+      expect(btnClasses).toContain("hover:text-accent-foreground");
+      expect(btnClasses).toContain("transition-colors");
+      expect(btnClasses).toContain("rounded-selector");
+
+      const icon = closeButton?.querySelector("svg");
+      expect(icon).not.toBeNull();
+      const iconClasses = icon?.getAttribute("class") ?? "";
+      expect(iconClasses).toContain("size-4");
+      expect(iconClasses).not.toContain("text-muted-foreground");
+      expect(iconClasses).not.toContain("hover:text-foreground");
+    });
+  });
+
+  describe("NumberRangeInputWidget clear button", () => {
+    it("renders clear button with standardized hover colors and inheriting icon", () => {
+      mount(
+        <NumberRangeInputWidget
+          id="num-range"
+          lowerValue={10}
+          upperValue={20}
+          nullable={true}
+          events={["OnChange"]}
+        />,
+      );
+
+      const clearButton = container.querySelector('button[aria-label="Clear"]');
+      expect(clearButton).not.toBeNull();
+
+      const btnClasses = clearButton?.className ?? "";
+      expect(btnClasses).toContain("text-muted-foreground");
+      expect(btnClasses).toContain("hover:bg-accent");
+      expect(btnClasses).toContain("hover:text-accent-foreground");
+      expect(btnClasses).toContain("transition-colors");
+      expect(btnClasses).toContain("rounded-selector");
+
+      const icon = clearButton?.querySelector("svg");
+      expect(icon).not.toBeNull();
+      const iconClasses = icon?.getAttribute("class") ?? "";
+      expect(iconClasses).toContain("size-4");
+      expect(iconClasses).not.toContain("text-muted-foreground");
+      expect(iconClasses).not.toContain("hover:text-foreground");
+    });
+  });
+});

--- a/src/frontend/src/components/ui/dialog.tsx
+++ b/src/frontend/src/components/ui/dialog.tsx
@@ -64,8 +64,8 @@ const DialogHeader = ({ className, children, hideCloseButton, ...props }: Dialog
   >
     <div className="flex-1">{children}</div>
     {!hideCloseButton && (
-      <DialogPrimitive.Close className="p-1 rounded-selector hover:bg-accent focus:outline-none cursor-pointer">
-        <X className="size-4 text-muted-foreground hover:text-foreground" />
+      <DialogPrimitive.Close className="p-1 rounded-selector text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors focus:outline-none cursor-pointer">
+        <X className="size-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>
     )}

--- a/src/frontend/src/components/ui/sheet.tsx
+++ b/src/frontend/src/components/ui/sheet.tsx
@@ -60,8 +60,8 @@ const SheetContent = React.forwardRef<
   <SheetPortal>
     <SheetOverlay />
     <SheetPrimitive.Content ref={ref} className={cn(sheetVariant({ side }), className)} {...props}>
-      <SheetPrimitive.Close className="absolute right-4 top-4 p-1 rounded hover:bg-accent focus:outline-none cursor-pointer">
-        <X className="size-4 text-muted-foreground hover:text-foreground" />
+      <SheetPrimitive.Close className="absolute right-4 top-4 p-1 rounded-selector text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors focus:outline-none cursor-pointer">
+        <X className="size-4" />
         <span className="sr-only">Close</span>
       </SheetPrimitive.Close>
       {children}

--- a/src/frontend/src/widgets/inputs/NumberRangeInputWidget.tsx
+++ b/src/frontend/src/widgets/inputs/NumberRangeInputWidget.tsx
@@ -396,9 +396,9 @@ export const NumberRangeInputWidget = memo(
                   tabIndex={-1}
                   aria-label="Clear"
                   onClick={handleClear}
-                  className="p-1 rounded hover:bg-accent focus:outline-none cursor-pointer"
+                  className="p-1 rounded-selector text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors focus:outline-none cursor-pointer"
                 >
-                  <X className="size-4 text-muted-foreground hover:text-foreground" />
+                  <X className="size-4" />
                 </button>
               )}
               {invalid && <InvalidIcon message={invalid} />}


### PR DESCRIPTION
# Summary

## Changes

Fixed close and clear button hover text/icon color contrast in Sheet overlays, Dialogs, and NumberRangeInputWidget. The hover styles and text colors were moved from the child 'X' icon to the parent button elements with `hover:bg-accent hover:text-accent-foreground transition-colors`, allowing the icon to inherit `currentColor` seamlessly in both resting and hovered states across all themes.

## API Changes

None.

## Files Modified

- `src/frontend/src/components/ui/sheet.tsx`: Updated `<SheetPrimitive.Close>` and `<X>` styling to standard hover tokens and inherited icon colors.
- `src/frontend/src/components/ui/dialog.tsx`: Updated `<DialogPrimitive.Close>` and `<X>` styling to standard hover tokens and inherited icon colors.
- `src/frontend/src/widgets/inputs/NumberRangeInputWidget.tsx`: Updated clear button and `<X>` styling to standard hover tokens and inherited icon colors.
- `src/frontend/src/components/ui/close-button.test.tsx`: Added frontend unit tests for Sheet, Dialog, and NumberRangeInputWidget close and clear buttons.

## Manual Testing

1. Launch Ivy Samples (`dotnet run --project src/Ivy.Samples/Ivy.Samples.csproj --browse --find-available-port`).
2. Navigate to the Sheet sample view under Widgets -> Sheet.
3. Open a Sheet overlay and switch themes (e.g. Forest, Dracula, Cyberpunk, Default).
4. Hover anywhere over the 'X' close button in the top-right corner of the sheet.
5. Observe that the button background changes to the theme's accent color, and the 'X' icon legibly changes to the theme's `accent-foreground` color with high contrast.
6. Open a Dialog and test hovering over the dialog close button as well.

---
- a19aba1 Fix sheet, dialog, and number range clear button hover font colors (Plan 00057)

---
Created using [Ivy Tendril](https://ivy.app).
