### PR TITLE
[00438] Derive CORS and Host Filtering From the Actual Bind Host

### DIFF
--- a/src/Ivy.Integration.Tests/CliCommandBindHostTests.cs
+++ b/src/Ivy.Integration.Tests/CliCommandBindHostTests.cs
@@ -1,0 +1,59 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Cors.Infrastructure;
+using Microsoft.AspNetCore.HostFiltering;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Ivy.Integration.Tests;
+
+/// <summary>
+/// A CLI-only command binds loopback whatever the requested host is, so the CORS and host filtering
+/// defaults have to be derived from the address actually bound. <c>Host = "*"</c> plus
+/// <c>Describe = true</c> reproduces the container and PORT cases without touching an environment
+/// variable, which matters because xUnit runs test classes in parallel.
+/// </summary>
+public class CliCommandBindHostTests
+{
+    [Fact]
+    public async Task CliCommand_WithWildcardHost_ValidatesTheLoopbackHostNames()
+    {
+        await using var app = BuildCliApplication();
+
+        var hostFiltering = app.Services.GetRequiredService<IOptions<HostFilteringOptions>>().Value;
+
+        Assert.Equal(new[] { "localhost", "127.0.0.1", "[::1]" }, hostFiltering.AllowedHosts);
+    }
+
+    [Fact]
+    public async Task CliCommand_WithWildcardHost_ReflectsLoopbackOriginsOnly()
+    {
+        await using var app = BuildCliApplication();
+
+        var corsOptions = app.Services.GetRequiredService<IOptions<CorsOptions>>().Value;
+        var policy = corsOptions.GetPolicy(corsOptions.DefaultPolicyName);
+
+        Assert.NotNull(policy);
+        Assert.True(policy.IsOriginAllowed("http://localhost:5173"));
+        Assert.False(policy.IsOriginAllowed("https://evil.example"));
+    }
+
+    /// <summary>
+    /// Builds the application without starting it: the CLI branch binds port 0 and only the DI
+    /// container is under test here.
+    /// </summary>
+    private static WebApplication BuildCliApplication()
+    {
+        var server = new Server(new ServerArgs
+        {
+            Port = 0,
+            Silent = true,
+            Host = "*",
+            Describe = true
+        });
+
+        var app = server.BuildWebApplication();
+        Assert.NotNull(app);
+
+        return app;
+    }
+}

--- a/src/Ivy/Server.cs
+++ b/src/Ivy/Server.cs
@@ -778,9 +778,13 @@ public class Server
         var hasPortEnv = Environment.GetEnvironmentVariable("PORT") != null;
         var host = _args.Host ?? (isContainer || hasPortEnv ? "*" : "localhost");
 
+        // A CLI-only command binds loopback below whatever `host` asks for, so the CORS and host
+        // filtering defaults have to key off the address actually bound, not off the intent.
+        var bindHost = _args.IsCliCommand ? "localhost" : host;
+
         if (_args.IsCliCommand)
         {
-            builder.WebHost.UseUrls("http://localhost:0");
+            builder.WebHost.UseUrls($"http://{bindHost}:0");
         }
         else
         {
@@ -851,7 +855,7 @@ public class Server
         // Ivy serves its own frontend, so production traffic is same-origin and never consults CORS.
         // The dev loop (Vite on another port) is loopback on both sides, so reflect loopback origins
         // only when the server itself binds loopback; anything else has to be configured explicitly.
-        var allowLoopbackOrigins = CorsOriginPolicy.IsLoopbackBound(host);
+        var allowLoopbackOrigins = CorsOriginPolicy.IsLoopbackBound(bindHost);
         var allowedCorsOrigins = _args.AllowedCorsOrigins;
         builder.Services.AddCors(options =>
         {
@@ -871,7 +875,7 @@ public class Server
         // unconditionally would clobber an app's own "AllowedHosts" configuration key.
         var allowedHosts = _allowedHosts.Length > 0
             ? _allowedHosts
-            : HostFilterPolicy.ResolveDefaultAllowedHosts(host, builder.Configuration["AllowedHosts"]);
+            : HostFilterPolicy.ResolveDefaultAllowedHosts(bindHost, builder.Configuration["AllowedHosts"]);
 
         if (allowedHosts is { Length: > 0 })
         {


### PR DESCRIPTION
# Summary

## Changes

`Server.BuildWebApplication` now computes the bind host once (`bindHost = _args.IsCliCommand ?
"localhost" : host`) and feeds that single value to the CLI listen URL, `CorsOriginPolicy.IsLoopbackBound`
and `HostFilterPolicy.ResolveDefaultAllowedHosts`. Previously a CLI-only command (`--describe`,
`--describe-connection`, `--test-connection`) bound loopback while both security policies were told
the intended host, so in a container, with `PORT` set, or with an explicit `--host`, the Host header
went unvalidated and loopback CORS origins were not reflected on a loopback socket. Non-CLI behaviour
is unchanged, because `bindHost == host` there.

## API Changes

None. `bindHost` is a local in a private code path; no public or internal signature changed.

## Files Modified

- `src/Ivy/Server.cs` - new `bindHost` local, used by the CLI `UseUrls` and both policy call sites.
- `src/Ivy.Integration.Tests/CliCommandBindHostTests.cs` (new) - two regression tests asserting the
  resolved `HostFilteringOptions.AllowedHosts` and default CORS policy for a CLI command started with
  `Host = "*"`.

## Manual Testing

N/A - internal change with no user-facing behaviour. No CLI command serves traffic (all three
`IsCliCommand` paths print and return from `RunAsync` before the only `app.StartAsync`), so nothing
observable changes for a served request. The behaviour is measured by
`CliCommandBindHostTests`, which fails on the pre-fix code (`AllowedHosts` resolves to `["*"]`) and
passes after.


---
## Commits

- 3b9eb43a0 Derive CORS and host filtering from the actual bind host (plan 00438)

---
Created using [Ivy Tendril](https://ivy.app).