### PR TITLE
[00420] Compare Local File Roots Case-Sensitively on Linux

### DIFF
--- a/src/Ivy.Test/LocalFileAccessPolicyTests.cs
+++ b/src/Ivy.Test/LocalFileAccessPolicyTests.cs
@@ -127,6 +127,37 @@ public class LocalFileAccessPolicyTests : IDisposable
         Assert.False(LocalFileAccessPolicy.TryResolve(link, roots, [], out _));
     }
 
+    [Fact]
+    public void TryResolve_InDifferentlyCasedSiblingDirectory_IsRejectedWhereTheFilesystemIsCaseSensitive()
+    {
+        var roots = LocalFileAccessPolicy.NormalizeRoots([_root]);
+
+        // The in-root half always runs, so the test measures something on every platform.
+        Assert.True(LocalFileAccessPolicy.TryResolve(CreateFile(_root, "photo.png"), roots, [], out _));
+
+        if (!OperatingSystem.IsLinux())
+            return; // "ROOT" and "root" are the same directory here; nothing to escape from.
+
+        // On a case-sensitive filesystem this is a genuinely different directory with its own
+        // contents, so the file really exists and the caller's File.Exists check would succeed.
+        var casedSibling = Directory.CreateDirectory(Path.Combine(_baseDirectory, "ROOT")).FullName;
+        var path = CreateFile(casedSibling, "id_rsa.png");
+
+        Assert.False(LocalFileAccessPolicy.TryResolve(path, roots, [], out _));
+    }
+
+    [Fact]
+    public void TryResolve_WithDifferentlyCasedRoot_IsAcceptedOnCaseInsensitivePlatforms()
+    {
+        if (OperatingSystem.IsLinux())
+            return; // An upper-cased root is a different directory here, so it must not confine.
+
+        var path = CreateFile(_root, "photo.png");
+        var roots = LocalFileAccessPolicy.NormalizeRoots([_root.ToUpperInvariant()]);
+
+        Assert.True(LocalFileAccessPolicy.TryResolve(path, roots, [], out _));
+    }
+
     #endregion
 
     #region Extensions
@@ -205,6 +236,24 @@ public class LocalFileAccessPolicyTests : IDisposable
         ]);
 
         Assert.Equal(new[] { _root }, roots);
+    }
+
+    [Fact]
+    public void NormalizeRoots_DeduplicatesDifferentlyCasedRootsOnlyOnCaseInsensitivePlatforms()
+    {
+        var upper = _root.ToUpperInvariant();
+
+        var roots = LocalFileAccessPolicy.NormalizeRoots([_root, upper]);
+
+        if (OperatingSystem.IsLinux())
+        {
+            // Two different directories on a case-sensitive filesystem, so both must survive.
+            Assert.Equal(new[] { _root, upper }, roots);
+        }
+        else
+        {
+            Assert.Equal(new[] { _root }, roots);
+        }
     }
 
     [Fact]

--- a/src/Ivy/Services/LocalFileAccessPolicy.cs
+++ b/src/Ivy/Services/LocalFileAccessPolicy.cs
@@ -9,6 +9,19 @@ namespace Ivy;
 internal static class LocalFileAccessPolicy
 {
     /// <summary>
+    /// Path comparison follows the platform instead of being hard-coded: Windows and macOS are
+    /// case-insensitive by default, Linux is not, and comparing case-insensitively there is more
+    /// permissive than the filesystem itself. A macOS volume can be formatted case-sensitive, so macOS
+    /// keeps the insensitive default rather than being probed.
+    /// </summary>
+    private static readonly StringComparison PathComparison =
+        OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+
+    private static readonly StringComparer PathComparer = StringComparer.FromComparison(PathComparison);
+
+    /// <summary>
     /// Normalizes configured roots to full paths without a trailing separator. Each root's own leaf
     /// link is resolved here, at configure time, so a symlinked root directory cannot cause a false
     /// mismatch against an already-resolved request path.
@@ -22,7 +35,7 @@ internal static class LocalFileAccessPolicy
             .Where(root => !string.IsNullOrWhiteSpace(root))
             .Select(root => Path.TrimEndingDirectorySeparator(ResolveLeafLink(Path.GetFullPath(root.Trim()))))
             .Where(root => root.Length > 0)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Distinct(PathComparer)
             .ToArray();
     }
 
@@ -87,12 +100,12 @@ internal static class LocalFileAccessPolicy
 
     private static bool IsWithin(string fullPath, string root)
     {
-        if (string.Equals(fullPath, root, StringComparison.OrdinalIgnoreCase))
+        if (string.Equals(fullPath, root, PathComparison))
             return true;
 
         // Requiring the separator is what stops root "/data/pub" from matching "/data/pub-secrets".
         return fullPath.Length > root.Length
-            && fullPath.StartsWith(root, StringComparison.OrdinalIgnoreCase)
+            && fullPath.StartsWith(root, PathComparison)
             && (fullPath[root.Length] == Path.DirectorySeparatorChar
                 || fullPath[root.Length] == Path.AltDirectorySeparatorChar);
     }


### PR DESCRIPTION
# Compare Local File Roots Case-Sensitively on Linux

Branch `tendril/00420-CompareLocalFileRootsCas`, tip `61b3e44aa`, 2 commits, 2 files, +68/-4.
All five verifications `Pass`.

## What changed

