### PR TITLE
[00404] Confine the Local File Endpoint and Scope the Default CORS Policy

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/01_Program.md
+++ b/src/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/01_Program.md
@@ -62,6 +62,9 @@ var server = new Server(new ServerArgs
 | `Browse` | `bool` | `false` | Automatically open browser on startup |
 | `Silent` | `bool` | `false` | Suppress startup messages |
 | `DefaultAppId` | `string?` | `null` | Set the default app to load |
+| `LocalFileRoots` | `string[]` | `[]` | Directories `GET /ivy/local-file` may serve from. Empty means any readable file on the machine. |
+| `LocalFileExtensions` | `string[]` | `[]` | File extensions `GET /ivy/local-file` may serve. Empty means any extension. |
+| `AllowedCorsOrigins` | `string[]` | `[]` | Cross-origin origins the default CORS policy reflects. Empty allows loopback origins only, and only when the server binds loopback. |
 | `Metadata.Title` | `string?` | `null` | HTML meta title |
 | `Metadata.Description` | `string?` | `null` | HTML meta description |
 | `Metadata.GitHubUrl` | `string?` | `null` | GitHub repository URL meta tag |
@@ -170,6 +173,7 @@ The server automatically reads configuration from environment variables:
 - `BASE_PATH` - Serve the app from a URL prefix
 - `VERBOSE` - Enable verbose logging
 - `IVY_TLS` - Control whether the server uses HTTPS (`true`, `1`, `yes`, `on`) or HTTP (`false`, `0`, `no`, `off`). When unset, Ivy defaults to HTTPS for local development and HTTP in containers or hosted environments (where a reverse proxy typically handles TLS).
+- `IVY_CORS_ORIGINS` - Comma- or semicolon-separated list of origins the default CORS policy allows (for example `https://app.example.com,https://admin.example.com`). Applied only when `AllowedCorsOrigins` is empty.
 
 When `BasePath` is set (via `ServerArgs`, CLI, or environment variable), Ivy applies ASP.NET Core `UsePathBase()` middleware to ensure routing and link generation work correctly under that prefix.
 
@@ -195,6 +199,46 @@ Enable HTTPS redirection for production:
 server.UseHttpRedirection();
 #endif
 ```
+
+### Local File Access
+
+`server.DangerouslyAllowLocalFiles()` enables the `/ivy/local-file` proxy endpoint that `Markdown` and
+`Image` use to render files from disk. The no-argument form serves **any readable file on the machine**,
+so pass the directories you actually need and Ivy answers 404 for everything outside them:
+
+```csharp
+server.DangerouslyAllowLocalFiles("C:/Users/me/Photos", "D:/Screenshots");
+```
+
+Narrow it further with an extension allowlist. Anything else — including an extensionless path — answers 404:
+
+```csharp
+server.AllowLocalFileExtensions(".png", ".jpg", ".webp");
+```
+
+Both are additive, so repeated calls extend the sets. Every rejection is a 404 rather than a 403, so the
+endpoint never reveals whether a path exists.
+
+### CORS and Host Filtering
+
+Ivy serves its own frontend, so browsers reach the hub and the controllers same-origin and never consult
+CORS. The default policy reflects loopback origins (which is what keeps the Vite dev server working) and
+only when the server itself binds loopback — a container or hosted server that binds `*` allows nothing
+it has not been told about. Add a genuinely cross-origin consumer explicitly:
+
+```csharp
+server.AllowCorsOrigins("https://app.example.com");
+```
+
+CORS cannot stop DNS rebinding: a page on a hostname rebound to `127.0.0.1` is *same-origin* with the
+server, so no CORS check runs. Validating the `Host` header is what rejects it. This is opt-in, because
+reverse proxies and tunnels forward their own public hostname:
+
+```csharp
+server.AllowHosts("localhost", "127.0.0.1", "[::1]");
+```
+
+With `AllowHosts` set, a request carrying any other `Host` header gets a 400.
 
 ### Metadata
 

--- a/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/14_Markdown.md
+++ b/src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/14_Markdown.md
@@ -333,7 +333,7 @@ public class LocalImagesView : ViewBase
 }
 ```
 
-> **Note:** The server must also opt in via `server.DangerouslyAllowLocalFiles()` in `Program.cs`. Images are served through a proxy endpoint (`/ivy/local-file`) — the browser never accesses `file://` URLs directly.
+> **Note:** The server must also opt in, in `Program.cs`. Prefer naming the directories you serve from — `server.DangerouslyAllowLocalFiles("C:/Users/me/Photos")` — because anything resolving outside them answers 404. The no-argument `server.DangerouslyAllowLocalFiles()` serves **every readable file on the machine** over `/ivy/local-file`, and prints a startup warning saying so. Images are served through that proxy endpoint — the browser never accesses `file://` URLs directly.
 
 ### Complete Example
 

--- a/src/Ivy.Integration.Tests/CorsPolicyTests.cs
+++ b/src/Ivy.Integration.Tests/CorsPolicyTests.cs
@@ -1,0 +1,97 @@
+using System.Net;
+
+namespace Ivy.Integration.Tests;
+
+/// <summary>
+/// The fixture binds Host = "127.0.0.1", so the default CORS policy allows loopback origins and
+/// nothing else. Assertions are on the CORS response headers only — CORS is browser-enforced, so a
+/// disallowed origin still gets the response body.
+/// </summary>
+public class CorsPolicyTests : IClassFixture<IvyTestFixture>
+{
+    private const string LoopbackOrigin = "http://localhost:5173";
+    private const string ForeignOrigin = "https://evil.example";
+
+    private readonly HttpClient _client;
+
+    public CorsPolicyTests(IvyTestFixture fixture)
+    {
+        _client = fixture.Client;
+    }
+
+    [Fact]
+    public async Task Health_WithLoopbackOrigin_EchoesAllowOriginAndCredentials()
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, "/ivy/health");
+        request.Headers.Add("Origin", LoopbackOrigin);
+
+        var response = await _client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(LoopbackOrigin, Assert.Single(response.Headers.GetValues("Access-Control-Allow-Origin")));
+        Assert.Equal("true", Assert.Single(response.Headers.GetValues("Access-Control-Allow-Credentials")));
+    }
+
+    [Fact]
+    public async Task Health_WithForeignOrigin_SendsNoAllowOrigin()
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, "/ivy/health");
+        request.Headers.Add("Origin", ForeignOrigin);
+
+        var response = await _client.SendAsync(request);
+
+        Assert.False(response.Headers.Contains("Access-Control-Allow-Origin"));
+        Assert.False(response.Headers.Contains("Access-Control-Allow-Credentials"));
+    }
+
+    [Fact]
+    public async Task Health_WithNullOrigin_SendsNoAllowOrigin()
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, "/ivy/health");
+        request.Headers.Add("Origin", "null");
+
+        var response = await _client.SendAsync(request);
+
+        Assert.False(response.Headers.Contains("Access-Control-Allow-Origin"));
+    }
+
+    [Fact]
+    public async Task LocalFile_WithForeignOrigin_SendsNoAllowOrigin()
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, "/ivy/local-file?path=C:/Windows/win.ini");
+        request.Headers.Add("Origin", ForeignOrigin);
+
+        var response = await _client.SendAsync(request);
+
+        // The endpoint itself is disabled here (no DangerouslyAllowLocalFiles), but the point is that
+        // a foreign page could not read the response even if it were enabled.
+        Assert.False(response.Headers.Contains("Access-Control-Allow-Origin"));
+    }
+
+    [Fact]
+    public async Task NegotiatePreflight_WithLoopbackOrigin_EchoesAllowOrigin()
+    {
+        var response = await SendNegotiatePreflight(LoopbackOrigin);
+
+        Assert.Equal(LoopbackOrigin, Assert.Single(response.Headers.GetValues("Access-Control-Allow-Origin")));
+        Assert.Equal("true", Assert.Single(response.Headers.GetValues("Access-Control-Allow-Credentials")));
+    }
+
+    [Fact]
+    public async Task NegotiatePreflight_WithForeignOrigin_SendsNoAllowOrigin()
+    {
+        var response = await SendNegotiatePreflight(ForeignOrigin);
+
+        Assert.False(response.Headers.Contains("Access-Control-Allow-Origin"));
+    }
+
+    private async Task<HttpResponseMessage> SendNegotiatePreflight(string origin)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Options, "/ivy/messages/negotiate?negotiateVersion=1");
+        request.Headers.Add("Origin", origin);
+        request.Headers.Add("Access-Control-Request-Method", "POST");
+        request.Headers.Add("Access-Control-Request-Headers", "x-requested-with,content-type");
+
+        return await _client.SendAsync(request);
+    }
+}

