### PR TITLE
[00058] Use Semantic Design Token for Tabs Variant Add Button Hover

### DIFF
--- a/src/frontend/src/widgets/layouts/tabs/TabsLayoutWidget.test.tsx
+++ b/src/frontend/src/widgets/layouts/tabs/TabsLayoutWidget.test.tsx
@@ -70,3 +70,31 @@ describe("TabsLayoutWidget - Content variant", () => {
     expect(highlight).toBeNull();
   });
 });
+
+describe("TabsLayoutWidget - Tabs variant", () => {
+  it("renders add button with semantic hover style and not hardcoded hover:bg-gray-200", () => {
+    mount(
+      <TabsLayoutWidget
+        id="test-tabs"
+        variant="Tabs"
+        selectedIndex={0}
+        addButtonText="+"
+        events={["OnAddButtonClick"]}
+      >
+        {[
+          <TabWidget key="tab-1" id="tab-1" title="Tab 1">
+            {[<div key="1">Content 1</div>]}
+          </TabWidget>,
+        ]}
+      </TabsLayoutWidget>,
+    );
+
+    const buttons = Array.from(container.querySelectorAll("button"));
+    const addButton = buttons.find((btn) => btn.textContent?.includes("+"));
+    expect(addButton).toBeDefined();
+
+    const className = addButton?.getAttribute("class") || "";
+    expect(className).toContain("hover:bg-muted/50");
+    expect(className).not.toContain("hover:bg-gray-200");
+  });
+});

--- a/src/frontend/src/widgets/layouts/tabs/components/Variants.tsx
+++ b/src/frontend/src/widgets/layouts/tabs/components/Variants.tsx
@@ -314,7 +314,7 @@ export const TabsVariant: React.FC<TabsVariantProps> = ({
                 {addButtonText && (
                   <button
                     onClick={() => safeEvent("OnAddButtonClick", [0])}
-                    className="py-2 cursor-pointer transition-colors duration-300 text-muted-foreground hover:text-foreground hover:bg-gray-200/20 rounded-[6px] flex-shrink-0 flex items-center justify-center aspect-square px-3 border-none ml-2"
+                    className="py-2 cursor-pointer transition-colors duration-300 text-muted-foreground hover:text-foreground hover:bg-muted/50 rounded-[6px] flex-shrink-0 flex items-center justify-center aspect-square px-3 border-none ml-2"
                   >
                     <div className="text-sm font-medium leading-4 whitespace-nowrap flex items-center justify-center">
                       {addButtonText}


### PR DESCRIPTION
# Summary

## Changes

Updated the `TabsVariant` add button in `Variants.tsx` to use the semantic design token `hover:bg-muted/50` instead of the hardcoded `hover:bg-gray-200/20` class. Added unit test coverage to ensure `TabsVariant` add buttons render with proper semantic hover styling across light and dark themes.

## API Changes

None.

## Files Modified

- `src/frontend/src/widgets/layouts/tabs/components/Variants.tsx` - Updated add button hover styling to `hover:bg-muted/50`.
- `src/frontend/src/widgets/layouts/tabs/TabsLayoutWidget.test.tsx` - Added unit test verifying semantic hover classes for `TabsVariant` add button.

## Manual Testing

1. Run frontend unit tests: `cd src/frontend && vp test src/widgets/layouts/tabs/TabsLayoutWidget.test.tsx`.
2. Observe that all tests in `TabsLayoutWidget.test.tsx` pass.
3. Launch Ivy Samples (`dotnet run --project src/Ivy.Samples/Ivy.Samples.csproj --browse --find-available-port`) and navigate to tabs samples featuring an add button in `Tabs` variant.
4. Hover over the add button in both light and dark modes to verify consistent background highlight color matching other tabs and buttons.

---
## Commits

- 53ccc7cea Use semantic design token for TabsVariant add button hover (00058)

---
Created using [Ivy Tendril](https://ivy.app).
