### PR TITLE
[00156] Remove Misleading Version Property from Ivy Analyser

### DIFF
--- a/src/Ivy.Analyser/Ivy.Analyser.csproj
+++ b/src/Ivy.Analyser/Ivy.Analyser.csproj
@@ -11,7 +11,6 @@
       analyzers/dotnet/cs by the PackIvyAnalyser target in ../Ivy/Ivy.csproj.
     -->
     <IsPackable>false</IsPackable>
-    <Version>1.0.0</Version>
     <Company>Ivy Interactive</Company>
     <Description>Roslyn analyzer for enforcing proper Ivy hook usage</Description>
     <LangVersion>latest</LangVersion>


### PR DESCRIPTION
# Summary

## Changes

Removed the obsolete `<Version>1.0.0</Version>` property from `src/Ivy.Analyser/Ivy.Analyser.csproj`. `Ivy.Analyser` is packed into `Ivy.nupkg` rather than published independently, and release versions are supplied at pack time via `/p:Version=`.

## API Changes

None.

## Files Modified

- `src/Ivy.Analyser/Ivy.Analyser.csproj`: Deleted `<Version>1.0.0</Version>` from `<PropertyGroup>`.

## Manual Testing

N/A: internal project configuration cleanup with no user-facing behavior.

---
- e89bcb77c Remove misleading Version property from Ivy.Analyser.csproj (Plan 00156)

---
Created using [Ivy Tendril](https://ivy.app).
