### PR TITLE
[00406] Fix Single Select Search Casing by Reusing the Shared Filter

### DIFF
--- a/src/frontend/src/widgets/inputs/SelectInputWidget/variants/CheckboxVariant.tsx
+++ b/src/frontend/src/widgets/inputs/SelectInputWidget/variants/CheckboxVariant.tsx
@@ -12,6 +12,7 @@ import { Densities } from "@/types/density";
 import { xIconVariant } from "@/components/ui/input/text-input-variant";
 import { SelectInputWidgetProps } from "../../select-types";
 import {
+  filterOptionsBySearch,
   computeClearAllValues,
   computeSelectAllValues,
   convertValuesToOriginalType,
@@ -96,27 +97,10 @@ export const CheckboxVariant: React.FC<SelectInputWidgetProps> = ({
 
   const [searchTerm, setSearchTerm] = useState("");
 
-  const filteredOptions = useMemo(() => {
-    if (!searchable || !searchTerm) return validOptions;
-
-    return validOptions.filter((option) => {
-      if (searchMode === "Fuzzy") {
-        let i = 0;
-        let j = 0;
-        const searchLower = searchTerm.toLowerCase();
-        const labelLower = (option.label || "").toLowerCase();
-        while (i < searchLower.length && j < labelLower.length) {
-          if (searchLower[i] === labelLower[j]) i++;
-          j++;
-        }
-        return i === searchLower.length;
-      }
-      const term = searchMode === "CaseInsensitive" ? searchTerm.toLowerCase() : searchTerm;
-      const label =
-        searchMode === "CaseInsensitive" ? (option.label || "").toLowerCase() : option.label || "";
-      return label.includes(term);
-    });
-  }, [validOptions, searchable, searchTerm, searchMode]);
+  const filteredOptions = useMemo(
+    () => (searchable ? filterOptionsBySearch(validOptions, searchTerm, searchMode) : validOptions),
+    [validOptions, searchable, searchTerm, searchMode],
+  );
 
   const visibleEnabledForBulkList = useMemo(
     () => filteredOptions.filter((o) => !disabled && !loading && !o.disabled),

--- a/src/frontend/src/widgets/inputs/SelectInputWidget/variants/ToggleVariant.tsx
+++ b/src/frontend/src/widgets/inputs/SelectInputWidget/variants/ToggleVariant.tsx
@@ -9,6 +9,7 @@ import { Densities } from "@/types/density";
 import { xIconVariant } from "@/components/ui/input/text-input-variant";
 import { SelectInputWidgetProps } from "../../select-types";
 import {
+  filterOptionsBySearch,
   computeClearAllValues,
   computeSelectAllValues,
   convertValuesToOriginalType,
@@ -73,27 +74,10 @@ export const ToggleVariant: React.FC<SelectInputWidgetProps> = ({
 
   const [searchTerm, setSearchTerm] = useState("");
 
-  const filteredOptions = useMemo(() => {
-    if (!searchable || !searchTerm) return validOptions;
-
-    return validOptions.filter((option) => {
-      if (searchMode === "Fuzzy") {
-        let i = 0;
-        let j = 0;
-        const searchLower = searchTerm.toLowerCase();
-        const labelLower = (option.label || "").toLowerCase();
-        while (i < searchLower.length && j < labelLower.length) {
-          if (searchLower[i] === labelLower[j]) i++;
-          j++;
-        }
-        return i === searchLower.length;
-      }
-      const term = searchMode === "CaseInsensitive" ? searchTerm.toLowerCase() : searchTerm;
-      const label =
-        searchMode === "CaseInsensitive" ? (option.label || "").toLowerCase() : option.label || "";
-      return label.includes(term);
-    });
-  }, [validOptions, searchable, searchTerm, searchMode]);
+  const filteredOptions = useMemo(
+    () => (searchable ? filterOptionsBySearch(validOptions, searchTerm, searchMode) : validOptions),
+    [validOptions, searchable, searchTerm, searchMode],
+  );
 
   const handleValueChange = useSelectValueHandler(
     id,

--- a/src/frontend/src/widgets/inputs/SelectSingleVariant.tsx
+++ b/src/frontend/src/widgets/inputs/SelectSingleVariant.tsx
@@ -27,7 +27,7 @@ import {
 } from "@/components/ui/input/text-input-variant";
 import { getWidth, inputStyles } from "@/lib/styles";
 import { SelectInputWidgetProps } from "./select-types";
-import { useSelectValueHandler } from "./select-utils";
+import { filterOptionsBySearch, useSelectValueHandler } from "./select-utils";
 import { EMPTY_ARRAY } from "@/lib/constants";
 
 export const SelectSingleVariant: React.FC<SelectInputWidgetProps> = ({
@@ -124,23 +124,11 @@ export const SelectSingleVariant: React.FC<SelectInputWidgetProps> = ({
   const isSearchEnabled =
     searchable === true || (searchable !== false && validOptions.length >= SEARCH_THRESHOLD);
 
-  const filteredOptions = useMemo(() => {
-    if (!isSearchEnabled || !searchTerm) return validOptions;
-    return validOptions.filter((option) => {
-      const term = searchMode === "CaseInsensitive" ? searchTerm.toLowerCase() : searchTerm;
-      const label = (option.label || "").toLowerCase();
-      if (searchMode === "Fuzzy") {
-        let i = 0,
-          j = 0;
-        while (i < term.length && j < label.length) {
-          if (term[i] === label[j]) i++;
-          j++;
-        }
-        return i === term.length;
-      }
-      return label.includes(term);
-    });
-  }, [validOptions, isSearchEnabled, searchTerm, searchMode]);
+  const filteredOptions = useMemo(
+    () =>
+      isSearchEnabled ? filterOptionsBySearch(validOptions, searchTerm, searchMode) : validOptions,
+    [validOptions, isSearchEnabled, searchTerm, searchMode],
+  );
 
   // Radix Select runs focusSelectedItem in a child useEffect: it focuses the selected item, or the
   // listbox when there are no items — which steals focus from the header search field whenever the

--- a/src/frontend/src/widgets/inputs/__tests__/selectUtils.test.ts
+++ b/src/frontend/src/widgets/inputs/__tests__/selectUtils.test.ts
@@ -211,16 +211,19 @@ describe("filterOptionsBySearch", () => {
     expect(result).toHaveLength(0);
   });
 
+  it("matches uppercase term case insensitively with Fuzzy mode", () => {
+    const result = filterOptionsBySearch(options, "AKV", "Fuzzy");
+    expect(result).toHaveLength(1);
+    expect(result[0].label).toBe("ArtemKhvorostianyi");
+  });
+
   it("returns empty array when no options match", () => {
     const result = filterOptionsBySearch(options, "xyz");
     expect(result).toEqual([]);
   });
 
   it("falls back to value when label is missing", () => {
-    const optionsNoLabel = [
-      { value: "rorychatt" },
-      { value: "artem" },
-    ];
+    const optionsNoLabel = [{ value: "rorychatt" }, { value: "artem" }];
     const result = filterOptionsBySearch(optionsNoLabel, "ror");
     expect(result).toHaveLength(1);
     expect(result[0].value).toBe("rorychatt");


### PR DESCRIPTION
# Summary

## Changes

Fixed a search casing bug in single select and collapsed three select variant components onto the shared `filterOptionsBySearch` helper. The bug prevented uppercase input from matching in Fuzzy and CaseSensitive search modes because the inline filter memo lowercased the label unconditionally while only lowercasing the search term for CaseInsensitive mode. The shared helper applies casing correctly to both sides, eliminating about 60 lines of duplicated filter logic across SelectSingleVariant, CheckboxVariant, and ToggleVariant.

## API Changes

None.

## Files Modified

**Implementation:**
- `src/frontend/src/widgets/inputs/SelectSingleVariant.tsx` — replaced inline filter memo with shared helper
- `src/frontend/src/widgets/inputs/SelectInputWidget/variants/CheckboxVariant.tsx` — replaced inline filter memo with shared helper
- `src/frontend/src/widgets/inputs/SelectInputWidget/variants/ToggleVariant.tsx` — replaced inline filter memo with shared helper

**Tests:**
- `src/frontend/src/widgets/inputs/__tests__/selectUtils.test.ts` — added test for uppercase Fuzzy matching

## Manual Testing

1. Run the Ivy Docs app: `dotnet run --project src/Ivy.Docs/Ivy.Docs.csproj --browse --find-available-port`
2. Navigate to Widgets > Inputs > SelectInput
3. Scroll to the "Fuzzy Search (Single Select)" demo (around line 227-248 in 05_SelectInput.md)
4. Type an uppercase letter like "J" in the search box
5. Observe: The dropdown now shows "Java" and "JavaScript" (previously showed "No items found")
6. Type "TS" in uppercase
7. Observe: The dropdown shows "TypeScript" (previously showed nothing)
8. Change search mode to "CaseSensitive" and type "Java" with capital J
9. Observe: The dropdown shows "Java" and "JavaScript" (previously showed nothing)

Expected: All three search modes now work correctly with uppercase input. The docs demo and Samples app SelectInputApp.cs (line 478) are no longer broken.

---

## Commits

- 1db501e7e Fix Single Select Search Casing by Reusing the Shared Filter

---
Created using [Ivy Tendril](https://ivy.app).
