### PR TITLE
[00419] Resolve the Whole Path When Confining Local File Access

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/01_Program.md
+++ b/src/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/01_Program.md
@@ -217,7 +217,8 @@ server.AllowLocalFileExtensions(".png", ".jpg", ".webp");
 ```
 
 Both are additive, so repeated calls extend the sets. Every rejection is a 404 rather than a 403, so the
-endpoint never reveals whether a path exists.
+endpoint never reveals whether a path exists. Symlinks and junctions are resolved along the whole path, so a
+link inside a root that points outside it answers 404.
 
 ### CORS and Host Filtering
 

--- a/src/Ivy.Integration.Tests/LocalFileEndpointTests.cs
+++ b/src/Ivy.Integration.Tests/LocalFileEndpointTests.cs
@@ -87,4 +87,63 @@ public class LocalFileEndpointTests : IAsyncLifetime
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
+
+    [Fact]
+    public async Task WithMidPathDirectoryLinkPointingOutsideRoot_Returns404()
+    {
+        var link = Path.Combine(_root, "link");
+
+        if (!TryCreateDirectoryLink(link, _outside))
+            return; // Directory link creation not permitted here; skip test.
+
+        await using var server = await IvyTestServer.CreateAsync(s => s.DangerouslyAllowLocalFiles(_root));
+        using var client = new HttpClient { BaseAddress = new Uri(server.BaseUrl) };
+
+        var pathThroughLink = Path.Combine(link, "secret.txt");
+        Assert.True(File.Exists(pathThroughLink), "Link should allow access to target file");
+
+        var response = await client.GetAsync($"/ivy/local-file?path={Uri.EscapeDataString(pathThroughLink)}");
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    private static bool TryCreateDirectoryLink(string link, string target)
+    {
+        try
+        {
+            Directory.CreateSymbolicLink(link, target);
+            return true;
+        }
+        catch (Exception e) when (e is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
+        {
+            // Symlink creation not permitted; try a Windows junction.
+        }
+
+        if (!OperatingSystem.IsWindows())
+            return false;
+
+        try
+        {
+            var process = new System.Diagnostics.Process
+            {
+                StartInfo = new System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = "cmd.exe",
+                    Arguments = $"/c mklink /J \"{link}\" \"{target}\"",
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    CreateNoWindow = true
+                }
+            };
+
+            process.Start();
+            process.WaitForExit(5000);
+
+            return Directory.Exists(link);
+        }
+        catch
+        {
+            return false;
+        }
+    }
 }

--- a/src/Ivy.Integration.Tests/LocalFileEndpointTests.cs
+++ b/src/Ivy.Integration.Tests/LocalFileEndpointTests.cs
@@ -25,6 +25,25 @@ public class LocalFileEndpointTests : IAsyncLifetime
     {
         if (Directory.Exists(_baseDirectory))
         {
+            // Delete directory links (junctions/symlinks) first, as Directory.Delete with recursive=true
+            // fails when encountering them on some platforms.
+            try
+            {
+                foreach (var dir in Directory.GetDirectories(_baseDirectory, "*", SearchOption.AllDirectories))
+                {
+                    var info = new DirectoryInfo(dir);
+                    if (info.LinkTarget != null || info.Attributes.HasFlag(FileAttributes.ReparsePoint))
+                    {
+                        // This is a link; delete it without recursing into its target.
+                        Directory.Delete(dir, recursive: false);
+                    }
+                }
+            }
+            catch
+            {
+                // Best effort; continue with the main cleanup.
+            }
+
             Directory.Delete(_baseDirectory, true);
         }
 

--- a/src/Ivy.Test/LocalFileAccessPolicyTests.cs
+++ b/src/Ivy.Test/LocalFileAccessPolicyTests.cs
@@ -19,6 +19,25 @@ public class LocalFileAccessPolicyTests : IDisposable
     {
         if (Directory.Exists(_baseDirectory))
         {
+            // Delete directory links (junctions/symlinks) first, as Directory.Delete with recursive=true
+            // fails when encountering them on some platforms.
+            try
+            {
+                foreach (var dir in Directory.GetDirectories(_baseDirectory, "*", SearchOption.AllDirectories))
+                {
+                    var info = new DirectoryInfo(dir);
+                    if (info.LinkTarget != null || info.Attributes.HasFlag(FileAttributes.ReparsePoint))
+                    {
+                        // This is a link; delete it without recursing into its target.
+                        Directory.Delete(dir, recursive: false);
+                    }
+                }
+            }
+            catch
+            {
+                // Best effort; continue with the main cleanup.
+            }
+
             Directory.Delete(_baseDirectory, true);
         }
     }

--- a/src/Ivy.Test/LocalFileAccessPolicyTests.cs
+++ b/src/Ivy.Test/LocalFileAccessPolicyTests.cs
@@ -127,6 +127,89 @@ public class LocalFileAccessPolicyTests : IDisposable
         Assert.False(LocalFileAccessPolicy.TryResolve(link, roots, [], out _));
     }
 
+    [Fact]
+    public void TryResolve_MidPathDirectoryLinkPointingOutsideRoot_IsRejected()
+    {
+        var target = CreateFile(_outside, "id_rsa");
+        var link = Path.Combine(_root, "link");
+        var roots = LocalFileAccessPolicy.NormalizeRoots([_root]);
+
+        // The non-link half of the assertion always runs, so the test is never vacuous.
+        Assert.True(LocalFileAccessPolicy.TryResolve(CreateFile(_root, "photo.png"), roots, [], out _));
+
+        if (!TryCreateDirectoryLink(link, _outside))
+            return; // Directory link creation not permitted here; skip the escape half.
+
+        var pathThroughLink = Path.Combine(link, "id_rsa");
+        Assert.True(File.Exists(pathThroughLink), "Link should allow access to target file");
+        Assert.False(LocalFileAccessPolicy.TryResolve(pathThroughLink, roots, [], out _));
+    }
+
+    [Fact]
+    public void TryResolve_RootReachedThroughADirectoryLink_StillConfines()
+    {
+        var real = Directory.CreateDirectory(Path.Combine(_baseDirectory, "real")).FullName;
+        var inside = CreateFile(real, "inside.png");
+        var outside = CreateFile(_outside, "secret.txt");
+        var link = Path.Combine(_baseDirectory, "link");
+
+        if (!TryCreateDirectoryLink(link, real))
+        {
+            // No directory link support; assert the real path works.
+            var roots = LocalFileAccessPolicy.NormalizeRoots([real]);
+            Assert.True(LocalFileAccessPolicy.TryResolve(inside, roots, [], out _));
+            Assert.False(LocalFileAccessPolicy.TryResolve(outside, roots, [], out _));
+            return;
+        }
+
+        // Configure the root as the link path.
+        var roots2 = LocalFileAccessPolicy.NormalizeRoots([link]);
+
+        // File inside root is accepted by both its link path and its real path.
+        Assert.True(LocalFileAccessPolicy.TryResolve(Path.Combine(link, "inside.png"), roots2, [], out _));
+        Assert.True(LocalFileAccessPolicy.TryResolve(inside, roots2, [], out _));
+
+        // File outside is still rejected.
+        Assert.False(LocalFileAccessPolicy.TryResolve(outside, roots2, [], out _));
+    }
+
+    [Fact]
+    public void TryResolve_MidPathLinkChainPointingOutsideRoot_IsRejected()
+    {
+        var intermediate = Directory.CreateDirectory(Path.Combine(_baseDirectory, "intermediate")).FullName;
+        var target = CreateFile(_outside, "secret.txt");
+        var link1 = Path.Combine(_root, "link1");
+        var link2 = Path.Combine(intermediate, "link2");
+        var roots = LocalFileAccessPolicy.NormalizeRoots([_root]);
+
+        if (!TryCreateDirectoryLink(link1, intermediate) || !TryCreateDirectoryLink(link2, _outside))
+            return; // Directory link creation not permitted here.
+
+        var pathThroughChain = Path.Combine(link1, "link2", "secret.txt");
+        Assert.True(File.Exists(pathThroughChain), "Link chain should allow access to target file");
+        Assert.False(LocalFileAccessPolicy.TryResolve(pathThroughChain, roots, [], out _));
+    }
+
+    [Fact]
+    public void TryResolve_MidPathDirectoryLinkStayingInsideRoot_IsAccepted()
+    {
+        var subdir = Directory.CreateDirectory(Path.Combine(_root, "subdir")).FullName;
+        var target = CreateFile(subdir, "photo.png");
+        var link = Path.Combine(_root, "link");
+        var roots = LocalFileAccessPolicy.NormalizeRoots([_root]);
+
+        if (!TryCreateDirectoryLink(link, subdir))
+        {
+            // No directory link support; assert the real path works.
+            Assert.True(LocalFileAccessPolicy.TryResolve(target, roots, [], out _));
+            return;
+        }
+
+        var pathThroughLink = Path.Combine(link, "photo.png");
+        Assert.True(File.Exists(pathThroughLink), "Link should allow access to target file");
+        Assert.True(LocalFileAccessPolicy.TryResolve(pathThroughLink, roots, [], out _));
+    }
+
     #endregion
 
     #region Extensions
@@ -204,7 +287,15 @@ public class LocalFileAccessPolicyTests : IDisposable
             ""
         ]);
 
-        Assert.Equal(new[] { _root }, roots);
+        // Assert the contract rather than the exact string, since on macOS the temp path itself may
+        // contain a symlink (e.g. /var -> /private/var).
+        Assert.Single(roots);
+        Assert.DoesNotEndWith(Path.DirectorySeparatorChar.ToString(), roots[0]);
+        Assert.DoesNotEndWith(Path.AltDirectorySeparatorChar.ToString(), roots[0]);
+
+        // A file created under the original root path should resolve as inside it.
+        var file = CreateFile(_root, "test.txt");
+        Assert.True(LocalFileAccessPolicy.TryResolve(file, roots, [], out _));
     }
 
     [Fact]
@@ -242,5 +333,51 @@ public class LocalFileAccessPolicyTests : IDisposable
         var path = Path.Combine(directory, fileName);
         File.WriteAllText(path, "content");
         return path;
+    }
+
+    /// <summary>
+    /// Creates a directory link, preferring a symlink and falling back to a Windows junction, which needs
+    /// no SeCreateSymbolicLinkPrivilege. Returns false when neither is available, so a caller can skip the
+    /// link half of its assertion rather than fail.
+    /// </summary>
+    private static bool TryCreateDirectoryLink(string link, string target)
+    {
+        try
+        {
+            Directory.CreateSymbolicLink(link, target);
+            return true;
+        }
+        catch (Exception e) when (e is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
+        {
+            // Symlink creation not permitted; try a Windows junction.
+        }
+
+        if (!OperatingSystem.IsWindows())
+            return false;
+
+        try
+        {
+            var process = new System.Diagnostics.Process
+            {
+                StartInfo = new System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = "cmd.exe",
+                    Arguments = $"/c mklink /J \"{link}\" \"{target}\"",
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    CreateNoWindow = true
+                }
+            };
+
+            process.Start();
+            process.WaitForExit(5000);
+
+            return Directory.Exists(link);
+        }
+        catch
+        {
+            return false;
+        }
     }
 }

--- a/src/Ivy.Test/LocalFileAccessPolicyTests.cs
+++ b/src/Ivy.Test/LocalFileAccessPolicyTests.cs
@@ -290,8 +290,8 @@ public class LocalFileAccessPolicyTests : IDisposable
         // Assert the contract rather than the exact string, since on macOS the temp path itself may
         // contain a symlink (e.g. /var -> /private/var).
         Assert.Single(roots);
-        Assert.DoesNotEndWith(Path.DirectorySeparatorChar.ToString(), roots[0]);
-        Assert.DoesNotEndWith(Path.AltDirectorySeparatorChar.ToString(), roots[0]);
+        Assert.False(roots[0].EndsWith(Path.DirectorySeparatorChar));
+        Assert.False(roots[0].EndsWith(Path.AltDirectorySeparatorChar));
 
         // A file created under the original root path should resolve as inside it.
         var file = CreateFile(_root, "test.txt");

--- a/src/Ivy/Services/LocalFileAccessPolicy.cs
+++ b/src/Ivy/Services/LocalFileAccessPolicy.cs
@@ -9,9 +9,9 @@ namespace Ivy;
 internal static class LocalFileAccessPolicy
 {
     /// <summary>
-    /// Normalizes configured roots to full paths without a trailing separator. Each root's own leaf
-    /// link is resolved here, at configure time, so a symlinked root directory cannot cause a false
-    /// mismatch against an already-resolved request path.
+    /// Normalizes configured roots to full paths without a trailing separator. The whole root path is
+    /// canonicalized at configure time, so a root reached through a directory link still matches request
+    /// paths canonicalized the same way.
     /// </summary>
     internal static string[] NormalizeRoots(IEnumerable<string>? roots)
     {
@@ -20,7 +20,7 @@ internal static class LocalFileAccessPolicy
 
         return roots
             .Where(root => !string.IsNullOrWhiteSpace(root))
-            .Select(root => Path.TrimEndingDirectorySeparator(ResolveLeafLink(Path.GetFullPath(root.Trim()))))
+            .Select(root => Path.TrimEndingDirectorySeparator(ResolveFullPath(Path.GetFullPath(root.Trim()))))
             .Where(root => root.Length > 0)
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToArray();
@@ -80,8 +80,17 @@ internal static class LocalFileAccessPolicy
         if (roots.Count == 0)
             return true;
 
-        // A symlink inside a root that points outside it is deliberately rejected.
-        var resolved = ResolveLeafLink(fullPath);
+        // A link inside a root that points outside it is deliberately rejected, wherever in the path it sits.
+        var resolved = ResolveFullPath(fullPath);
+
+        // Check extension allowlist against resolved path too, so a symlink cannot rename the extension.
+        if (extensions.Count > 0)
+        {
+            var resolvedExtension = Path.GetExtension(resolved);
+            if (string.IsNullOrEmpty(resolvedExtension) || !extensions.Contains(resolvedExtension, StringComparer.OrdinalIgnoreCase))
+                return false;
+        }
+
         return roots.Any(root => IsWithin(resolved, root));
     }
 
@@ -97,17 +106,50 @@ internal static class LocalFileAccessPolicy
                 || fullPath[root.Length] == Path.AltDirectorySeparatorChar);
     }
 
-    private static string ResolveLeafLink(string fullPath)
+    /// <summary>
+    /// Resolves every link in <paramref name="fullPath"/>, not only its final component, by walking the
+    /// path from its root and following any segment that turns out to be a symlink or a junction. A
+    /// directory link in the middle of the path is what a leaf-only resolver misses.
+    /// </summary>
+    private static string ResolveFullPath(string fullPath)
+    {
+        var pathRoot = Path.GetPathRoot(fullPath);
+        if (string.IsNullOrEmpty(pathRoot))
+            return fullPath;
+
+        var current = pathRoot;
+
+        foreach (var segment in fullPath[pathRoot.Length..].Split(
+                     [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
+                     StringSplitOptions.RemoveEmptyEntries))
+        {
+            var candidate = Path.Join(current, segment);
+            current = ResolveLink(candidate) ?? candidate;
+        }
+
+        return current;
+    }
+
+    private static string? ResolveLink(string candidate)
     {
         try
         {
-            return new FileInfo(fullPath).ResolveLinkTarget(returnFinalTarget: true)?.FullName ?? fullPath;
+            // FileInfo resolves a directory link too, so one call covers both segment kinds, and
+            // returnFinalTarget follows a chain of links in a single step.
+            var target = new FileInfo(candidate).ResolveLinkTarget(returnFinalTarget: true);
+            if (target == null)
+                return null;
+
+            // A relative link target belongs to the link's own directory, never to the process working
+            // directory. GetFullPath ignores the base when the target is already rooted.
+            return Path.GetFullPath(target.FullName, Path.GetDirectoryName(candidate) ?? candidate);
         }
         catch (Exception e) when (e is IOException or UnauthorizedAccessException)
         {
-            // Nothing there to resolve (or nothing we may read); fall back to the literal path,
-            // which the caller's File.Exists check rejects.
-            return fullPath;
+            // The segment does not exist, or is an unresolvable link such as a cycle. Treat it as a
+            // literal name: a path we cannot resolve cannot be opened either, so the caller's
+            // File.Exists check rejects it for the same reason.
+            return null;
         }
     }
 }


### PR DESCRIPTION
﻿# Summary

## Changes

LocalFileAccessPolicy now resolves every link in a path, not only the leaf, closing a security vulnerability where a directory junction in the middle of a path allowed files outside configured roots to be served. Both root canonicalization and request path resolution now use the same whole-path resolver, preventing false negatives when roots are accessed through directory links. Extension checking now validates both the requested path and the resolved path, preventing symlink-based extension renaming attacks.

## API Changes

None - all changes are internal to `LocalFileAccessPolicy`. The public API signature of `TryResolve` remains unchanged.

## Files Modified

**Core Implementation:**
- `src/Ivy/Services/LocalFileAccessPolicy.cs` - Replaced `ResolveLeafLink` with `ResolveFullPath` and `ResolveLink` methods, updated `TryResolve` and `NormalizeRoots` to use whole-path resolution, added extension check on resolved paths

**Tests:**
- `src/Ivy.Test/LocalFileAccessPolicyTests.cs` - Added 4 new regression tests for mid-path links, updated `TryCreateDirectoryLink` helper for Windows junction support, fixed disposal logic to handle junctions
- `src/Ivy.Integration.Tests/LocalFileEndpointTests.cs` - Added end-to-end test for mid-path directory link returning 404, fixed disposal logic

**Documentation:**
- `src/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/01_Program.md` - Added sentence documenting symlink/junction resolution in Local File Access section

## Manual Testing

**Prerequisites:** Windows machine with ability to create junctions (no elevation required), or Unix with ability to create directory symlinks.

1. Launch Ivy.Samples app: `dotnet run --project src/Ivy.Samples/Ivy.Samples.csproj`
2. Navigate to any sample that uses local file access (e.g. Settings app with Photos directory configured)
3. In PowerShell/terminal, create a junction inside the configured root that points outside it:
   - Windows: `cmd /c mklink /J "C:\Users\YourUser\Photos\escape" "C:\Windows\System32"`
   - Unix: `ln -s /etc "~/Photos/escape"`
4. Attempt to access a file through the junction via the Ivy app (e.g. try to display `Photos/escape/drivers/etc/hosts` as an image)
5. **Expected:** Ivy returns 404 (file not found), never serves the file
6. **Before this fix:** File would be served if it existed and had an allowed extension

Alternatively, run the new tests directly to verify the fix:
```
cd src && dotnet test Ivy-Framework.slnx --filter "FullyQualifiedName~TryResolve_MidPathDirectoryLinkPointingOutsideRoot_IsRejected"
```

---

## Commits

- 9390a72a3 Resolve whole path when confining local file access
- 1d187caa4 Fix xUnit assertion method
- 82924ac19 Fix junction cleanup in test disposal
- c95aa3543 Fix junction cleanup in integration test disposal

---
Created using [Ivy Tendril](https://ivy.app).