### PR TITLE
[00487] Log When a Session Queue Silently Drops Queued UI Work

### DIFF
--- a/src/Ivy.Test/EventDispatchQueueTests.cs
+++ b/src/Ivy.Test/EventDispatchQueueTests.cs
@@ -2,7 +2,6 @@ using System.Collections.Concurrent;
 using Ivy.Core;
 using Ivy.Core.Server;
 using Microsoft.Extensions.Logging;
-using Xunit;
 
 namespace Ivy.Test;
 

--- a/src/Ivy.Test/EventDispatchQueueTests.cs
+++ b/src/Ivy.Test/EventDispatchQueueTests.cs
@@ -1,0 +1,160 @@
+using System.Collections.Concurrent;
+using Ivy.Core;
+using Ivy.Core.Server;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Ivy.Test;
+
+public class EventDispatchQueueTests
+{
+    [Fact]
+    public async Task DrainedQueue_DropsNothingAndLogsNothing()
+    {
+        var logger = new RecordingLogger();
+        using var cts = new CancellationTokenSource();
+        using var queue = new EventDispatchQueue(cts.Token, logger, "test-session");
+
+        var counter = 0;
+        for (var i = 0; i < 10; i++)
+        {
+            var captured = i;
+            queue.Enqueue(() => { counter = captured; });
+        }
+
+        await Task.Delay(100);
+
+        Assert.Equal(9, counter);
+        Assert.Equal(0, queue.DroppedCount);
+        Assert.DoesNotContain(logger.Entries, e => e.Level == LogLevel.Warning);
+    }
+
+    [Fact]
+    public async Task OverflowByOne_CountsOneDropAndLogsOnce()
+    {
+        var logger = new RecordingLogger();
+        using var cts = new CancellationTokenSource();
+        using var queue = new EventDispatchQueue(cts.Token, logger, "overflow-session");
+
+        var started = new TaskCompletionSource();
+        var gate = new TaskCompletionSource();
+
+        queue.Enqueue(async () =>
+        {
+            started.SetResult();
+            await gate.Task;
+        });
+
+        await started.Task;
+
+        for (var i = 0; i < 1024; i++)
+        {
+            queue.Enqueue(() => { });
+        }
+
+        queue.Enqueue(() => { });
+
+        gate.SetResult();
+        await Task.Delay(100);
+
+        Assert.Equal(1, queue.DroppedCount);
+        var warnings = logger.Entries.Where(e => e.Level == LogLevel.Warning).ToList();
+        Assert.Single(warnings);
+        Assert.Contains("overflow-session", warnings[0].Message);
+    }
+
+    [Fact]
+    public async Task SustainedOverflow_LogsFarFewerLinesThanItDrops()
+    {
+        var logger = new RecordingLogger();
+        using var cts = new CancellationTokenSource();
+        using var queue = new EventDispatchQueue(cts.Token, logger, "sustained-overflow");
+
+        var started = new TaskCompletionSource();
+        var gate = new TaskCompletionSource();
+
+        queue.Enqueue(async () =>
+        {
+            started.SetResult();
+            await gate.Task;
+        });
+
+        await started.Task;
+
+        for (var i = 0; i < 1024; i++)
+        {
+            queue.Enqueue(() => { });
+        }
+
+        for (var i = 0; i < 500; i++)
+        {
+            queue.Enqueue(() => { });
+        }
+
+        gate.SetResult();
+        await Task.Delay(100);
+
+        Assert.Equal(500, queue.DroppedCount);
+        var warningCount = logger.Entries.Count(e => e.Level == LogLevel.Warning);
+        Assert.InRange(warningCount, 1, 3);
+    }
+
+    [Fact]
+    public async Task ClientSenderOverflowByOne_CountsOneDropAndLogsOnce()
+    {
+        var logger = new RecordingLogger();
+        var notifier = new FakeClientNotifier();
+
+        var started = new TaskCompletionSource();
+        var gate = new TaskCompletionSource();
+        notifier.OnNotify = async (connectionId, method, message) =>
+        {
+            started.SetResult();
+            await gate.Task;
+        };
+
+        using var sender = new ClientSender(notifier, "test-connection", logger);
+
+        sender.Send("FirstMessage", null);
+        await started.Task;
+
+        for (var i = 0; i < 2048; i++)
+        {
+            sender.Send("FillMessage", i);
+        }
+
+        sender.Send("OverflowMessage", null);
+
+        gate.SetResult();
+        await Task.Delay(100);
+
+        Assert.Equal(1, sender.DroppedCount);
+        var warnings = logger.Entries.Where(e => e.Level == LogLevel.Warning).ToList();
+        Assert.Single(warnings);
+        Assert.Contains("test-connection", warnings[0].Message);
+    }
+
+    private class RecordingLogger : ILogger
+    {
+        public ConcurrentBag<(LogLevel Level, string Message)> Entries { get; } = new();
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            Entries.Add((logLevel, formatter(state, exception)));
+        }
+    }
+
+    private class FakeClientNotifier : IClientNotifier
+    {
+        public Func<string, string, object?, Task>? OnNotify { get; set; }
+
+        public Task NotifyClientAsync(string connectionId, string method, object? message)
+        {
+            return OnNotify?.Invoke(connectionId, method, message) ?? Task.CompletedTask;
+        }
+    }
+}

