### PR TITLE
[00170] Pass CancellationToken to Async Operations in Filter Eval Console

### DIFF
--- a/src/Ivy.Agent.Filter.Eval.Console/ModelCostService.cs
+++ b/src/Ivy.Agent.Filter.Eval.Console/ModelCostService.cs
@@ -13,10 +13,12 @@ public class ModelCostService
         _httpClient = httpClient;
     }
 
-    public async Task<bool> LoadModelCostsFromLiteLLMAsync(string apiKey)
+    public async Task<bool> LoadModelCostsFromLiteLLMAsync(string apiKey, CancellationToken cancellationToken = default)
     {
         try
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             if (string.IsNullOrEmpty(apiKey))
             {
                 return false;
@@ -26,13 +28,13 @@ public class ModelCostService
             _httpClient.DefaultRequestHeaders.Add("accept", "application/json");
             _httpClient.DefaultRequestHeaders.Add("x-litellm-api-key", apiKey);
 
-            var response = await _httpClient.GetAsync("https://llmproxy.ivy.app/model_group/info");
+            var response = await _httpClient.GetAsync("https://llmproxy.ivy.app/model_group/info", cancellationToken);
             if (!response.IsSuccessStatusCode)
             {
                 return false;
             }
 
-            var content = await response.Content.ReadAsStringAsync();
+            var content = await response.Content.ReadAsStringAsync(cancellationToken);
             var result = JsonSerializer.Deserialize<LiteLLMResponse>(content);
 
             if (result?.Data != null)
@@ -52,6 +54,10 @@ public class ModelCostService
             }
 
             return false;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch
         {

--- a/src/Ivy.Agent.Filter.Eval.Console/RunCommand.cs
+++ b/src/Ivy.Agent.Filter.Eval.Console/RunCommand.cs
@@ -50,7 +50,7 @@ public class RunCommand : AsyncCommand<RunCommand.Settings>
         // Initialize cost service
         var httpClient = new HttpClient();
         var costService = new ModelCostService(httpClient);
-        var costsLoaded = await costService.LoadModelCostsFromLiteLLMAsync(apiKey);
+        var costsLoaded = await costService.LoadModelCostsFromLiteLLMAsync(apiKey, cancellationToken);
 
         if (!costsLoaded)
         {
@@ -63,6 +63,7 @@ public class RunCommand : AsyncCommand<RunCommand.Settings>
         // Run tests for each model
         foreach (var modelName in testDoc.Models.Where(m => !string.IsNullOrWhiteSpace(m)))
         {
+            cancellationToken.ThrowIfCancellationRequested();
             AnsiConsole.MarkupLine($"\n[bold blue]Testing model:[/] {modelName}");
 
             var chatClient = CreateChatClient(modelName, apiKey, endpoint);
@@ -84,12 +85,14 @@ public class RunCommand : AsyncCommand<RunCommand.Settings>
             // Run all tests across all suites
             foreach (var suite in testDoc.Suites)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 AnsiConsole.MarkupLine($"  [dim]Running suite:[/] {suite.Name}");
 
                 foreach (var test in suite.Tests)
                 {
+                    cancellationToken.ThrowIfCancellationRequested();
                     var sw = Stopwatch.StartNew();
-                    var result = await agent.Parse(test.Filter, suite.Fields);
+                    var result = await agent.Parse(test.Filter, suite.Fields, cancellationToken);
                     sw.Stop();
 
                     var timeMs = sw.Elapsed.TotalMilliseconds;

--- a/src/Ivy.Agent.Filter.Tests/FilterParserAgentCancellationTests.cs
+++ b/src/Ivy.Agent.Filter.Tests/FilterParserAgentCancellationTests.cs
@@ -1,0 +1,94 @@
+using Microsoft.Extensions.AI;
+
+namespace Ivy.Agent.Filter.Tests;
+
+using ChatMessage = Microsoft.Extensions.AI.ChatMessage;
+using ChatRole = Microsoft.Extensions.AI.ChatRole;
+
+public class FilterParserAgentCancellationTests
+{
+    private readonly FieldMeta[] _testFields =
+    [
+        new FieldMeta("Name", "name", FieldType.Text),
+        new FieldMeta("Age", "age", FieldType.Number)
+    ];
+
+    [Fact]
+    public async Task Parse_PassesCancellationTokenToChatClient()
+    {
+        // Arrange
+        using var cts = new CancellationTokenSource();
+        var fakeClient = new FakeChatClient();
+        var agent = new FilterParserAgent(fakeClient);
+
+        // Act
+        var result = await agent.Parse("test filter", _testFields, cts.Token);
+
+        // Assert
+        Assert.Equal(cts.Token, fakeClient.LastCancellationToken);
+    }
+
+    [Fact]
+    public async Task Parse_WhenAlreadyCancelled_ThrowsOperationCanceledException()
+    {
+        // Arrange
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var fakeClient = new FakeChatClient();
+        var agent = new FilterParserAgent(fakeClient);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            agent.Parse("test filter", _testFields, cts.Token));
+    }
+
+    [Fact]
+    public async Task Parse_WhenChatClientThrowsOperationCanceledException_RethrowsException()
+    {
+        // Arrange
+        using var cts = new CancellationTokenSource();
+        var fakeClient = new FakeChatClient
+        {
+            Handler = (_, _, token) => throw new OperationCanceledException(token)
+        };
+        var agent = new FilterParserAgent(fakeClient);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            agent.Parse("test filter", _testFields, cts.Token));
+    }
+
+    private class FakeChatClient : IChatClient
+    {
+        public CancellationToken LastCancellationToken { get; private set; }
+        public Func<IEnumerable<ChatMessage>, ChatOptions?, CancellationToken, Task<ChatResponse>>? Handler { get; set; }
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> chatMessages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+        {
+            LastCancellationToken = cancellationToken;
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (Handler != null)
+            {
+                return Handler(chatMessages, options, cancellationToken);
+            }
+
+            return Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, "[Name] = \"Test\"")));
+        }
+
+        public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> chatMessages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+
+        public void Dispose() { }
+    }
+}