`LocalFileAccessPolicy` compared configured roots against request paths with
`StringComparison.OrdinalIgnoreCase` on every platform. On Linux that is **more permissive than the
kernel**: `/srv/pub` and `/srv/PUB` are two different directories with their own contents and
permissions, but the prefix check treated one as inside the other. The comparison is now derived from the
platform (`OrdinalIgnoreCase` on Windows and macOS, `Ordinal` elsewhere) and applied at the three root
comparison sites: the `Distinct` in `NormalizeRoots` and both comparisons in `IsWithin`.

The extension allowlist stays case-insensitive on purpose. `.PNG` and `.png` are the same image, which is
why `NormalizeExtensions` lower-cases its input; that is a spelling question, not a filesystem boundary.

The exposure was small and the originating recommendation said so: an attacker who picks the path can
usually pick the correctly-cased one. What the fix buys is that `TryResolve`'s answer means what its name
says, so a second check layered on top cannot be bypassed by re-casing.

**One correction to the source recommendation.** Its example, `/SRV/PUB/../secrets/key` against root
`/srv/pub`, was already rejected under either comparison: `Path.GetFullPath` collapses the `..` first,
and nothing under `/SRV` survives the separator check. The demonstrable shape is a differently-cased
*sibling* directory, and that is what the new test uses.

## Tests

Three, in `LocalFileAccessPolicyTests.cs`: the Linux-only escape, its case-insensitive mirror, and a
dedup test pinning `NormalizeRoots` to the same platform rule so the two cannot drift apart.

Both directions were proven with throwaway probes rather than assumed. Forcing `Ordinal` on Windows
rejected a re-cased path that `File.Exists` confirms is real, and failed the two mirror tests; forcing
`OrdinalIgnoreCase` back let the escape succeed. So the platform branch is load-bearing and the new tests
genuinely fail against the old code. Both probes were reverted and never committed.

## The plan had drifted, in a way that mattered

Three sibling plans from the same parent landed while this one waited: 00421 (#4798), 00418 (#4799) and
00419 (#4800). Line numbers moved, and the extension check the plan described as one site is now two
(00419 added the second); both were left insensitive.

00419 is the interesting one. It replaced leaf-only link resolution with whole-path `ResolveFullPath`,
and the plan had called out the invariant that whoever merged second must protect: roots and request
paths must be canonicalized by the *same* function, because case-sensitive comparison makes that symmetry
load-bearing. If one side acquired the on-disk casing and the other did not, legitimate requests would
start returning 404. After the merge both sides go through `ResolveFullPath`, so the invariant holds, and
the merged doc comment now says why in prose.

`src/Ivy.Integration.Tests` is in `src/Ivy-Framework.slnx:37` as of 00421, so a solution-scoped filtered
run selects `LocalFileEndpointTests` directly. This retires the memory note claiming it sits outside the
solution file.

## An external reset deleted this plan mid-run, and what it cost

At **11:51:25Z**, with implementation complete, all four gates measured `Pass` and their reports written,
plan 00420 was reset underneath the running job: `state: Draft`, `commits: []`, every verification
`Pending`, and `Verification/`, `Artifacts/` and `Worktrees/` deleted. The next build failed with
`MSB1009: Project file does not exist`.

The branch ref survived, so this cost bookkeeping rather than work. Recovery, in order: a salvage ref
first (`refs/salvage/00420-job01952`), then `worktree prune`, then a hand-rolled `git worktree add` onto
the *existing* branch. Not `tendril plan add-worktree`, which cuts a fresh branch from the base and
deletes the prior one, destroying exactly what is being recovered.

The restoration is provably faithful: `git write-tree` in the restored worktree returns
`55bcb8919369d1b66a666473d2f7e27da6d31ff1`, identical to `HEAD^{tree}`, and `dotnet format` re-run there
still exits 0. So the `Pass` verdicts describe the bytes now on disk. Build and test were not re-measured,
because the deletion also took untracked `node_modules` and the build shells out to `vp install`; sibling
ivy-framework job 01958 was live, and a concurrent install is what produced `MSB3073 â€¦ exited with code
38` earlier in this job.

**The cause is diagnosable and is not a mystery cancel.** `D:\.tendril\crash.log` shows
`Ivy.Tendril.Test` tests, running from plan 00428's ivy-tendril worktree, writing into the **live**
`D:\.tendril` home at 11:46:04Z through 11:47:35Z: `JobServiceSlotLeakTests` and `JobLauncherTests`,
which exercise job launch and plan-state transitions. `PlanWatcher FSW error: â€¦ Access is denied` follows
at 11:47:54Z, consistent with plan directories being deleted under the watcher, and the reset lands
minutes later. A test suite for the orchestrator is running against the orchestrator's production home
directory. That is filed as a High-impact recommendation.

## For the next job

- `node_modules` is absent from the restored worktree. Install before any `vp` command, and not while a
  sibling ivy-framework worktree is live. A bare config load otherwise fails with "No project-local
  vite-plus installation was found", which reads as a fault in this diff and is not one.
- `origin/development` was still `aa7f76570` at handover, and the branch is 2 ahead / 0 behind, so the
  merge is current and no conflict resolution is pending.
- `refs/salvage/00420-job01952` can be deleted once a PR exists:
  `git update-ref -d refs/salvage/00420-job01952 61b3e44aa`.
- `tendril job status` could not report throughout the recovery ("No Tendril server is running (no
  .master file found)") even though `tendril job list` and the file-based `plan` commands worked. Progress
  messages for this job are therefore stale in the UI.


---

## Commits

- 61b3e44aa Merge development into 00420 and keep the platform-derived path comparison
- 531cf5822 Compare local file roots case-sensitively where the filesystem is (plan 00420)

---
Created using [Ivy Tendril](https://ivy.app).