### PR TITLE
[00481] Narrow the IVY_TLS Docs to the Real Platform Defaults

### DIFF
--- a/src/Ivy.Docs.Shared/Docs/01_Onboarding/01_GettingStarted/02_Installation.md
+++ b/src/Ivy.Docs.Shared/Docs/01_Onboarding/01_GettingStarted/02_Installation.md
@@ -58,7 +58,7 @@ Ivy Framework strictly requires the following toolchains to develop applications
 Ivy uses Rust-compiled native libraries under the hood for high-performance JSON diffing and document processing. These ship as precompiled NuGet packages — no Rust installation required.
 </Callout>
 
-Ivy serves over HTTPS in local development. On macOS and Windows, run the following once to trust the development certificate:
+Ivy defaults to HTTPS for local development on Windows. On macOS and Linux, HTTPS applies when you set `IVY_TLS=true`, or on macOS when running through `Ivy.Desktop`. To use HTTPS, run the following once to trust the development certificate (on macOS and Windows):
 
 ```terminal
 >dotnet dev-certs https --trust
@@ -199,7 +199,7 @@ The server automatically optimizes its behavior based on the current environment
 | **Caching**         | Disabled for immediate changes  | Aggressive ETag & compression    |
 | **Logging**         | Debug & Information             | Warning & Error only             |
 | **Port Management** | Conflict detection & auto-shift | Strict port binding              |
-| **HTTPS** | Dev certificate (`dotnet dev-certs https --trust`) | Reverse proxy handles TLS |
+| **HTTPS** | Dev certificate (Windows default, or when `IVY_TLS=true`) | Reverse proxy handles TLS |
 
 ### Troubleshooting "command not found"
 

--- a/src/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/01_Program.md
+++ b/src/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/01_Program.md
@@ -172,10 +172,17 @@ The server automatically reads configuration from environment variables:
 - `PORT` - Override the default port
 - `BASE_PATH` - Serve the app from a URL prefix
 - `VERBOSE` - Enable verbose logging
-- `IVY_TLS` - Control whether the server uses HTTPS (`true`, `1`, `yes`, `on`) or HTTP (`false`, `0`, `no`, `off`). When unset, Ivy defaults to HTTPS for local development and HTTP in containers or hosted environments (where a reverse proxy typically handles TLS).
+- `IVY_TLS` - Control whether the server uses HTTPS (`true`, `1`, `yes`, `on`) or HTTP (`false`, `0`, `no`, `off`). When unset, the default is HTTPS for local development on Windows only. On macOS and Linux, the default is HTTP unless you set `IVY_TLS=true` after generating a dev certificate with `dotnet dev-certs https`. In containers (`DOTNET_RUNNING_IN_CONTAINER=true`) or when `PORT` is set, the default is always HTTP on every OS, as a reverse proxy typically handles TLS in those environments. `Ivy.Desktop` behaves differently: it defaults `IVY_TLS` to `true` on Windows and macOS, and supplies its own certificate (falling back to a self-signed one under `~/.ivy/certs` when no ASP.NET Core dev certificate is present).
 - `IVY_CORS_ORIGINS` - Comma- or semicolon-separated list of origins the default CORS policy allows (for example `https://app.example.com,https://admin.example.com`). Applied only when `AllowedCorsOrigins` is empty.
 - `AllowedHosts` - Standard ASP.NET Core key, semicolon separated, e.g. `localhost;127.0.0.1`. Setting
   it (including to `*`) overrides the loopback default described under CORS and Host Filtering.
+
+The table below summarizes the default scheme by entry point and platform:
+
+| Entry point | Windows | macOS | Linux | Container, or `PORT` set |
+| --- | --- | --- | --- | --- |
+| `dotnet run` | HTTPS | HTTP | HTTP | HTTP |
+| `Ivy.Desktop` | HTTPS | HTTPS | HTTP | not applicable |
 
 When `BasePath` is set (via `ServerArgs`, CLI, or environment variable), Ivy applies ASP.NET Core `UsePathBase()` middleware to ensure routing and link generation work correctly under that prefix.
 

