### PR TITLE
[00396] Filter Multi Select Options While Typing and Highlight the Best Match

### DIFF
--- a/src/frontend/src/components/ui/multiselect.test.tsx
+++ b/src/frontend/src/components/ui/multiselect.test.tsx
@@ -25,11 +25,11 @@ function mount(element: React.ReactElement) {
 }
 
 function getCommandInput(): HTMLInputElement | null {
-  return document.body.querySelector('[cmdk-input]') as HTMLInputElement;
+  return document.body.querySelector("[cmdk-input]") as HTMLInputElement;
 }
 
 function getCommandItems(): HTMLElement[] {
-  return Array.from(document.body.querySelectorAll('[cmdk-item]'));
+  return Array.from(document.body.querySelectorAll("[cmdk-item]"));
 }
 
 function openPopover() {
@@ -44,7 +44,11 @@ function typeInInput(text: string) {
   const input = getCommandInput();
   if (!input) throw new Error("Command input not found");
   act(() => {
-    input.value = text;
+    const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+      window.HTMLInputElement.prototype,
+      "value",
+    )?.set;
+    nativeInputValueSetter?.call(input, text);
     input.dispatchEvent(new Event("input", { bubbles: true }));
   });
 }
@@ -116,7 +120,9 @@ describe("MultipleSelector filtering and highlighting", () => {
 
     const items = getCommandItems();
     expect(items).toHaveLength(1);
-    const highlighted = items[0].getAttribute("aria-selected") === "true" || items[0].getAttribute("data-selected") === "true";
+    const highlighted =
+      items[0].getAttribute("aria-selected") === "true" ||
+      items[0].getAttribute("data-selected") === "true";
     expect(highlighted).toBe(true);
   });
 

