### PR TITLE
[00421] Add the Excluded Test Projects to Ivy-Framework.slnx

### DIFF
--- a/src/Ivy-Framework.slnx
+++ b/src/Ivy-Framework.slnx
@@ -27,12 +27,14 @@
   <Folder Name="/Auth/examples/">
     <Project Path="auth/examples/SliplaneExample/SliplaneExample.csproj" />
   </Folder>
+  <Project Path="Ivy.Analyser.Test/Ivy.Analyser.Test.csproj" />
   <Project Path="Ivy.Desktop/Ivy.Desktop.csproj" />
   <Project Path="Ivy.Docs.Helpers/Ivy.Docs.Helpers.csproj" />
   <Project Path="Ivy.Docs.Shared/Ivy.Docs.Shared.csproj" />
   <Project Path="Ivy.Docs.Test/Ivy.Docs.Test.csproj" />
   <Project Path="Ivy.Docs/Ivy.Docs.csproj" />
   <Project Path="Ivy.Hooks.Pty.Test/Ivy.Hooks.Pty.Test.csproj" />
+  <Project Path="Ivy.Integration.Tests/Ivy.Integration.Tests.csproj" />
   <Project Path="Ivy.Samples.Shared/Ivy.Samples.Shared.csproj" />
   <Project Path="Ivy.Samples/Ivy.Samples.csproj" />
   <Project Path="Ivy.Test/Ivy.Test.csproj" />

--- a/src/Ivy.Integration.Tests/IvyTestServer.cs
+++ b/src/Ivy.Integration.Tests/IvyTestServer.cs
@@ -24,6 +24,9 @@ public class IvyTestServer : IAsyncDisposable
     /// </param>
     public static async Task<IvyTestServer> CreateAsync(Action<Server>? configure = null)
     {
+        // Pin to HTTP for CI - Windows runners may not have a trusted ASP.NET Core dev certificate
+        Environment.SetEnvironmentVariable("IVY_TLS", "0");
+
         var sessionStore = new AppSessionStore();
         var server = new Server(new ServerArgs { Port = 0, Silent = true, Host = "127.0.0.1" });
         server.AddApp(new AppDescriptor

--- a/src/Ivy.Integration.Tests/TestServerSchemeTests.cs
+++ b/src/Ivy.Integration.Tests/TestServerSchemeTests.cs
@@ -1,0 +1,11 @@
+namespace Ivy.Integration.Tests;
+
+public class TestServerSchemeTests
+{
+    [Fact]
+    public async Task TestServerUsesHttp()
+    {
+        await using var server = await IvyTestServer.CreateAsync();
+        Assert.StartsWith("http://", server.BaseUrl);
+    }
+}

--- a/src/Ivy.Test/SolutionMembershipTests.cs
+++ b/src/Ivy.Test/SolutionMembershipTests.cs
@@ -1,0 +1,57 @@
+using System.Xml.Linq;
+
+namespace Ivy.Test;
+
+public class SolutionMembershipTests
+{
+    private static readonly string SrcDirectory = FindSrcDirectory();
+
+    private static string FindSrcDirectory()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !File.Exists(Path.Combine(dir.FullName, "Ivy-Framework.slnx")))
+        {
+            dir = dir.Parent;
+        }
+
+        Assert.NotNull(dir);
+        return dir.FullName;
+    }
+
+    [Fact]
+    public void EveryTestProjectDirectlyUnderSrcIsASolutionMember()
+    {
+        var slnxPath = Path.Combine(SrcDirectory, "Ivy-Framework.slnx");
+        var doc = XDocument.Load(slnxPath);
+
+        var solutionProjects = doc.Descendants()
+            .Where(e => e.Name.LocalName == "Project")
+            .Select(e => e.Attribute("Path")?.Value)
+            .Where(p => p != null)
+            .Select(p => p!.Replace('\\', '/'))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var testDirectories = Directory.GetDirectories(SrcDirectory)
+            .Select(d => new DirectoryInfo(d))
+            .Where(d => d.Name.EndsWith(".Test", StringComparison.Ordinal) ||
+                       d.Name.EndsWith(".Tests", StringComparison.Ordinal))
+            .ToList();
+
+        var missingProjects = new List<string>();
+
+        foreach (var testDir in testDirectories)
+        {
+            var projectFile = Path.Combine(testDir.FullName, $"{testDir.Name}.csproj");
+            if (File.Exists(projectFile))
+            {
+                var relativePath = $"{testDir.Name}/{testDir.Name}.csproj";
+                if (!solutionProjects.Contains(relativePath))
+                {
+                    missingProjects.Add(relativePath);
+                }
+            }
+        }
+
+        Assert.Empty(missingProjects);
+    }
+}

