### PR TITLE
[00185] Guard the Retired Ivy.Plugin.Abstractions Package ID

### DIFF
--- a/.github/workflows/backend-checks-linux.yml
+++ b/.github/workflows/backend-checks-linux.yml
@@ -51,11 +51,13 @@ jobs:
       - name: Build solution
         run: dotnet build --configuration Release
 
-      # Plugin API compatibility check (runs EnablePackageValidation against baseline)
+      # Plugin API compatibility check (runs EnablePackageValidation against baseline).
+      # Ivy.Plugin.Abstractions sets IsPackable=false to protect its retired package ID, and
+      # package validation only runs when IsPackable is true, so this step re-enables it here.
       - name: Check plugin API compatibility
         run: |
           dotnet pack Ivy/Ivy.csproj --configuration Release --output ./nupkg /p:Version=99.0.0
-          dotnet pack Ivy.Plugin.Abstractions/Ivy.Plugin.Abstractions.csproj --configuration Release --output ./nupkg /p:Version=99.0.0
+          dotnet pack Ivy.Plugin.Abstractions/Ivy.Plugin.Abstractions.csproj --configuration Release --output ./nupkg /p:Version=99.0.0 /p:IsPackable=true
 
       # Run tests
       - name: Run tests

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -9,9 +9,11 @@ API compatibility is enforced in CI via `EnablePackageValidation`. If your chang
 surface, the pack step will fail. See "Handling intentional breaks" below.
 
 `Ivy.Plugin.Abstractions` is no longer published as its own NuGet package: its assembly ships
-inside `Ivy.nupkg` under `lib/net10.0/`. The project keeps its own `PackageValidationBaselineVersion`
-and is still packed in CI purely to run that API-compat check, so both projects below must be packed
-when regenerating suppressions.
+inside `Ivy.nupkg` under `lib/net10.0/`. The project sets `IsPackable=false` to protect this retired
+package ID from an incidental solution-wide `dotnet pack`, but keeps its own
+`PackageValidationBaselineVersion` and is still packed in CI purely to run that API-compat check, so
+both projects below must be packed when regenerating suppressions, and packing
+`Ivy.Plugin.Abstractions` for that purpose needs `/p:IsPackable=true`.
 
 Because `Ivy.csproj` sets `PrivateAssets="all"` on its reference to `Ivy.Plugin.Abstractions` (to avoid emitting an external package dependency), `Ivy.Plugin.Abstractions.dll` does not flow transitively through in-repo `ProjectReference` chains. Any in-repo project consuming types from the `Ivy.Plugins` namespace (e.g. plugin hosts, test suites, example apps) must include an explicit project reference:
 
@@ -93,7 +95,7 @@ If a breaking change is truly necessary:
 1. Regenerate `CompatibilitySuppressions.xml` by running pack with the suppression flag:
    ```bash
    GITHUB_ACTIONS=true dotnet pack src/Ivy/Ivy.csproj --configuration Release /p:ApiCompatGenerateSuppressionFile=true /p:Version=99.0.0
-   GITHUB_ACTIONS=true dotnet pack src/Ivy.Plugin.Abstractions/Ivy.Plugin.Abstractions.csproj --configuration Release /p:ApiCompatGenerateSuppressionFile=true /p:Version=99.0.0
+   GITHUB_ACTIONS=true dotnet pack src/Ivy.Plugin.Abstractions/Ivy.Plugin.Abstractions.csproj --configuration Release /p:ApiCompatGenerateSuppressionFile=true /p:Version=99.0.0 /p:IsPackable=true
    ```
    `GITHUB_ACTIONS=true` matches CI's `GenerateAssemblyInfo` behavior; `/p:Version=99.0.0` ensures
    the assembly version exceeds the baseline (required by CP0003). Only run for project(s) you changed.

--- a/src/Ivy.Plugin.Abstractions/Ivy.Plugin.Abstractions.csproj
+++ b/src/Ivy.Plugin.Abstractions/Ivy.Plugin.Abstractions.csproj
@@ -7,6 +7,16 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <NoWarn>CS1591;CS1573</NoWarn>
+    <!--
+      Retired package ID: the built assembly is packed into Ivy.nupkg under lib/net10.0
+      by the PackPluginAbstractions target in ../Ivy/Ivy.csproj. Not packable by default so
+      a solution-wide `dotnet pack` cannot rebuild and republish the retired ID. The NuGet
+      metadata below stays because the plugin API compatibility step in
+      .github/workflows/backend-checks-linux.yml packs this project with /p:IsPackable=true
+      to run EnablePackageValidation against the baseline (PackageValidationBaselineName
+      defaults to PackageId, so PackageId must remain).
+    -->
+    <IsPackable>false</IsPackable>
     <PackageId>Ivy.Plugin.Abstractions</PackageId>
     <Company>Ivy</Company>
     <Description>Abstractions for Ivy plugins</Description>


### PR DESCRIPTION
# Summary

## Changes

Set `IsPackable=false` on `Ivy.Plugin.Abstractions.csproj` so an incidental solution-wide
`dotnet pack` can no longer rebuild and republish this retired NuGet package ID (its content now
ships inside `Ivy.nupkg`). The one CI step and the one documented command that still need to pack
this project for the plugin API compatibility check were updated to pass `/p:IsPackable=true`,
preserving that gate exactly as-is. The plan's second premise — that two `InternalsVisibleTo`
entries in `Ivy.csproj` were stale — was investigated and found false (both resolve to live,
git-tracked test projects), so `Ivy.csproj` was left unchanged.

## API Changes

None. This is build/packaging metadata only — no public API surface changed.

## Files Modified

- `src/Ivy.Plugin.Abstractions/Ivy.Plugin.Abstractions.csproj` — added `<IsPackable>false</IsPackable>` with explanatory comment
- `.github/workflows/backend-checks-linux.yml` — plugin API compat pack step now passes `/p:IsPackable=true`
- `src/CLAUDE.md` — suppression-regeneration command updated with `/p:IsPackable=true`; prose extended to explain the new default

## Manual Testing

N/A — internal build/packaging change with no user-facing behavior. Verified via:
1. `dotnet build src/Ivy-Framework.slnx --configuration Release --warnaserror` succeeds with 0 warnings/errors.
2. `dotnet pack src/Ivy-Framework.slnx --configuration Release` no longer produces an `Ivy.Plugin.Abstractions.*.nupkg`.
3. `dotnet pack src/Ivy.Plugin.Abstractions/Ivy.Plugin.Abstractions.csproj /p:IsPackable=true` still runs `RunPackageValidation` and produces the package (needed for the CI compat gate).
4. `Ivy.99.0.0.nupkg` still embeds `lib/net10.0/Ivy.Plugin.Abstractions.dll`.


---
## Commits

- 678348a2f Guard the retired Ivy.Plugin.Abstractions package ID (Plan 00185)

---
Created using [Ivy Tendril](https://ivy.app).