--- a/src/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/14_Secrets.md
+++ b/src/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/14_Secrets.md
@@ -144,6 +144,6 @@ Common runtime variables include:
 - `PORT` - Server port override.
 - `BASE_PATH` - URL prefix to serve the app under (for example `/my-app`).
 - `VERBOSE` - Enable verbose startup logging.
-- `IVY_TLS` - Force HTTPS on (`true`) or off (`false`). Defaults to HTTPS for local dev, HTTP in containers/hosted environments.
+- `IVY_TLS` - Force HTTPS on (`true`) or off (`false`). Defaults to HTTPS for local development on Windows only (HTTP on macOS and Linux unless set). See [Program](./01_Program.md#environment-variables) for the full platform rule.
 
 Use `BASE_PATH` when deploying behind a reverse proxy or ingress that routes your app from a sub-path instead of `/`.

--- a/src/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/04_Authentication/01_AuthenticationOverview.md
+++ b/src/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/04_Authentication/01_AuthenticationOverview.md
@@ -351,7 +351,7 @@ Server.AuthCookiePrefix = "clerk";
 
 ## HTTPS in Development
 
-Ivy uses secure (`Secure = true`) authentication cookies, which means your browser will only send them over HTTPS. In local development, Ivy automatically serves over HTTPS using the ASP.NET Core development certificate.
+Ivy uses secure (`Secure = true`) authentication cookies, which means your browser will only send them over HTTPS. In local development on Windows, Ivy automatically serves over HTTPS using the ASP.NET Core development certificate. On macOS and Linux, set `IVY_TLS=true` after generating the certificate to enable HTTPS.
 
 ### macOS and Windows
 
@@ -365,7 +365,7 @@ After this, your app will be accessible at `https://localhost:5010`.
 
 ### Linux
 
-Linux requires additional manual steps to trust the development certificate — see [Installation](../../01_GettingStarted/02_Installation.md#prerequisites) for details.
+Linux requires additional manual steps to trust the development certificate. See [Installation](../../01_GettingStarted/02_Installation.md#prerequisites) for details.
 
 ## Best Practices
 


### PR DESCRIPTION
# Summary

## Changes

Corrected IVY_TLS documentation across five sites to reflect the actual platform-specific defaults. The docs previously claimed HTTPS works by default on all platforms, but the code only enables it on Windows for `dotnet run`, and on Windows plus macOS for `Ivy.Desktop`.

## API Changes

None.

## Files Modified

Documentation files:
- `src/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/01_Program.md` - Added entry-point/platform table, rewrote IVY_TLS default explanation
- `src/Ivy.Docs.Shared/Docs/01_Onboarding/02_Concepts/14_Secrets.md` - Scoped one-sentence summary to Windows with link to full rule
- `src/Ivy.Docs.Shared/Docs/01_Onboarding/01_GettingStarted/02_Installation.md` - Reframed prerequisite block and qualified HTTPS table row
- `src/Ivy.Docs.Shared/Docs/01_Onboarding/03_CLI/04_Authentication/01_AuthenticationOverview.md` - Qualified HTTPS claims, removed em dash

## Manual Testing

Open the Ivy Docs application and verify the documentation accurately describes the platform behavior:

1. Run `dotnet run --project src/Ivy.Docs/Ivy.Docs.csproj --find-available-port`
2. Navigate to "Program" under Onboarding > Concepts
3. Verify the IVY_TLS environment variable description includes the entry-point/platform table showing Windows-only HTTPS for `dotnet run`
4. Navigate to "Installation" under Onboarding > Getting Started
5. Verify the HTTPS prerequisite section describes Windows as the default and macOS/Linux as opt-in
6. Navigate to "Authentication Overview" under Onboarding > CLI
7. Verify the "HTTPS in Development" section correctly scopes automatic HTTPS to Windows

---
## Commits
- b179df6c2 - Narrow IVY_TLS docs to the real platform defaults (plan 00481)

---
Created using [Ivy Tendril](https://ivy.app).