--- a/src/Ivy.Test/SolutionMembershipTests.cs
+++ b/src/Ivy.Test/SolutionMembershipTests.cs
@@ -8,7 +8,7 @@ public class SolutionMembershipTests
 
     private static string FindSrcDirectory()
     {
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        var dir = new DirectoryInfo(System.AppContext.BaseDirectory);
         while (dir != null && !File.Exists(Path.Combine(dir.FullName, "Ivy-Framework.slnx")))
         {
             dir = dir.Parent;


### PR DESCRIPTION
## Problem

Both backend workflows declare `defaults: run: working-directory: src` and then run `dotnet restore`, `dotnet format --verify-no-changes`, `dotnet build --configuration Release` and `dotnet test --configuration Release --no-build --verbosity normal` with **no project argument**. `src/Ivy-Framework.slnx` is the only solution file in that directory, so all four steps resolve it. A project that is not a member of the slnx is never formatted, never compiled and never run.

Two projects are not members:
- `Ivy.Integration.Tests` — 28 tests that have never run in CI
- `Ivy.Analyser.Test` — 121 tests with no CI coverage

## Solution

### 1. Add both projects to `src/Ivy-Framework.slnx`

Two `Project` elements added to maintain alphabetical order.

### 2. Pin the integration test server to HTTP

Set `IVY_TLS` to `0` in `IvyTestServer.CreateAsync` so the suite doesn't require a trusted dev certificate on Windows CI.

### 3. Guard the slnx against future omissions

New test `SolutionMembershipTests` walks all `*.Test` and `*.Tests` directories under `src` and asserts they're in the slnx.

---

## Commits

e4739fdd3 Fix AppContext reference in SolutionMembershipTests
c2f2d32cd Add excluded test projects to solution and pin integration tests to HTTP
5f203ccb3 Merge pull request #4797 from Ivy-Interactive/tendril/00406-FixSingleSelectSearchCas
1db501e7e Fix Single Select Search Casing by Reusing the Shared Filter
cf8bf7f7c Merge pull request #4796 from Ivy-Interactive/tendril/00404-ConfineTheLocalFileEndpo
b3e8c67c1 Document local file roots, CORS origins and host filtering (00404)
9f5d39da6 Test local file confinement, CORS scoping and host filtering (00404)
a01f53668 Confine local file endpoint and scope default CORS policy (00404)
d76dee1a8 Merge pull request #4795 from Ivy-Interactive/tendril/00396-FilterMultiSelectOptions
e0eba8f77 Fix multiselect tests to properly trigger React controlled input
771fc82d9 Filter multi select options while typing and highlight the best match
4ee3e1ea9 Merge pull request #4794 from Ivy-Interactive/tendril/00393-RemoveUnusedIvyCoreUsing
ca47d0a4d Remove unused Ivy.Core using directives from wireframe widgets
c711daa98 Merge pull request #4793 from Ivy-Interactive/tendril/00382-FixLinkNavigationInTermi
55dfb3400 Handle external localhost URLs in DesktopWindow and add tests (00382)
707adae5e Fix link navigation on macOS in Terminal widget (00382)
d39e18631 Merge pull request #4792 from Ivy-Interactive/tendril/00259-RetireLegacyPublishNuGetWorkflow
3a80a36a8 Retire legacy publish-nuget workflow and update release workflow (Plan 00259)
5367148e9 Merge pull request #4791 from Ivy-Interactive/development
6045dc8c8 Merge pull request #4790 from Ivy-Interactive/tendril/00233-DisableSetupVPInstallAcrossGitHubActionsWorkflows
05905773a Disable setup-vp root install across GitHub Actions workflows (Plan 00233)
21257efb3 Merge pull request #4789 from Ivy-Interactive/feat/wireframe-widgets-ivyml-theming-and-run
a2943302f Merge remote-tracking branch 'origin/development' into feat/wireframe-widgets-ivyml-theming-and-run
8d1476c67 feat(wireframe): add eight wireframe widgets, theme fonts, and ivyml run
1c8675f5d Merge pull request #4788 from Ivy-Interactive/tendril/00196-AddTestModeDryRunToggleToPublishNuGetWorkflow
38fe1676b Add test-mode dry-run toggle to publish-nuget workflow
27046ba67 Merge pull request #4787 from Ivy-Interactive/tendril/00185-GuardTheRetiredIvyPluginAbstractionsPackageID
678348a2f Guard the retired Ivy.Plugin.Abstractions package ID (Plan 00185)
739327a9e Merge pull request #4786 from Ivy-Interactive/tendril/00178-ReplaceLegacyEmDashesInAGENTSmdAndSyncSkillReferences
e717aee09 Plan 00178: Replace legacy em dashes in AGENTS.md and sync skill references
444c66d30 Merge pull request #4785 from Ivy-Interactive/tendril/00177-FixReleaseAndPublishNuGetWorkflows
b42f5d193 Fix release and publish NuGet workflows (00177)
1a20d6447 Merge pull request #4784 from Ivy-Interactive/tendril/00168-CleanUpObsoleteDocumentationAndAgentSkills
f01ec0b74 Merge pull request #4783 from Ivy-Interactive/tendril/00170-PassCancellationTokenToAsyncOperationsInFilterEvalConsole
c25880f9d [00168] Update claude-plugin skills and sync references with AGENTS.md
29178aa64 [00168] Remove obsolete CLI and MCP guidance from README and AGENTS.md
334ae216a [00168] Clean up obsolete MCP and CLI documentation
a152c857b Plan 00170: Pass CancellationToken to async operations in Filter Eval Console
7f89adce2 Merge pull request #4781 from Ivy-Interactive/tendril/00159-FixSpectreCommandsInFilterEvalConsoleAndAddFilterProjectsToS
5553bbfba Merge pull request #4782 from Ivy-Interactive/tendril/00155-PackExternalWidgetTargetsInIvyNuGetPackage
c06c572ee Merge pull request #4780 from Ivy-Interactive/tendril/00161-ConfigurePeerDependencyRulesForAliasedViteInCoreFrontend
616c26f63 Merge pull request #4779 from Ivy-Interactive/tendril/00157-MarkAntlr4BuildTasksAsPrivateAssetInIvy
604b43e03 Merge pull request #4778 from Ivy-Interactive/tendril/00156-RemoveMisleadingVersionPropertyFromIvyAnalyser
a6d24ed22 Plan 00157: Mark Antlr4BuildTasks as private asset in Ivy
158d0cb84 Plan 00161: Configure peer dependency rules for aliased Vite in core frontend
219e42295 Add Filter projects to solution and remove redundant usings (Plan 00159)
39961910b Guard FilterParserAgentTests against missing OpenAI secrets (Plan 00159)
e29fae558 Fix Spectre command signatures and disambiguate Table in Filter Eval Console (Plan 00159)
e89bcb77c Remove misleading Version property from Ivy.Analyser.csproj (Plan 00156)
a7981e8fb Add unit tests for external widget build targets and package configuration (Plan 00155)
0aa156ced Update external widget package documentation for automatic targets import (Plan 00155)
186f47b87 Pack external widget targets in Ivy NuGet package (Plan 00155)
51dbdca04 Merge pull request #4777 from Ivy-Interactive/tendril/00154-DocumentIvyPluginAbstractionsProjectReferenceRequirementInCL
ac53dc57c Document Ivy.Plugin.Abstractions ProjectReference requirement (00154)
eef4ed73d Merge pull request #4776 from Ivy-Interactive/tendril/00145-ConfigurePeerDependencyRulesForViteAndTypeScriptInWidgetFron
a99e30ded Merge remote-tracking branch 'origin/development' into tendril/00145-ConfigurePeerDependencyRulesForViteAndTypeScriptInWidgetFron
d05a131c8 Merge pull request #4775 from Ivy-Interactive/tendril/00119-ConsolidateNuGetPackagesIntoIvyIvyAuthAndIvyDesktop
8f4c3d0f1 Merge remote-tracking branch 'origin/development' into tendril/00119-ConsolidateNuGetPackagesIntoIvyIvyAuthAndIvyDesktop
4c048d0b6 Plan 00145: Configure peer dependency rules and update Vite Plus across widget frontends
be0c6ee09 Plan 00145: Update Vite Plus to 0.3.0 in core frontend
901cc867f Document the 3-package layout and the 1.4.0 migration (Plan 00119)
30a5f3a21 Replace publish-external-widgets.yml with publish-nuget.yml (Plan 00119)
979bcc268 Compile the widgets, analyzer, Agent.Filter, Hooks.Pty and Plugin.Abstractions into Ivy (Plan 00119)
16997fcf4 Merge the eight auth providers into a single Ivy.Auth package (Plan 00119)
831c88012 Merge pull request #4774 from Ivy-Interactive/tendril/00133-ResolveVitePlusUnmetPeerWarningsInTiptapWidgetFrontend
fbcfdb234 Silence unmet peer warnings for typescript and vite in Tiptap frontend (Plan 00133)
9371f0bcc Merge pull request #4773 from Ivy-Interactive/tendril/00126-BumpTiptapDependenciesTo3313ToClearUnmetPeerWarnings
20ed563a2 Bump Tiptap deps to 3.31.3 to clear unmet peer warnings (Plan 00126)
15940c8ee Merge pull request #4772 from Ivy-Interactive/tendril/00107-Resolve52OpenDependabotSecurityAlerts
893b34da8 Upgrade Tiptap widget to v3 to resolve prototype pollution alert (Plan 00107)
ae15f0329 Bump postcss/browserslist/postcss-selector-parser in widget frontends (Plan 00107)
052a4c130 Bump core frontend deps for Dependabot alerts (Plan 00107)
f0434f430 Merge pull request #4771 from Ivy-Interactive/development
84fa8ce5a Merge pull request #4770 from Ivy-Interactive/tendril/00045-FixFilterInputTextObscuredByAutocompleteDropdown
21a5c85c9 Fix filter input text obscured by autocomplete dropdown (Plan 00045)
54f0d662a Merge pull request #4769 from Ivy-Interactive/tendril/00058-UseSemanticDesignTokenForTabsVariantAddButtonHover
53ccc7cea Use semantic design token for TabsVariant add button hover (00058)
911b958a5 Merge pull request #4768 from Ivy-Interactive/tendril/00057-FixSheetCloseButtonHoverFontColor
d85ddfe46 Merge pull request #4767 from Ivy-Interactive/tendril/00052-FixHoverStylesForContentTabsVariant
a19aba1b3 Fix sheet, dialog, and number range clear button hover font colors (Plan 00057)
3cc9ad4bb Fix TabsLayoutWidget test children typing (00052)
a6a3c647f Fix hover styles for Content tabs variant (00052)
1ba478ef6 chore: better bold colors
a7c773e3c chore: fix color vars
caa3e9f49 chore: fix fonts
f0d53ef8d chore: fix color vars
302e1a2b5 chore: fix bad color vars
ff920cc70 chore: fix incorrect color var
969028080 Merge pull request #4764 from Ivy-Interactive/yolo/richtext-strikethrough-links
69069506d fix(rich-text): keep strikethrough visible on links
a76c0bd0d Merge pull request #4763 from Ivy-Interactive/yolo/button-strike-through
8779b1d71 feat(button): add StrikeThrough prop for struck-out, muted buttons and links
aa39560cb Support arbitrary URL query parameters as appArgs in frontend getAppArgs (#4762)
1dac2400c perf(diff-view): optimize large diff scrolling with content-visibility virtualization (#4761)
877b66824 docs(releases): add weekly release notes for v1.3.21
3e9b54dca fix(button): ensure disabled:cursor-not-allowed and disabled:pointer-events-none take precedence over cursor-pointer
ce7f95832 fix(tooltip): support tooltips on disabled buttons and elements via trigger wrapper
66b684a96 fix(dropdown): remove stray margin from DropdownMenuSubContent
07e4b4a7f fix(desktop): load cert with EphemeralKeySet and skip redundant trust prompt on mac
4461b30a7 chore: remove weird change
aaa433321 chore: update packages lock json
57fc345f1 Merge pull request #4760 from Ivy-Interactive/development
f7cef4fcc fix(backend): safely URL-encode SignalR connection parameters in use-backend (#4759)
8d5de0379 Merge pull request #4758 from Ivy-Interactive/tendril/00676-UseTheCommandGlyphForMacModifierLabelsInTooltips
107e81bd6 Use ⌘ glyph for Mac modifier labels in tooltips (plan 00676)
efd7be976 Merge pull request #4757 from Ivy-Interactive/tendril/00661-ShowCmdBInSidebarToggleTooltipOnMac
bfa0e3dbf Show Cmd+B in sidebar toggle tooltip on Mac (plan 00661)
ce3191532 fix(ui): position toast notifications at bottom-right corner (#4756)
5e3b87374 test: add unit test verifying prompt return when child process holds inherited pipe open
06f70aaf7 Wait on process exit without hanging indefinitely on redirected stream EOF (#4755)
213b0d3f5 Persist main sidebar open state in localStorage for plan 00017
7b755d4a3 fix(primitives): ensure TextBlock Block variant and Ellipsis overflow truncate properly (#4753)
a0170e6e0 fix(diff-view): key collapsed state by file path and reset on diff change (#4752)
2b4a59d07 fix(sidebar): ensure full width for collapsed sidebar footer and dropdown trigger (#4751)
4c2436e29 Merge pull request #4750 from Ivy-Interactive/tendril/00076-FixUTF8CorruptionAndAddOutputCaptureToIvyHooksPty
f49eea237 sample(hooks-pty): detect URLs in captured PTY output
e33578c52 sample(hooks-pty): add Output Capture demo app
a51f3246d docs(hooks-pty): add Ivy.Hooks.Pty README, rewrite stale Xterm README
faf7d463f test(hooks-pty): add Ivy.Hooks.Pty.Test project
630fc483f fix(hooks-pty): fix UTF-8 chunk-boundary corruption, add output capture
e05cc6823 Merge pull request #4749 from Ivy-Interactive/tendril/00074-OpenReviewActionsInAPTYTerminalTab
303be4cab Plan 00074: Surface process id on PtyHandle for explicit tree kill
6d7ac4894 Merge pull request #4748 from Ivy-Interactive/development
f7ff73179 Merge pull request #4747 from Ivy-Interactive/fix-macos-cert-trust-and-connection-errors
381032540 chore: cleanup Commits.json
55b45034c fix(desktop): fix macOS certificate trust and prevent password prompt on launch
2d2ffdc08 chore: fix sert mac os edgecase

---
Created using [Ivy Tendril](https://ivy.app).
