### PR TITLE
[00133] Resolve Vite Plus Unmet Peer Warnings in Tiptap Widget Frontend

### DIFF
--- a/src/widgets/Ivy.Widgets.Tiptap/frontend/package.json
+++ b/src/widgets/Ivy.Widgets.Tiptap/frontend/package.json
@@ -18,19 +18,26 @@
   "devDependencies": {
     "@types/react": "19.2.8",
     "@types/react-dom": "19.2.3",
+    "@vitejs/plugin-react": "6.0.1",
     "autoprefixer": "10.4.23",
     "postcss": "8.5.23",
     "tailwindcss": "3.4.19",
     "typescript": "7.0.2",
     "vite": "npm:@voidzero-dev/vite-plus-core@0.2.1",
-    "vite-plus": "0.2.1",
-    "@vitejs/plugin-react": "6.0.1"
+    "vite-plus": "0.2.1"
   },
   "peerDependencies": {
     "react": "19.2.3",
     "react-dom": "19.2.3"
   },
+  "packageManager": "pnpm@10.33.0",
   "pnpm": {
+    "peerDependencyRules": {
+      "allowAny": [
+        "typescript",
+        "vite"
+      ]
+    },
     "overrides": {
       "lodash-es": "4.18.1",
       "markdown-it": ">=14.2.0",
@@ -46,6 +53,5 @@
       "@tiptap/extension-bubble-menu": "3.31.3",
       "@tiptap/extension-floating-menu": "3.31.3"
     }
-  },
-  "packageManager": "pnpm@10.33.0"
+  }
 }


### PR DESCRIPTION
# Summary

## Changes

Configured pnpm `peerDependencyRules.allowAny` in the Tiptap widget frontend (`src/widgets/Ivy.Widgets.Tiptap/frontend/package.json`) to allow `typescript` and `vite`. This silences benign unmet peer dependency warnings during `vp install` that arose from TypeScript 7 upgrade and Vite Plus Core aliasing.

## API Changes

None.

## Files Modified

- `src/widgets/Ivy.Widgets.Tiptap/frontend/package.json`: Added `peerDependencyRules` under the `pnpm` configuration object and formatted the file with `vp fmt`.

## Manual Testing

N/A: internal change with no user-facing behavior. To verify in the terminal:
1. Navigate to `src/widgets/Ivy.Widgets.Tiptap/frontend`.
2. Run `vp install` (or force resolution) and verify that no unmet peer dependency warnings appear for `typescript` or `vite`.
3. Run `vp build` and verify the build passes cleanly.

---

## Commits

- fbcfdb234 Silence unmet peer warnings for typescript and vite in Tiptap frontend (Plan 00133)

---
Created using [Ivy Tendril](https://ivy.app).
