### PR TITLE
[00457] Drop the Dead IsCliCommand Term From the TLS Default

### DIFF
--- a/src/Ivy/Server.cs
+++ b/src/Ivy/Server.cs
@@ -790,8 +790,8 @@ public class Server
         {
             var ivyTlsEnv = Environment.GetEnvironmentVariable("IVY_TLS");
             var useTls = !string.IsNullOrEmpty(ivyTlsEnv)
-                ? ivyTlsEnv?.ToLowerInvariant() is "1" or "true" or "yes" or "on"
-                : !isContainer && !hasPortEnv && !_args.IsCliCommand && OperatingSystem.IsWindows(); // default: TLS for local dev only on Windows
+                ? ivyTlsEnv.ToLowerInvariant() is "1" or "true" or "yes" or "on"
+                : !isContainer && !hasPortEnv && OperatingSystem.IsWindows(); // default: TLS for local dev only on Windows
             var scheme = useTls ? "https" : "http";
             builder.WebHost.UseUrls($"{scheme}://{host}:{_args.Port}");
         }


### PR DESCRIPTION
# Summary

## Changes

Removed two unreachable subexpressions from the TLS default in `Server.BuildWebApplication`
(`src/Ivy/Server.cs:792-794`): the `!_args.IsCliCommand` conjunct, which sat inside the `else` of
`if (_args.IsCliCommand)` and was therefore always `true`, and the `?.` in
`ivyTlsEnv?.ToLowerInvariant()`, which sat in the true branch of `!string.IsNullOrEmpty(ivyTlsEnv)`
where flow analysis already knows the value is non-null. This is a readability fix and a no-op at
runtime: the truth table of `useTls` is identical for every combination of `IVY_TLS`,
`DOTNET_RUNNING_IN_CONTAINER`, `PORT`, `--host` and OS.

## API Changes

None. `useTls` is a local variable inside an internal method; no public surface is touched.

## Files Modified

- `src/Ivy/Server.cs` - the `useTls` expression in `BuildWebApplication` (2 lines changed).

## Manual Testing

N/A - internal readability change with no user-facing behavior. The scheme selection is unchanged, so
nothing observable differs. If you want to confirm that for yourself:

1. Run `dotnet run --project src/Ivy.Samples/Ivy.Samples.csproj` on Windows with `IVY_TLS` unset and
   check the startup URL is still `https://localhost:<port>`.
2. Re-run with `IVY_TLS=0` and check it is `http://localhost:<port>`.
3. Re-run with `IVY_TLS=on` and check it is back to `https`.

---

## Commits

- 9144ecc0e Drop the dead IsCliCommand term from the TLS default (plan 00457)

---
Created using [Ivy Tendril](https://ivy.app).