### PR TITLE
[00155] Pack External Widget Targets in Ivy NuGet Package

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/07_Advanced/05_ExternalWidgets.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/07_Advanced/05_ExternalWidgets.md
@@ -344,20 +344,18 @@ A publishable external widget project needs NuGet package metadata in its `.cspr
 ```
 
 Combine this with the frontend build and `EmbeddedResource` items from
-[Standalone widget project](#standalone-widget-project) above — the built assets must be embedded in
+[Standalone widget project](#standalone-widget-project) above: the built assets must be embedded in
 the assembly for `ScriptPath`/`StylePath` to resolve at runtime.
 
-Rather than writing that build logic yourself, you can copy
-`src/Ivy/Build/Ivy.ExternalWidget.targets` from the
-[Ivy Framework repository](https://github.com/Ivy-Interactive/Ivy-Framework) next to your `.csproj`
-and import it:
+When your project references `Ivy` via `<PackageReference Include="Ivy" />`, the package automatically imports build targets that detect `frontend/package.json`. During project compilation, it runs `vp install` and `vp build` in `frontend/` and embeds `frontend/dist/**` under the resource names `ExternalWidgetController` looks for.
+
+If you prefer to manage the frontend build independently, you can opt out of the automatic build targets:
 
 ```xml
-<Import Project="Ivy.ExternalWidget.targets" />
+<PropertyGroup>
+  <IvyEnableExternalWidgets>false</IvyEnableExternalWidgets>
+</PropertyGroup>
 ```
-
-It runs `vp install` / `vp build` in `frontend/` and embeds `frontend/dist/**` under the resource
-names `ExternalWidgetController` looks for.
 
 ### Release Workflow
 

--- a/src/Ivy.Test/Widgets/External/ExternalWidgetBuildTargetsTests.cs
+++ b/src/Ivy.Test/Widgets/External/ExternalWidgetBuildTargetsTests.cs
@@ -1,0 +1,95 @@
+using System.Xml.Linq;
+
+namespace Ivy.Test.Widgets.External;
+
+public class ExternalWidgetBuildTargetsTests
+{
+    private static readonly string SrcDirectory = FindSrcDirectory();
+
+    private static string FindSrcDirectory()
+    {
+        var dir = new DirectoryInfo(System.AppContext.BaseDirectory);
+        while (dir != null && !File.Exists(Path.Combine(dir.FullName, "Ivy-Framework.slnx")))
+        {
+            dir = dir.Parent;
+        }
+
+        Assert.NotNull(dir);
+        return dir.FullName;
+    }
+
+    [Fact]
+    public void BuildTargetFilesExistOnDisk()
+    {
+        var ivyTargets = Path.Combine(SrcDirectory, "Ivy", "Build", "Ivy.targets");
+        var externalWidgetTargets = Path.Combine(SrcDirectory, "Ivy", "Build", "Ivy.ExternalWidget.targets");
+
+        Assert.True(File.Exists(ivyTargets), $"Expected '{ivyTargets}' to exist.");
+        Assert.True(File.Exists(externalWidgetTargets), $"Expected '{externalWidgetTargets}' to exist.");
+    }
+
+    [Fact]
+    public void BuildTargetFilesAreValidXml()
+    {
+        var ivyTargets = Path.Combine(SrcDirectory, "Ivy", "Build", "Ivy.targets");
+        var externalWidgetTargets = Path.Combine(SrcDirectory, "Ivy", "Build", "Ivy.ExternalWidget.targets");
+
+        var doc1 = XDocument.Load(ivyTargets);
+        var doc2 = XDocument.Load(externalWidgetTargets);
+
+        Assert.NotNull(doc1.Root);
+        Assert.NotNull(doc2.Root);
+    }
+
+    [Fact]
+    public void IvyTargetsImportsExternalWidgetTargets()
+    {
+        var ivyTargets = Path.Combine(SrcDirectory, "Ivy", "Build", "Ivy.targets");
+        var doc = XDocument.Load(ivyTargets);
+
+        var import = doc.Descendants()
+            .FirstOrDefault(e => e.Name.LocalName == "Import" &&
+                                (e.Attribute("Project")?.Value.Contains("Ivy.ExternalWidget.targets") ?? false));
+
+        Assert.NotNull(import);
+        Assert.Equal("$(MSBuildThisFileDirectory)Ivy.ExternalWidget.targets", import.Attribute("Project")?.Value);
+        Assert.Equal("'$(IvyEnableExternalWidgets)' != 'false'", import.Attribute("Condition")?.Value);
+    }
+
+    [Fact]
+    public void IvyCsprojPacksTargetFilesUnderBuildPackagePath()
+    {
+        var ivyCsproj = Path.Combine(SrcDirectory, "Ivy", "Ivy.csproj");
+        var doc = XDocument.Load(ivyCsproj);
+
+        var noneElements = doc.Descendants()
+            .Where(e => e.Name.LocalName == "None")
+            .ToList();
+
+        var ivyTargetsItem = noneElements.FirstOrDefault(e => e.Attribute("Include")?.Value == "Build/Ivy.targets");
+        Assert.NotNull(ivyTargetsItem);
+        Assert.Equal("true", ivyTargetsItem.Attribute("Pack")?.Value);
+        Assert.Equal("build", ivyTargetsItem.Attribute("PackagePath")?.Value);
+
+        var externalWidgetTargetsItem = noneElements.FirstOrDefault(e => e.Attribute("Include")?.Value == "Build/Ivy.ExternalWidget.targets");
+        Assert.NotNull(externalWidgetTargetsItem);
+        Assert.Equal("true", externalWidgetTargetsItem.Attribute("Pack")?.Value);
+        Assert.Equal("build", externalWidgetTargetsItem.Attribute("PackagePath")?.Value);
+    }
+
+    [Fact]
+    public void IvyExternalWidgetTargetsUsesForwardSlashesAndGuardsDistResources()
+    {
+        var externalWidgetTargets = Path.Combine(SrcDirectory, "Ivy", "Build", "Ivy.ExternalWidget.targets");
+        var content = File.ReadAllText(externalWidgetTargets);
+
+        Assert.DoesNotContain("frontend\\", content);
+
+        var doc = XDocument.Load(externalWidgetTargets);
+        var distTarget = doc.Descendants()
+            .FirstOrDefault(e => e.Name.LocalName == "Target" && e.Attribute("Name")?.Value == "IncludeFrontendDistResources");
+
+        Assert.NotNull(distTarget);
+        Assert.Equal("Exists('frontend/package.json')", distTarget.Attribute("Condition")?.Value);
+    }
+}

--- a/src/Ivy/Build/Ivy.ExternalWidget.targets
+++ b/src/Ivy/Build/Ivy.ExternalWidget.targets
@@ -1,11 +1,11 @@
 <Project>
   <!-- Frontend source files for incremental build detection -->
   <ItemGroup Condition="Exists('frontend/package.json')">
-    <FrontendSourceFiles Include="frontend\src\**\*" />
-    <FrontendSourceFiles Include="frontend\package.json" />
-    <FrontendSourceFiles Include="frontend\pnpm-lock.yaml" Condition="Exists('frontend\pnpm-lock.yaml')" />
-    <FrontendSourceFiles Include="frontend\tsconfig.json" Condition="Exists('frontend\tsconfig.json')" />
-    <FrontendSourceFiles Include="frontend\vite.config.*" Condition="Exists('frontend\vite.config.ts') Or Exists('frontend\vite.config.js')" />
+    <FrontendSourceFiles Include="frontend/src/**/*" />
+    <FrontendSourceFiles Include="frontend/package.json" />
+    <FrontendSourceFiles Include="frontend/pnpm-lock.yaml" Condition="Exists('frontend/pnpm-lock.yaml')" />
+    <FrontendSourceFiles Include="frontend/tsconfig.json" Condition="Exists('frontend/tsconfig.json')" />
+    <FrontendSourceFiles Include="frontend/vite.config.*" Condition="Exists('frontend/vite.config.ts') Or Exists('frontend/vite.config.js')" />
   </ItemGroup>
 
   <PropertyGroup>
@@ -13,22 +13,22 @@
   </PropertyGroup>
 
   <Target Name="NpmInstall" BeforeTargets="BuildFrontend" Condition="Exists('frontend/package.json')"
-          Inputs="frontend\package.json;frontend\pnpm-lock.yaml"
-          Outputs="frontend\node_modules\.package-lock.json">
+          Inputs="frontend/package.json;frontend/pnpm-lock.yaml"
+          Outputs="frontend/node_modules/.package-lock.json">
     <Exec Command="vp install -- --config.confirmModulesPurge=false" WorkingDirectory="frontend" EnvironmentVariables="CI=$(CI)" />
   </Target>
 
   <Target Name="BuildFrontend" BeforeTargets="AssignTargetPaths" Condition="Exists('frontend/package.json')"
           Inputs="@(FrontendSourceFiles)"
-          Outputs="frontend\dist\.build-stamp">
+          Outputs="frontend/dist/.build-stamp">
     <Exec Command="vp build" WorkingDirectory="frontend" EnvironmentVariables="CI=$(CI)" />
-    <Touch Files="frontend\dist\.build-stamp" AlwaysCreate="true" />
+    <Touch Files="frontend/dist/.build-stamp" AlwaysCreate="true" />
   </Target>
 
   <!-- Add frontend dist as embedded resources AFTER BuildFrontend but BEFORE AssignTargetPaths/SplitResourcesByCulture -->
-  <Target Name="IncludeFrontendDistResources" BeforeTargets="AssignTargetPaths" DependsOnTargets="BuildFrontend">
+  <Target Name="IncludeFrontendDistResources" BeforeTargets="AssignTargetPaths" DependsOnTargets="BuildFrontend" Condition="Exists('frontend/package.json')">
     <ItemGroup>
-      <EmbeddedResource Include="frontend\dist\**\*" Exclude="frontend\dist\.build-stamp" />
+      <EmbeddedResource Include="frontend/dist/**/*" Exclude="frontend/dist/.build-stamp" />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/Ivy/Build/Ivy.targets
+++ b/src/Ivy/Build/Ivy.targets
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="$(MSBuildThisFileDirectory)Ivy.ExternalWidget.targets" Condition="'$(IvyEnableExternalWidgets)' != 'false'" />
+</Project>

--- a/src/Ivy/Ivy.csproj
+++ b/src/Ivy/Ivy.csproj
@@ -46,6 +46,11 @@
     <None Include="../Ivy.Docs.Shared/Docs/**/*.md" Pack="true" PackagePath="docs/generated" Visible="false" />
     <EmbeddedResource Include="../frontend/src/routing-constants.json" LogicalName="RoutingConstants" Visible="false" />
   </ItemGroup>
+
+  <ItemGroup>
+    <None Include="Build/Ivy.targets" Pack="true" PackagePath="build" />
+    <None Include="Build/Ivy.ExternalWidget.targets" Pack="true" PackagePath="build" />
+  </ItemGroup>
   
   <!--
     External widgets live under Widgets/External/<Name>/ and compile into Ivy.dll.


### PR DESCRIPTION
# Summary

## Changes

Packed `Ivy.ExternalWidget.targets` and a new `Ivy.targets` into the `Ivy` NuGet package under the `build/` directory so external widget projects referencing `Ivy` automatically import the frontend build and embedded resource pipeline. Updated documentation and added automated unit tests verifying the build target definitions and NuGet packaging metadata.

## API Changes

None.

## Files Modified

- `src/Ivy/Build/Ivy.targets` - Standard NuGet entry point importing `Ivy.ExternalWidget.targets` conditioned on `$(IvyEnableExternalWidgets)`.
- `src/Ivy/Build/Ivy.ExternalWidget.targets` - Normalized target inputs/outputs to forward slashes and guarded resource inclusion with `frontend/package.json` check.
- `src/Ivy/Ivy.csproj` - Added `None` packaging items targeting package directory `build`.
- `src/Ivy.Docs.Shared/Docs/02_Widgets/07_Advanced/05_ExternalWidgets.md` - Updated instructions from manual copying to automatic package import.
- `src/Ivy.Test/Widgets/External/ExternalWidgetBuildTargetsTests.cs` - Unit test suite validating XML structure, import definitions, and packaging configuration.

## Manual Testing

1. Pack the `Ivy` NuGet package:
   ```bash
   dotnet pack src/Ivy/Ivy.csproj --configuration Release --output ./nupkg /p:Version=99.0.0
   ```
2. Inspect the contents of the generated `.nupkg`:
   ```bash
   unzip -l ./nupkg/Ivy.99.0.0.nupkg | grep -E "build/Ivy(\.ExternalWidget)?\.targets"
   ```
3. Observe that both `build/Ivy.targets` and `build/Ivy.ExternalWidget.targets` are present in the package archive.

---
- a7981e8fb Add unit tests for external widget build targets and package configuration (Plan 00155)
- 0aa156ced Update external widget package documentation for automatic targets import (Plan 00155)
- 186f47b87 Pack external widget targets in Ivy NuGet package (Plan 00155)

---
Created using [Ivy Tendril](https://ivy.app).
