### PR TITLE
[00418] Make Unconfined Local File Access Explicit and Unsilenceable

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/01_Program.md
+++ b/src/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/01_Program.md
@@ -203,8 +203,11 @@ server.UseHttpRedirection();
 ### Local File Access
 
 `server.DangerouslyAllowLocalFiles()` enables the `/ivy/local-file` proxy endpoint that `Markdown` and
-`Image` use to render files from disk. The no-argument form serves **any readable file on the machine**,
-so pass the directories you actually need and Ivy answers 404 for everything outside them:
+`Image` use to render files from disk. **The endpoint is unauthenticated**, so the roots you pass are the
+only server-side confinement. The no-argument form serves **any readable file on the machine** and always
+warns on stderr; it is retained deliberately for consumers that mitigate the endpoint another way (e.g.,
+with middleware that validates the request origin and host). For most cases, pass the directories you
+actually need and Ivy answers 404 for everything outside them:
 
 ```csharp
 server.DangerouslyAllowLocalFiles("C:/Users/me/Photos", "D:/Screenshots");

--- a/src/Ivy.Test/LocalFileControllerTests.cs
+++ b/src/Ivy.Test/LocalFileControllerTests.cs
@@ -313,6 +313,79 @@ public class LocalFileControllerTests : IDisposable
         Assert.IsType<NotFoundResult>(result);
     }
 
+    [Fact]
+    public void DescribeUnconfinedAccess_WithNoArgumentOverload_ReturnsWarning()
+    {
+        // Arrange
+        var args = new ServerArgs { DangerouslyAllowLocalFiles = true };
+
+        // Act
+        var warning = LocalFileAccessPolicy.DescribeUnconfinedAccess(args);
+
+        // Assert
+        Assert.NotNull(warning);
+    }
+
+    [Fact]
+    public void DescribeUnconfinedAccess_WithRoots_ReturnsNull()
+    {
+        // Arrange
+        var server = new Server(new ServerArgs());
+        server.DangerouslyAllowLocalFiles("C:/Test");
+        var args = server.Args;
+
+        // Act
+        var warning = LocalFileAccessPolicy.DescribeUnconfinedAccess(args);
+
+        // Assert
+        Assert.Null(warning);
+    }
+
+    [Fact]
+    public void DescribeUnconfinedAccess_WhenFlagIsOff_ReturnsNull()
+    {
+        // Arrange
+        var args = new ServerArgs { DangerouslyAllowLocalFiles = false };
+
+        // Act
+        var warning = LocalFileAccessPolicy.DescribeUnconfinedAccess(args);
+
+        // Assert
+        Assert.Null(warning);
+    }
+
+    [Fact]
+    public void DescribeUnconfinedAccess_WithSilentTrue_StillReturnsWarning()
+    {
+        // Arrange — this is the regression this plan exists to prevent
+        var args = new ServerArgs
+        {
+            DangerouslyAllowLocalFiles = true,
+            Silent = true
+        };
+
+        // Act
+        var warning = LocalFileAccessPolicy.DescribeUnconfinedAccess(args);
+
+        // Assert
+        Assert.NotNull(warning);
+    }
+
+    [Fact]
+    public void DescribeUnconfinedAccess_WarningMentionsKeyDetails()
+    {
+        // Arrange
+        var args = new ServerArgs { DangerouslyAllowLocalFiles = true };
+
+        // Act
+        var warning = LocalFileAccessPolicy.DescribeUnconfinedAccess(args);
+
+        // Assert
+        Assert.Contains("/ivy/local-file", warning);
+        Assert.Contains("roots", warning);
+        Assert.Contains("AllowLocalFileExtensions", warning);
+    }
+
     private string CreateTempFile(string fileName, string content)
     {
         var filePath = Path.Combine(_tempDirectory, fileName);

--- a/src/Ivy/Server.cs
+++ b/src/Ivy/Server.cs
@@ -964,10 +964,10 @@ public class Server
             app.UsePathBase(_args.BasePath);
         }
 
-        if (_args.DangerouslyAllowLocalFiles && _args.LocalFileRoots.Length == 0 && !_args.Silent)
+        var unconfinedWarning = LocalFileAccessPolicy.DescribeUnconfinedAccess(_args);
+        if (unconfinedWarning != null)
         {
-            Console.WriteLine("[WARNING] DangerouslyAllowLocalFiles() with no roots serves any readable file on this machine over");
-            Console.WriteLine("          GET /ivy/local-file. Pass roots, e.g. DangerouslyAllowLocalFiles(\"C:/Users/me/Photos\").");
+            Console.Error.WriteLine(unconfinedWarning);
         }
 
         app.Use(async (context, next) =>

--- a/src/Ivy/Services/LocalFileAccessPolicy.cs
+++ b/src/Ivy/Services/LocalFileAccessPolicy.cs
@@ -97,6 +97,21 @@ internal static class LocalFileAccessPolicy
                 || fullPath[root.Length] == Path.AltDirectorySeparatorChar);
     }
 
+    /// <summary>
+    /// The startup warning for an enabled but unconfined endpoint, or null when the configuration
+    /// needs no warning.
+    /// </summary>
+    internal static string? DescribeUnconfinedAccess(ServerArgs args)
+    {
+        if (!args.DangerouslyAllowLocalFiles || args.LocalFileRoots.Length > 0)
+            return null;
+
+        return "[WARNING] DangerouslyAllowLocalFiles() with no roots serves any readable file on this machine over\n" +
+               "          the unauthenticated GET /ivy/local-file endpoint. Pass roots to confine it, e.g.\n" +
+               "          DangerouslyAllowLocalFiles(\"C:/Users/me/Photos\"), or call AllowLocalFileExtensions(...)\n" +
+               "          to narrow it further when the roots are not known ahead of time.";
+    }
+
     private static string ResolveLeafLink(string fullPath)
     {
         try


### PR DESCRIPTION
# Summary

## Changes

Made the unconfined local file access warning unsuppressible by routing it to stderr and removing the Silent flag gate. Extracted the warning logic into a testable helper method in LocalFileAccessPolicy, updated the text to mention the endpoint is unauthenticated, and documented the deliberate retention of the no-argument form in the program docs.

## API Changes

**Added:**
- `LocalFileAccessPolicy.DescribeUnconfinedAccess(ServerArgs)` - internal static helper that returns the warning text or null

**Modified:**
- Warning output in `Server.cs` now routes to stderr via `Console.Error.WriteLine` instead of stdout, and cannot be suppressed by the `Silent` flag

**No public API changes** - the new helper is internal only.

## Files Modified

**Core implementation:**
- `src/Ivy/Services/LocalFileAccessPolicy.cs` - added DescribeUnconfinedAccess helper
- `src/Ivy/Server.cs` - replaced inline warning with helper call and stderr routing

**Documentation:**
- `src/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/01_Program.md` - updated Local File Access section to explain the endpoint is unauthenticated, the no-argument form is retained deliberately, and it always warns on stderr

**Tests:**
- `src/Ivy.Test/LocalFileControllerTests.cs` - added 5 tests for the new helper covering all behaviors including the Silent=true regression

## Manual Testing

1. Create a minimal Ivy server with `DangerouslyAllowLocalFiles()` (no arguments) and `Silent = true`
2. Launch the server and observe stderr output
3. Verify the warning appears despite `Silent = true`, mentions the unauthenticated endpoint, and includes guidance about roots and AllowLocalFileExtensions
4. Configure roots via `DangerouslyAllowLocalFiles("C:/Test")` and verify the warning disappears

---

## Commits

- 6ceb2d4ac Make unconfined local file access warning unsuppressible

---
Created using [Ivy Tendril](https://ivy.app).