--- a/src/Ivy/Core/EventDispatchQueue.cs
+++ b/src/Ivy/Core/EventDispatchQueue.cs
@@ -1,24 +1,37 @@
 using System.Threading.Channels;
+using Microsoft.Extensions.Logging;
 
 namespace Ivy.Core;
 
 public sealed class EventDispatchQueue : IDisposable
 {
     private const int DefaultChannelCapacity = 1024;
+    private const int DropLogIntervalMs = 5000;
     private readonly Channel<Func<Task>> _channel;
     private readonly CancellationTokenSource _cts;
     private readonly Task _worker;
+    private readonly ILogger? _logger;
+    private readonly string _sessionLabel;
+    private long _droppedCount;
+    private long _lastDropLogTicks;
     private volatile bool _disposed;
 
+    internal long DroppedCount => Interlocked.Read(ref _droppedCount);
+
     public EventDispatchQueue(CancellationToken externalCancellation)
+        : this(externalCancellation, null, null) { }
+
+    internal EventDispatchQueue(CancellationToken externalCancellation, ILogger? logger, string? sessionLabel)
     {
+        _logger = logger;
+        _sessionLabel = sessionLabel ?? "unknown";
         var options = new BoundedChannelOptions(DefaultChannelCapacity)
         {
             SingleReader = true,
             SingleWriter = false,
             FullMode = BoundedChannelFullMode.DropOldest
         };
-        _channel = Channel.CreateBounded<Func<Task>>(options);
+        _channel = Channel.CreateBounded<Func<Task>>(options, OnItemDropped);
         _cts = CancellationTokenSource.CreateLinkedTokenSource(externalCancellation);
 
         _worker = Task.Run(async () =>
@@ -42,6 +55,26 @@ public sealed class EventDispatchQueue : IDisposable
             }
             catch (OperationCanceledException) { }
         }, _cts.Token);
+    }
+
+    private void OnItemDropped(Func<Task> dropped)
+    {
+        var total = Interlocked.Increment(ref _droppedCount);
+        var now = Environment.TickCount64;
+        var last = Interlocked.Read(ref _lastDropLogTicks);
+        if (total != 1 && now - last < DropLogIntervalMs) return;
+        if (Interlocked.CompareExchange(ref _lastDropLogTicks, now, last) != last) return;
+
+        if (_logger is not null)
+        {
+            _logger.LogWarning(
+                "EventDispatchQueue for session {Session} dropped {DroppedTotal} queued UI update(s), capacity {Capacity}; this session may be rendering stale content.",
+                _sessionLabel, total, DefaultChannelCapacity);
+        }
+        else
+        {
+            Console.WriteLine($"WARN: EventDispatchQueue for session {_sessionLabel} dropped {total} queued UI update(s), capacity {DefaultChannelCapacity}; this session may be rendering stale content.");
+        }
     }
 
     public void Enqueue(Action action)

