### PR TITLE
[00422] Validate the Host Header by Default on a Loopback Bind

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/01_Program.md
+++ b/src/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/01_Program.md
@@ -174,6 +174,8 @@ The server automatically reads configuration from environment variables:
 - `VERBOSE` - Enable verbose logging
 - `IVY_TLS` - Control whether the server uses HTTPS (`true`, `1`, `yes`, `on`) or HTTP (`false`, `0`, `no`, `off`). When unset, Ivy defaults to HTTPS for local development and HTTP in containers or hosted environments (where a reverse proxy typically handles TLS).
 - `IVY_CORS_ORIGINS` - Comma- or semicolon-separated list of origins the default CORS policy allows (for example `https://app.example.com,https://admin.example.com`). Applied only when `AllowedCorsOrigins` is empty.
+- `AllowedHosts` - Standard ASP.NET Core key, semicolon separated, e.g. `localhost;127.0.0.1`. Setting
+  it (including to `*`) overrides the loopback default described under CORS and Host Filtering.
 
 When `BasePath` is set (via `ServerArgs`, CLI, or environment variable), Ivy applies ASP.NET Core `UsePathBase()` middleware to ensure routing and link generation work correctly under that prefix.
 
@@ -234,14 +236,30 @@ server.AllowCorsOrigins("https://app.example.com");
 ```
 
 CORS cannot stop DNS rebinding: a page on a hostname rebound to `127.0.0.1` is *same-origin* with the
-server, so no CORS check runs. Validating the `Host` header is what rejects it. This is opt-in, because
-reverse proxies and tunnels forward their own public hostname:
+server, so no CORS check runs. Validating the `Host` header is what rejects it, so when the server
+binds loopback (the `dotnet run` default) Ivy validates it for you: `localhost`, `127.0.0.1` and
+`[::1]` are accepted and anything else answers 400 with `Bad Request - Invalid Hostname`. A server that
+binds `*`, `+` or a public address (a container, a hosted deployment, or anything started with `PORT`
+set) accepts any `Host` header, because a reverse proxy in front of it forwards its own public
+hostname.
+
+Name hosts explicitly to validate them on a non-loopback bind:
 
 ```csharp