--- a/src/Ivy.Agent.Filter.Tests/Ivy.Agent.Filter.Tests.csproj
+++ b/src/Ivy.Agent.Filter.Tests/Ivy.Agent.Filter.Tests.csproj
@@ -30,6 +30,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Ivy\Ivy.csproj" />
+    <ProjectReference Include="..\Ivy.Agent.Filter.Eval.Console\Ivy.Agent.Filter.Eval.Console.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Ivy.Agent.Filter.Tests/ModelCostServiceCancellationTests.cs
+++ b/src/Ivy.Agent.Filter.Tests/ModelCostServiceCancellationTests.cs
@@ -1,0 +1,104 @@
+using System.Net;
+using Ivy.Agent.Filter.Eval.Console;
+
+namespace Ivy.Agent.Filter.Tests;
+
+public class ModelCostServiceCancellationTests
+{
+    [Fact]
+    public async Task LoadModelCostsFromLiteLLMAsync_PassesCancellationTokenToHttpCalls()
+    {
+        // Arrange
+        using var cts = new CancellationTokenSource();
+        var handlerInvoked = false;
+        var handler = new MockHttpMessageHandler
+        {
+            Handler = (_, token) =>
+            {
+                handlerInvoked = true;
+                // Verifies that the cancellation token passed to HttpClient is linked to cts
+                Assert.False(token.IsCancellationRequested);
+                cts.Cancel();
+                Assert.True(token.IsCancellationRequested);
+
+                var response = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("""
+                    {
+                        "data": [
+                            {
+                                "model_group": "gpt-4o",
+                                "input_cost_per_token": 0.000005,
+                                "output_cost_per_token": 0.000015
+                            }
+                        ]
+                    }
+                    """)
+                };
+                return Task.FromResult(response);
+            }
+        };
+
+        var httpClient = new HttpClient(handler);
+        var costService = new ModelCostService(httpClient);
+
+        // Act
+        var result = await costService.LoadModelCostsFromLiteLLMAsync("test-api-key", cts.Token);
+
+        // Assert
+        Assert.True(result);
+        Assert.True(handlerInvoked);
+        Assert.Equal(0.000020m, costService.CalculateCost("gpt-4o", 1, 1));
+    }
+
+    [Fact]
+    public async Task LoadModelCostsFromLiteLLMAsync_WhenAlreadyCancelled_ThrowsOperationCanceledException()
+    {
+        // Arrange
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var handler = new MockHttpMessageHandler();
+        var httpClient = new HttpClient(handler);
+        var costService = new ModelCostService(httpClient);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            costService.LoadModelCostsFromLiteLLMAsync("test-api-key", cts.Token));
+    }
+
+    [Fact]
+    public async Task LoadModelCostsFromLiteLLMAsync_WhenHttpThrowsOperationCanceledException_RethrowsException()
+    {
+        // Arrange
+        using var cts = new CancellationTokenSource();
+        var handler = new MockHttpMessageHandler
+        {
+            Handler = (_, token) => throw new OperationCanceledException(token)
+        };
+        var httpClient = new HttpClient(handler);
+        var costService = new ModelCostService(httpClient);
+
+        // Act & Assert
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            costService.LoadModelCostsFromLiteLLMAsync("test-api-key", cts.Token));
+    }
+
+    private class MockHttpMessageHandler : HttpMessageHandler
+    {
+        public Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>>? Handler { get; set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (Handler != null)
+            {
+                return Handler(request, cancellationToken);
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"data\": []}")
+            });
+        }
+    }
+}

--- a/src/Ivy/Agent/Filter/FilterParserAgent.cs
+++ b/src/Ivy/Agent/Filter/FilterParserAgent.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.AI;
+using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
 using YamlDotNet.Serialization;
 
