### PR TITLE
[00382] Fix Link Navigation in Terminal Widget and Desktop Window

### DIFF
--- a/src/Ivy.Desktop/DesktopWindow.cs
+++ b/src/Ivy.Desktop/DesktopWindow.cs
@@ -430,23 +430,20 @@ public class DesktopWindow(Server server)
 
             if (!args.Cancel && Uri.TryCreate(e.Url, UriKind.Absolute, out var uri))
             {
-                if (uri.Scheme == "http" || uri.Scheme == "https")
+                if ((uri.Scheme == "http" || uri.Scheme == "https") && !IsInternalUrl(uri, server.Args.Port))
                 {
-                    if (uri.Host != "localhost" && uri.Host != "127.0.0.1")
+                    args.Cancel = true;
+                    try
                     {
-                        args.Cancel = true;
-                        try
+                        System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
                         {
-                            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
-                            {
-                                FileName = e.Url,
-                                UseShellExecute = true
-                            });
-                        }
-                        catch (Exception ex)
-                        {
-                            Console.Error.WriteLine($"[Ivy.Desktop] Failed to open external link: {ex.Message}");
-                        }
+                            FileName = e.Url,
+                            UseShellExecute = true
+                        });
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.Error.WriteLine($"[Ivy.Desktop] Failed to open external link: {ex.Message}");
                     }
                 }
             }
@@ -622,5 +619,14 @@ public class DesktopWindow(Server server)
         var logicalWidth = (int)Math.Round(width / scale, MidpointRounding.AwayFromZero);
         var logicalHeight = (int)Math.Round(height / scale, MidpointRounding.AwayFromZero);
         return (logicalWidth, logicalHeight);
+    }
+
+    internal static bool IsInternalUrl(Uri uri, int internalPort)
+    {
+        if (uri.Scheme != "http" && uri.Scheme != "https")
+            return false;
+
+        var isLoopback = uri.IsLoopback || uri.Host.Equals("localhost", StringComparison.OrdinalIgnoreCase);
+        return isLoopback && uri.Port == internalPort;
     }
 }

--- a/src/Ivy.Desktop/Ivy.Desktop.csproj
+++ b/src/Ivy.Desktop/Ivy.Desktop.csproj
@@ -26,6 +26,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Ivy.Test" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Ivy\Ivy.csproj" />
   </ItemGroup>
 

--- a/src/Ivy.Test/DesktopNavigationTests.cs
+++ b/src/Ivy.Test/DesktopNavigationTests.cs
@@ -1,0 +1,58 @@
+using Ivy.Desktop;
+
+namespace Ivy.Test;
+
+public class DesktopNavigationTests
+{
+    [Theory]
+    [InlineData("http://localhost:5000", 5000, true)]
+    [InlineData("http://localhost:5000/app/page", 5000, true)]
+    [InlineData("https://localhost:5001", 5001, true)]
+    [InlineData("http://127.0.0.1:5000", 5000, true)]
+    [InlineData("http://127.0.0.1:5000/some/route?query=1", 5000, true)]
+    [InlineData("https://127.0.0.1:8080", 8080, true)]
+    [InlineData("http://[::1]:5000", 5000, true)]
+    public void IsInternalUrl_LoopbackMatchingPort_ReturnsTrue(string url, int port, bool expected)
+    {
+        var uri = new Uri(url);
+        var result = DesktopWindow.IsInternalUrl(uri, port);
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("http://localhost:5173", 5000)]
+    [InlineData("http://localhost:3000", 5000)]
+    [InlineData("http://127.0.0.1:4200", 5000)]
+    [InlineData("http://localhost:8080", 5000)]
+    [InlineData("https://127.0.0.1:3000", 5001)]
+    public void IsInternalUrl_LoopbackDifferentPort_ReturnsFalse(string url, int internalPort)
+    {
+        var uri = new Uri(url);
+        var result = DesktopWindow.IsInternalUrl(uri, internalPort);
+        Assert.False(result);
+    }
+
+    [Theory]
+    [InlineData("https://github.com", 5000)]
+    [InlineData("https://github.com/Ivy-Interactive/Ivy", 5000)]
+    [InlineData("http://example.com", 5000)]
+    [InlineData("http://example.com:5000", 5000)]
+    public void IsInternalUrl_ExternalHosts_ReturnsFalse(string url, int internalPort)
+    {
+        var uri = new Uri(url);
+        var result = DesktopWindow.IsInternalUrl(uri, internalPort);
+        Assert.False(result);
+    }
+
+    [Theory]
+    [InlineData("file:///path/to/file.html", 5000)]
+    [InlineData("ws://localhost:5000", 5000)]
+    [InlineData("wss://localhost:5000", 5000)]
+    [InlineData("custom-scheme://localhost:5000", 5000)]
+    public void IsInternalUrl_NonHttpOrHttpsSchemes_ReturnsFalse(string url, int internalPort)
+    {
+        var uri = new Uri(url);
+        var result = DesktopWindow.IsInternalUrl(uri, internalPort);
+        Assert.False(result);
+    }
+}

--- a/src/Ivy.Test/Ivy.Test.csproj
+++ b/src/Ivy.Test/Ivy.Test.csproj
@@ -34,6 +34,7 @@
     <ProjectReference Include="../Ivy/Ivy.csproj" />
     <!-- Ivy ships this assembly inside its NuGet package, so in-repo consumers reference the project directly -->
     <ProjectReference Include="../Ivy.Plugin.Abstractions/Ivy.Plugin.Abstractions.csproj" />
+    <ProjectReference Include="../Ivy.Desktop/Ivy.Desktop.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Ivy/Widgets/External/Xterm/frontend/src/Terminal.tsx
+++ b/src/Ivy/Widgets/External/Xterm/frontend/src/Terminal.tsx
@@ -97,6 +97,8 @@ const mapCursorStyle = (style?: CursorStyle): "block" | "underline" | "bar" => {
   }
 };
 