-server.AllowHosts("localhost", "127.0.0.1", "[::1]");
+server.AllowHosts("app.example.com");
 ```
 
-With `AllowHosts` set, a request carrying any other `Host` header gets a 400.
+`AllowHosts` replaces the list rather than extending it, so include the loopback names when you still
+want them:
+
+```csharp
+server.AllowHosts("localhost", "127.0.0.1", "[::1]", "my-tunnel.ngrok-free.app");
+```
+
+That is the case to reach for when a tunnel (ngrok, Cloudflare, or editor port forwarding) forwards its
+own hostname to a loopback bind. The standard ASP.NET Core `AllowedHosts` configuration key is the
+other way out: it wins over Ivy's default entirely, so `AllowedHosts=*` in the environment or in
+`appsettings.json` turns the check off again.
 
 ### Metadata
 

--- a/src/Ivy.Integration.Tests/HostFilteringTests.cs
+++ b/src/Ivy.Integration.Tests/HostFilteringTests.cs
@@ -3,8 +3,8 @@ using System.Net;
 namespace Ivy.Integration.Tests;
 
 /// <summary>
-/// Host header validation is the DNS rebinding mitigation and is opt-in: these tests measure both
-/// the opted-in behaviour and the unchanged default.
+/// Host header validation is the DNS rebinding mitigation. A loopback bind validates the loopback
+/// names by default, and <c>AllowHosts</c> replaces that list: these tests measure both.
 /// </summary>
 public class HostFilteringTests
 {
@@ -22,20 +22,54 @@ public class HostFilteringTests
     }
 
     [Fact]
-    public async Task WithoutAllowHosts_ForeignHostHeader_IsAccepted()
+    public async Task LoopbackBound_ForeignHostHeader_ReturnsBadRequest()
     {
         await using var server = await IvyTestServer.CreateAsync();
         using var client = CreateClient(server);
 
         var response = await client.SendAsync(WithHost("evil.example"));
 
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Theory]
+    [InlineData("localhost")]
+    [InlineData("127.0.0.1")]
+    [InlineData("[::1]")]
+    public async Task LoopbackBound_LoopbackHostHeaders_AreAccepted(string host)
+    {
+        await using var server = await IvyTestServer.CreateAsync();
+        using var client = CreateClient(server);
+
+        var response = await client.SendAsync(WithHost(host));
+
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    /// <summary>
+    /// <c>AllowHosts</c> replaces the loopback default rather than extending it, so naming only a
+    /// tunnel hostname stops the loopback names from working.
+    /// </summary>
+    [Fact]
+    public async Task WithAllowHosts_ReplacesTheLoopbackDefault()
+    {
+        await using var server = await IvyTestServer.CreateAsync(s => s.AllowHosts("app.example.com"));
+        using var client = CreateClient(server);
+
+        var response = await client.SendAsync(WithHost("localhost"));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
     private static HttpRequestMessage WithHost(string host)
     {
         var request = new HttpRequestMessage(HttpMethod.Get, "/ivy/health");
-        request.Headers.Host = host;
+
+        // A bracketed IPv6 literal does not survive the typed Host setter's validation, and the
+        // header has to reach the server verbatim for HostString to match it.
+        if (!request.Headers.TryAddWithoutValidation("Host", host))
+            request.Headers.Host = host;
+
         return request;
     }
 

--- a/src/Ivy.Integration.Tests/HostFilteringTests.cs
+++ b/src/Ivy.Integration.Tests/HostFilteringTests.cs
@@ -65,10 +65,9 @@ public class HostFilteringTests
     {
         var request = new HttpRequestMessage(HttpMethod.Get, "/ivy/health");
 
-        // A bracketed IPv6 literal does not survive the typed Host setter's validation, and the
-        // header has to reach the server verbatim for HostString to match it.
-        if (!request.Headers.TryAddWithoutValidation("Host", host))
-            request.Headers.Host = host;
+        // Set verbatim rather than through the typed Host setter, so the value under test reaches
+        // the server exactly as written and it is the server's parsing that is measured here.
+        request.Headers.TryAddWithoutValidation("Host", host);
 
         return request;
     }

--- a/src/Ivy.Test/HostFilterPolicyTests.cs
+++ b/src/Ivy.Test/HostFilterPolicyTests.cs
@@ -1,0 +1,65 @@
+using Ivy.Core.Server;
+
+namespace Ivy.Test;
+
+public class HostFilterPolicyTests
+{
+    private static readonly string[] LoopbackDefault = ["localhost", "127.0.0.1", "[::1]"];
+
+    #region Loopback binds get the default list
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("  ")]
+    [InlineData("localhost")]
+    [InlineData("LocalHost")]
+    [InlineData("127.0.0.1")]
+    [InlineData("[::1]")]
+    [InlineData("::1")]
+    public void ResolveDefaultAllowedHosts_LoopbackBind_ReturnsLoopbackHosts(string? bindHost)
+    {
+        var resolved = HostFilterPolicy.ResolveDefaultAllowedHosts(bindHost, null);
+
+        Assert.Equal(LoopbackDefault, resolved);
+    }
+
+    [Fact]
+    public void ResolveDefaultAllowedHosts_OtherLoopbackLiteral_AddsTheBindHost()
+    {
+        var resolved = HostFilterPolicy.ResolveDefaultAllowedHosts("127.0.0.2", null);
+
+        Assert.NotNull(resolved);
+        Assert.Equal(["localhost", "127.0.0.1", "[::1]", "127.0.0.2"], resolved);
+    }
+
+    #endregion
+
+    #region Non-loopback binds are left alone
+
+    [Theory]
+    [InlineData("*")]
+    [InlineData("+")]
+    [InlineData("0.0.0.0")]
+    [InlineData("10.0.0.5")]
+    [InlineData("example.com")]
+    public void ResolveDefaultAllowedHosts_NonLoopbackBind_ReturnsNull(string bindHost)
+    {
+        Assert.Null(HostFilterPolicy.ResolveDefaultAllowedHosts(bindHost, null));
+    }
+
+    #endregion
+
+    #region A configured key wins
+
+    [Theory]
+    [InlineData("*")]
+    [InlineData("")]
+    [InlineData("example.com")]
+    public void ResolveDefaultAllowedHosts_ConfiguredKey_ReturnsNull(string configuredAllowedHosts)
+    {
+        Assert.Null(HostFilterPolicy.ResolveDefaultAllowedHosts("localhost", configuredAllowedHosts));
+    }
+
+    #endregion
+}

--- a/src/Ivy/Core/Server/HostFilterPolicy.cs
+++ b/src/Ivy/Core/Server/HostFilterPolicy.cs
@@ -1,0 +1,44 @@
+using System.Net;
+using System.Net.Sockets;
+
+namespace Ivy.Core.Server;
+
+/// <summary>
+/// Decides whether Ivy supplies a default <c>AllowedHosts</c> list. Host header validation is the DNS
+/// rebinding mitigation: a page on a hostname whose DNS answer flips to 127.0.0.1 is same-origin with
+/// the server, so no CORS check runs and only the Host header separates it from a real local request.
+/// </summary>
+internal static class HostFilterPolicy
+{
+    private static readonly string[] LoopbackHosts = ["localhost", "127.0.0.1", "[::1]"];
+
+    /// <summary>
+    /// Returns the list to install, or null when Ivy must not touch the option: either the app
+    /// configured <c>AllowedHosts</c> itself (ASP.NET Core reads that key only while the option list is
+    /// empty, so filling it here would clobber the key), or the server does not bind loopback, where a
+    /// proxy or tunnel may legitimately forward its own hostname.
+    /// </summary>
+    internal static string[]? ResolveDefaultAllowedHosts(string? bindHost, string? configuredAllowedHosts)
+    {
+        if (configuredAllowedHosts != null)
+            return null;
+
+        if (!CorsOriginPolicy.IsLoopbackBound(bindHost))
+            return null;
+
+        var trimmed = bindHost?.Trim();
+        if (string.IsNullOrEmpty(trimmed))
+            return LoopbackHosts;
+
+        // A bind on another loopback literal (127.0.0.2, ::1 without brackets) has to be reachable
+        // under its own name too. HostString compares IPv6 in bracketed form.
+        var pattern = IPAddress.TryParse(trimmed.Trim('[', ']'), out var address)
+                      && address.AddressFamily == AddressFamily.InterNetworkV6
+            ? $"[{address}]"
+            : trimmed;
+
+        return LoopbackHosts.Contains(pattern, StringComparer.OrdinalIgnoreCase)
+            ? LoopbackHosts
+            : [.. LoopbackHosts, pattern];
+    }
+}

--- a/src/Ivy/Server.cs
+++ b/src/Ivy/Server.cs
@@ -617,8 +617,11 @@ public class Server
     /// <summary>
     /// Restricts the <c>Host</c> header to the given hosts, answering 400 for anything else. This is
     /// the DNS rebinding mitigation, which CORS cannot substitute for: a page on a hostname rebound
-    /// to 127.0.0.1 is same-origin with the server, so no CORS check runs. Off by default, because
-    /// reverse proxies and tunnels forward their own public hostname.
+    /// to 127.0.0.1 is same-origin with the server, so no CORS check runs. A loopback bind validates
+    /// the loopback names by default (see <see cref="Core.Server.HostFilterPolicy"/>); a server that
+    /// binds "*" or a public address validates nothing until this method names the hosts, because a
+    /// reverse proxy or tunnel in front of it forwards its own public hostname. The list replaces the
+    /// default rather than extending it, so include the loopback names when you still want them.
     /// </summary>
     public Server AllowHosts(params string[] hosts)
     {
@@ -862,14 +865,19 @@ public class Server
             });
         });
 
-        // WebApplication.CreateBuilder already registers HostFilteringStartupFilter, whose
-        // PostConfigure falls back to "*" only while AllowedHosts is empty — so setting it here wins
-        // and no extra middleware is needed.
-        if (_allowedHosts.Length > 0)
+        // WebApplication.CreateBuilder already registers HostFilteringStartupFilter, whose PostConfigure
+        // falls back to "*" only while AllowedHosts is empty, so setting it here wins and no extra
+        // middleware is needed. That is also why the default is conditional: filling the option
+        // unconditionally would clobber an app's own "AllowedHosts" configuration key.
+        var allowedHosts = _allowedHosts.Length > 0
+            ? _allowedHosts
+            : HostFilterPolicy.ResolveDefaultAllowedHosts(host, builder.Configuration["AllowedHosts"]);
+
+        if (allowedHosts is { Length: > 0 })
         {
             builder.Services.Configure<HostFilteringOptions>(options =>
             {
-                options.AllowedHosts = [.. _allowedHosts];
+                options.AllowedHosts = [.. allowedHosts];
             });
         }
 


### PR DESCRIPTION
# Summary

## Changes

Ivy now validates the `Host` header by default when the server binds a loopback address, which closes
the DNS rebinding hole that `dotnet run` shipped with (CORS cannot help, because a hostname rebound to
`127.0.0.1` is same-origin). A new internal `HostFilterPolicy` supplies `localhost`, `127.0.0.1` and
`[::1]` only when the bind is loopback and the app has not set the `AllowedHosts` configuration key
itself, so `appsettings.json`, the environment variable and `AllowHosts(...)` all still win, and a
container, hosted or tunnelled `*` bind is left permissive for the proxy in front of it.

## API Changes

- **New internal** `Ivy.Core.Server.HostFilterPolicy` with
  `internal static string[]? ResolveDefaultAllowedHosts(string? bindHost, string? configuredAllowedHosts)`.
  `internal`, so the plugin contract is unchanged; visible to `Ivy.Test` and `Ivy.Integration.Tests`
  via the existing `InternalsVisibleTo` entries.
- **No public API added, changed or removed.** `Server.AllowHosts(params string[])` keeps its
  signature and its replace-the-list semantics; only its XML doc changed.
- **Behaviour change:** the effective `AllowedHosts` on a loopback bind is
  `localhost;127.0.0.1;[::1]` instead of `*`. A request carrying any other `Host` header now answers
  `400 Bad Request - Invalid Hostname`. The documented escape hatches are `AllowHosts(...)` (include
  the loopback names) and the standard ASP.NET Core `AllowedHosts` configuration key, including
  `AllowedHosts=*` to turn the check off.

## Files Modified

**Framework**

- `src/Ivy/Core/Server/HostFilterPolicy.cs` (new) - the decision, including the "return null so the
  configuration key wins" rule and bracketed-IPv6 normalization for a non-standard loopback literal.
- `src/Ivy/Server.cs` - `BuildWebApplication` now falls back to the policy when `AllowHosts` was not
  called; `AllowHosts`'s XML doc no longer says host validation is off by default.

**Tests**

- `src/Ivy.Test/HostFilterPolicyTests.cs` (new) - 17 cases covering loopback binds, non-loopback binds
  (where binding `*` in an integration test would invite a firewall prompt) and a present configuration
  key.
- `src/Ivy.Integration.Tests/HostFilteringTests.cs` - `WithoutAllowHosts_ForeignHostHeader_IsAccepted`
  measured the old default and became `LoopbackBound_ForeignHostHeader_ReturnsBadRequest`; two cases
  added for the loopback names being accepted and for `AllowHosts` replacing the default.

**Documentation**

- `src/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/01_Program.md` - the `CORS and Host Filtering`
  section no longer says validation is opt-in, and the environment variable list gains `AllowedHosts`.

## Manual Testing

1. Run any Ivy app locally, e.g. `dotnet run --project src/Ivy.Samples/Ivy.Samples.csproj --find-available-port`,
   and note the port it prints (`https://localhost:<port>`).