--- a/src/Ivy.Integration.Tests/HostFilteringTests.cs
+++ b/src/Ivy.Integration.Tests/HostFilteringTests.cs
@@ -1,0 +1,55 @@
+using System.Net;
+
+namespace Ivy.Integration.Tests;
+
+/// <summary>
+/// Host header validation is the DNS rebinding mitigation and is opt-in: these tests measure both
+/// the opted-in behaviour and the unchanged default.
+/// </summary>
+public class HostFilteringTests
+{
+    [Fact]
+    public async Task WithAllowHosts_ForeignHostHeader_ReturnsBadRequest()
+    {
+        await using var server = await IvyTestServer.CreateAsync(s => s.AllowHosts("localhost", "127.0.0.1"));
+        using var client = CreateClient(server);
+
+        var allowed = await client.GetAsync("/ivy/health");
+        Assert.Equal(HttpStatusCode.OK, allowed.StatusCode);
+
+        var rejected = await client.SendAsync(WithHost("evil.example"));
+        Assert.Equal(HttpStatusCode.BadRequest, rejected.StatusCode);
+    }
+
+    [Fact]
+    public async Task WithoutAllowHosts_ForeignHostHeader_IsAccepted()
+    {
+        await using var server = await IvyTestServer.CreateAsync();
+        using var client = CreateClient(server);
+
+        var response = await client.SendAsync(WithHost("evil.example"));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    private static HttpRequestMessage WithHost(string host)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, "/ivy/health");
+        request.Headers.Host = host;
+        return request;
+    }
+
+    /// <summary>
+    /// Overriding the Host header also changes the TLS SNI name the handler validates the
+    /// certificate against, so the dev certificate has to be accepted without a name match.
+    /// </summary>
+    private static HttpClient CreateClient(IvyTestServer server)
+    {
+        var handler = new HttpClientHandler
+        {
+            ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
+        };
+
+        return new HttpClient(handler) { BaseAddress = new Uri(server.BaseUrl) };
+    }
+}

--- a/src/Ivy.Integration.Tests/IvyTestServer.cs
+++ b/src/Ivy.Integration.Tests/IvyTestServer.cs
@@ -18,7 +18,11 @@ public class IvyTestServer : IAsyncDisposable
         BaseUrl = baseUrl;
     }
 
-    public static async Task<IvyTestServer> CreateAsync()
+    /// <param name="configure">
+    /// Optional hook applied to the <see cref="Server"/> before the web application is built, for
+    /// tests that need builder methods such as <c>AllowHosts</c> or <c>DangerouslyAllowLocalFiles</c>.
+    /// </param>
+    public static async Task<IvyTestServer> CreateAsync(Action<Server>? configure = null)
     {
         var sessionStore = new AppSessionStore();
         var server = new Server(new ServerArgs { Port = 0, Silent = true, Host = "127.0.0.1" });
@@ -30,6 +34,8 @@ public class IvyTestServer : IAsyncDisposable
             Group = [],
             IsVisible = true
         });
+
+        configure?.Invoke(server);
 
         var app = server.BuildWebApplication(sessionStore)!;
         await app.StartAsync();

