### PR TITLE
[00393] Remove Unused Ivy.Core Usings in Wireframe Widgets

### DIFF
--- a/src/Ivy/Widgets/Wireframe/WireframeMockup.cs
+++ b/src/Ivy/Widgets/Wireframe/WireframeMockup.cs
@@ -1,5 +1,3 @@
-using Ivy.Core;
-
 // ReSharper disable once CheckNamespace
 namespace Ivy;
 

--- a/src/Ivy/Widgets/Wireframe/WireframeTransform.cs
+++ b/src/Ivy/Widgets/Wireframe/WireframeTransform.cs
@@ -1,5 +1,3 @@
-using Ivy.Core;
-
 // ReSharper disable once CheckNamespace
 namespace Ivy;
 


### PR DESCRIPTION
# Summary

## Changes

Removed unused `using Ivy.Core;` directives from `WireframeMockup.cs` and `WireframeTransform.cs` that were causing `IDE0005` formatting errors in the Backend Checks (Linux and Windows) CI workflows. The CI gate had been failing since 2026-09-09 when PR 4789 was merged.

## API Changes

None.

## Files Modified

- `src/Ivy/Widgets/Wireframe/WireframeMockup.cs` - Removed unused using directive
- `src/Ivy/Widgets/Wireframe/WireframeTransform.cs` - Removed unused using directive

## Manual Testing

N/A — internal change with no user-facing behavior. The fix addresses a build-time code formatting issue that was blocking CI. The verifications confirm:
- `dotnet format --verify-no-changes` now passes (resolves the CI gate failure)
- Solution builds successfully with zero warnings/errors
- All unit tests pass

---

## Commits

- ca47d0a4d Remove unused Ivy.Core using directives from wireframe widgets

---
Created using [Ivy Tendril](https://ivy.app).
