### PR TITLE
[00161] Configure Peer Dependency Rules for Aliased Vite in Core Frontend

### DIFF
--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -142,6 +142,11 @@
   },
   "packageManager": "pnpm@10.33.0",
   "pnpm": {
+    "peerDependencyRules": {
+      "allowAny": [
+        "vite"
+      ]
+    },
     "overrides": {
       "brace-expansion": "5.0.9",
       "postcss": "8.5.23",

--- a/src/frontend/pnpm-lock.yaml
+++ b/src/frontend/pnpm-lock.yaml
@@ -3280,7 +3280,6 @@ packages:
 
   mdast@3.0.0:
     resolution: {integrity: sha512-xySmf8g4fPKMeC07jXGz971EkLbWAJ83s4US2Tj9lEdnZ142UP5grN73H1Xd3HzrdbU5o9GYYP/y8F9ZSwLE9g==}
-    deprecated: '`mdast` was renamed to `remark`'
 
   mermaid@11.16.1:
     resolution: {integrity: sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==}


### PR DESCRIPTION
# Summary

## Changes

Configured `peerDependencyRules.allowAny: ["vite"]` in `src/frontend/package.json` under `pnpm` settings, matching the configuration established across widget frontends in Plan 00145. This eliminates benign unmet peer dependency warnings during lockfile regeneration caused by aliasing `vite` to `@voidzero-dev/vite-plus-core@0.3.0`.

## API Changes

None.

## Files Modified

- Frontend Configuration:
  - `src/frontend/package.json`: Added `peerDependencyRules` under `pnpm`.
  - `src/frontend/pnpm-lock.yaml`: Synchronized lockfile.

## Manual Testing

N/A: internal package manager configuration change with no user-facing behavior. To verify build integrity:
1. Run `cd src/frontend && vp install` and observe zero unmet peer dependency warnings for `vite`.
2. Run `cd src/frontend && vp build && vp test && vp lint .` to confirm frontend builds and tests pass.
3. Run `dotnet build src/Ivy-Framework.slnx --warnaserror` to confirm the backend solution builds cleanly.

---

## Commits
- 158d0cb84 Plan 00161: Configure peer dependency rules for aliased Vite in core frontend

---
Created using [Ivy Tendril](https://ivy.app).