--- a/src/Ivy.Integration.Tests/LocalFileEndpointTests.cs
+++ b/src/Ivy.Integration.Tests/LocalFileEndpointTests.cs
@@ -1,0 +1,90 @@
+using System.Net;
+
+namespace Ivy.Integration.Tests;
+
+/// <summary>
+/// End-to-end reads through <c>GET /ivy/local-file</c> with roots configured on the server.
+/// </summary>
+public class LocalFileEndpointTests : IAsyncLifetime
+{
+    private string _root = null!;
+    private string _outside = null!;
+    private string _baseDirectory = null!;
+
+    public Task InitializeAsync()
+    {
+        _baseDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        _root = Directory.CreateDirectory(Path.Combine(_baseDirectory, "root")).FullName;
+        _outside = Directory.CreateDirectory(Path.Combine(_baseDirectory, "outside")).FullName;
+        File.WriteAllText(Path.Combine(_root, "photo.png"), "Fake PNG content");
+        File.WriteAllText(Path.Combine(_outside, "secret.txt"), "Secret content");
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync()
+    {
+        if (Directory.Exists(_baseDirectory))
+        {
+            Directory.Delete(_baseDirectory, true);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task WithConfiguredRoot_ServesFileInsideItAndRejectsEverythingElse()
+    {
+        await using var server = await IvyTestServer.CreateAsync(s => s.DangerouslyAllowLocalFiles(_root));
+        using var client = new HttpClient { BaseAddress = new Uri(server.BaseUrl) };
+
+        var inside = await client.GetAsync($"/ivy/local-file?path={Uri.EscapeDataString(Path.Combine(_root, "photo.png"))}");
+        Assert.Equal(HttpStatusCode.OK, inside.StatusCode);
+        Assert.Equal("image/png", inside.Content.Headers.ContentType?.MediaType);
+        Assert.Equal("Fake PNG content", await inside.Content.ReadAsStringAsync());
+
+        var outside = await client.GetAsync($"/ivy/local-file?path={Uri.EscapeDataString(Path.Combine(_outside, "secret.txt"))}");
+        Assert.Equal(HttpStatusCode.NotFound, outside.StatusCode);
+
+        var traversal = Path.Combine(_root, "..", "outside", "secret.txt");
+        var escaped = await client.GetAsync($"/ivy/local-file?path={Uri.EscapeDataString(traversal)}");
+        Assert.Equal(HttpStatusCode.NotFound, escaped.StatusCode);
+    }
+
+    [Fact]
+    public async Task WithoutRoots_StillServesAnyReadableFile()
+    {
+        // The no-argument overload is deliberately unconfined; this is the compatibility assertion.
+        await using var server = await IvyTestServer.CreateAsync(s => s.DangerouslyAllowLocalFiles());
+        using var client = new HttpClient { BaseAddress = new Uri(server.BaseUrl) };
+
+        var response = await client.GetAsync($"/ivy/local-file?path={Uri.EscapeDataString(Path.Combine(_outside, "secret.txt"))}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("Secret content", await response.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task WithExtensionAllowlist_RejectsUnlistedExtensions()
+    {
+        await using var server = await IvyTestServer.CreateAsync(s =>
+            s.DangerouslyAllowLocalFiles(_root, _outside).AllowLocalFileExtensions("png"));
+        using var client = new HttpClient { BaseAddress = new Uri(server.BaseUrl) };
+
+        var allowed = await client.GetAsync($"/ivy/local-file?path={Uri.EscapeDataString(Path.Combine(_root, "photo.png"))}");
+        Assert.Equal(HttpStatusCode.OK, allowed.StatusCode);
+
+        var rejected = await client.GetAsync($"/ivy/local-file?path={Uri.EscapeDataString(Path.Combine(_outside, "secret.txt"))}");
+        Assert.Equal(HttpStatusCode.NotFound, rejected.StatusCode);
+    }
+
+    [Fact]
+    public async Task WithoutOptIn_ReturnsNotFound()
+    {
+        await using var server = await IvyTestServer.CreateAsync();
+        using var client = new HttpClient { BaseAddress = new Uri(server.BaseUrl) };
+
+        var response = await client.GetAsync($"/ivy/local-file?path={Uri.EscapeDataString(Path.Combine(_root, "photo.png"))}");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+}

--- a/src/Ivy.Test/CorsOriginPolicyTests.cs
+++ b/src/Ivy.Test/CorsOriginPolicyTests.cs
@@ -1,0 +1,145 @@
+using Ivy.Core.Server;
+
+namespace Ivy.Test;
+
+public class CorsOriginPolicyTests
+{
+    #region IsLoopbackBound
+
+    [Theory]
+    [InlineData(null, true)]
+    [InlineData("", true)]
+    [InlineData("localhost", true)]
+    [InlineData("LOCALHOST", true)]
+    [InlineData("127.0.0.1", true)]
+    [InlineData("127.0.0.5", true)]
+    [InlineData("::1", true)]
+    [InlineData("[::1]", true)]
+    [InlineData("*", false)]
+    [InlineData("+", false)]
+    [InlineData("0.0.0.0", false)]
+    [InlineData("app.example.com", false)]
+    [InlineData("192.168.1.10", false)]
+    public void IsLoopbackBound_ClassifiesBindHost(string? bindHost, bool expected)
+    {
+        Assert.Equal(expected, CorsOriginPolicy.IsLoopbackBound(bindHost));
+    }
+
+    #endregion
+
+    #region IsOriginAllowed — loopback
+
+    [Theory]
+    [InlineData("http://localhost:5173")]
+    [InlineData("https://localhost:5010")]
+    [InlineData("https://127.0.0.1:5010")]
+    [InlineData("http://[::1]:1234")]
+    [InlineData("http://localhost")]
+    public void IsOriginAllowed_LoopbackOrigin_DependsOnAllowLoopback(string origin)
+    {
+        Assert.True(CorsOriginPolicy.IsOriginAllowed(origin, [], allowLoopback: true));
+        Assert.False(CorsOriginPolicy.IsOriginAllowed(origin, [], allowLoopback: false));
+    }
+
+    [Theory]
+    [InlineData("https://evil.example")]
+    [InlineData("http://attacker.example:8080")]
+    [InlineData("null")]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("file:///x")]
+    [InlineData("chrome-extension://abc")]
+    [InlineData("moz-extension://abc")]
+    [InlineData("not a url")]
+    [InlineData("/relative")]
+    public void IsOriginAllowed_NonLoopbackOrUnusableOrigin_IsAlwaysRejected(string origin)
+    {
+        Assert.False(CorsOriginPolicy.IsOriginAllowed(origin, [], allowLoopback: true));
+        Assert.False(CorsOriginPolicy.IsOriginAllowed(origin, [], allowLoopback: false));
+    }
+
+    [Fact]
+    public void IsOriginAllowed_NullOrigin_IsRejected()
+    {
+        Assert.False(CorsOriginPolicy.IsOriginAllowed(null, [], allowLoopback: true));
+    }
+
+    #endregion
+
+    #region IsOriginAllowed — allowlist
+
+    [Fact]
+    public void IsOriginAllowed_ConfiguredOrigin_IsAllowedWithoutLoopback()
+    {
+        string[] allowed = ["https://app.example.com"];
+
+        Assert.True(CorsOriginPolicy.IsOriginAllowed("https://app.example.com", allowed, allowLoopback: false));
+    }
+
+    [Theory]
+    [InlineData("https://app.example.com:8443")] // different port
+    [InlineData("http://app.example.com")]       // different scheme
+    [InlineData("https://sub.app.example.com")]  // subdomain of a configured origin
+    [InlineData("https://app.example.com.evil")] // suffix attack
+    [InlineData("https://example.com")]          // parent domain
+    public void IsOriginAllowed_NearMissOfConfiguredOrigin_IsRejected(string origin)
+    {
+        string[] allowed = ["https://app.example.com"];
+
+        Assert.False(CorsOriginPolicy.IsOriginAllowed(origin, allowed, allowLoopback: false));
+    }
+
+    [Theory]
+    [InlineData("https://APP.example.com")]
+    [InlineData("https://app.example.com/")]
+    [InlineData("HTTPS://app.example.com")]
+    public void IsOriginAllowed_ConfiguredOriginMatchesCaseAndTrailingSlashInsensitively(string origin)
+    {
+        string[] allowed = ["https://app.example.com"];
+
+        Assert.True(CorsOriginPolicy.IsOriginAllowed(origin, allowed, allowLoopback: false));
+    }
+
+    [Fact]
+    public void IsOriginAllowed_DefaultPortIsElidedOnBothSides()
+    {
+        Assert.True(CorsOriginPolicy.IsOriginAllowed("https://app.example.com", ["https://app.example.com:443"], allowLoopback: false));
+        Assert.True(CorsOriginPolicy.IsOriginAllowed("https://app.example.com:443", ["https://app.example.com"], allowLoopback: false));
+    }
+
+    [Fact]
+    public void IsOriginAllowed_WildcardEntry_IsNotHonoured()
+    {
+        Assert.False(CorsOriginPolicy.IsOriginAllowed("https://evil.example", ["*"], allowLoopback: false));
+        Assert.False(CorsOriginPolicy.IsOriginAllowed("https://sub.example.com", ["https://*.example.com"], allowLoopback: false));
+    }
+
+    #endregion
+
+    #region NormalizeOrigins
+
+    [Fact]
+    public void NormalizeOrigins_DropsUnusableEntriesAndDuplicates()
+    {
+        var normalized = CorsOriginPolicy.NormalizeOrigins(
+        [
+            "https://app.example.com",
+            "https://APP.example.com/",
+            "  http://localhost:5173  ",
+            "file:///x",
+            "not a url",
+            "",
+            "  "
+        ]);
+
+        Assert.Equal(new[] { "https://app.example.com", "http://localhost:5173" }, normalized);
+    }
+
+    [Fact]
+    public void NormalizeOrigins_WithNull_ReturnsEmpty()
+    {
+        Assert.Empty(CorsOriginPolicy.NormalizeOrigins(null));
+    }
+
+    #endregion
+}

--- a/src/Ivy.Test/LocalFileAccessPolicyTests.cs
+++ b/src/Ivy.Test/LocalFileAccessPolicyTests.cs
@@ -1,0 +1,246 @@
+namespace Ivy.Test;
+
+public class LocalFileAccessPolicyTests : IDisposable
+{
+    private readonly string _baseDirectory;
+    private readonly string _root;
+    private readonly string _outside;
+
+    public LocalFileAccessPolicyTests()
+    {
+        _baseDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        _root = Path.Combine(_baseDirectory, "root");
+        _outside = Path.Combine(_baseDirectory, "outside");
+        Directory.CreateDirectory(_root);
+        Directory.CreateDirectory(_outside);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_baseDirectory))
+        {
+            Directory.Delete(_baseDirectory, true);
+        }
+    }
+
+    #region Roots
+
+    [Fact]
+    public void TryResolve_WithNoRoots_AcceptsAnyPath()
+    {
+        var path = CreateFile(_outside, "secret.txt");
+
+        Assert.True(LocalFileAccessPolicy.TryResolve(path, [], [], out var fullPath));
+        Assert.Equal(path, fullPath);
+    }
+
+    [Fact]
+    public void TryResolve_InsideRoot_IsAccepted()
+    {
+        var path = CreateFile(_root, "photo.png");
+        var roots = LocalFileAccessPolicy.NormalizeRoots([_root]);
+
+        Assert.True(LocalFileAccessPolicy.TryResolve(path, roots, [], out var fullPath));
+        Assert.Equal(path, fullPath);
+    }
+
+    [Fact]
+    public void TryResolve_InNestedDirectoryUnderRoot_IsAccepted()
+    {
+        var nested = Directory.CreateDirectory(Path.Combine(_root, "a", "b")).FullName;
+        var path = CreateFile(nested, "deep.png");
+        var roots = LocalFileAccessPolicy.NormalizeRoots([_root]);
+
+        Assert.True(LocalFileAccessPolicy.TryResolve(path, roots, [], out _));
+    }
+
+    [Fact]
+    public void TryResolve_OutsideRoot_IsRejected()
+    {
+        var path = CreateFile(_outside, "secret.txt");
+        var roots = LocalFileAccessPolicy.NormalizeRoots([_root]);
+
+        Assert.False(LocalFileAccessPolicy.TryResolve(path, roots, [], out _));
+    }
+
+    [Fact]
+    public void TryResolve_TraversalOutOfRoot_IsRejectedAfterNormalization()
+    {
+        CreateFile(_outside, "secret.txt");
+        var traversal = Path.Combine(_root, "..", "outside", "secret.txt");
+        var roots = LocalFileAccessPolicy.NormalizeRoots([_root]);
+
+        Assert.False(LocalFileAccessPolicy.TryResolve(traversal, roots, [], out _));
+    }
+
+    [Fact]
+    public void TryResolve_SiblingDirectoryWithRootAsPrefix_IsRejected()
+    {
+        var siblingPrefix = Directory.CreateDirectory(_root + "-secrets").FullName;
+        var path = CreateFile(siblingPrefix, "key.pem");
+        var roots = LocalFileAccessPolicy.NormalizeRoots([_root]);
+
+        Assert.False(LocalFileAccessPolicy.TryResolve(path, roots, [], out _));
+    }
+
+    [Fact]
+    public void TryResolve_WithMultipleRoots_AcceptsAnyOfThem()
+    {
+        var second = Directory.CreateDirectory(Path.Combine(_baseDirectory, "second")).FullName;
+        var path = CreateFile(second, "photo.png");
+        var roots = LocalFileAccessPolicy.NormalizeRoots([_root, second]);
+
+        Assert.True(LocalFileAccessPolicy.TryResolve(path, roots, [], out _));
+    }
+
+    [Fact]
+    public void TryResolve_RootConfiguredWithTrailingSeparator_StillConfines()
+    {
+        var inside = CreateFile(_root, "photo.png");
+        var outside = CreateFile(_outside, "secret.txt");
+        var roots = LocalFileAccessPolicy.NormalizeRoots([_root + Path.DirectorySeparatorChar]);
+
+        Assert.True(LocalFileAccessPolicy.TryResolve(inside, roots, [], out _));
+        Assert.False(LocalFileAccessPolicy.TryResolve(outside, roots, [], out _));
+    }
+
+    [Fact]
+    public void TryResolve_LeafSymlinkPointingOutsideRoot_IsRejected()
+    {
+        var target = CreateFile(_outside, "secret.txt");
+        var link = Path.Combine(_root, "link.txt");
+        var roots = LocalFileAccessPolicy.NormalizeRoots([_root]);
+
+        // The non-symlink half of the assertion always runs, so the test is never vacuous even on a
+        // platform (or account) where creating a symlink is not permitted.
+        Assert.True(LocalFileAccessPolicy.TryResolve(CreateFile(_root, "photo.png"), roots, [], out _));
+
+        try
+        {
+            File.CreateSymbolicLink(link, target);
+        }
+        catch (Exception e) when (e is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
+        {
+            return; // Symlink creation not permitted here; skip the escape half.
+        }
+
+        Assert.False(LocalFileAccessPolicy.TryResolve(link, roots, [], out _));
+    }
+
+    #endregion
+
+    #region Extensions
+
+    [Theory]
+    [InlineData("photo.png", true)]
+    [InlineData("photo.PNG", true)]
+    [InlineData("photo.jpg", true)]
+    [InlineData("config.yml", false)]
+    [InlineData("key.pem", false)]
+    [InlineData("noextension", false)]
+    public void TryResolve_WithExtensionAllowlist_AcceptsOnlyListedExtensions(string fileName, bool expected)
+    {
+        var path = CreateFile(_root, fileName);
+        var extensions = LocalFileAccessPolicy.NormalizeExtensions([".png", "jpg"]);
+
+        Assert.Equal(expected, LocalFileAccessPolicy.TryResolve(path, [], extensions, out _));
+    }
+
+    [Fact]
+    public void TryResolve_WithNoExtensionAllowlist_AcceptsAnyExtension()
+    {
+        Assert.True(LocalFileAccessPolicy.TryResolve(CreateFile(_root, "key.pem"), [], [], out _));
+        Assert.True(LocalFileAccessPolicy.TryResolve(CreateFile(_root, "noextension"), [], [], out _));
+    }
+
+    [Fact]
+    public void TryResolve_AppliesRootsAndExtensionsTogether()
+    {
+        var extensions = LocalFileAccessPolicy.NormalizeExtensions([".png"]);
+        var roots = LocalFileAccessPolicy.NormalizeRoots([_root]);
+
+        Assert.True(LocalFileAccessPolicy.TryResolve(CreateFile(_root, "in.png"), roots, extensions, out _));
+        Assert.False(LocalFileAccessPolicy.TryResolve(CreateFile(_root, "in.yml"), roots, extensions, out _));
+        Assert.False(LocalFileAccessPolicy.TryResolve(CreateFile(_outside, "out.png"), roots, extensions, out _));
+    }
+
+    #endregion
+
+    #region Bad input
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void TryResolve_WithBlankPath_IsRejected(string? path)
+    {
+        Assert.False(LocalFileAccessPolicy.TryResolve(path, [], [], out var fullPath));
+        Assert.Equal(string.Empty, fullPath);
+    }
+
+    [Fact]
+    public void TryResolve_WithNonExistentPathInsideRoot_StillReportsTheResolvedPath()
+    {
+        // Existence is the caller's check; the policy only answers "may this path be served".
+        var roots = LocalFileAccessPolicy.NormalizeRoots([_root]);
+        var missing = Path.Combine(_root, "missing.png");
+
+        Assert.True(LocalFileAccessPolicy.TryResolve(missing, roots, [], out var fullPath));
+        Assert.Equal(missing, fullPath);
+    }
+
+    #endregion
+
+    #region Normalization
+
+    [Fact]
+    public void NormalizeRoots_DropsBlanksTrailingSeparatorsAndDuplicates()
+    {
+        var roots = LocalFileAccessPolicy.NormalizeRoots(
+        [
+            _root,
+            _root + Path.DirectorySeparatorChar,
+            "  ",
+            ""
+        ]);
+
+        Assert.Equal(new[] { _root }, roots);
+    }
+
+    [Fact]
+    public void NormalizeRoots_WithNull_ReturnsEmpty()
+    {
+        Assert.Empty(LocalFileAccessPolicy.NormalizeRoots(null));
+    }
+
+    [Theory]
+    [InlineData(".png", ".png")]
+    [InlineData("png", ".png")]
+    [InlineData(".PNG", ".png")]
+    [InlineData("  JPG  ", ".jpg")]
+    public void NormalizeExtensions_AddsTheDotAndLowerCases(string input, string expected)
+    {
+        Assert.Equal(new[] { expected }, LocalFileAccessPolicy.NormalizeExtensions([input]));
+    }
+
+    [Fact]
+    public void NormalizeExtensions_DropsBlanksBareDotsAndDuplicates()
+    {
+        Assert.Equal(new[] { ".png" }, LocalFileAccessPolicy.NormalizeExtensions([".png", "PNG", ".", "", "  "]));
+    }
+
+    [Fact]
+    public void NormalizeExtensions_WithNull_ReturnsEmpty()
+    {
+        Assert.Empty(LocalFileAccessPolicy.NormalizeExtensions(null));
+    }
+
+    #endregion
+
+    private static string CreateFile(string directory, string fileName)
+    {
+        var path = Path.Combine(directory, fileName);
+        File.WriteAllText(path, "content");
+        return path;
+    }
+}

--- a/src/Ivy.Test/LocalFileControllerTests.cs
+++ b/src/Ivy.Test/LocalFileControllerTests.cs
@@ -220,6 +220,99 @@ public class LocalFileControllerTests : IDisposable
         Assert.Contains($"filename=\"{fileName}\"", contentDisposition);
     }
 
+    [Fact]
+    public void GetFile_WithConfiguredRoot_ServesFileInsideIt()
+    {
+        // Arrange
+        var filePath = CreateTempFile("photo.png", "Fake PNG content");
+        var controller = CreateController(allowLocalFiles: true, roots: [_tempDirectory]);
+
+        // Act
+        var result = controller.GetFile(filePath);
+
+        // Assert
+        Assert.IsType<PhysicalFileResult>(result);
+    }
+
+    [Fact]
+    public void GetFile_WithConfiguredRoot_ReturnsNotFoundForFileOutsideIt()
+    {
+        // Arrange
+        var root = Directory.CreateDirectory(Path.Combine(_tempDirectory, "root")).FullName;
+        var filePath = CreateTempFile("secret.txt", "Content");
+        var controller = CreateController(allowLocalFiles: true, roots: [root]);
+
+        // Act
+        var result = controller.GetFile(filePath);
+
+        // Assert — never 403, so the endpoint is not an existence oracle
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public void GetFile_WithConfiguredRoot_ReturnsNotFoundForTraversalOutOfIt()
+    {
+        // Arrange
+        var root = Directory.CreateDirectory(Path.Combine(_tempDirectory, "root")).FullName;
+        CreateTempFile("secret.txt", "Content");
+        var traversal = Path.Combine(root, "..", "secret.txt");
+        var controller = CreateController(allowLocalFiles: true, roots: [root]);
+
+        // Act
+        var result = controller.GetFile(traversal);
+
+        // Assert
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public void GetFile_WithConfiguredRoot_ReturnsNotFoundForSiblingDirectoryWithRootAsPrefix()
+    {
+        // Arrange
+        var root = Directory.CreateDirectory(Path.Combine(_tempDirectory, "root")).FullName;
+        var siblingPrefix = Directory.CreateDirectory(root + "-secrets").FullName;
+        var filePath = Path.Combine(siblingPrefix, "key.pem");
+        File.WriteAllText(filePath, "Content");
+        var controller = CreateController(allowLocalFiles: true, roots: [root]);
+
+        // Act
+        var result = controller.GetFile(filePath);
+
+        // Assert
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public void GetFile_WithExtensionAllowlist_ServesAllowedExtension()
+    {
+        // Arrange
+        var filePath = CreateTempFile("photo.png", "Fake PNG content");
+        var controller = CreateController(allowLocalFiles: true, extensions: [".png"]);
+
+        // Act
+        var result = controller.GetFile(filePath);
+
+        // Assert
+        Assert.IsType<PhysicalFileResult>(result);
+    }
+
+    [Theory]
+    [InlineData("config.yml")]
+    [InlineData("key.pem")]
+    [InlineData("noextension")]
+    public void GetFile_WithExtensionAllowlist_ReturnsNotFoundForOtherExtensions(string fileName)
+    {
+        // Arrange
+        var filePath = CreateTempFile(fileName, "Content");
+        var controller = CreateController(allowLocalFiles: true, extensions: [".png"]);
+
+        // Act
+        var result = controller.GetFile(filePath);
+
+        // Assert
+        Assert.IsType<NotFoundResult>(result);
+    }
+
     private string CreateTempFile(string fileName, string content)
     {
         var filePath = Path.Combine(_tempDirectory, fileName);
@@ -228,13 +321,24 @@ public class LocalFileControllerTests : IDisposable
         return filePath;
     }
 
-    private LocalFileController CreateController(bool allowLocalFiles)
+    private LocalFileController CreateController(
+        bool allowLocalFiles,
+        string[]? roots = null,
+        string[]? extensions = null)
     {
         var serverArgs = new ServerArgs
         {
             DangerouslyAllowLocalFiles = allowLocalFiles
         };
         var server = new Server(serverArgs);
+
+        // Configure through the builder methods, so these tests exercise the same normalization a
+        // real Program.cs gets.
+        if (roots is { Length: > 0 })
+            server.DangerouslyAllowLocalFiles(roots);
+        if (extensions is { Length: > 0 })
+            server.AllowLocalFileExtensions(extensions);
+
         var controller = new LocalFileController(server);
 
         // Set up HTTP context for the controller

--- a/src/Ivy/Core/Server/CorsOriginPolicy.cs
+++ b/src/Ivy/Core/Server/CorsOriginPolicy.cs
@@ -1,0 +1,85 @@
+using System.Net;
+
+namespace Ivy.Core.Server;
+
+/// <summary>
+/// Decides which origins the default CORS policy reflects. Ivy serves its own frontend, so
+/// production traffic is same-origin and never consults CORS at all; the cross-origin case that has
+/// to keep working is the dev loop, where both sides are loopback.
+/// </summary>
+internal static class CorsOriginPolicy
+{
+    /// <summary>
+    /// True when the server binds a loopback address, in which case loopback origins are allowed
+    /// without configuration. Container and hosted servers bind "*" and land on false.
+    /// </summary>
+    internal static bool IsLoopbackBound(string? bindHost)
+    {
+        if (string.IsNullOrWhiteSpace(bindHost))
+            return true;
+
+        var host = bindHost.Trim();
+
+        if (host is "*" or "+")
+            return false;
+
+        if (string.Equals(host, "localhost", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        return IPAddress.TryParse(host.Trim('[', ']'), out var address) && IPAddress.IsLoopback(address);
+    }
+
+    /// <summary>
+    /// Normalizes configured origins to <c>scheme://host[:port]</c>, dropping anything that is not
+    /// an absolute http/https URL. Wildcards are not supported.
+    /// </summary>
+    internal static string[] NormalizeOrigins(IEnumerable<string>? origins)
+    {
+        if (origins == null)
+            return [];
+
+        return origins
+            .Select(Normalize)
+            .Where(origin => origin != null)
+            .Select(origin => origin!)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    /// <summary>
+    /// True when <paramref name="origin"/> is explicitly listed in <paramref name="allowed"/>, or
+    /// when it is a loopback origin and <paramref name="allowLoopback"/> is set. Anything that is
+    /// not an absolute http/https URL is rejected outright, which covers <c>Origin: null</c>,
+    /// <c>file://</c> and extension schemes.
+    /// </summary>
+    internal static bool IsOriginAllowed(string? origin, IReadOnlyList<string> allowed, bool allowLoopback)
+    {
+        var normalized = Normalize(origin);
+        if (normalized == null)
+            return false;
+
+        for (var i = 0; i < allowed.Count; i++)
+        {
+            if (string.Equals(normalized, Normalize(allowed[i]), StringComparison.Ordinal))
+                return true;
+        }
+
+        return allowLoopback && new Uri(normalized).IsLoopback;
+    }
+
+    private static string? Normalize(string? origin)
+    {
+        if (string.IsNullOrWhiteSpace(origin))
+            return null;
+
+        if (!Uri.TryCreate(origin.Trim(), UriKind.Absolute, out var uri))
+            return null;
+
+        if (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps)
+            return null;
+
+        // GetLeftPart lower-cases the scheme and host and elides a default port, so
+        // "HTTP://LocalHost:80" and "http://localhost" compare equal.
+        return uri.GetLeftPart(UriPartial.Authority);
+    }
+}

--- a/src/Ivy/Server.cs
+++ b/src/Ivy/Server.cs
@@ -14,6 +14,7 @@ using MessagePack;
 using MessagePack.Resolvers;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.HostFiltering;
 using Microsoft.AspNetCore.Http; //do not remove - used in RELEASE
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.SignalR;
@@ -57,6 +58,25 @@ public record ServerArgs
     public Assembly? AssetAssembly { get; set; } = null;
     public bool EnableDevTools { get; set; } = false;
     public bool DangerouslyAllowLocalFiles { get; set; } = false;
+
+    /// <summary>
+    /// Directories that <c>GET /ivy/local-file</c> may serve from. Empty (the default) means any
+    /// readable file on the machine is served — see <see cref="Server.DangerouslyAllowLocalFiles(string[])"/>.
+    /// </summary>
+    public string[] LocalFileRoots { get; set; } = [];
+
+    /// <summary>
+    /// File extensions that <c>GET /ivy/local-file</c> may serve, e.g. ".png". Empty (the default)
+    /// means any extension.
+    /// </summary>
+    public string[] LocalFileExtensions { get; set; } = [];
+
+    /// <summary>
+    /// Cross-origin origins the default CORS policy reflects, e.g. "https://app.example.com". Empty
+    /// (the default) allows loopback origins only, and only when the server itself binds loopback.
+    /// </summary>
+    public string[] AllowedCorsOrigins { get; set; } = [];
+
 #if DEBUG
     public bool FindAvailablePort { get; set; } = true;
 #else
@@ -110,6 +130,7 @@ public class Server
     private ManifestOptions? _manifestOptions;
     private ServerArgs _args;
     private bool _presetsLoaded;
+    private string[] _allowedHosts = [];
 
     public Server(ServerArgs? args = null)
     {
@@ -132,6 +153,16 @@ public class Server
         if (_args.BasePath == null && Environment.GetEnvironmentVariable("BASE_PATH") is { } basePath)
         {
             _args = _args with { BasePath = "/" + basePath.TrimStart('/') };
+        }
+
+        if (_args.AllowedCorsOrigins.Length == 0 &&
+            Environment.GetEnvironmentVariable("IVY_CORS_ORIGINS") is { } corsOrigins)
+        {
+            _args = _args with
+            {
+                AllowedCorsOrigins = CorsOriginPolicy.NormalizeOrigins(
+                    corsOrigins.Split([',', ';'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            };
         }
 
         _args = _args with
@@ -531,9 +562,71 @@ public class Server
         return this;
     }
 
+    /// <summary>
+    /// Enables <c>GET /ivy/local-file</c> for <b>any readable file on the machine</b>. Prefer the
+    /// overload that takes roots, which confines the endpoint to the directories you name.
+    /// </summary>
     public Server DangerouslyAllowLocalFiles()
     {
         _args = _args with { DangerouslyAllowLocalFiles = true };
+        return this;
+    }
+
+    /// <summary>
+    /// Enables <c>GET /ivy/local-file</c> and confines it to <paramref name="roots"/>. Anything
+    /// resolving outside them answers 404. Repeated calls add to the set.
+    /// </summary>
+    public Server DangerouslyAllowLocalFiles(params string[] roots)
+    {
+        _args = _args with
+        {
+            DangerouslyAllowLocalFiles = true,
+            LocalFileRoots = LocalFileAccessPolicy.NormalizeRoots([.. _args.LocalFileRoots, .. roots])
+        };
+        return this;
+    }
+
+    /// <summary>
+    /// Narrows <c>GET /ivy/local-file</c> to the given file extensions (with or without the leading
+    /// dot). Anything else — including an extensionless path — answers 404. Repeated calls add to
+    /// the set.
+    /// </summary>
+    public Server AllowLocalFileExtensions(params string[] extensions)
+    {
+        _args = _args with
+        {
+            LocalFileExtensions = LocalFileAccessPolicy.NormalizeExtensions([.. _args.LocalFileExtensions, .. extensions])
+        };
+        return this;
+    }
+
+    /// <summary>
+    /// Adds cross-origin origins to the default CORS policy, e.g. "https://app.example.com".
+    /// Loopback origins are already allowed when the server itself binds loopback, so this is only
+    /// needed for a genuinely cross-origin consumer. Also settable via <c>IVY_CORS_ORIGINS</c>.
+    /// </summary>
+    public Server AllowCorsOrigins(params string[] origins)
+    {
+        _args = _args with
+        {
+            AllowedCorsOrigins = CorsOriginPolicy.NormalizeOrigins([.. _args.AllowedCorsOrigins, .. origins])
+        };
+        return this;
+    }
+
+    /// <summary>
+    /// Restricts the <c>Host</c> header to the given hosts, answering 400 for anything else. This is
+    /// the DNS rebinding mitigation, which CORS cannot substitute for: a page on a hostname rebound
+    /// to 127.0.0.1 is same-origin with the server, so no CORS check runs. Off by default, because
+    /// reverse proxies and tunnels forward their own public hostname.
+    /// </summary>
+    public Server AllowHosts(params string[] hosts)
+    {
+        _allowedHosts =
+        [
+            .. _allowedHosts,
+            .. hosts.Where(host => !string.IsNullOrWhiteSpace(host)).Select(host => host.Trim())
+        ];
         return this;
     }
 
@@ -752,16 +845,33 @@ public class Server
             builder.Services.Add(service);
         }
 
+        // Ivy serves its own frontend, so production traffic is same-origin and never consults CORS.
+        // The dev loop (Vite on another port) is loopback on both sides, so reflect loopback origins
+        // only when the server itself binds loopback; anything else has to be configured explicitly.
+        var allowLoopbackOrigins = CorsOriginPolicy.IsLoopbackBound(host);
+        var allowedCorsOrigins = _args.AllowedCorsOrigins;
         builder.Services.AddCors(options =>
         {
             options.AddDefaultPolicy(policy =>
             {
-                policy.SetIsOriginAllowed(_ => true)
+                policy.SetIsOriginAllowed(origin =>
+                        CorsOriginPolicy.IsOriginAllowed(origin, allowedCorsOrigins, allowLoopbackOrigins))
                     .AllowAnyHeader()
                     .AllowAnyMethod()
                     .AllowCredentials(); // Required for SignalR
             });
         });
+
+        // WebApplication.CreateBuilder already registers HostFilteringStartupFilter, whose
+        // PostConfigure falls back to "*" only while AllowedHosts is empty — so setting it here wins
+        // and no extra middleware is needed.
+        if (_allowedHosts.Length > 0)
+        {
+            builder.Services.Configure<HostFilteringOptions>(options =>
+            {
+                options.AllowedHosts = [.. _allowedHosts];
+            });
+        }
 
         if (_useHttpRedirection)
         {
@@ -852,6 +962,12 @@ public class Server
         {
             Console.WriteLine($"Using base path: {_args.BasePath}");
             app.UsePathBase(_args.BasePath);
+        }
+
+        if (_args.DangerouslyAllowLocalFiles && _args.LocalFileRoots.Length == 0 && !_args.Silent)
+        {
+            Console.WriteLine("[WARNING] DangerouslyAllowLocalFiles() with no roots serves any readable file on this machine over");
+            Console.WriteLine("          GET /ivy/local-file. Pass roots, e.g. DangerouslyAllowLocalFiles(\"C:/Users/me/Photos\").");
         }
 
         app.Use(async (context, next) =>

--- a/src/Ivy/Services/LocalFileAccessPolicy.cs
+++ b/src/Ivy/Services/LocalFileAccessPolicy.cs
@@ -1,0 +1,113 @@
+// ReSharper disable once CheckNamespace
+namespace Ivy;
+
+/// <summary>
+/// Decides whether <c>GET /ivy/local-file</c> may serve a path, given the roots and extensions
+/// configured on the server. An empty root or extension list means "no restriction", which is what
+/// the no-argument <see cref="Server.DangerouslyAllowLocalFiles()"/> overload leaves behind.
+/// </summary>
+internal static class LocalFileAccessPolicy
+{
+    /// <summary>
+    /// Normalizes configured roots to full paths without a trailing separator. Each root's own leaf
+    /// link is resolved here, at configure time, so a symlinked root directory cannot cause a false
+    /// mismatch against an already-resolved request path.
+    /// </summary>
+    internal static string[] NormalizeRoots(IEnumerable<string>? roots)
+    {
+        if (roots == null)
+            return [];
+
+        return roots
+            .Where(root => !string.IsNullOrWhiteSpace(root))
+            .Select(root => Path.TrimEndingDirectorySeparator(ResolveLeafLink(Path.GetFullPath(root.Trim()))))
+            .Where(root => root.Length > 0)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    /// <summary>
+    /// Normalizes configured extensions to lower-case with a leading dot, accepting input with or
+    /// without the dot.
+    /// </summary>
+    internal static string[] NormalizeExtensions(IEnumerable<string>? extensions)
+    {
+        if (extensions == null)
+            return [];
+
+        return extensions
+            .Where(extension => !string.IsNullOrWhiteSpace(extension))
+            .Select(extension => extension.Trim().ToLowerInvariant())
+            .Select(extension => extension.StartsWith('.') ? extension : "." + extension)
+            .Where(extension => extension.Length > 1)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    /// <summary>
+    /// Resolves <paramref name="path"/> and reports whether the policy allows serving it. Returns
+    /// false rather than throwing for any unusable path, so the caller can answer 404 uniformly and
+    /// never turn the endpoint into an existence oracle.
+    /// </summary>
+    internal static bool TryResolve(
+        string? path,
+        IReadOnlyList<string> roots,
+        IReadOnlyList<string> extensions,
+        out string fullPath)
+    {
+        fullPath = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(path))
+            return false;
+
+        try
+        {
+            fullPath = Path.GetFullPath(path);
+        }
+        catch (Exception e) when (e is ArgumentException or NotSupportedException or PathTooLongException or IOException)
+        {
+            fullPath = string.Empty;
+            return false;
+        }
+
+        if (extensions.Count > 0)
+        {
+            var extension = Path.GetExtension(fullPath);
+            if (string.IsNullOrEmpty(extension) || !extensions.Contains(extension, StringComparer.OrdinalIgnoreCase))
+                return false;
+        }
+
+        if (roots.Count == 0)
+            return true;
+
+        // A symlink inside a root that points outside it is deliberately rejected.
+        var resolved = ResolveLeafLink(fullPath);
+        return roots.Any(root => IsWithin(resolved, root));
+    }
+
+    private static bool IsWithin(string fullPath, string root)
+    {
+        if (string.Equals(fullPath, root, StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        // Requiring the separator is what stops root "/data/pub" from matching "/data/pub-secrets".
+        return fullPath.Length > root.Length
+            && fullPath.StartsWith(root, StringComparison.OrdinalIgnoreCase)
+            && (fullPath[root.Length] == Path.DirectorySeparatorChar
+                || fullPath[root.Length] == Path.AltDirectorySeparatorChar);
+    }
+
+    private static string ResolveLeafLink(string fullPath)
+    {
+        try
+        {
+            return new FileInfo(fullPath).ResolveLinkTarget(returnFinalTarget: true)?.FullName ?? fullPath;
+        }
+        catch (Exception e) when (e is IOException or UnauthorizedAccessException)
+        {
+            // Nothing there to resolve (or nothing we may read); fall back to the literal path,
+            // which the caller's File.Exists check rejects.
+            return fullPath;
+        }
+    }
+}

--- a/src/Ivy/Services/LocalFileController.cs
+++ b/src/Ivy/Services/LocalFileController.cs
@@ -32,7 +32,15 @@ public class LocalFileController(Server server) : Controller
         if (string.IsNullOrWhiteSpace(path))
             return BadRequest("Path is required");
 
-        var fullPath = Path.GetFullPath(path);
+        // Every rejection is a 404, never a 403 — the endpoint must not become an existence oracle
+        // for paths the caller may not read.
+        if (!LocalFileAccessPolicy.TryResolve(
+                path,
+                server.Args.LocalFileRoots,
+                server.Args.LocalFileExtensions,
+                out var fullPath))
+            return NotFound();
+
         if (!System.IO.File.Exists(fullPath))
             return NotFound();
 


### PR DESCRIPTION
# Summary

## Changes

`GET /ivy/local-file` can now be confined to a set of allowed root directories and an optional file
extension allowlist, with every rejection answered as 404 rather than 403 so the endpoint is not an
existence oracle. The default CORS policy no longer reflects every origin: it allows loopback origins
only while the server itself binds loopback, plus any explicitly configured origins. Host header
validation was added as an opt-in builder method, because CORS cannot stop DNS rebinding — a rebound
hostname is same-origin, so the CORS middleware never runs.

## API Changes

New builder methods on `Server`, all additive and chainable:

- `DangerouslyAllowLocalFiles(params string[] roots)` — enables the endpoint **and** confines it to
  `roots`. Additive across calls.
- `AllowLocalFileExtensions(params string[] extensions)` — narrows to these extensions (leading dot
  optional). Extensionless paths are rejected. Additive.
- `AllowCorsOrigins(params string[] origins)` — adds cross-origin origins to the default CORS policy.
- `AllowHosts(params string[] hosts)` — opts into `Host` header validation; any other host gets 400.

New `ServerArgs` properties, all defaulting to `[]` (empty = previous behaviour):
`LocalFileRoots`, `LocalFileExtensions`, `AllowedCorsOrigins`.

New environment variable: `IVY_CORS_ORIGINS` (comma- or semicolon-separated), applied only when
`AllowedCorsOrigins` is empty.

**Unchanged:** `DangerouslyAllowLocalFiles()` with no arguments. C# prefers the normal-form overload
over the `params` expanded form, so no existing source or compiled call site changes meaning. It is
deliberately **not** `[Obsolete]` — `TreatWarningsAsErrors=true` in `src/Directory.Build.props` would
turn the attribute into a build break for every consumer. It now prints a startup warning instead.

No public type was added or removed; both new policy classes are `internal static`, reachable from
tests via the existing `InternalsVisibleTo`.

## Files Modified

**Framework** (commit `a01f53668`)

- `src/Ivy/Services/LocalFileAccessPolicy.cs` — new. `TryResolve` plus root/extension normalization.
  Separator-required prefix match, so root `/data/pub` does not match `/data/pub-secrets`; leaf symlink
  resolved via `ResolveLinkTarget(returnFinalTarget: true)`.
- `src/Ivy/Core/Server/CorsOriginPolicy.cs` — new. `IsLoopbackBound`, `IsOriginAllowed`,
  `NormalizeOrigins`.
- `src/Ivy/Server.cs` — three `ServerArgs` properties, four builder methods, `IVY_CORS_ORIGINS`,
  rewritten CORS registration, `HostFilteringOptions`, startup warning.
- `src/Ivy/Services/LocalFileController.cs` — routes through `TryResolve`, 404 on rejection.

**Tests** (commit `9f5d39da6`)

- `src/Ivy.Test/LocalFileAccessPolicyTests.cs` (29) and `CorsOriginPolicyTests.cs` (42) — new.
- `src/Ivy.Test/LocalFileControllerTests.cs` — 11 pre-existing tests untouched, 7 added (20 total).
- `src/Ivy.Integration.Tests/CorsPolicyTests.cs` (6), `LocalFileEndpointTests.cs` (4),
  `HostFilteringTests.cs` (2) — new.
- `src/Ivy.Integration.Tests/IvyTestServer.cs` — optional `Action<Server>` configure hook; still binds
  `127.0.0.1`.

**Docs** (commit `b3e8c67c1`)

- `src/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/01_Program.md` — ServerArgs rows,
  `IVY_CORS_ORIGINS`, new "Local File Access" and "CORS and Host Filtering" sections.
- `src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/14_Markdown.md` — recommends the roots overload.

Base `c711daa98` → `b3e8c67c1`; 13 files, 1114 insertions(+), 5 deletions(-).

## Manual Testing

**A. Local file confinement**

1. In a sample app's `Program.cs`, call `server.DangerouslyAllowLocalFiles("C:/Users/<you>/Photos")`
   and put a `photo.png` in that folder plus a `secret.txt` somewhere outside it. Run the app.
2. Open `https://localhost:5010/ivy/local-file?path=C:/Users/<you>/Photos/photo.png` →
   **200**, image renders.
3. Open `…/ivy/local-file?path=C:/Users/<you>/secret.txt` → **404**.
4. Open `…/ivy/local-file?path=C:/Users/<you>/Photos/../secret.txt` → **404** (traversal collapsed).
5. Add `server.AllowLocalFileExtensions(".png")`, restart, and request a `.txt` inside the root →
   **404**. Every rejection is 404, never 403.
6. Change the call to `server.DangerouslyAllowLocalFiles()` with no arguments and restart. The console
   prints a `[WARNING]` about serving any readable file, and step 3 now returns **200** — the
   documented, unchanged compatibility behaviour.

**B. CORS scoping**

1. Run any Ivy app locally and confirm the UI still loads and stays connected — the hub is same-origin,
   so this is the "nothing broke" check.
2. `curl -k -i -H "Origin: https://evil.example" https://localhost:5010/ivy/health` → no
   `Access-Control-Allow-Origin` header in the response.
3. `curl -k -i -H "Origin: http://localhost:5173" https://localhost:5010/ivy/health` → the header comes
   back, together with `Access-Control-Allow-Credentials: true`. This is the Vite dev-server case.
4. Add `server.AllowCorsOrigins("https://app.example.com")` (or set
   `IVY_CORS_ORIGINS=https://app.example.com`), restart, and repeat step 2 with that origin → now
   echoed.

**C. Host validation**

1. Add `server.AllowHosts("localhost", "127.0.0.1")` and restart.
2. `curl -k -i -H "Host: evil.example" https://localhost:5010/ivy/health` → **400**.
3. `curl -k -i https://localhost:5010/ivy/health` → **200**.
4. Remove the `AllowHosts` call and repeat step 2 → **200**, confirming the default is unchanged.

**D. Automated suites** (all green; see `Verification/`)

- `dotnet test src/Ivy-Framework.slnx --filter "<plan filter>"` → 91 passed.
- `dotnet test src/Ivy.Integration.Tests/Ivy.Integration.Tests.csproj` → 28 passed. This second command
  is **required**: the project is not in the slnx, so the filtered run above matches zero integration
  tests (filed as a recommendation).
- `dotnet test src/Ivy.Docs.Test/Ivy.Docs.Test.csproj` → 17 passed (the docs changes).
- `AppHubIntegrationTests` (5 passed) is the check that scoping the origin set did not break the SignalR
  hub whose `AllowCredentials` is annotated "Required for SignalR".
- The new CORS tests were proved to discriminate: reverting `Server.cs` to `SetIsOriginAllowed(_ => true)`
  failed exactly the four foreign/null-origin tests and no others.

---
## Commits

- a01f53668 Confine local file endpoint and scope default CORS policy (00404)
- 9f5d39da6 Test local file confinement, CORS scoping and host filtering (00404)
- b3e8c67c1 Document local file roots, CORS origins and host filtering (00404)

---
Created using [Ivy Tendril](https://ivy.app).