### PR TITLE
[00177] Fix Release and Publish NuGet Workflows

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -60,6 +60,9 @@ jobs:
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
+      - name: Build solution
+        run: dotnet build --configuration Release
+
       # Ivy contains the external widgets, the analyzer and Ivy.Plugin.Abstractions;
       # Ivy.Auth contains all eight auth providers.
       - name: Pack packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: write
     
     steps:
 
@@ -41,3 +42,9 @@ jobs:
           tag_name: v${{ github.event.inputs.version }}
           generate_release_notes: true
           make_latest: true
+
+      - name: Trigger publish-nuget workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run publish-nuget.yml -f version="${{ github.event.inputs.version }}"


### PR DESCRIPTION
# Summary

## Changes

Added an explicit Release build step prior to packing in `publish-nuget.yml` so that required analyzer binaries (`Ivy.Analyser.dll`) exist before NuGet packaging begins. Updated `release.yml` with `actions: write` permissions and added a workflow dispatch step to trigger `publish-nuget.yml` upon release creation.

## API Changes

None.

## Files Modified

- **Workflows**:
  - `.github/workflows/publish-nuget.yml`: Added `dotnet build --configuration Release` step before packing.
  - `.github/workflows/release.yml`: Added `actions: write` permission and GitHub CLI dispatch step for `publish-nuget.yml`.

## Manual Testing

N/A: internal CI/CD change with no runtime application behavior. Can be verified by reviewing workflow definitions and triggering workflow runs in GitHub Actions.

---
- b42f5d193 Fix release and publish NuGet workflows (00177)

---
Created using [Ivy Tendril](https://ivy.app).