2. Open `https://localhost:<port>` in a browser. The app loads exactly as before, and so does the Vite
   dev loop (`cd src/frontend; vp dev`), because loopback origins and loopback host names are both
   still allowed.
3. Send a request with a foreign `Host` header, which is what a rebound DNS name looks like to the
   server:
   ```powershell
   curl.exe -k -H "Host: evil.example" https://localhost:<port>/ivy/health
   ```
   Expect `400` with the body `Bad Request - Invalid Hostname`. Before this change it answered `200`.
4. Prove the escape hatch: stop the app, set `AllowedHosts=*` (or add `"AllowedHosts": "*"` to
   `appsettings.json`), start it again, and repeat step 3. Expect `200` again, showing the
   configuration key overrides Ivy's default rather than being overridden by it.
5. Confirm a container-shaped bind is untouched: start with `PORT=5099` set (which makes Ivy bind `*`)
   and repeat step 3 against `http://localhost:5099/ivy/health`. Expect `200`, because a reverse proxy
   in front of such a server forwards its own public hostname.

---

## Commits

- b5fe4a354 Validate the Host header by default on a loopback bind (plan 00422)
- c32162713 Test the loopback host filtering default (plan 00422)
- 96b55b45b Document the loopback host filtering default (plan 00422)
- 1edf75cf4 Fix an inaccurate comment in the host header test helper

---
Created using [Ivy Tendril](https://ivy.app).