+const isMac = typeof navigator !== "undefined" && /Mac|iPod|iPhone|iPad/.test(navigator.userAgent);
+
 export const Terminal: React.FC<TerminalProps> = ({
   id,
   width = "Full",
@@ -171,7 +173,7 @@ export const Terminal: React.FC<TerminalProps> = ({
       if (!isReadOnlyRef.current && typeof eventHandlerRef.current === "function") {
         try {
           eventHandlerRef.current("OnInput", id, [data]);
-        } catch { }
+        } catch {}
       }
     },
     [id],
@@ -182,7 +184,7 @@ export const Terminal: React.FC<TerminalProps> = ({
       if (eventsRef.current.includes("OnResize") && typeof eventHandlerRef.current === "function") {
         try {
           eventHandlerRef.current("OnResize", id, [{ cols: size.cols, rows: size.rows }]);
-        } catch { }
+        } catch {}
       }
     },
     [id],
@@ -190,8 +192,9 @@ export const Terminal: React.FC<TerminalProps> = ({
 
   const handleLinkClick = useCallback(
     (event: MouseEvent, uri: string) => {
-      // Only activate link if CTRL is held
-      if (!event.ctrlKey) return;
+      // Only activate link if modifier key is held (Ctrl, or Cmd on macOS)
+      const isModifierActive = event.ctrlKey || (isMac && event.metaKey);
+      if (!isModifierActive) return;
 
       if (
         eventsRef.current.includes("OnLinkClick") &&
@@ -269,7 +272,9 @@ export const Terminal: React.FC<TerminalProps> = ({
     if (background) {
       const bg = `var(--${background.toLowerCase()})`;
       container.style.setProperty("--background", bg);
-      const computedBg = getComputedStyle(container).getPropertyValue("--" + background.toLowerCase()).trim();
+      const computedBg = getComputedStyle(container)
+        .getPropertyValue("--" + background.toLowerCase())
+        .trim();
       if (computedBg) mergedTheme.background = computedBg;
     } else {
       container.style.setProperty("--background", mergedTheme.background || "#000000");
@@ -277,7 +282,9 @@ export const Terminal: React.FC<TerminalProps> = ({
     if (foreground) {
       const fg = `var(--${foreground.toLowerCase()})`;
       container.style.setProperty("--foreground", fg);
-      const computedFg = getComputedStyle(container).getPropertyValue("--" + foreground.toLowerCase()).trim();
+      const computedFg = getComputedStyle(container)
+        .getPropertyValue("--" + foreground.toLowerCase())
+        .trim();
       if (computedFg) mergedTheme.foreground = computedFg;
     } else {
       container.style.setProperty("--foreground", mergedTheme.foreground || "#d4d4d4");
@@ -321,7 +328,7 @@ export const Terminal: React.FC<TerminalProps> = ({
       box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
       border: 1px solid #e0e0e0;
     `;
-    tooltip.textContent = "Ctrl+Click to Follow Link";
+    tooltip.textContent = isMac ? "Cmd+Click to Follow Link" : "Ctrl+Click to Follow Link";
     document.body.appendChild(tooltip);
 
     // Load WebLinks addon with custom handler and hover


### PR DESCRIPTION
# Summary

## Changes

Fixed link navigation in the Terminal widget on macOS by recognizing Cmd+Click (metaKey) in addition to Ctrl+Click, and updating the link hover tooltip text to dynamically show "Cmd+Click to Follow Link" on macOS. Fixed DesktopWindow external URL navigation by identifying loopback URLs on non-internal ports (such as dev servers on ports 5173, 3000, 4200) as external links so they are opened in the default browser instead of intercepted by the desktop webview.

## API Changes

None. (Added `internal static bool IsInternalUrl(Uri uri, int internalPort)` in `Ivy.Desktop.DesktopWindow` with `InternalsVisibleTo` for `Ivy.Test`.)

## Files Modified

- **Terminal Widget Frontend**:
  - `src/Ivy/Widgets/External/Xterm/frontend/src/Terminal.tsx`: Added macOS platform detection, enabled metaKey modifier support on macOS for link clicks, and set dynamic tooltip shortcut text.
- **Desktop Window**:
  - `src/Ivy.Desktop/DesktopWindow.cs`: Added `IsInternalUrl` method and updated the `Navigating` handler to cancel and open in the external browser any HTTP/HTTPS links not matching the internal server port.
  - `src/Ivy.Desktop/Ivy.Desktop.csproj`: Added `InternalsVisibleTo` for `Ivy.Test`.
- **Tests**:
  - `src/Ivy.Test/Ivy.Test.csproj`: Added project reference to `Ivy.Desktop`.
  - `src/Ivy.Test/DesktopNavigationTests.cs`: Added unit tests verifying loopback matching ports, non-internal ports, external hosts, and non-HTTP schemes.

## Manual Testing

1. Run an Ivy desktop sample with external URL links or links to a local development server (e.g., `http://localhost:5173`).
2. Click a link pointing to `http://localhost:5173`: verify it launches in the external web browser rather than attempting to navigate the desktop webview.
3. Open a view with the Terminal widget on macOS, hover over a displayed URL, and verify the tooltip displays "Cmd+Click to Follow Link".
4. Cmd+Click the link in the terminal on macOS and verify the URL opens in a browser tab.

---
### Commits

- 55dfb3400 Handle external localhost URLs in DesktopWindow and add tests (00382)
- 707adae5e Fix link navigation on macOS in Terminal widget (00382)

---
Created using [Ivy Tendril](https://ivy.app).
