### PR TITLE
[00157] Mark Antlr4BuildTasks as Private Asset in Ivy

### DIFF
--- a/src/Ivy/Ivy.csproj
+++ b/src/Ivy/Ivy.csproj
@@ -104,7 +104,7 @@
     <PackageReference Include="Microsoft.OpenApi" Version="3.9.0" />
     <!-- Absorbed from Ivy.Agent.Filter -->
     <PackageReference Include="Antlr4.Runtime.Standard" Version="4.13.1" />
-    <PackageReference Include="Antlr4BuildTasks" Version="12.11.0" />
+    <PackageReference Include="Antlr4BuildTasks" Version="12.11.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.AI" Version="10.4.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
     <!-- Absorbed from Ivy.Hooks.Pty -->


### PR DESCRIPTION
# Summary

## Changes

Marked the `Antlr4BuildTasks` package reference in `Ivy.csproj` with `PrivateAssets="all"`. This keeps the MSBuild task available for compiling the ANTLR filter grammar during framework builds while preventing `Antlr4BuildTasks.dll` from leaking as a package dependency and deployment asset to downstream Ivy consumers. `Antlr4.Runtime.Standard` remains untouched to provide required runtime types.

## API Changes

None.

## Files Modified

- `src/Ivy/Ivy.csproj`: Added `PrivateAssets="all"` to `<PackageReference Include="Antlr4BuildTasks" Version="12.11.0" />`.

## Manual Testing

N/A: internal packaging and dependency change with no user-facing behavior.

To verify the package dependency exclusion manually:
1. Run `dotnet pack src/Ivy/Ivy.csproj --configuration Release /p:Version=99.0.0`.
2. Inspect the generated `.nuspec` inside `src/Ivy/bin/Release/Ivy.99.0.0.nupkg` (for example: `unzip -p src/Ivy/bin/Release/Ivy.99.0.0.nupkg '*.nuspec'`).
3. Verify that `Antlr4BuildTasks` is not present under `<dependencies>`, and `Antlr4.Runtime.Standard` is present.

---
- a6d24ed22 Plan 00157: Mark Antlr4BuildTasks as private asset in Ivy

---
Created using [Ivy Tendril](https://ivy.app).