@@ -16,7 +16,7 @@ public class FilterParserAgent(IChatClient chatClient, ILogger? logger = null)
     private readonly IChatClient _chatClient = chatClient
         .AsBuilder().UseFunctionInvocation().Build();
 
-    public async Task<FilterParseResult> Parse(string filterExpression, FieldMeta[] fields)
+    public async Task<FilterParseResult> Parse(string filterExpression, FieldMeta[] fields, CancellationToken cancellationToken = default)
     {
         var fieldsYaml = SerializeFieldsAsYaml(fields);
         var grammarContent = LoadGrammarFile();
@@ -64,11 +64,13 @@ public class FilterParserAgent(IChatClient chatClient, ILogger? logger = null)
         // Try up to MaxRetries times
         for (int attempt = 1; attempt <= MaxRetries; attempt++)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             logger?.LogDebug("Filter parsing attempt {Attempt}/{MaxRetries}", attempt, MaxRetries);
 
             try
             {
-                var completion = await _chatClient.GetResponseAsync(messages, chatOptions);
+                var completion = await _chatClient.GetResponseAsync(messages, chatOptions, cancellationToken);
 
                 // Track usage
                 if (completion.Usage != null)
@@ -141,6 +143,10 @@ public class FilterParserAgent(IChatClient chatClient, ILogger? logger = null)
                 messages.Add(new ChatMessage(ChatRole.User,
                     $"The filter expression failed to parse with these errors: {errors}\n" +
                     $"Please try again with a corrected expression."));
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
             }
             catch (Exception ex)
             {

--- a/src/Ivy/Views/DataTables/DataTableService.cs
+++ b/src/Ivy/Views/DataTables/DataTableService.cs
@@ -144,7 +144,7 @@ public class DataTableService(
                 .ToArray();
 
             var agent = new FilterParserAgent(chatClient, logger);
-            var agentResult = await agent.Parse(request.FilterExpression, fields);
+            var agentResult = await agent.Parse(request.FilterExpression, fields, context.CancellationToken);
 
             if (agentResult.HasErrors)
             {
@@ -158,6 +158,10 @@ public class DataTableService(
             };
         }
         catch (RpcException)
+        {
+            throw;
+        }
+        catch (OperationCanceledException)
         {
             throw;
         }


### PR DESCRIPTION
# Summary

## Changes

Added CancellationToken support and propagation across the Filter Eval Console and FilterParserAgent. Downstream HTTP calls in ModelCostService, model evaluation loops in RunCommand, and agent parsing operations in FilterParserAgent and DataTableService now promptly abort when cancellation is requested.

## API Changes

- Updated `ModelCostService.LoadModelCostsFromLiteLLMAsync`: added optional parameter `CancellationToken cancellationToken = default`.
- Updated `FilterParserAgent.Parse`: added optional parameter `CancellationToken cancellationToken = default`.

## Files Modified

- **Filter Eval Console**:
  - `src/Ivy.Agent.Filter.Eval.Console/ModelCostService.cs`: Accept and pass CancellationToken to HTTP client requests and rethrow OperationCanceledException.
  - `src/Ivy.Agent.Filter.Eval.Console/RunCommand.cs`: Pass cancellationToken to cost service and parser agent, and check ThrowIfCancellationRequested in evaluation loops.
- **Core Framework**:
  - `src/Ivy/Agent/Filter/FilterParserAgent.cs`: Accept CancellationToken in Parse, pass to chat client, check cancellation in retry loop, and preserve OperationCanceledException.
  - `src/Ivy/Views/DataTables/DataTableService.cs`: Pass context.CancellationToken to agent.Parse and rethrow OperationCanceledException.
- **Tests**:
  - `src/Ivy.Agent.Filter.Tests/FilterParserAgentCancellationTests.cs`: New tests verifying token forwarding and cancellation handling for FilterParserAgent.
  - `src/Ivy.Agent.Filter.Tests/ModelCostServiceCancellationTests.cs`: New tests verifying token forwarding and cancellation handling for ModelCostService.
  - `src/Ivy.Agent.Filter.Tests/Ivy.Agent.Filter.Tests.csproj`: Added project reference to Ivy.Agent.Filter.Eval.Console.

## Manual Testing

1. Run the test suite:
   ```bash
   dotnet test src/Ivy.Agent.Filter.Tests/Ivy.Agent.Filter.Tests.csproj
   ```
   Verify that all 168 tests pass including the new cancellation tests.
2. Launch the Filter Eval Console:
   ```bash
   dotnet run --project src/Ivy.Agent.Filter.Eval.Console/Ivy.Agent.Filter.Eval.Console.csproj -- run <path-to-test-file.yaml>
   ```
   Press `Ctrl+C` while tests are running.
3. Observe:
   The application terminates immediately instead of hanging or continuing through remaining tests and model suites.

---
- a152c857b Plan 00170: Pass CancellationToken to async operations in Filter Eval Console

---
Created using [Ivy Tendril](https://ivy.app).