--- a/src/frontend/src/components/ui/multiselect.test.tsx
+++ b/src/frontend/src/components/ui/multiselect.test.tsx
@@ -1,0 +1,195 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { MultipleSelector, Option } from "./multiselect";
+import { EventHandlerProvider } from "@/components/event-handler";
+
+let container: HTMLDivElement;
+let root: Root;
+
+const testOptions: Option[] = [
+  { label: "rorychatt", value: "rorychatt" },
+  { label: "ArtemKhvorostianyi", value: "artem" },
+  { label: "pavel", value: "pavel" },
+  { label: "mikael", value: "mikael" },
+  { label: "john", value: "john" },
+  { label: "jane", value: "jane" },
+  { label: "alice", value: "alice" },
+  { label: "bob", value: "bob" },
+];
+
+function mount(element: React.ReactElement) {
+  act(() => {
+    root.render(<EventHandlerProvider eventHandler={() => {}}>{element}</EventHandlerProvider>);
+  });
+}
+
+function getCommandInput(): HTMLInputElement | null {
+  return document.body.querySelector('[cmdk-input]') as HTMLInputElement;
+}
+
+function getCommandItems(): HTMLElement[] {
+  return Array.from(document.body.querySelectorAll('[cmdk-item]'));
+}
+
+function openPopover() {
+  const input = getCommandInput();
+  if (!input) throw new Error("Command input not found");
+  act(() => {
+    input.focus();
+  });
+}
+
+function typeInInput(text: string) {
+  const input = getCommandInput();
+  if (!input) throw new Error("Command input not found");
+  act(() => {
+    input.value = text;
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+describe("MultipleSelector filtering and highlighting", () => {
+  it("renders all options when popover is opened with empty input", () => {
+    mount(
+      <MultipleSelector
+        value={[]}
+        defaultOptions={testOptions}
+        onValueChange={() => {}}
+        searchable={true}
+      />,
+    );
+
+    openPopover();
+
+    const items = getCommandItems();
+    expect(items).toHaveLength(8);
+  });
+
+  it("filters options by typed search term", () => {
+    mount(
+      <MultipleSelector
+        value={[]}
+        defaultOptions={testOptions}
+        onValueChange={() => {}}
+        searchable={true}
+      />,
+    );
+
+    openPopover();
+    typeInInput("ror");
+
+    const items = getCommandItems();
+    expect(items).toHaveLength(1);
+    expect(items[0].textContent).toContain("rorychatt");
+  });
+
+  it("highlights the first matching option when filtering", async () => {
+    mount(
+      <MultipleSelector
+        value={[]}
+        defaultOptions={testOptions}
+        onValueChange={() => {}}
+        searchable={true}
+      />,
+    );
+
+    openPopover();
+    typeInInput("ror");
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    });
+
+    const items = getCommandItems();
+    expect(items).toHaveLength(1);
+    const highlighted = items[0].getAttribute("aria-selected") === "true" || items[0].getAttribute("data-selected") === "true";
+    expect(highlighted).toBe(true);
+  });
+
+  it("renders all options when searchable is false", () => {
+    mount(
+      <MultipleSelector
+        value={[]}
+        defaultOptions={testOptions}
+        onValueChange={() => {}}
+        searchable={false}
+      />,
+    );
+
+    openPopover();
+    typeInInput("ror");
+
+    const items = getCommandItems();
+    expect(items).toHaveLength(8);
+  });
+
+  it("shows no matches message when search yields no results", () => {
+    mount(
+      <MultipleSelector
+        value={[]}
+        defaultOptions={testOptions}
+        onValueChange={() => {}}
+        searchable={true}
+      />,
+    );
+
+    openPopover();
+    typeInInput("xyz123notfound");
+
+    const items = getCommandItems();
+    expect(items).toHaveLength(0);
+
+    const noMatchesText = document.body.textContent;
+    expect(noMatchesText).toContain("No matches");
+  });
+
+  it("respects searchMode CaseSensitive", () => {
+    mount(
+      <MultipleSelector
+        value={[]}
+        defaultOptions={testOptions}
+        onValueChange={() => {}}
+        searchable={true}
+        searchMode="CaseSensitive"
+      />,
+    );
+
+    openPopover();
+    typeInInput("ROR");
+
+    const items = getCommandItems();
+    expect(items).toHaveLength(0);
+  });
+
+  it("shows custom emptyIndicator when provided", () => {
+    mount(
+      <MultipleSelector
+        value={[]}
+        defaultOptions={testOptions}
+        onValueChange={() => {}}
+        searchable={true}
+        emptyIndicator={<span>Custom empty message</span>}
+      />,
+    );
+
+    openPopover();
+    typeInInput("xyz123notfound");
+
+    const emptyText = document.body.textContent;
+    expect(emptyText).toContain("Custom empty message");
+  });
+});

--- a/src/frontend/src/components/ui/multiselect.tsx
+++ b/src/frontend/src/components/ui/multiselect.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { X, ChevronDown } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import { Command, CommandGroup, CommandItem } from "@/components/ui/command";
+import { Command, CommandGroup, CommandItem, CommandList } from "@/components/ui/command";
 import { Command as CommandPrimitive } from "cmdk";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover";
@@ -10,6 +10,8 @@ import {
   computeClearAllValues,
   computeSelectAllValues,
   filterOptionsLikeCmdk,
+  filterOptionsBySearch,
+  SelectSearchMode,
 } from "@/widgets/inputs/select-utils";
 import { cva } from "class-variance-authority";
 import { Densities } from "@/types/density";
@@ -78,6 +80,8 @@ interface MultipleSelectorProps {
   onNullableClear?: () => void;
   autoFocus?: boolean;
   rightSlot?: React.ReactNode;
+  searchable?: boolean | null;
+  searchMode?: SelectSearchMode;
 }
 
 const MultipleSelector = React.forwardRef<
@@ -107,6 +111,8 @@ const MultipleSelector = React.forwardRef<
       onNullableClear,
       autoFocus = false,
       rightSlot,
+      searchable,
+      searchMode = "CaseInsensitive",
     },
     ref,
   ) => {
@@ -284,6 +290,15 @@ const MultipleSelector = React.forwardRef<
       }));
       return filterOptionsLikeCmdk(labeled, inputValue);
     }, [defaultOptions, inputValue]);