--- a/src/Ivy/Core/Server/AppHub.cs
+++ b/src/Ivy/Core/Server/AppHub.cs
@@ -84,7 +84,7 @@ public class AppHub(
             var httpContext = Context.GetHttpContext()!;
             var parentId = AppRouter.GetParentId(httpContext);
 
-            var clientProvider = new ClientProvider(new ClientSender(clientNotifier, Context.ConnectionId));
+            var clientProvider = new ClientProvider(new ClientSender(clientNotifier, Context.ConnectionId, logger));
 
             if (server.Services.All(sd => sd.ServiceType != typeof(IExceptionHandler)))
             {
@@ -246,7 +246,7 @@ public class AppHub(
             };
 
             var connectionAborted = Context.ConnectionAborted;
-            appState.EventQueue = new EventDispatchQueue(connectionAborted);
+            appState.EventQueue = new EventDispatchQueue(connectionAborted, logger, $"{routeResult.AppId}/{Context.ConnectionId}");
 
             if (parentId == null)
             {
@@ -1060,20 +1060,33 @@ public class AppHub(
 
 public class ClientSender : IClientSender, IDisposable
 {
+    private const int ChannelCapacity = 2048;
+    private const int DropLogIntervalMs = 5000;
     private readonly System.Threading.Channels.Channel<(string method, object? data)> _channel;
     private readonly CancellationTokenSource _cts = new();
     private readonly Task _worker;
+    private readonly ILogger? _logger;
+    private readonly string _connectionId;
+    private long _droppedCount;
+    private long _lastDropLogTicks;
     private volatile bool _disposed;
 
+    internal long DroppedCount => Interlocked.Read(ref _droppedCount);
+
     public ClientSender(IClientNotifier clientNotifier, string connectionId)
+        : this(clientNotifier, connectionId, null) { }
+
+    internal ClientSender(IClientNotifier clientNotifier, string connectionId, ILogger? logger)
     {
-        var options = new System.Threading.Channels.BoundedChannelOptions(2048)
+        _logger = logger;
+        _connectionId = connectionId;
+        var options = new System.Threading.Channels.BoundedChannelOptions(ChannelCapacity)
         {
             SingleReader = true,
             SingleWriter = false,
             FullMode = System.Threading.Channels.BoundedChannelFullMode.DropOldest
         };
-        _channel = System.Threading.Channels.Channel.CreateBounded<(string, object?)>(options);
+        _channel = System.Threading.Channels.Channel.CreateBounded<(string, object?)>(options, OnItemDropped);
 
         _worker = Task.Factory.StartNew(async () =>
         {
@@ -1098,13 +1111,33 @@ public class ClientSender : IClientSender, IDisposable
         }, _cts.Token, TaskCreationOptions.LongRunning, TaskScheduler.Default).Unwrap();
     }
 
+    private void OnItemDropped((string method, object? data) dropped)
+    {
+        var total = Interlocked.Increment(ref _droppedCount);
+        var now = Environment.TickCount64;
+        var last = Interlocked.Read(ref _lastDropLogTicks);
+        if (total != 1 && now - last < DropLogIntervalMs) return;
+        if (Interlocked.CompareExchange(ref _lastDropLogTicks, now, last) != last) return;
+
+        if (_logger is not null)
+        {
+            _logger.LogWarning(
+                "ClientSender for connection {ConnectionId} dropped {DroppedTotal} outbound message(s), capacity {Capacity}; client may be receiving stale content.",
+                _connectionId, total, ChannelCapacity);
+        }
+        else
+        {
+            Console.WriteLine($"WARN: ClientSender for connection {_connectionId} dropped {total} outbound message(s), capacity {ChannelCapacity}; client may be receiving stale content.");
+        }
+    }
+
     public void Send(string method, object? data)
     {
         if (_disposed) return;
 
         if (!_channel.Writer.TryWrite((method, data)))
         {
-            // Channel full or completed — try async write, but guard against disposal race
+            // DropOldest mode never reports a full channel; TryWrite fails only once the channel is completed
             if (_disposed) return;
             try
             {


### PR DESCRIPTION
# Summary

## Changes

Added drop logging to EventDispatchQueue and ClientSender to make queue overflow observable. When either queue discards messages due to capacity overflow, it now logs a warning with the session/connection ID, total dropped count, and capacity. Logging is rate-limited to one line per 5 seconds to avoid flooding logs during sustained overflow.

## API Changes

**Internal additions** (no public API changes):
- `EventDispatchQueue.DroppedCount` property (internal) - returns total messages dropped
- `EventDispatchQueue(CancellationToken, ILogger?, string?)` constructor (internal) - accepts logger and session label
- `ClientSender.DroppedCount` property (internal) - returns total messages dropped
- `ClientSender(IClientNotifier, string, ILogger?)` constructor (internal) - accepts logger

Existing public constructors remain unchanged for plugin compatibility.

## Files Modified

**Core changes:**
- `src/Ivy/Core/EventDispatchQueue.cs` - Added logging infrastructure and OnItemDropped callback
- `src/Ivy/Core/Server/AppHub.cs` - Pass logger to EventDispatchQueue and ClientSender; fix misleading comment

**Tests:**
- `src/Ivy.Test/EventDispatchQueueTests.cs` - New test file with 4 tests covering overflow scenarios

## Manual Testing

N/A — internal diagnostic change with no user-facing behavior.

The logging only triggers when a session queue overflows (1024+ queued UI updates for EventDispatchQueue, or 2048+ outbound messages for ClientSender). Under normal operation, no drops occur and no logs are written. The new tests verify correct behavior at overflow boundaries.

---
## Commits
- cb516dcfe Add drop logging to EventDispatchQueue and ClientSender
- e4bab33b5 Add tests for queue overflow logging
- 61bac5eb8 Fix lint error from DotnetFormat

---
Created using [Ivy Tendril](https://ivy.app).
