### PR TITLE
[00154] Document Ivy.Plugin.Abstractions ProjectReference Requirement in CLAUDE.md

### DIFF
--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -8,10 +8,18 @@ A signature change can cause `MissingMethodException` for deployed plugins.
 API compatibility is enforced in CI via `EnablePackageValidation`. If your change breaks the API
 surface, the pack step will fail. See "Handling intentional breaks" below.
 
-`Ivy.Plugin.Abstractions` is no longer published as its own NuGet package — its assembly ships
+`Ivy.Plugin.Abstractions` is no longer published as its own NuGet package: its assembly ships
 inside `Ivy.nupkg` under `lib/net10.0/`. The project keeps its own `PackageValidationBaselineVersion`
 and is still packed in CI purely to run that API-compat check, so both projects below must be packed
 when regenerating suppressions.
+
+Because `Ivy.csproj` sets `PrivateAssets="all"` on its reference to `Ivy.Plugin.Abstractions` (to avoid emitting an external package dependency), `Ivy.Plugin.Abstractions.dll` does not flow transitively through in-repo `ProjectReference` chains. Any in-repo project consuming types from the `Ivy.Plugins` namespace (e.g. plugin hosts, test suites, example apps) must include an explicit project reference:
+
+```xml
+<ProjectReference Include="../Ivy.Plugin.Abstractions/Ivy.Plugin.Abstractions.csproj" />
+```
+
+External NuGet consumers referencing `<PackageReference Include="Ivy" />` are unaffected because the assembly is packaged directly inside `Ivy.nupkg` under `lib/net10.0/`.
 
 ## Rules
 


### PR DESCRIPTION
## Problem
In 00119-ConsolidateNuGetPackagesIntoIvyIvyAuthAndIvyDesktop, `Ivy.Plugin.Abstractions` was consolidated so its assembly ships directly inside `Ivy.nupkg` under `lib/net10.0/`. To prevent emitting an external package dependency, `Ivy.csproj` sets `PrivateAssets="all"` on its reference to `Ivy.Plugin.Abstractions.csproj`.

However, `PrivateAssets="all"` prevents the assembly from flowing transitively through in-repo `ProjectReference` chains. As a result, four existing projects (`Ivy.Test`, `Ivy.Docs.Shared`, `plugins/hosts/HelloWorldHost`, and `plugins/plugins/Ivy.Plugin.Example.AppProvider`) required explicit references to `Ivy.Plugin.Abstractions.csproj`.

Without documentation, anyone adding a new in-repo plugin host, sample, or test project that uses `Ivy.Plugins` types will encounter confusing "type or namespace not found" compile errors despite having a reference to `Ivy`.

## Solution
Update `src/CLAUDE.md` in the plugin documentation section to explicitly document this requirement:

1. Locate the packaging notes in `src/CLAUDE.md`.
2. Add an explanation clarifying that:
   - `PrivateAssets="all"` on `Ivy.csproj` stops `Ivy.Plugin.Abstractions.dll` from flowing transitively to projects referencing `Ivy` via `ProjectReference`.
   - Any in-repo project consuming types from the `Ivy.Plugins` namespace (e.g. plugin hosts, test suites, example apps) must include an explicit `<ProjectReference Include=".../Ivy.Plugin.Abstractions.csproj" />`.
   - External NuGet consumers referencing `<PackageReference Include="Ivy" />` are unaffected because the assembly is packaged in `lib/net10.0/`.

---
- ac53dc57c Document Ivy.Plugin.Abstractions ProjectReference requirement (00154)

---
Created using [Ivy Tendril](https://ivy.app).