+
+    const filterEnabled = searchable !== false;
+    const visibleOptions = React.useMemo(
+      () =>
+        filterEnabled
+          ? filterOptionsBySearch(defaultOptions, inputValue, searchMode)
+          : defaultOptions,
+      [defaultOptions, inputValue, filterEnabled, searchMode],
+    );
 
     const visibleEnabledForBulk = React.useMemo(() => {
       const set = new Set(filteredForBulk.map((f) => f.value));
@@ -528,65 +543,78 @@ const MultipleSelector = React.forwardRef<
           >
             {defaultOptions.length > 0 ? (
               <>
-                <CommandGroup
-                  className="h-full overflow-auto slim-scrollbar"
+                <CommandList
+                  className="h-full overflow-auto slim-scrollbar max-h-none"
                   style={{ maxHeight: "min(300px, var(--radix-popover-content-available-height))" }}
                 >
-                  {defaultOptions.map((option) => {
-                    const selected = isSelected(option);
-                    return (
-                      <CommandItem
-                        key={option.value}
-                        onMouseDown={(e) => {
-                          e.preventDefault();
-                          e.stopPropagation();
-                        }}
-                        onSelect={() => {
-                          setInputValue("");
-                          toggleOption(option);
-                        }}
-                        className={cn(
-                          menuItemVariant({ density }),
-                          "flex items-center justify-between",
-                        )}
-                        disabled={option.disable}
-                      >
-                        {option.tooltip ? (
-                          <TooltipProvider>
-                            <Tooltip delayDuration={300}>
-                              <TooltipTrigger asChild>
-                                <div className="flex items-center justify-between w-full">
-                                  <span>{option.label}</span>
-                                  {selected && (
-                                    <X
-                                      className={cn(
-                                        xIconVariant({ density }),
-                                        "text-muted-foreground hover:text-foreground",
-                                      )}
-                                    />
-                                  )}
-                                </div>
-                              </TooltipTrigger>
-                              <TooltipContent>{option.tooltip}</TooltipContent>
-                            </Tooltip>
-                          </TooltipProvider>
-                        ) : (
-                          <>
-                            <span>{option.label}</span>
-                            {selected && (
-                              <X
-                                className={cn(
-                                  xIconVariant({ density }),
-                                  "text-muted-foreground hover:text-foreground",
-                                )}
-                              />
+                  <CommandGroup>
+                    {visibleOptions.length > 0 ? (
+                      visibleOptions.map((option) => {
+                        const selected = isSelected(option);
+                        return (
+                          <CommandItem
+                            key={option.value}
+                            value={option.value}
+                            onMouseDown={(e) => {
+                              e.preventDefault();
+                              e.stopPropagation();
+                            }}
+                            onSelect={() => {
+                              setInputValue("");
+                              toggleOption(option);
+                            }}
+                            className={cn(
+                              menuItemVariant({ density }),
+                              "flex items-center justify-between",
                             )}
-                          </>
-                        )}
-                      </CommandItem>
-                    );
-                  })}
-                </CommandGroup>
+                            disabled={option.disable}
+                          >
+                            {option.tooltip ? (
+                              <TooltipProvider>
+                                <Tooltip delayDuration={300}>
+                                  <TooltipTrigger asChild>
+                                    <div className="flex items-center justify-between w-full">
+                                      <span>{option.label}</span>
+                                      {selected && (
+                                        <X
+                                          className={cn(
+                                            xIconVariant({ density }),
+                                            "text-muted-foreground hover:text-foreground",
+                                          )}
+                                        />
+                                      )}
+                                    </div>
+                                  </TooltipTrigger>
+                                  <TooltipContent>{option.tooltip}</TooltipContent>
+                                </Tooltip>
+                              </TooltipProvider>
+                            ) : (
+                              <>
+                                <span>{option.label}</span>
+                                {selected && (
+                                  <X
+                                    className={cn(
+                                      xIconVariant({ density }),
+                                      "text-muted-foreground hover:text-foreground",
+                                    )}
+                                  />
+                                )}
+                              </>
+                            )}
+                          </CommandItem>
+                        );
+                      })
+                    ) : emptyIndicator ? (
+                      <div className="px-2 py-3 text-sm text-muted-foreground text-center">
+                        {emptyIndicator}
+                      </div>
+                    ) : (
+                      <div className="px-2 py-3 text-sm text-muted-foreground text-center">
+                        No matches
+                      </div>
+                    )}
+                  </CommandGroup>
+                </CommandList>
                 {showActions && (
                   <div
                     className="border-t border-border p-2 flex justify-between items-center gap-2 text-sm shrink-0"

--- a/src/frontend/src/widgets/inputs/SelectMultiVariant.tsx
+++ b/src/frontend/src/widgets/inputs/SelectMultiVariant.tsx
@@ -34,6 +34,9 @@ export const SelectMultiVariant: React.FC<SelectInputWidgetProps> = ({
   ghost = false,
   showActions = false,
   nullable = false,
+  searchable,
+  searchMode = "CaseInsensitive",
+  emptyMessage,
   density,
   "data-testid": dataTestId,
   width,
@@ -213,6 +216,9 @@ export const SelectMultiVariant: React.FC<SelectInputWidgetProps> = ({
       showActions={showActions && selectMany}
       maxSelections={maxSelections}
       minSelections={minSelections}
+      searchable={searchable}
+      searchMode={searchMode}
+      emptyIndicator={emptyMessage}
       onNullableClear={
         nullable
           ? () => {

--- a/src/frontend/src/widgets/inputs/__tests__/selectUtils.test.ts
+++ b/src/frontend/src/widgets/inputs/__tests__/selectUtils.test.ts
@@ -3,6 +3,7 @@ import {
   computeSelectAllValues,
   computeClearAllValues,
   convertValuesToOriginalType,
+  filterOptionsBySearch,
 } from "../select-utils";
 
 // ---------------------------------------------------------------------------
@@ -155,5 +156,79 @@ describe("convertValuesToOriginalType", () => {
   it("returns empty array for empty stringValues with undefined original (selectMany)", () => {
     const result = convertValuesToOriginalType([], undefined, stringOptions, true);
     expect(result).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// filterOptionsBySearch
+// ---------------------------------------------------------------------------
+
+describe("filterOptionsBySearch", () => {
+  const options = [
+    { label: "rorychatt", value: "rorychatt" },
+    { label: "ArtemKhvorostianyi", value: "artem" },
+    { label: "pavel", value: "pavel" },
+    { label: "mikael", value: "mikael" },
+  ];
+
+  it("returns all options when search term is empty", () => {
+    const result = filterOptionsBySearch(options, "");
+    expect(result).toEqual(options);
+    expect(result).toBe(options);
+  });
+
+  it("filters case insensitively by default", () => {
+    const result = filterOptionsBySearch(options, "ror");
+    expect(result).toHaveLength(1);
+    expect(result[0].label).toBe("rorychatt");
+  });
+
+  it("matches uppercase search term case insensitively", () => {
+    const result = filterOptionsBySearch(options, "ROR");
+    expect(result).toHaveLength(1);
+    expect(result[0].label).toBe("rorychatt");
+  });
+
+  it("matches with CaseSensitive mode", () => {
+    const result = filterOptionsBySearch(options, "Artem", "CaseSensitive");
+    expect(result).toHaveLength(1);
+    expect(result[0].label).toBe("ArtemKhvorostianyi");
+  });
+
+  it("rejects mismatched case with CaseSensitive mode", () => {
+    const result = filterOptionsBySearch(options, "artem", "CaseSensitive");
+    expect(result).toHaveLength(0);
+  });
+
+  it("matches non-contiguous subsequence with Fuzzy mode", () => {
+    const result = filterOptionsBySearch(options, "akv", "Fuzzy");
+    expect(result).toHaveLength(1);
+    expect(result[0].label).toBe("ArtemKhvorostianyi");
+  });
+
+  it("rejects out-of-order term with Fuzzy mode", () => {
+    const result = filterOptionsBySearch(options, "vka", "Fuzzy");
+    expect(result).toHaveLength(0);
+  });
+
+  it("returns empty array when no options match", () => {
+    const result = filterOptionsBySearch(options, "xyz");
+    expect(result).toEqual([]);
+  });
+
+  it("falls back to value when label is missing", () => {
+    const optionsNoLabel = [
+      { value: "rorychatt" },
+      { value: "artem" },
+    ];
+    const result = filterOptionsBySearch(optionsNoLabel, "ror");
+    expect(result).toHaveLength(1);
+    expect(result[0].value).toBe("rorychatt");
+  });
+
+  it("matches substring in the middle of label", () => {
+    const result = filterOptionsBySearch(options, "khvo");
+    expect(result).toHaveLength(1);
+    expect(result[0].label).toBe("ArtemKhvorostianyi");
   });
 });

--- a/src/frontend/src/widgets/inputs/select-utils.ts
+++ b/src/frontend/src/widgets/inputs/select-utils.ts
@@ -13,6 +13,31 @@ export function filterOptionsLikeCmdk(
   return options.filter((o) => defaultFilter(o.label, term, []) > 0);
 }
 
+export type SelectSearchMode = "CaseInsensitive" | "CaseSensitive" | "Fuzzy";
+
+/** Filter options by a typed search term, matching on label. Empty term returns the input unchanged. */
+export function filterOptionsBySearch<T extends { label?: string; value: unknown }>(
+  options: T[],
+  search: string,
+  mode: SelectSearchMode = "CaseInsensitive",
+): T[] {
+  if (!search) return options;
+  const caseSensitive = mode === "CaseSensitive";
+  const term = caseSensitive ? search : search.toLowerCase();
+  return options.filter((option) => {
+    const raw = option.label ?? String(option.value ?? "");
+    const label = caseSensitive ? raw : raw.toLowerCase();
+    if (mode === "Fuzzy") {
+      let i = 0;
+      for (let j = 0; i < term.length && j < label.length; j++) {
+        if (term[i] === label[j]) i++;
+      }
+      return i === term.length;
+    }
+    return label.includes(term);
+  });
+}
+
 /** Merge current selection with all enabled options in `visibleOptions`, preserving selections outside that set; cap with `maxSelections`. */
 export function computeSelectAllValues(
   selectedValues: (string | number)[],


### PR DESCRIPTION
# Summary

## Changes

Added searchable filtering and keyboard navigation to Ivy's multi-select widget. Users can now type to filter options in real-time, and the first matching option is automatically highlighted for quick selection with Enter. The feature is opt-in via the existing `Searchable(true)` fluent API.

## API Changes

**`SelectInputWidgetProps` (already existed, now honored in multi-select):**
- `searchable?: boolean | null` — When true (default), typing filters the option list. When false, shows all options regardless of input.
- `searchMode?: "CaseInsensitive" | "CaseSensitive" | "Fuzzy"` — Defaults to `"CaseInsensitive"`. Controls how typed text matches against option labels.
- `emptyMessage?: string` — Custom message shown when no options match the filter.

**New exports from `select-utils.ts`:**
- `SelectSearchMode` type — Union type for the three search modes.
- `filterOptionsBySearch<T>(options: T[], search: string, mode?: SelectSearchMode): T[]` — Filters options by search term with configurable matching logic. Falls back to option.value when label is missing.

**Behavior changes:**
- Multi-select now filters options while typing (previously showed all options unfiltered).
- First matching option is highlighted and can be selected with Enter (previously Enter did nothing).
- Arrow keys now navigate the filtered list (previously had no effect).

## Files Modified

**Frontend TypeScript:**
- `src/frontend/src/widgets/inputs/select-utils.ts` — Added `SelectSearchMode` type and `filterOptionsBySearch` function
- `src/frontend/src/widgets/inputs/SelectMultiVariant.tsx` — Pass `searchable`, `searchMode`, and `emptyMessage` through to `MultipleSelector`
- `src/frontend/src/components/ui/multiselect.tsx` — Filter rendered options based on `searchable` prop and `inputValue`; wrap list in `CommandList` for keyboard navigation; add explicit `value` prop to each `CommandItem`
- `src/frontend/src/widgets/inputs/__tests__/selectUtils.test.ts` — Added 10 test cases for `filterOptionsBySearch`
- `src/frontend/src/components/ui/multiselect.test.tsx` — New file with 7 test cases covering filtering, highlighting, and search modes

## Manual Testing

1. **Launch the Ivy Samples app** — Run `dotnet run --project src/Ivy.Samples/Ivy.Samples.csproj --browse --find-available-port`
2. **Navigate to Select Input samples** — Open the Widgets > Inputs > Select Input page
3. **Find a multi-select example** — Look for a select input with `SelectMany = true`
4. **Test filtering:**
   - Click into the multi-select to open the dropdown
   - Type a few characters (e.g., "ar" if the options include names)
   - Verify the option list narrows to show only matching options
   - Verify the first match is highlighted (different background color)
5. **Test keyboard navigation:**
   - Press `ArrowDown` or `ArrowUp` to move the highlight
   - Press `Enter` to add the highlighted option
   - Verify the selected badge appears in the input
6. **Test `searchable={false}` behavior:**
   - If there's an example with `Searchable(false)`, type in it
   - Verify all options remain visible (no filtering)
7. **Test edge cases:**
   - Type a term that matches nothing — verify "No matches" appears
   - Backspace on an empty input — verify the last badge is removed
   - Type to filter, then click away — verify the filter is cleared when reopening

---

**Commits:**
- e0eba8f77 Fix multiselect tests to properly trigger React controlled input
- 771fc82d9 Filter multi select options while typing and highlight the best match

---
Created using [Ivy Tendril](https://ivy.app).