### PR TITLE
[00483] Share One IVY_TLS Parser and Drop the Dead OS Fallback in DesktopWindow

### DIFF
--- a/src/Ivy.Desktop/DesktopWindow.cs
+++ b/src/Ivy.Desktop/DesktopWindow.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Net;
 using System.Reflection;
+using Ivy.Core.Server;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Rustino.NET;
@@ -269,11 +270,13 @@ public class DesktopWindow(Server server)
             ivyTlsEnv = "true";
         }
 
+        // The block above already applied the Windows and macOS default, so an empty value here means
+        // the process is neither: no TLS.
+        var useTls = TlsPolicy.IsEnabled(ivyTlsEnv, fallback: false);
+
         // Configure Kestrel HTTPS defaults using UseWebApplicationBuilder
         server.UseWebApplicationBuilder(builder =>
         {
-            var currentIvyTls = Environment.GetEnvironmentVariable("IVY_TLS");
-            var useTls = !string.IsNullOrEmpty(currentIvyTls) && currentIvyTls.ToLowerInvariant() is "1" or "true" or "yes" or "on";
             if (useTls)
             {
                 builder.WebHost.ConfigureKestrel(options =>
@@ -295,9 +298,6 @@ public class DesktopWindow(Server server)
         // FindAvailablePort) completes before the first await, so Args.Port is
         // already updated to the actual port the server will bind to.
         var port = server.Args.Port;
-        var useTls = !string.IsNullOrEmpty(ivyTlsEnv)
-            ? ivyTlsEnv.ToLowerInvariant() is "1" or "true" or "yes" or "on"
-            : OperatingSystem.IsWindows() || OperatingSystem.IsMacOS(); // Default to true on Windows and macOS
         var url = $"{(useTls ? "https" : "http")}://localhost:{port}";
 
         // Show splash while the server starts

--- a/src/Ivy.Test/TlsPolicyTests.cs
+++ b/src/Ivy.Test/TlsPolicyTests.cs
@@ -1,0 +1,64 @@
+using Ivy.Core.Server;
+
+namespace Ivy.Test;
+
+public class TlsPolicyTests
+{
+    [Theory]
+    [InlineData("1", true)]
+    [InlineData("true", true)]
+    [InlineData("yes", true)]
+    [InlineData("on", true)]
+    [InlineData("True", true)]
+    [InlineData("TRUE", true)]
+    [InlineData("Yes", true)]
+    [InlineData("YES", true)]
+    [InlineData("On", true)]
+    [InlineData("ON", true)]
+    public void IsEnabled_AcceptedTokens_ReturnsTrue(string value, bool expected)
+    {
+        Assert.Equal(expected, TlsPolicy.IsEnabled(value, fallback: false));
+        Assert.Equal(expected, TlsPolicy.IsEnabled(value, fallback: true));
+    }
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("false")]
+    [InlineData("no")]
+    [InlineData("off")]
+    [InlineData("False")]
+    [InlineData("NO")]
+    [InlineData("OFF")]
+    public void IsEnabled_RejectedTokens_ReturnsFalse(string value)
+    {
+        Assert.False(TlsPolicy.IsEnabled(value, fallback: false));
+        Assert.False(TlsPolicy.IsEnabled(value, fallback: true));
+    }
+
+    [Theory]
+    [InlineData("banana")]
+    [InlineData("maybe")]
+    [InlineData("1.0")]
+    [InlineData("yes please")]
+    [InlineData(" true")]
+    [InlineData("true ")]
+    public void IsEnabled_UnrecognizedValue_ReturnsFalse_EvenWithTrueFallback(string value)
+    {
+        Assert.False(TlsPolicy.IsEnabled(value, fallback: false));
+        Assert.False(TlsPolicy.IsEnabled(value, fallback: true));
+    }
+
+    [Fact]
+    public void IsEnabled_NullValue_ReturnsFallback()
+    {
+        Assert.False(TlsPolicy.IsEnabled(null, fallback: false));
+        Assert.True(TlsPolicy.IsEnabled(null, fallback: true));
+    }
+
+    [Fact]
+    public void IsEnabled_EmptyString_ReturnsFallback()
+    {
+        Assert.False(TlsPolicy.IsEnabled("", fallback: false));
+        Assert.True(TlsPolicy.IsEnabled("", fallback: true));
+    }
+}

--- a/src/Ivy/Core/Server/TlsPolicy.cs
+++ b/src/Ivy/Core/Server/TlsPolicy.cs
@@ -1,0 +1,17 @@
+namespace Ivy.Core.Server;
+
+/// <summary>
+/// Reads the IVY_TLS environment variable. The accepted token set is shared by the server and by
+/// the desktop host, which each supply their own default for an unset value.
+/// </summary>
+internal static class TlsPolicy
+{
+    /// <summary>
+    /// True when the value asks for TLS. An unset or empty value yields
+    /// <paramref name="fallback"/>; any other unrecognized value is off, not a fallback.
+    /// </summary>
+    internal static bool IsEnabled(string? value, bool fallback) =>
+        string.IsNullOrEmpty(value)
+            ? fallback
+            : value.ToLowerInvariant() is "1" or "true" or "yes" or "on";
+}

--- a/src/Ivy/Ivy.csproj
+++ b/src/Ivy/Ivy.csproj
@@ -124,6 +124,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Ivy.Test" />
     <InternalsVisibleTo Include="Ivy.Docs" />
+    <InternalsVisibleTo Include="Ivy.Desktop" />
     <InternalsVisibleTo Include="Ivy.XamlBuilder" />
     <InternalsVisibleTo Include="Ivy.XamlBuilder.Test" />
     <InternalsVisibleTo Include="Ivy.Integration.Tests" />

--- a/src/Ivy/Server.cs
+++ b/src/Ivy/Server.cs
@@ -789,9 +789,7 @@ public class Server
         else
         {
             var ivyTlsEnv = Environment.GetEnvironmentVariable("IVY_TLS");
-            var useTls = !string.IsNullOrEmpty(ivyTlsEnv)
-                ? ivyTlsEnv.ToLowerInvariant() is "1" or "true" or "yes" or "on"
-                : !isContainer && !hasPortEnv && OperatingSystem.IsWindows(); // default: TLS for local dev only on Windows
+            var useTls = TlsPolicy.IsEnabled(ivyTlsEnv, fallback: !isContainer && !hasPortEnv && OperatingSystem.IsWindows()); // default: TLS for local dev only on Windows
             var scheme = useTls ? "https" : "http";
             builder.WebHost.UseUrls($"{scheme}://{host}:{_args.Port}");
         }


### PR DESCRIPTION
# Summary

## Changes

Created a shared TlsPolicy helper to parse IVY_TLS environment variable tokens, eliminating three duplicate token tests across Server.cs and DesktopWindow.cs. Removed the dead OS fallback predicate in DesktopWindow.RunInternal that could never be reached after the Windows/macOS default was forced earlier in the method.

## API Changes

- **New internal class**: `Ivy.Core.Server.TlsPolicy` with static method `IsEnabled(string? value, bool fallback)` for parsing IVY_TLS tokens
- **InternalsVisibleTo**: Added `Ivy.Desktop` to `Ivy.csproj` to grant access to the internal TlsPolicy class

## Files Modified

**Core changes:**
- `src/Ivy/Core/Server/TlsPolicy.cs` - New shared IVY_TLS parser
- `src/Ivy/Ivy.csproj` - Added InternalsVisibleTo for Ivy.Desktop
- `src/Ivy/Server.cs` - Replaced inline token parsing with TlsPolicy.IsEnabled
- `src/Ivy.Desktop/DesktopWindow.cs` - Hoisted useTls computation, removed dead OS fallback and duplicate parsing

**Tests:**
- `src/Ivy.Test/TlsPolicyTests.cs` - New test coverage for IVY_TLS token parsing

## Manual Testing

N/A — internal refactor with no user-facing behavior change. All platforms continue to behave identically for all values of IVY_TLS. The test suite verifies the token parsing logic, and existing ServerConfigurationTests and DesktopNavigationTests confirm no regressions.

---

**Commits:**
- 127930b71 Share one IVY_TLS parser and drop dead OS fallback in DesktopWindow

---
Created using [Ivy Tendril](https://ivy.app).
