### PR TITLE
[00233] Disable Setup VP Install Across GitHub Actions Workflows

### DIFF
--- a/.github/workflows/backend-checks-linux.yml
+++ b/.github/workflows/backend-checks-linux.yml
@@ -21,6 +21,8 @@ jobs:
 
       # Setup Node.js (needed for integrated frontend build in dotnet build)
       - uses: voidzero-dev/setup-vp@v1
+        with:
+          run-install: false
 
       # Setup Java (needed for ANTLR4)
       - name: Setup Java

--- a/.github/workflows/backend-checks-windows.yml
+++ b/.github/workflows/backend-checks-windows.yml
@@ -17,6 +17,8 @@ jobs:
 
       # Setup Node.js (needed for integrated frontend build in dotnet build)
       - uses: voidzero-dev/setup-vp@v1
+        with:
+          run-install: false
 
       # Setup Java (needed for ANTLR4)
       - name: Setup Java

--- a/.github/workflows/e2e-docs-tests.yml
+++ b/.github/workflows/e2e-docs-tests.yml
@@ -15,6 +15,8 @@
 
 #       # Setup Node.js (needed for integrated frontend build in dotnet build)
 #       - uses: voidzero-dev/setup-vp@v1
+#         with:
+#           run-install: false
 
 #       # Setup Java (needed for ANTLR4)
 #       - name: Setup Java

--- a/.github/workflows/e2e-samples-tests.yml
+++ b/.github/workflows/e2e-samples-tests.yml
@@ -15,6 +15,8 @@
 
 #       # Setup Node.js (needed for integrated frontend build in dotnet build)
 #       - uses: voidzero-dev/setup-vp@v1
+#         with:
+#           run-install: false
 
 #       # Setup Java (needed for ANTLR4)
 #       - name: Setup Java

--- a/.github/workflows/frontend-formatting-linting-checks.yml
+++ b/.github/workflows/frontend-formatting-linting-checks.yml
@@ -20,6 +20,8 @@ jobs:
 
       # Setup Node.js
       - uses: voidzero-dev/setup-vp@v1
+        with:
+          run-install: false
 
       - name: Install dependencies
         working-directory: ./src/frontend

--- a/.github/workflows/frontend-unit-tests.yml
+++ b/.github/workflows/frontend-unit-tests.yml
@@ -14,6 +14,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: voidzero-dev/setup-vp@v1
+        with:
+          run-install: false
 
       - name: Install dependencies
         working-directory: ./src/frontend

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -34,6 +34,8 @@ jobs:
 
       # Setup Node.js (needed for the frontend and external widget builds in dotnet pack)
       - uses: voidzero-dev/setup-vp@v1
+        with:
+          run-install: false
 
       # Setup Java (needed for ANTLR4)
       - name: Setup Java


### PR DESCRIPTION
# Summary

## Changes

Configured `run-install: false` for all active and commented invocations of `voidzero-dev/setup-vp@v1` across GitHub Actions workflows. This prevents `setup-vp` from attempting to run package installation in the repository root where no `package.json` file exists.

## API Changes

None.

## Files Modified

- GitHub Actions Workflows:
  - `.github/workflows/publish-nuget.yml` - added `with: run-install: false` to `setup-vp@v1` step
  - `.github/workflows/backend-checks-linux.yml` - added `with: run-install: false` to `setup-vp@v1` step
  - `.github/workflows/backend-checks-windows.yml` - added `with: run-install: false` to `setup-vp@v1` step
  - `.github/workflows/frontend-formatting-linting-checks.yml` - added `with: run-install: false` to `setup-vp@v1` step
  - `.github/workflows/frontend-unit-tests.yml` - added `with: run-install: false` to `setup-vp@v1` step
  - `.github/workflows/e2e-docs-tests.yml` - added commented `with: run-install: false` to commented `setup-vp@v1` step
  - `.github/workflows/e2e-samples-tests.yml` - added commented `with: run-install: false` to commented `setup-vp@v1` step

## Manual Testing

N/A - internal CI workflow configuration change with no user-facing behavior. Syntax verified with Ruby YAML parser and full .NET solution build and tests verified.

---
## Commits

- 05905773a Disable setup-vp root install across GitHub Actions workflows (Plan 00233)

---
Created using [Ivy Tendril](https://ivy.app).